### PR TITLE
Refine recap display lifecycle

### DIFF
--- a/.changeset/fresh-recaps-stop.md
+++ b/.changeset/fresh-recaps-stop.md
@@ -1,0 +1,5 @@
+---
+"@zhcsyncer/pi-recap": patch
+---
+
+Cancel in-flight automatic recaps when new input starts, prevent stale runs from writing results, and replace the independent widget toggle with mutually exclusive status/widget display modes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Release
+
+- 发版必须走 Changesets 的 version PR 流程：用户可见变更先附带 changeset 合入 `main`，等待 `.github/workflows/release.yml` 创建或更新 `chore: version packages` PR，审核并合并该 PR 后再由 GitHub Actions 发布。
+- 不要直接运行版本升级或发布命令，也不要绕过 version PR 直接向 `main` 提交发版版本、推送发布 tag 或手动发布 npm 包。

--- a/packages/pi-recap/README.md
+++ b/packages/pi-recap/README.md
@@ -8,6 +8,8 @@ Features:
 
 - Generate a recent activity recap with `/recap`.
 - Automatically recap after the agent has been idle for a while.
+- Cancel an unfinished automatic recap when a new message arrives, preventing stale results from being stored or displayed.
+- Display recaps through mutually exclusive footer status or editor widget modes.
 - Generate a short title as a recap side effect.
 - Optionally apply the title to the Pi session name.
 - Optionally sync Pi session name changes to the current tmux window name.
@@ -112,9 +114,8 @@ Default config:
   },
   "display": {
     "notify": true,
-    "widget": false,
-    "widgetPlacement": "aboveEditor",
-    "clearWidgetOnNextAgentStart": true
+    "mode": "status",
+    "widgetPlacement": "aboveEditor"
   },
   "title": {
     "generate": true,
@@ -165,16 +166,20 @@ Use a specific recap model:
 }
 ```
 
-Enable widget display:
+Switch to widget display:
 
 ```json
 {
   "display": {
-    "widget": true,
+    "mode": "widget",
     "widgetPlacement": "aboveEditor"
   }
 }
 ```
+
+`display.mode` accepts `"status"` or `"widget"`. The modes are mutually exclusive: both generation progress and the completed recap use only the selected surface. The status or widget is cleared when the next message starts. If an automatic recap is still running, it is cancelled and cannot later store or redisplay a stale result.
+
+Legacy `display.widget: true/false` settings are migrated at load time to `display.mode: "widget"/"status"`; `clearWidgetOnNextAgentStart` is no longer needed.
 
 Customize tmux window name:
 

--- a/packages/pi-recap/README.zh-CN.md
+++ b/packages/pi-recap/README.zh-CN.md
@@ -8,6 +8,8 @@
 
 - 手动 `/recap` 生成最近活动摘要；
 - agent 完成后空闲一段时间自动生成 recap；
+- 发送新消息时取消尚未完成的自动 recap，避免写入或展示过期结果；
+- 使用互斥的 footer status 或 editor widget 展示 recap；
 - recap 时顺便生成短 title；
 - 是否用 title 更新 Pi session name 由配置控制；
 - session name 变化时可选同步 tmux window name；
@@ -112,9 +114,8 @@ examples/recap.json
   },
   "display": {
     "notify": true,
-    "widget": false,
-    "widgetPlacement": "aboveEditor",
-    "clearWidgetOnNextAgentStart": true
+    "mode": "status",
+    "widgetPlacement": "aboveEditor"
   },
   "title": {
     "generate": true,
@@ -165,16 +166,20 @@ examples/recap.json
 }
 ```
 
-启用 widget 展示：
+切换为 widget 展示：
 
 ```json
 {
   "display": {
-    "widget": true,
+    "mode": "widget",
     "widgetPlacement": "aboveEditor"
   }
 }
 ```
+
+`display.mode` 可选 `"status"` 或 `"widget"`。两种模式互斥：生成中的提示和最终 recap 都只使用当前模式。status 或 widget 会在下一条消息开始时清除；如果自动 recap 仍在生成，该任务也会被取消，并且不会在稍后写入或重新展示过期结果。
+
+旧配置中的 `display.widget: true/false` 会在读取时自动迁移为 `display.mode: "widget"/"status"`；`clearWidgetOnNextAgentStart` 已不再需要。
 
 自定义 tmux window 名称：
 

