### PR TITLE
ci: bootstrap todo npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Create version PR or publish packages
         id: changesets
         uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           version: pnpm version-packages
           publish: pnpm release


### PR DESCRIPTION
## Summary
- temporarily expose the repository `NPM_TOKEN` secret to the Changesets publish step
- bootstrap the first public `@zhcsyncer/pi-todo` release through the generated version PR

## Cleanup
After the first Todo publish succeeds, configure its npm trusted publisher, remove this workflow wiring in a follow-up PR, and delete the temporary repository secret.

No package changeset is needed because this is release infrastructure only.