### PR TITLE
Keep repository release marked latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,7 @@ jobs:
 
             gh release create "$RECAP_TAG" \
               --verify-tag \
+              --latest=false \
               --notes "$RECAP_NOTES" \
               --title "pi-recap v$VERSION"
           fi


### PR DESCRIPTION
## Summary

- create package-specific `pi-recap` releases with `--latest=false`
- preserve `pi-extensions vX.Y.Z` as the repository's Latest release

The existing v0.1.3 release metadata has already been corrected to match this behavior.

## Validation

- `pnpm check`
- `pnpm changeset status`
- `bash -n` on the extracted release script
- Ruby YAML parse
- `git diff --check`