--- a/packages/pi-recap/examples/recap.json
+++ b/packages/pi-recap/examples/recap.json
@@ -14,9 +14,8 @@
   },
   "display": {
     "notify": true,
-    "widget": false,
-    "widgetPlacement": "aboveEditor",
-    "clearWidgetOnNextAgentStart": true
+    "mode": "status",
+    "widgetPlacement": "aboveEditor"
   },
   "title": {
     "generate": true,

--- a/packages/pi-recap/extensions/recap.ts
+++ b/packages/pi-recap/extensions/recap.ts
@@ -33,6 +33,7 @@ const STATUS_KEY = "recap";
 
 type RecapReason = "manual" | "auto";
 type TitleApplyPolicy = "never" | "if-empty" | "if-empty-or-auto" | "always";
+type DisplayMode = "status" | "widget";
 type WidgetPlacement = "aboveEditor" | "belowEditor";
 
 type RecapConfig = {
@@ -51,9 +52,8 @@ type RecapConfig = {
 	};
 	display: {
 		notify: boolean;
-		widget: boolean;
+		mode: DisplayMode;
 		widgetPlacement: WidgetPlacement;
-		clearWidgetOnNextAgentStart: boolean;
 	};
 	title: {
 		generate: boolean;
@@ -105,9 +105,8 @@ const DEFAULT_CONFIG: RecapConfig = {
 	},
 	display: {
 		notify: true,
-		widget: false,
+		mode: "status",
 		widgetPlacement: "aboveEditor",
-		clearWidgetOnNextAgentStart: true,
 	},
 	title: {
 		generate: true,
@@ -142,6 +141,19 @@ function deepMerge<T extends Record<string, unknown>>(base: T, override: unknown
 	return result as T;
 }
 
+function migrateLegacyConfig(value: unknown): unknown {
+	if (!isRecord(value) || !isRecord(value.display)) return value;
+
+	const display = { ...value.display };
+	if (!("mode" in display) && typeof display.widget === "boolean") {
+		display.mode = display.widget ? "widget" : "status";
+	}
+	delete display.widget;
+	delete display.clearWidgetOnNextAgentStart;
+
+	return { ...value, display };
+}
+
 async function readJsonIfExists(file: string): Promise<unknown | undefined> {
 	try {
 		return JSON.parse(await readFile(file, "utf8"));
@@ -164,11 +176,11 @@ async function saveGlobalConfig(config: RecapConfig): Promise<void> {
 async function loadConfig(ctx: ExtensionContext): Promise<RecapConfig> {
 	let config = deepMerge(DEFAULT_CONFIG as unknown as Record<string, unknown>, {}) as RecapConfig;
 
-	const globalConfig = await readJsonIfExists(path.join(getAgentDir(), "recap.json"));
+	const globalConfig = migrateLegacyConfig(await readJsonIfExists(path.join(getAgentDir(), "recap.json")));
 	config = deepMerge(config as unknown as Record<string, unknown>, globalConfig) as RecapConfig;
 
 	if (ctx.isProjectTrusted()) {
-		const projectConfig = await readJsonIfExists(path.join(ctx.cwd, CONFIG_DIR_NAME, "recap.json"));
+		const projectConfig = migrateLegacyConfig(await readJsonIfExists(path.join(ctx.cwd, CONFIG_DIR_NAME, "recap.json")));
 		config = deepMerge(config as unknown as Record<string, unknown>, projectConfig) as RecapConfig;
 	}
 
@@ -176,7 +188,7 @@ async function loadConfig(ctx: ExtensionContext): Promise<RecapConfig> {
 }
 
 function normalizeConfig(config: RecapConfig): RecapConfig {
-	const normalized = {
+	const normalized: RecapConfig = {
 		recap: {
 			...DEFAULT_CONFIG.recap,
 			...config.recap,
@@ -188,6 +200,7 @@ function normalizeConfig(config: RecapConfig): RecapConfig {
 		display: {
 			...DEFAULT_CONFIG.display,
 			...config.display,
+			mode: normalizeDisplayMode(config.display?.mode),
 			widgetPlacement: config.display?.widgetPlacement === "belowEditor" ? "belowEditor" : "aboveEditor",
 		},
 		title: {
@@ -215,6 +228,10 @@ function positiveNumber(value: unknown, fallback: number): number {
 function normalizeTitlePolicy(value: unknown): TitleApplyPolicy {
 	if (value === "never" || value === "if-empty" || value === "if-empty-or-auto" || value === "always") return value;
 	return DEFAULT_CONFIG.title.applyPolicy;
+}
+
+function normalizeDisplayMode(value: unknown): DisplayMode {
+	return value === "widget" ? "widget" : "status";
 }
 
 function currentSessionName(pi: ExtensionAPI, ctx: ExtensionContext): string | undefined {
@@ -391,7 +408,7 @@ function cleanOneLine(value: string, maxLength?: number): string {
 	return cleaned;
 }
 
-async function resolveRecapModel(ctx: ExtensionContext, config: RecapConfig) {
+function resolveRecapModel(ctx: ExtensionContext, config: RecapConfig) {
 	if (config.recap.model === "current") return ctx.model;
 
 	const separator = config.recap.model.indexOf("/");
@@ -456,19 +473,37 @@ async function runRecap(
 		return undefined;
 	}
 
-	const model = await resolveRecapModel(ctx, config);
+	const model = resolveRecapModel(ctx, config);
 	if (!model) {
 		if (ctx.hasUI) ctx.ui.notify("No model available for recap", "warning");
 		return undefined;
 	}
+	if (signal?.aborted) return undefined;
+
+	const controller = reason === "auto" ? new AbortController() : undefined;
+	const runSignal = signal ?? controller?.signal ?? ctx.signal;
+	const run: ActiveRecapRun = {
+		id: ++state.nextRunId,
+		reason,
+		controller,
+		signal: runSignal,
+	};
+	let displayed = false;
 
 	state.running = true;
-	ctx.ui.setStatus(STATUS_KEY, "recap...");
+	state.activeRun = run;
+	showRecapProgress(ctx, config);
 
 	try {
 		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-		if (!auth.ok || !auth.apiKey) {
-			if (ctx.hasUI) ctx.ui.notify(auth.ok ? `No API key for ${model.provider}` : auth.error, "warning");
+		if (!isCurrentRecapRun(state, run)) return undefined;
+		if (!auth.ok) {
+			const message = "error" in auth ? auth.error : `Failed to resolve API key for ${model.provider}`;
+			if (ctx.hasUI) ctx.ui.notify(message, "warning");
+			return undefined;
+		}
+		if (!auth.apiKey) {
+			if (ctx.hasUI) ctx.ui.notify(`No API key for ${model.provider}`, "warning");
 			return undefined;
 		}
 
@@ -489,11 +524,11 @@ async function runRecap(
 				headers: auth.headers,
 				env: auth.env,
 				maxTokens: config.recap.maxTokens,
-				signal: signal ?? ctx.signal,
+				signal: runSignal,
 			},
 		);
 
-		if (response.stopReason === "aborted") return undefined;
+		if (!isCurrentRecapRun(state, run) || response.stopReason === "aborted") return undefined;
 
 		const raw = response.content
 			.filter((item): item is { type: "text"; text: string } => item.type === "text")
@@ -539,15 +574,41 @@ async function runRecap(
 		state.lastRecapAt = data.generatedAt;
 
 		displayRecap(ctx, config, data);
+		displayed = true;
 		return data;
+	} catch (error) {
+		if (runSignal?.aborted || state.activeRun !== run) return undefined;
+		throw error;
 	} finally {
-		state.running = false;
-		ctx.ui.setStatus(STATUS_KEY, undefined);
+		if (state.activeRun === run) {
+			state.activeRun = undefined;
+			state.running = false;
+			if (!displayed) clearRecapDisplay(ctx);
+		}
 	}
 }
 
+function isCurrentRecapRun(state: RecapState, run: ActiveRecapRun): boolean {
+	return state.activeRun === run && !run.signal?.aborted;
+}
+
+function clearRecapDisplay(ctx: ExtensionContext) {
+	ctx.ui.setStatus(STATUS_KEY, undefined);
+	ctx.ui.setWidget(WIDGET_KEY, undefined);
+}
+
+function showRecapProgress(ctx: ExtensionContext, config: RecapConfig) {
+	clearRecapDisplay(ctx);
+	if (config.display.mode === "status") {
+		ctx.ui.setStatus(STATUS_KEY, "Generating recap...");
+		return;
+	}
+
+	ctx.ui.setWidget(WIDGET_KEY, ["RECAP  Generating..."], { placement: config.display.widgetPlacement });
+}
+
 function displayRecapWidget(ctx: ExtensionContext, config: RecapConfig, data: RecapEntryData) {
-	if (!config.display.widget || ctx.mode !== "tui") return;
+	if (ctx.mode !== "tui") return;
 
 	ctx.ui.setWidget(
 		WIDGET_KEY,
@@ -569,16 +630,22 @@ function displayRecapWidget(ctx: ExtensionContext, config: RecapConfig, data: Re
 	);
 }
 
-function displayRecap(ctx: ExtensionContext, config: RecapConfig, data: RecapEntryData) {
-	if (config.display.notify && ctx.hasUI) {
-		ctx.ui.notify(`Recap: ${data.recap}`, "info");
+function displayRecapSurface(ctx: ExtensionContext, config: RecapConfig, data: RecapEntryData) {
+	clearRecapDisplay(ctx);
+	if (config.display.mode === "status") {
+		ctx.ui.setStatus(STATUS_KEY, `Recap: ${data.recap}`);
+		return;
 	}
 
 	displayRecapWidget(ctx, config, data);
 }
 
-function clearWidget(ctx: ExtensionContext) {
-	ctx.ui.setWidget(WIDGET_KEY, undefined);
+function displayRecap(ctx: ExtensionContext, config: RecapConfig, data: RecapEntryData) {
+	if (config.display.notify && ctx.hasUI) {
+		ctx.ui.notify(`Recap: ${data.recap}`, "info");
+	}
+
+	displayRecapSurface(ctx, config, data);
 }
 
 function boolValue(value: boolean): string {
@@ -623,16 +690,16 @@ function settingItems(config: RecapConfig): SettingItem[] {
 			values: ["on", "off"],
 		},
 		{
-			id: "display.widget",
-			label: "Widget display",
-			description: "Keep latest recap near the editor.",
-			currentValue: boolValue(config.display.widget),
-			values: ["on", "off"],
+			id: "display.mode",
+			label: "Display mode",
+			description: "Show recap in either the footer status or an editor widget.",
+			currentValue: config.display.mode,
+			values: ["status", "widget"],
 		},
 		{
 			id: "display.widgetPlacement",
 			label: "Widget placement",
-			description: "Where to render recap widget if enabled.",
+			description: "Where to render recap when widget mode is selected.",
 			currentValue: config.display.widgetPlacement,
 			values: ["aboveEditor", "belowEditor"],
 		},
@@ -673,8 +740,8 @@ function applyConfigSetting(config: RecapConfig, id: string, value: string): Rec
 		case "display.notify":
 			next.display.notify = on;
 			break;
-		case "display.widget":
-			next.display.widget = on;
+		case "display.mode":
+			next.display.mode = normalizeDisplayMode(value);
 			break;
 		case "display.widgetPlacement":
 			next.display.widgetPlacement = value === "belowEditor" ? "belowEditor" : "aboveEditor";
@@ -700,10 +767,11 @@ async function editConfigJson(pi: ExtensionAPI, ctx: ExtensionContext, state: Re
 	if (edited === undefined) return;
 
 	try {
-		const parsed = JSON.parse(edited) as unknown;
+		const parsed = migrateLegacyConfig(JSON.parse(edited) as unknown);
 		const next = normalizeConfig(deepMerge(DEFAULT_CONFIG as unknown as Record<string, unknown>, parsed) as RecapConfig);
 		state.config = next;
-		if (!next.recap.enabled || !next.recap.auto) clearAutoTimer(state);
+		if (!next.recap.enabled || !next.recap.auto) stopAutomaticRecap(ctx, state);
+		refreshRecapDisplay(ctx, state);
 		await saveGlobalConfig(next);
 		await updateTmuxWindow(pi, ctx, next, state);
 		ctx.ui.notify(`Saved recap config: ${getGlobalConfigPath()}`, "info");
@@ -734,12 +802,11 @@ async function openConfigUi(pi: ExtensionAPI, ctx: ExtensionContext, state: Reca
 				state.config = next;
 				settingsList.updateValue(id, newValue);
 
-				if (!next.recap.enabled || !next.recap.auto) clearAutoTimer(state);
+				if (!next.recap.enabled || !next.recap.auto) stopAutomaticRecap(ctx, state);
+				refreshRecapDisplay(ctx, state);
 				void saveGlobalConfig(next)
 					.then(async () => {
 						await updateTmuxWindow(pi, ctx, next, state);
-						ctx.ui.setStatus("recap-config", "saved");
-						setTimeout(() => ctx.ui.setStatus("recap-config", undefined), 2000);
 					})
 					.catch((error) => {
 						ctx.ui.notify(`Failed to save recap config: ${error instanceof Error ? error.message : String(error)}`, "error");
@@ -836,9 +903,18 @@ async function restoreTmuxWindow(state: RecapState) {
 	}
 }
 
+type ActiveRecapRun = {
+	id: number;
+	reason: RecapReason;
+	controller?: AbortController;
+	signal?: AbortSignal;
+};
+
 type RecapState = {
 	config: RecapConfig;
 	running: boolean;
+	nextRunId: number;
+	activeRun?: ActiveRecapRun;
 	applyingSessionName: boolean;
 	lastRecap?: RecapEntryData;
 	lastRecapAt?: number;
@@ -854,6 +930,29 @@ function clearAutoTimer(state: RecapState) {
 	state.autoTimer = undefined;
 }
 
+function cancelActiveAutoRecap(state: RecapState): boolean {
+	const run = state.activeRun;
+	if (!run || run.reason !== "auto") return false;
+
+	state.activeRun = undefined;
+	state.running = false;
+	run.controller?.abort();
+	return true;
+}
+
+function stopAutomaticRecap(ctx: ExtensionContext, state: RecapState) {
+	clearAutoTimer(state);
+	cancelActiveAutoRecap(state);
+	clearRecapDisplay(ctx);
+}
+
+function refreshRecapDisplay(ctx: ExtensionContext, state: RecapState) {
+	clearRecapDisplay(ctx);
+	if (state.config.recap.enabled && state.lastRecap) {
+		displayRecapSurface(ctx, state.config, state.lastRecap);
+	}
+}
+
 function scheduleAutoRecap(pi: ExtensionAPI, ctx: ExtensionContext, state: RecapState) {
 	clearAutoTimer(state);
 
@@ -864,7 +963,10 @@ function scheduleAutoRecap(pi: ExtensionAPI, ctx: ExtensionContext, state: Recap
 	state.autoTimer = setTimeout(() => {
 		state.autoTimer = undefined;
 		if (!ctx.isIdle() || ctx.hasPendingMessages()) return;
-		void runRecap(pi, ctx, state.config, state, "auto");
+		void runRecap(pi, ctx, state.config, state, "auto").catch((error) => {
+			const message = error instanceof Error ? error.message : String(error);
+			ctx.ui.notify(`Failed to generate automatic recap: ${message}`, "error");
+		});
 	}, config.recap.idleAfterTurnMs);
 }
 
@@ -885,6 +987,7 @@ export default function (pi: ExtensionAPI) {
 	const state: RecapState = {
 		config: DEFAULT_CONFIG,
 		running: false,
+		nextRunId: 0,
 		applyingSessionName: false,
 		lastAppliedSessionName: false,
 	};
@@ -898,7 +1001,7 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		await refreshStateFromSession(ctx, state);
-		if (state.lastRecap) displayRecapWidget(ctx, state.config, state.lastRecap);
+		refreshRecapDisplay(ctx, state);
 		await updateTmuxWindow(pi, ctx, state.config, state);
 	});
 
@@ -910,17 +1013,20 @@ export default function (pi: ExtensionAPI) {
 		await updateTmuxWindow(pi, ctx, state.config, state);
 	});
 
+	pi.on("input", async (_event, ctx) => {
+		stopAutomaticRecap(ctx, state);
+	});
+
 	pi.on("agent_start", async (_event, ctx) => {
-		clearAutoTimer(state);
-		if (state.config.display.clearWidgetOnNextAgentStart) clearWidget(ctx);
+		stopAutomaticRecap(ctx, state);
 	});
 
 	pi.on("agent_end", async (_event, ctx) => {
 		scheduleAutoRecap(pi, ctx, state);
 	});
 
-	pi.on("session_shutdown", async (event, _ctx) => {
-		clearAutoTimer(state);
+	pi.on("session_shutdown", async (event, ctx) => {
+		stopAutomaticRecap(ctx, state);
 		if (state.config.tmux.restoreOnShutdown && event.reason !== "reload") {
 			await restoreTmuxWindow(state);
 		}
@@ -929,6 +1035,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerCommand("recap", {
 		description: "Generate a recent activity recap",
 		handler: async (_args, ctx: ExtensionCommandContext) => {
+			stopAutomaticRecap(ctx, state);
 			if (!state.config.recap.manualCommand) {
 				ctx.ui.notify("/recap is disabled by config", "warning");
 				return;
@@ -972,6 +1079,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerCommand("recap-config", {
 		description: "Configure recap extension",
 		handler: async (args, ctx) => {
+			stopAutomaticRecap(ctx, state);
 			const mode = args.trim();
 			if (mode === "json") {
 				await editConfigJson(pi, ctx, state);


### PR DESCRIPTION
## Summary

- cancel in-flight automatic recaps when new input or an agent run starts
- prevent cancelled/stale runs from persisting or redisplaying results
- replace the independent widget toggle with mutually exclusive `status` / `widget` display modes
- migrate legacy recap display config at load time
- document the Changesets version-PR release requirement in `AGENTS.md`

## Validation

- `pnpm check`
- `pnpm dlx --package=typescript@5.9.3 tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck packages/pi-recap/extensions/recap.ts`
- `git diff --check`
