### PR TITLE
fix: support bootstrap npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Create version PR or publish packages
         id: changesets
         uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           version: pnpm version-packages
           publish: pnpm release


### PR DESCRIPTION
## Summary
- pass an optional `NPM_TOKEN` secret to Changesets Action
- retain OIDC trusted publishing when the secret is absent
- unblock the first publish of `@zhcsyncer/pi-tool-display-intent` after the 0.2.0 version PR

## Context
Release run 29648913883 partially published `@zhcsyncer/pi-extensions@0.2.0` and `@zhcsyncer/pi-recap@0.2.0`, but npm returned E404 for the new package because trusted publishing can only be configured from an existing package settings page.

## Validation
- release workflow YAML parses successfully
- `git diff --check` passes

Do not merge until the repository Actions secret `NPM_TOKEN` is configured with a short-lived npm token that can create packages under the `@zhcsyncer` scope.