### PR TITLE
chore: remove bootstrap npm token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,6 @@ jobs:
       - name: Create version PR or publish packages
         id: changesets
         uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           version: pnpm version-packages
           publish: pnpm release


### PR DESCRIPTION
## Summary
- remove the temporary `NPM_TOKEN` wiring used only to create `@zhcsyncer/pi-tool-display-intent` on npm
- restore OIDC-only trusted publishing for normal releases

## Validation
- all three packages are published at 0.2.0
- all 0.2.0 tags and GitHub Releases exist
- the repository Actions secret has already been deleted
- release workflow YAML parses successfully