### PR TITLE
feat: collapse long Bash tool calls

### DIFF
--- a/.changeset/bright-search-docs.md
+++ b/.changeset/bright-search-docs.md
@@ -1,0 +1,5 @@
+---
+"@zhcsyncer/pi-extensions": patch
+---
+
+Add structurally aligned English and Simplified Chinese documentation for the root bundle and its private Search Hub fork. Document Search Hub's intent-aware semantic call lines, backend and reader result status, inherited display modes, shared preview budget, and Jina CSS selector semantics, and verify both README variants in npm pack checks.

--- a/.changeset/calm-bash-intents.md
+++ b/.changeset/calm-bash-intents.md
@@ -1,0 +1,8 @@
+---
+"@zhcsyncer/pi-extensions": minor
+"@zhcsyncer/pi-tool-display-intent": minor
+---
+
+Collapse long and multiline Bash call arguments into a width-aware preview with line and size metadata, while letting Ctrl+O reveal the complete original command. Add `toolCalls.bashCommandPreviewRows` to control the collapsed command budget and keep Claude-style intents in an intent-first header.
+
+Emphasize model-written tool intents with the theme accent color while rendering deterministic commands, paths, and queries as normal text and retaining muted fallback intents.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,5 @@
 
 - 发版必须走 Changesets 的 version PR 流程：用户可见变更先附带 changeset 合入 `main`，等待 `.github/workflows/release.yml` 创建或更新 `chore: version packages` PR，审核并合并该 PR 后再由 GitHub Actions 发布。
 - 不要直接运行版本升级或发布命令，也不要绕过 version PR 直接向 `main` 提交发版版本、推送发布 tag 或手动发布 npm 包。
+- 准备发布根包 `@zhcsyncer/pi-extensions` 时，先检查并处理 [`BACKLOG.md`](./BACKLOG.md) 中标记为下一次根包发布前完成的未勾选事项。
 - 发版前必须先向用户列出计划更新的包、当前版本和目标版本，并等待用户明确 review/确认；确认前不得将发版变更推送到 `main`、合并 version PR 或触发发布。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@
 
 - 发版必须走 Changesets 的 version PR 流程：用户可见变更先附带 changeset 合入 `main`，等待 `.github/workflows/release.yml` 创建或更新 `chore: version packages` PR，审核并合并该 PR 后再由 GitHub Actions 发布。
 - 不要直接运行版本升级或发布命令，也不要绕过 version PR 直接向 `main` 提交发版版本、推送发布 tag 或手动发布 npm 包。
+- 发版前必须先向用户列出计划更新的包、当前版本和目标版本，并等待用户明确 review/确认；确认前不得将发版变更推送到 `main`、合并 version PR 或触发发布。

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,23 @@
+# Backlog
+
+Repository-level follow-up work that should remain discoverable across sessions.
+
+## Next root bundle release
+
+- [x] Refresh the root bundle and Search Hub documentation before the next release of `@zhcsyncer/pi-extensions`.
+
+  Acceptance criteria:
+
+  - Documentation is bilingual, with English as the default:
+    - root: `README.md` in English and `README.zh-CN.md` in Simplified Chinese;
+    - Search Hub: `packages/pi-search-hub/README.md` in English and `packages/pi-search-hub/README.zh-CN.md` in Simplified Chinese.
+  - The root README clearly explains that the bundle includes the private Search Hub extension and links to its documentation.
+  - The Search Hub README explains the local customization relative to upstream, including:
+    - integration with `pi-tool-display-intent` and model-written `displaySummary` intents;
+    - semantic call lines that display the search query or shortened URL instead of `(N args)`;
+    - backend, reader, result-count, combine-health, content-length, and truncation status;
+    - inherited global `results.mode` and shared `previewRows` behavior;
+    - `web_read.objective` being a Jina CSS selector rather than a natural-language question.
+  - Both language versions stay structurally aligned and link to one another.
+  - Package file lists and pack checks include both language versions where applicable.
+  - Add an appropriate changeset if the documentation update accompanies user-visible behavior changes.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # pi-extensions
 
+[简体中文](./README.zh-CN.md)
+
 A collection of Pi extensions by zhcsyncer.
 
 ## Packages
 
 - [`@zhcsyncer/pi-recap`](./packages/pi-recap) — recent activity recap extension with optional session title and tmux window sync.
-- [`@zhcsyncer/pi-tool-display-intent`](./packages/pi-tool-display-intent) — compact tool rendering with model-written intent phrases, RPC-visible summaries, and adaptive diffs.
+- [`@zhcsyncer/pi-tool-display-intent`](./packages/pi-tool-display-intent) — compact tool rendering with model-written intent phrases, RPC-visible summaries, adaptive diffs, and bounded Bash call previews.
 - [`@zhcsyncer/pi-todo`](./packages/pi-todo) — maintained fork of `@juicesharp/rpiv-todo` with a persistent task overlay and no duplicate successful tool nodes.
 - [`@zhcsyncer/pi-search-hub`](./packages/pi-search-hub) — bundle-private `web_search` and `web_read` tools integrated with intent-aware rendering.
+
+## Bundle-private Search Hub
+
+The aggregate `@zhcsyncer/pi-extensions` package includes the private Search Hub fork and registers its `web_search` and `web_read` tools. Search Hub is not published as a standalone npm package; install the root bundle to use it.
+
+This fork keeps upstream multi-backend search and page extraction while integrating model-written `displaySummary` intents, semantic query/URL call lines, backend and reader status, and the shared tool-display result modes. See the [Search Hub documentation](./packages/pi-search-hub/README.md) or its [Simplified Chinese version](./packages/pi-search-hub/README.zh-CN.md) for configuration and local behavior.
 
 ## Install from Git
 
@@ -25,7 +33,7 @@ pi -e git:github.com/zhcsyncer/pi-extensions
 
 ## Install from npm
 
-Install the complete bundle:
+Install the complete bundle, including the private Search Hub fork:
 
 ```bash
 pi install npm:@zhcsyncer/pi-extensions
@@ -76,7 +84,7 @@ Add a changeset to each user-facing pull request:
 pnpm changeset
 ```
 
-Public packages version independently. A changed child package must include the aggregate root package in the same release plan because the root tarball embeds child sources; unchanged siblings do not release. After changes land on `main`, GitHub Actions opens a version PR, and merging that PR publishes the planned packages and creates their GitHub Releases. See [RELEASING.md](./RELEASING.md) for one-time npm and GitHub setup.
+Public packages version independently. A changed child package must include the aggregate root package in the same release plan because the root tarball embeds child sources; unchanged siblings do not release. Before pushing a release-bearing change, present the planned packages and target versions for user review. After approved changes land on `main`, GitHub Actions opens a version PR, and merging that reviewed PR publishes the planned packages and creates their GitHub Releases. See [RELEASING.md](./RELEASING.md) for the complete workflow and one-time npm/GitHub setup.
 
 ## License
 
@@ -86,4 +94,4 @@ MIT
 
 `pi-todo` is forked from MIT-licensed [`@juicesharp/rpiv-todo`](https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-todo) 1.20.0. The exact revision and preserved notices are recorded in [`packages/pi-todo/UPSTREAM_SOURCE.md`](./packages/pi-todo/UPSTREAM_SOURCE.md), [`LICENSE`](./packages/pi-todo/LICENSE), and [`UPSTREAM_LICENSE`](./packages/pi-todo/UPSTREAM_LICENSE).
 
-`pi-search-hub` is forked from [`ronnieops/pi-search-hub`](https://github.com/ronnieops/pi-search-hub) 2.8.0, whose package metadata and README declare MIT. Its exact revision and preserved notices are recorded in `packages/pi-search-hub/UPSTREAM_*` files.
+`pi-search-hub` is forked from [`ronnieops/pi-search-hub`](https://github.com/ronnieops/pi-search-hub) 2.8.0, whose package metadata and README declare MIT. Its exact revision and preserved notices are recorded in [`packages/pi-search-hub/UPSTREAM_SOURCE.md`](./packages/pi-search-hub/UPSTREAM_SOURCE.md) and [`UPSTREAM_NOTICE.md`](./packages/pi-search-hub/UPSTREAM_NOTICE.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,97 @@
+# pi-extensions
+
+[English](./README.md)
+
+zhcsyncer 维护的一组 Pi extensions。
+
+## 包列表
+
+- [`@zhcsyncer/pi-recap`](./packages/pi-recap) — 最近活动回顾扩展，可选同步 Session 标题和 tmux 窗口名。
+- [`@zhcsyncer/pi-tool-display-intent`](./packages/pi-tool-display-intent) — 紧凑工具展示，支持模型生成的 intent、RPC 可见摘要、自适应 diff 和受限的 Bash 调用预览。
+- [`@zhcsyncer/pi-todo`](./packages/pi-todo) — `@juicesharp/rpiv-todo` 的维护 fork，提供持久 Todo overlay，且不会重复展示成功的工具节点。
+- [`@zhcsyncer/pi-search-hub`](./packages/pi-search-hub) — bundle 私有的 `web_search` 和 `web_read` 工具，集成 intent-aware 展示。
+
+## Bundle 私有 Search Hub
+
+聚合包 `@zhcsyncer/pi-extensions` 内置私有 Search Hub fork，并注册其 `web_search` 和 `web_read` 工具。Search Hub 不作为独立 npm 包发布；需要安装根 bundle 才能使用。
+
+该 fork 保留上游多后端搜索和页面提取能力，同时集成模型生成的 `displaySummary` intent、语义化 query/URL 调用行、backend 和 reader 状态，以及共享的工具结果展示模式。配置与本地行为详见 [Search Hub 中文文档](./packages/pi-search-hub/README.zh-CN.md) 或其 [英文版本](./packages/pi-search-hub/README.md)。
+
+## 从 Git 安装
+
+从本仓库安装完整 extension bundle：
+
+```bash
+pi install git:github.com/zhcsyncer/pi-extensions@v0.4.0
+```
+
+不安装直接试用：
+
+```bash
+pi -e git:github.com/zhcsyncer/pi-extensions
+```
+
+## 从 npm 安装
+
+安装包含私有 Search Hub fork 的完整 bundle：
+
+```bash
+pi install npm:@zhcsyncer/pi-extensions
+```
+
+仅安装 recap：
+
+```bash
+pi install npm:@zhcsyncer/pi-recap
+```
+
+仅安装 intent-aware tool display：
+
+```bash
+pi install npm:@zhcsyncer/pi-tool-display-intent
+```
+
+仅安装 Todo：
+
+```bash
+pi install npm:@zhcsyncer/pi-todo
+```
+
+## 开发
+
+测试根 bundle：
+
+```bash
+pi -e . --list-models nope
+```
+
+直接测试单个 package：
+
+```bash
+pi -e ./packages/pi-recap --list-models nope
+pi --no-extensions -e ./packages/pi-tool-display-intent
+pi --no-extensions -e ./packages/pi-todo --list-models nope
+pi --no-extensions -e ./packages/pi-search-hub --list-models nope
+```
+
+测试 `pi-tool-display-intent` 时，不要同时加载原始 `pi-tool-display` 或 `pi-tool-display-summary`，因为三者都可能持有同名内置工具。
+
+## 发版
+
+每个用户可见的 pull request 都要添加 changeset：
+
+```bash
+pnpm changeset
+```
+
+公开包独立管理版本。根 tarball 会内嵌子包源码，因此子包发生变更时，同一 release plan 必须包含聚合根包；未变更的其他子包无需发版。推送带发版计划的变更前，必须先向用户展示计划更新的包和目标版本并等待 review。获批变更进入 `main` 后，GitHub Actions 会创建 version PR；合并已审核的 version PR 后才会发布计划中的 package 并创建 GitHub Releases。完整流程和 npm/GitHub 一次性配置见 [RELEASING.md](./RELEASING.md)。
+
+## 许可证
+
+MIT
+
+`pi-tool-display-intent` 修改自 MIT 许可的 [`MasuRii/pi-tool-display`](https://github.com/MasuRii/pi-tool-display) 0.5.0，并改编了 MIT 许可的 [`mertdeveci5/pi-tool-display-summary`](https://github.com/mertdeveci5/pi-tool-display-summary) 0.1.0 中的 `displaySummary` 机制。完整归属和保留声明见 [`packages/pi-tool-display-intent/README.md`](./packages/pi-tool-display-intent/README.md)、[`LICENSE`](./packages/pi-tool-display-intent/LICENSE) 和 [`UPSTREAM_LICENSE`](./packages/pi-tool-display-intent/UPSTREAM_LICENSE)。
+
+`pi-todo` fork 自 MIT 许可的 [`@juicesharp/rpiv-todo`](https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-todo) 1.20.0。准确 revision 和保留声明见 [`packages/pi-todo/UPSTREAM_SOURCE.md`](./packages/pi-todo/UPSTREAM_SOURCE.md)、[`LICENSE`](./packages/pi-todo/LICENSE) 和 [`UPSTREAM_LICENSE`](./packages/pi-todo/UPSTREAM_LICENSE)。
+
+`pi-search-hub` fork 自 [`ronnieops/pi-search-hub`](https://github.com/ronnieops/pi-search-hub) 2.8.0，其 package metadata 和 README 声明为 MIT。准确 revision 和保留声明见 [`packages/pi-search-hub/UPSTREAM_SOURCE.md`](./packages/pi-search-hub/UPSTREAM_SOURCE.md) 与 [`UPSTREAM_NOTICE.md`](./packages/pi-search-hub/UPSTREAM_NOTICE.md)。

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,6 +51,16 @@ Select each affected public package and its bump type. When selecting a child pa
 
 Changes that do not need a release, such as CI-only or internal documentation changes, do not need a changeset.
 
+## Release review gate
+
+Before pushing a release-bearing change to `main`:
+
+1. Run `pnpm changeset status` to calculate the complete release plan.
+2. Show the user every planned package with its current version, bump type, and target version.
+3. Wait for explicit user review and approval.
+
+Do not push the release-bearing change to `main`, merge the generated version PR, or trigger publishing before that approval.
+
 ## Automated flow
 
 1. Changes with one or more changesets land on `main`.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "license": "MIT",
   "type": "module",
   "files": [
+    "README.md",
+    "README.zh-CN.md",
     "packages/*/extensions/**/*.ts",
     "packages/*/extensions/**/*.js",
     "packages/*/src/**/*.ts",
@@ -68,7 +70,7 @@
     "check": "pnpm check:release-policy && pnpm check:smoke && pnpm check:pack",
     "check:release-policy": "node --test scripts/release-policy.test.mjs && node scripts/check-release-policy.mjs",
     "check:smoke": "node scripts/check-smoke.mjs",
-    "check:pack": "npm pack --dry-run . && npm pack --dry-run ./packages/pi-recap && npm pack --dry-run ./packages/pi-tool-display-intent && npm pack --dry-run ./packages/pi-todo"
+    "check:pack": "node scripts/check-pack.mjs"
   },
   "pi": {
     "extensions": [

--- a/packages/pi-search-hub/.npmignore
+++ b/packages/pi-search-hub/.npmignore
@@ -13,9 +13,10 @@ reddit-post.md
 .git/
 .gitignore
 
-# All markdown except README
+# All markdown except bilingual README files
 *.md
 !README.md
+!README.zh-CN.md
 
 # All TypeScript in extensions/ — allow all (modular structure)
 # !extensions/search-hub.ts  --  old rule for monolith, not needed anymore

--- a/packages/pi-search-hub/README.md
+++ b/packages/pi-search-hub/README.md
@@ -1,25 +1,112 @@
 # pi-search-hub
 
-`@zhcsyncer/pi-extensions` 内置的 Search Hub 扩展 fork。它提供统一的 `web_search` 与 `web_read` 工具，并支持多个搜索与内容读取后端。
+[简体中文](./README.zh-CN.md)
 
-当前 fork 保持上游 `pi-search-hub` 2.8.0 的搜索行为，并通过 `pi-tool-display-intent` 的合作式消费 API 为两个工具增加模型意图字段、统一调用行和继承全局 `results.mode` 的结果展示。调用行会用搜索词或缩短后的 URL 代替通用参数计数，并展示 backend、结果上限、reader、读取模式等关键元数据；结果区会展示实际 backend/reader、结果数、字符数、组合后端可用率和截断状态，同时去掉与语义状态重复的原始搜索头部。搜索正文的数量与截断仍由 Search Hub 自己负责。
+A bundle-private fork of Search Hub for `@zhcsyncer/pi-extensions`. It provides unified `web_search` and `web_read` tools across multiple search and content-reading backends.
 
-## 来源
+This package is private and is not published separately. Install `@zhcsyncer/pi-extensions` to use it.
 
-- 上游：[`ronnieops/pi-search-hub`](https://github.com/ronnieops/pi-search-hub)
-- 基线：`v2.8.0` / `96ccf692123d35a3cf4b615d597a80fe9e9f6229`
-- 上游文档：[`UPSTREAM_README.md`](./UPSTREAM_README.md)
-- 上游版本历史：[`UPSTREAM_CHANGELOG.md`](./UPSTREAM_CHANGELOG.md)
+## Tools
 
-该包目前作为 workspace 私有包随根 bundle 使用，不单独发布。
+### `web_search`
 
-## 开发
+Searches the web through an explicitly selected backend or through automatic fallback. `combine=true` queries multiple enabled backends and merges/deduplicates their results; `combineMode: "targeted"` in `search.json` limits fan-out while still collecting multiple usable result sets.
+
+Important call options include:
+
+- `query` — natural-language search query;
+- `numResults` — requested result count from 1 to 20;
+- `backend` — a specific backend or `auto`;
+- `combine` — enable multi-backend search;
+- `compact` — return title-and-URL lines instead of verbose search content.
+
+DuckDuckGo is the keyless fallback when no backend is explicitly enabled. Other supported backends include Jina Search, Marginalia, Serper, Tavily, Exa, Exa MCP, OpenAI Codex, Brave, Brave LLM Context, LangSearch, Firecrawl, WebSearchAPI, Perplexity, SearXNG, Linkup, You.com, fastCRW, and Sofya.
+
+### `web_read`
+
+Fetches a URL and returns extracted Markdown. The default Jina reader supports cache bypass, keywords, `rush`/`smart` modes, and targeted extraction. Sofya, Firecrawl, Exa, and Exa MCP readers are also available.
+
+Important call options include:
+
+- `url` — page URL;
+- `fresh` — bypass reader caches where supported;
+- `keywords` — terms used to focus long-page extraction;
+- `mode` — `rush` for speed or `smart` for better narrowing;
+- `reader` — override the configured reader;
+- `objective` — a Jina CSS target selector.
+
+> `web_read.objective` is a CSS selector passed to Jina as `x-target-selector`. It is not a natural-language question or extraction instruction. Use values such as `main`, `article`, or `#pricing`, and use `keywords` for semantic focus.
+
+## Intent-aware display in this fork
+
+Both tools use the cooperative API from [`pi-tool-display-intent`](../pi-tool-display-intent) rather than maintaining separate TUI renderers:
+
+- the current model writes a required `displaySummary` intent in the normal tool call, with no additional inference request;
+- the presentation-only field is removed before Search Hub execution;
+- call lines show the search query or a shortened URL instead of generic `(N args)` text;
+- result rendering inherits the active global `results.mode` through `outputMode: "inherit"`.
+
+Semantic call metadata includes:
+
+| Tool | Target | Metadata |
+|---|---|---|
+| `web_search` | Search query | Requested backend, combine mode, result limit, compact mode |
+| `web_read` | Shortened URL | Reader, rush/smart mode, keyword count, fresh mode, selector presence |
+
+Semantic result status includes:
+
+| Tool | Status |
+|---|---|
+| `web_search` | Actual backend, result count, fallback state, and usable/attempted backend health for combined searches |
+| `web_read` | Actual reader, extracted character count, and whether display content was truncated to the 10k-character presentation limit |
+
+Verbose search output begins with a raw `## Search Results:` header. The shared renderer skips that duplicated header when its semantic status is already visible.
+
+Global `results.mode` controls whether Search Hub results are hidden, summarized, or previewed in the transcript. Content previews use the same wrapped-row `results.previewRows` budget as other decorated tools. Search Hub still owns the content sent to the model, including backend selection, result quantity, compact result generation, and backend-level truncation. In particular, the `web_search.compact` argument changes the tool result itself and is independent of the TUI-only global result mode.
+
+## Configuration
+
+Search Hub reads configuration from:
+
+1. `$PI_CODING_AGENT_DIR/extensions/search.json` for global settings;
+2. `.pi/search.json` in the current project.
+
+Project settings win. Backend maps are merged per backend, so a project can override one backend without repeating every global entry. Configuration is refreshed during use, with a short in-process cache.
+
+Minimal example:
+
+```json
+{
+  "defaultBackend": "auto",
+  "combineMode": "targeted",
+  "reader": "jina",
+  "backends": {
+    "duckduckgo": { "enabled": true },
+    "serper": { "enabled": true, "apiKey": "SERPER_API_KEY" }
+  }
+}
+```
+
+Copy [`search.json.example`](./search.json.example) for a larger backend matrix. Credential values may be environment-variable names such as `SERPER_API_KEY`, shell commands prefixed with `!`, or literal keys. Prefer environment variables or a secret manager, and never commit credentials.
+
+See [`UPSTREAM_README.md`](./UPSTREAM_README.md) for the upstream backend-specific reference. Local behavior described in this README takes precedence for the bundled fork.
+
+## Upstream source
+
+- Repository: [`ronnieops/pi-search-hub`](https://github.com/ronnieops/pi-search-hub)
+- Baseline: `v2.8.0` / `96ccf692123d35a3cf4b615d597a80fe9e9f6229`
+- Preserved documentation: [`UPSTREAM_README.md`](./UPSTREAM_README.md)
+- Preserved release history: [`UPSTREAM_CHANGELOG.md`](./UPSTREAM_CHANGELOG.md)
+
+The exact source provenance is recorded in [`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md).
+
+## Development
 
 ```bash
 pnpm --filter @zhcsyncer/pi-search-hub check
 pi --no-extensions -e ./packages/pi-search-hub --list-models __pi_search_hub_check__
 ```
 
-## 许可证
+## License
 
-上游 `package.json` 和 README 将项目声明为 MIT，但 `v2.8.0` 标签未包含独立许可证文件。来源说明见 [`UPSTREAM_NOTICE.md`](./UPSTREAM_NOTICE.md)。本 fork 的修改见 [`LICENSE`](./LICENSE)。
+The upstream `package.json` and README declare MIT, but the `v2.8.0` tag does not contain a standalone license file. See [`UPSTREAM_NOTICE.md`](./UPSTREAM_NOTICE.md) for the preserved notice and [`LICENSE`](./LICENSE) for this fork's combined terms.

--- a/packages/pi-search-hub/README.zh-CN.md
+++ b/packages/pi-search-hub/README.zh-CN.md
@@ -1,0 +1,112 @@
+# pi-search-hub
+
+[English](./README.md)
+
+`@zhcsyncer/pi-extensions` 使用的 bundle 私有 Search Hub fork。它通过多个搜索和内容读取 backend 提供统一的 `web_search` 与 `web_read` 工具。
+
+该 package 是私有包，不会单独发布。安装 `@zhcsyncer/pi-extensions` 后即可使用。
+
+## 工具
+
+### `web_search`
+
+通过明确指定的 backend 搜索，或使用自动 fallback。`combine=true` 会并行查询多个已启用 backend，并合并、去重结果；在 `search.json` 中设置 `combineMode: "targeted"` 可以限制 fan-out，同时仍收集多个可用结果集。
+
+主要调用参数：
+
+- `query` — 自然语言搜索词；
+- `numResults` — 1 到 20 的目标结果数；
+- `backend` — 指定 backend 或 `auto`；
+- `combine` — 启用多 backend 搜索；
+- `compact` — 返回标题与 URL 单行，而不是详细搜索正文。
+
+没有明确启用 backend 时，DuckDuckGo 是无需 key 的 fallback。其他受支持 backend 包括 Jina Search、Marginalia、Serper、Tavily、Exa、Exa MCP、OpenAI Codex、Brave、Brave LLM Context、LangSearch、Firecrawl、WebSearchAPI、Perplexity、SearXNG、Linkup、You.com、fastCRW 和 Sofya。
+
+### `web_read`
+
+读取 URL 并返回提取后的 Markdown。默认 Jina reader 支持绕过缓存、keywords、`rush`/`smart` 模式和定向提取，也可以使用 Sofya、Firecrawl、Exa 与 Exa MCP reader。
+
+主要调用参数：
+
+- `url` — 页面 URL；
+- `fresh` — 在 reader 支持时绕过缓存；
+- `keywords` — 聚焦长页面提取的关键词；
+- `mode` — `rush` 优先速度，`smart` 提高筛选质量；
+- `reader` — 覆盖配置的 reader；
+- `objective` — Jina CSS target selector。
+
+> `web_read.objective` 是通过 `x-target-selector` 传给 Jina 的 CSS selector，不是自然语言问题或提取指令。应使用 `main`、`article`、`#pricing` 等值；语义聚焦请使用 `keywords`。
+
+## 本 fork 的 intent-aware 展示
+
+两个工具都使用 [`pi-tool-display-intent`](../pi-tool-display-intent) 的合作式 API，而不是维护独立 TUI renderer：
+
+- 当前模型在正常 tool call 中写入必填的 `displaySummary` intent，不会增加额外推理请求；
+- 纯展示字段会在 Search Hub 执行前移除；
+- 调用行显示搜索词或缩短后的 URL，而不是通用 `(N args)`；
+- 结果通过 `outputMode: "inherit"` 继承当前全局 `results.mode`。
+
+语义化调用元数据包括：
+
+| 工具 | Target | 元数据 |
+|---|---|---|
+| `web_search` | 搜索词 | 请求的 backend、combine 模式、结果上限、compact 模式 |
+| `web_read` | 缩短后的 URL | reader、rush/smart 模式、keyword 数量、fresh 模式、是否使用 selector |
+
+语义化结果状态包括：
+
+| 工具 | 状态 |
+|---|---|
+| `web_search` | 实际 backend、结果数、fallback 状态，以及组合搜索中可用/已尝试 backend 健康度 |
+| `web_read` | 实际 reader、提取字符数，以及展示内容是否被截断到 1 万字符上限 |
+
+详细搜索输出以原始 `## Search Results:` header 开头。共享 renderer 已显示语义状态时，会跳过这个重复 header。
+
+全局 `results.mode` 控制 Search Hub 结果在 transcript 中隐藏、显示摘要还是显示预览。内容预览与其他装饰工具共用折行后的 `results.previewRows` 行预算。发送给模型的内容仍由 Search Hub 负责，包括 backend 选择、结果数量、compact 结果生成和 backend 级截断。特别是，`web_search.compact` 参数会改变工具结果本身，与仅影响 TUI 的全局结果模式相互独立。
+
+## 配置
+
+Search Hub 从以下位置读取配置：
+
+1. `$PI_CODING_AGENT_DIR/extensions/search.json`：全局设置；
+2. 当前项目的 `.pi/search.json`。
+
+项目设置优先。backend map 会按单个 backend 合并，因此项目可以只覆盖一个 backend，无需重复全部全局条目。配置会在使用过程中刷新，并带有较短的进程内缓存。
+
+最小示例：
+
+```json
+{
+  "defaultBackend": "auto",
+  "combineMode": "targeted",
+  "reader": "jina",
+  "backends": {
+    "duckduckgo": { "enabled": true },
+    "serper": { "enabled": true, "apiKey": "SERPER_API_KEY" }
+  }
+}
+```
+
+可以复制 [`search.json.example`](./search.json.example) 获取更完整的 backend 配置矩阵。Credential 可以是 `SERPER_API_KEY` 这样的环境变量名、以 `!` 开头的 shell command，或 literal key。优先使用环境变量或 secret manager，绝不要提交凭据。
+
+上游 backend 专属参考见 [`UPSTREAM_README.md`](./UPSTREAM_README.md)。对于 bundle fork，本 README 描述的本地行为优先。
+
+## 上游来源
+
+- 仓库：[`ronnieops/pi-search-hub`](https://github.com/ronnieops/pi-search-hub)
+- 基线：`v2.8.0` / `96ccf692123d35a3cf4b615d597a80fe9e9f6229`
+- 保留文档：[`UPSTREAM_README.md`](./UPSTREAM_README.md)
+- 保留版本历史：[`UPSTREAM_CHANGELOG.md`](./UPSTREAM_CHANGELOG.md)
+
+准确来源记录见 [`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md)。
+
+## 开发
+
+```bash
+pnpm --filter @zhcsyncer/pi-search-hub check
+pi --no-extensions -e ./packages/pi-search-hub --list-models __pi_search_hub_check__
+```
+
+## 许可证
+
+上游 `package.json` 和 README 声明为 MIT，但 `v2.8.0` tag 不包含独立许可证文件。保留声明见 [`UPSTREAM_NOTICE.md`](./UPSTREAM_NOTICE.md)，本 fork 的合并许可条款见 [`LICENSE`](./LICENSE)。

--- a/packages/pi-search-hub/package.json
+++ b/packages/pi-search-hub/package.json
@@ -39,6 +39,7 @@
     "extensions/",
     "search.json.example",
     "README.md",
+    "README.zh-CN.md",
     "LICENSE",
     "UPSTREAM_NOTICE.md",
     "UPSTREAM_README.md",

--- a/packages/pi-tool-display-intent/README.md
+++ b/packages/pi-tool-display-intent/README.md
@@ -92,7 +92,8 @@ When `PI_CODING_AGENT_DIR` is unset, Pi's default agent directory is used. Exten
     "language": "en"
   },
   "toolCalls": {
-    "style": "claude"
+    "style": "claude",
+    "bashCommandPreviewRows": 1
   },
   "results": {
     "mode": "summary",
@@ -106,7 +107,7 @@ See [`config/config.example.json`](./config/config.example.json) for every confi
 | Section | Configurable fields | Purpose |
 |---|---|---|
 | `intent` | `enabled`, `language`, `maxLength` | Model-written tool intent. |
-| `toolCalls` | `style` | `compact` or Claude Code-inspired call framing. |
+| `toolCalls` | `style`, `bashCommandPreviewRows` | Call framing and the wrapped-row budget for collapsed Bash command arguments. |
 | `results` | `mode`, `previewRows` | Result amount and one shared wrapped-row preview budget. |
 | `diff` | `layout`, `indicators`, `splitMinWidth`, `collapsedRows`, `wordWrap` | Edit/write diff presentation. |
 | `transcript` | `userMessageStyle`, `thinkingLabel` | User messages and reasoning labels. |
@@ -122,6 +123,10 @@ See [`config/config.example.json`](./config/config.example.json) for every confi
 | `preview` | Show content previews | Show a content preview |
 
 Every content preview, including custom tools and bash live/error output, uses `results.previewRows`. It counts terminal rows after wrapping, so a minified JSON object, base64 payload, or other long single line cannot bypass the limit. `advanced.expandedRows` separately caps expanded output.
+
+`toolCalls.bashCommandPreviewRows` is a separate `1`–`8` wrapped-row budget for Bash command arguments and defaults to `1`. Short commands stay inline. Long or multiline commands collapse with exact line/size metadata; Claude-style calls keep intent in the header and put the command preview on its own row. `Ctrl+O` reveals the complete original command. This setting does not affect command output.
+
+Model-written intent uses the theme's regular `accent` color without bold or background styling. Deterministic commands, paths, and queries use normal `text`; metadata, separators, and deterministic fallback intents remain `muted`.
 
 `tools.passthrough` lists built-in tools whose renderer should remain untouched; it does not disable those tools. A `tools.custom` entry exists only when decoration is enabled, for example: `"web_search": { "renderer": "generic", "mode": "summary" }`. The bundle-private Search Hub already uses the cooperative API, so it needs no such entry unless you want to pin a mode instead of inheriting `results.mode`.
 

--- a/packages/pi-tool-display-intent/README.zh-CN.md
+++ b/packages/pi-tool-display-intent/README.zh-CN.md
@@ -92,7 +92,8 @@ $PI_CODING_AGENT_DIR/extensions/pi-tool-display-intent/config.json
     "language": "zh-CN"
   },
   "toolCalls": {
-    "style": "claude"
+    "style": "claude",
+    "bashCommandPreviewRows": 1
   },
   "results": {
     "mode": "summary",
@@ -106,7 +107,7 @@ $PI_CODING_AGENT_DIR/extensions/pi-tool-display-intent/config.json
 | 分组 | 可配置字段 | 作用 |
 |---|---|---|
 | `intent` | `enabled`、`language`、`maxLength` | 模型生成的工具调用意图。 |
-| `toolCalls` | `style` | `compact` 或 Claude Code 风格调用外框。 |
+| `toolCalls` | `style`、`bashCommandPreviewRows` | 调用外框和 Bash 命令参数折叠后的视觉行预算。 |
 | `results` | `mode`、`previewRows` | 结果显示量和统一的折行后视觉行预算。 |
 | `diff` | `layout`、`indicators`、`splitMinWidth`、`collapsedRows`、`wordWrap` | edit/write diff 展示。 |
 | `transcript` | `userMessageStyle`、`thinkingLabel` | 用户消息和 reasoning 标签。 |
@@ -122,6 +123,10 @@ $PI_CODING_AGENT_DIR/extensions/pi-tool-display-intent/config.json
 | `preview` | 显示内容预览 | 显示内容预览 |
 
 所有内容预览，包括 custom tool、bash 流式和错误输出，都使用 `results.previewRows`。它统计终端折行后的视觉行，因此压缩 JSON、base64 或其他超长单行无法绕过限制。`advanced.expandedRows` 单独限制展开后的输出。
+
+`toolCalls.bashCommandPreviewRows` 单独控制 Bash 命令参数折叠后的视觉行预算，可设为 `1`–`8`，默认是 `1`。短命令保持行内展示；长命令或多行命令会附带准确的行数和大小信息。Claude 风格会把 intent 留在标题行，并把命令预览放到独立行。按 `Ctrl+O` 可查看完整原始命令。该配置不影响命令输出。
+
+模型生成的 intent 使用主题的常规 `accent` 色，不加粗、不加背景。确定性的命令、路径和 query 使用普通 `text`；元数据、分隔符和确定性 fallback intent 继续使用 `muted`。
 
 `tools.passthrough` 表示继续使用原 renderer 的内置工具，不会禁用工具。`tools.custom` 条目存在即启用展示装饰，例如：`"web_search": { "renderer": "generic", "mode": "summary" }`。bundle 私有的 Search Hub 已使用合作式 API，因此无需该配置；只有想固定模式而不继承 `results.mode` 时才需要添加。
 

--- a/packages/pi-tool-display-intent/config/config.example.json
+++ b/packages/pi-tool-display-intent/config/config.example.json
@@ -7,7 +7,8 @@
     "maxLength": 96
   },
   "toolCalls": {
-    "style": "claude"
+    "style": "claude",
+    "bashCommandPreviewRows": 1
   },
   "results": {
     "mode": "summary",

--- a/packages/pi-tool-display-intent/config/config.schema.json
+++ b/packages/pi-tool-display-intent/config/config.schema.json
@@ -36,6 +36,13 @@
         "style": {
           "enum": ["compact", "claude"],
           "default": "compact"
+        },
+        "bashCommandPreviewRows": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 8,
+          "default": 1,
+          "description": "Maximum rendered terminal rows used by collapsed Bash command arguments. Ctrl+O shows the complete command."
         }
       }
     },

--- a/packages/pi-tool-display-intent/src/bash-display.ts
+++ b/packages/pi-tool-display-intent/src/bash-display.ts
@@ -1,13 +1,24 @@
-import { Text } from "@earendil-works/pi-tui";
+import { formatSize } from "@earendil-works/pi-coding-agent";
+import {
+	Text,
+	truncateToWidth,
+	visibleWidth,
+	type Component,
+} from "@earendil-works/pi-tui";
 import { resolveDisplaySummaryForTool } from "./display-summary-fallback.js";
 import { registerCleanup, registerTimer } from "./disposable.js";
-import { formatClaudeToolCall } from "./tool-call-style.js";
+import { layoutPreviewRows } from "./preview-text.js";
+import {
+	formatClaudeStatusMarker,
+	formatClaudeToolCall,
+} from "./tool-call-style.js";
 import type { ToolCallStyle, ToolIntentConfig } from "./types.js";
 
 const BASH_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
 const BASH_SPINNER_INTERVAL_MS = 200;
 const BASH_SPINNER_STATE_KEY = "__piToolDisplayIntentBashSpinner";
 const BASH_SPINNER_TOOL_CALL_ID_KEY = "__piToolDisplayIntentBashSpinnerToolCallId";
+const MIN_COLLAPSED_COMMAND_COLUMNS = 8;
 
 interface BashCallArgs {
 	command?: string;
@@ -37,12 +48,33 @@ interface BashSpinnerStateCarrier {
 
 interface BashCallRenderContextLike {
 	executionStarted: boolean;
+	expanded?: boolean;
 	isError?: boolean;
 	isPartial: boolean;
 	invalidate?: () => void;
 	lastComponent?: unknown;
 	state?: unknown;
 	toolCallId?: string;
+}
+
+interface BashCallViewState {
+	args: BashCallArgs;
+	theme: BashCallRenderTheme;
+	spinnerFrame?: string;
+	elapsedMs?: number;
+	toolIntentConfig?: BashToolIntentConfig;
+	toolCallStyle: ToolCallStyle;
+	context: BashCallRenderContextLike;
+	commandPreviewRows: number;
+}
+
+interface BashCallPresentation {
+	commandDisplay: string;
+	shellSuffix: string;
+	timeoutSuffix: string;
+	spinnerPrefix: string;
+	elapsedSuffix: string;
+	intentSuffix: string;
 }
 
 const spinnerStatesByToolCallId = new Map<string, BashSpinnerState>();
@@ -143,15 +175,13 @@ function buildCommandDisplay(args: BashCallArgs): string {
 	return prefix ? `${prefix} ${command}` : command;
 }
 
-function buildBashCallText(
+function buildBashCallPresentation(
 	args: BashCallArgs,
 	theme: BashCallRenderTheme,
 	spinnerFrame?: string,
 	elapsedMs?: number,
 	toolIntentConfig?: BashToolIntentConfig,
-	toolCallStyle: ToolCallStyle = "compact",
-	context?: BashCallRenderContextLike,
-): string {
+): BashCallPresentation {
 	const commandDisplay = buildCommandDisplay(args);
 	const shellSuffix =
 		typeof args.shellPath === "string" &&
@@ -171,13 +201,39 @@ function buildBashCallText(
 		? resolveDisplaySummaryForTool(args, "bash", toolIntentConfig)
 		: undefined;
 	const intentSuffix = displaySummary
-		? `${theme.fg("muted", " — ")}${theme.fg(displaySummary.source === "model" ? "text" : "muted", displaySummary.text)}`
+		? `${theme.fg("muted", " — ")}${theme.fg(displaySummary.source === "model" ? "accent" : "muted", displaySummary.text)}`
 		: "";
+
+	return {
+		commandDisplay,
+		shellSuffix,
+		timeoutSuffix,
+		spinnerPrefix,
+		elapsedSuffix,
+		intentSuffix,
+	};
+}
+
+function buildExpandedBashCallText(
+	presentation: BashCallPresentation,
+	theme: BashCallRenderTheme,
+	toolCallStyle: ToolCallStyle,
+	context: BashCallRenderContextLike,
+	spinnerFrame?: string,
+): string {
+	const {
+		commandDisplay,
+		shellSuffix,
+		timeoutSuffix,
+		spinnerPrefix,
+		elapsedSuffix,
+		intentSuffix,
+	} = presentation;
 
 	if (toolCallStyle === "claude") {
 		return formatClaudeToolCall(
 			"bash",
-			theme.fg("accent", commandDisplay),
+			theme.fg("text", commandDisplay),
 			`${shellSuffix}${timeoutSuffix}${elapsedSuffix}`,
 			intentSuffix,
 			theme,
@@ -186,7 +242,195 @@ function buildBashCallText(
 		);
 	}
 
-	return `${spinnerPrefix}${theme.fg("toolTitle", theme.bold("$"))} ${theme.fg("accent", commandDisplay)}${shellSuffix}${timeoutSuffix}${elapsedSuffix}${intentSuffix}`;
+	return `${spinnerPrefix}${theme.fg("toolTitle", theme.bold("$"))} ${theme.fg("text", commandDisplay)}${shellSuffix}${timeoutSuffix}${elapsedSuffix}${intentSuffix}`;
+}
+
+function normalizeCommandLines(commandDisplay: string): string[] {
+	return commandDisplay.replace(/\r\n?/g, "\n").split("\n");
+}
+
+function chooseCollapsedSuffix(commandDisplay: string, lineCount: number, contentWidth: number): string {
+	const size = formatSize(Buffer.byteLength(commandDisplay, "utf8"));
+	const candidates = lineCount > 1
+		? [
+			` … (${lineCount} lines · ${size} · Ctrl+O)`,
+			` … (${lineCount} lines · Ctrl+O)`,
+			` … (${lineCount} lines)`,
+			" …",
+		]
+		: [
+			` … (${size} · Ctrl+O)`,
+			" … (Ctrl+O)",
+			" …",
+		];
+	const suffixBudget = Math.max(0, contentWidth - MIN_COLLAPSED_COMMAND_COLUMNS);
+	return candidates.find((candidate) => visibleWidth(candidate) <= suffixBudget)
+		?? (contentWidth >= 2 ? " …" : "");
+}
+
+function buildCollapsedCommandRows(
+	presentation: BashCallPresentation,
+	theme: BashCallRenderTheme,
+	toolCallStyle: ToolCallStyle,
+	spinnerFrame: string | undefined,
+	commandPreviewRows: number,
+	width: number,
+): string[] | undefined {
+	const safeWidth = Number.isFinite(width) ? Math.max(1, Math.floor(width)) : 1;
+	const firstPrefixPlain = toolCallStyle === "claude"
+		? "  $ "
+		: `${spinnerFrame ? `${spinnerFrame} ` : ""}$ `;
+	const continuationPrefixPlain = toolCallStyle === "claude" ? "    " : "  ";
+	const prefixWidth = Math.max(
+		visibleWidth(firstPrefixPlain),
+		visibleWidth(continuationPrefixPlain),
+	);
+	const contentWidth = Math.max(1, safeWidth - prefixWidth);
+	const lines = normalizeCommandLines(presentation.commandDisplay);
+	const normalizedPreviewRows = Number.isFinite(commandPreviewRows)
+		? Math.max(1, Math.floor(commandPreviewRows))
+		: 1;
+	const layout = layoutPreviewRows(lines, normalizedPreviewRows, contentWidth);
+	const isCollapsed = layout.hiddenLineCount > 0 || layout.longLineTruncated || layout.rowLimitReached;
+	if (!isCollapsed) {
+		return undefined;
+	}
+
+	const rows = layout.rows.length > 0 ? [...layout.rows] : [""];
+	const suffix = chooseCollapsedSuffix(presentation.commandDisplay, lines.length, contentWidth);
+	const lastIndex = rows.length - 1;
+	const lastContentWidth = Math.max(0, contentWidth - visibleWidth(suffix));
+	rows[lastIndex] = `${truncateToWidth(rows[lastIndex] ?? "", lastContentWidth, "")}${suffix}`;
+
+	const firstPrefix = toolCallStyle === "claude"
+		? `${theme.fg("muted", "  ")}${theme.fg("toolTitle", theme.bold("$"))} `
+		: `${presentation.spinnerPrefix}${theme.fg("toolTitle", theme.bold("$"))} `;
+	const continuationPrefix = theme.fg("muted", continuationPrefixPlain);
+
+	return rows.map((row, index) =>
+		`${index === 0 ? firstPrefix : continuationPrefix}${theme.fg("text", row)}`,
+	);
+}
+
+function buildCollapsedBashCallText(
+	presentation: BashCallPresentation,
+	theme: BashCallRenderTheme,
+	toolCallStyle: ToolCallStyle,
+	context: BashCallRenderContextLike,
+	spinnerFrame: string | undefined,
+	commandPreviewRows: number,
+	width: number,
+): string | undefined {
+	if (context.expanded) {
+		return undefined;
+	}
+
+	const commandRows = buildCollapsedCommandRows(
+		presentation,
+		theme,
+		toolCallStyle,
+		spinnerFrame,
+		commandPreviewRows,
+		width,
+	);
+	if (!commandRows) {
+		return undefined;
+	}
+
+	const metadata = `${presentation.shellSuffix}${presentation.timeoutSuffix}${presentation.elapsedSuffix}`;
+	if (toolCallStyle === "claude") {
+		const marker = formatClaudeStatusMarker(theme, context, spinnerFrame);
+		const header = `${marker} ${theme.fg("toolTitle", theme.bold("Bash"))}${metadata}${presentation.intentSuffix}`;
+		return `${header}\n${commandRows.join("\n")}`;
+	}
+
+	const details = `${metadata}${presentation.intentSuffix}`;
+	return details
+		? `${commandRows.join("\n")}\n${theme.fg("muted", "  ")}${details}`
+		: commandRows.join("\n");
+}
+
+export class BashCallComponent implements Component {
+	private renderedContent?: string;
+	private renderedText?: Text;
+
+	constructor(private viewState: BashCallViewState) {}
+
+	update(viewState: BashCallViewState): void {
+		this.viewState = viewState;
+	}
+
+	render(width: number): string[] {
+		const {
+			args,
+			theme,
+			spinnerFrame,
+			elapsedMs,
+			toolIntentConfig,
+			toolCallStyle,
+			context,
+			commandPreviewRows,
+		} = this.viewState;
+		const presentation = buildBashCallPresentation(
+			args,
+			theme,
+			spinnerFrame,
+			elapsedMs,
+			toolIntentConfig,
+		);
+		const content = buildCollapsedBashCallText(
+			presentation,
+			theme,
+			toolCallStyle,
+			context,
+			spinnerFrame,
+			commandPreviewRows,
+			width,
+		) ?? buildExpandedBashCallText(
+			presentation,
+			theme,
+			toolCallStyle,
+			context,
+			spinnerFrame,
+		);
+		if (!this.renderedText) {
+			this.renderedText = new Text(content, 0, 0);
+			this.renderedContent = content;
+		} else if (this.renderedContent !== content) {
+			this.renderedText.setText(content);
+			this.renderedContent = content;
+		}
+		return this.renderedText.render(width);
+	}
+
+	invalidate(): void {
+		this.renderedText?.invalidate();
+		this.renderedContent = undefined;
+		this.renderedText = undefined;
+	}
+}
+
+function updateBashCallComponent(
+	component: BashCallComponent,
+	args: BashCallArgs,
+	theme: BashCallRenderTheme,
+	context: BashCallRenderContextLike,
+	spinnerFrame: string | undefined,
+	elapsedMs: number | undefined,
+	toolIntentConfig: BashToolIntentConfig | undefined,
+	toolCallStyle: ToolCallStyle,
+	commandPreviewRows: number,
+): void {
+	component.update({
+		args,
+		theme,
+		spinnerFrame,
+		elapsedMs,
+		toolIntentConfig,
+		toolCallStyle,
+		context,
+		commandPreviewRows,
+	});
 }
 
 export function renderBashCall(
@@ -195,8 +439,18 @@ export function renderBashCall(
 	context: BashCallRenderContextLike,
 	toolIntentConfig?: BashToolIntentConfig,
 	toolCallStyle: ToolCallStyle = "compact",
-): Text {
-	const text = context.lastComponent instanceof Text ? context.lastComponent : new Text("", 0, 0);
+	commandPreviewRows = 1,
+): BashCallComponent {
+	const component = context.lastComponent instanceof BashCallComponent
+		? context.lastComponent
+		: new BashCallComponent({
+			args,
+			theme,
+			toolIntentConfig,
+			toolCallStyle,
+			context,
+			commandPreviewRows,
+		});
 	const carrier = toStateCarrier(context.state);
 	const toolCallId = getToolCallId(context);
 	const spinnerState = getOrCreateSpinnerState(toolCallId, carrier);
@@ -204,8 +458,18 @@ export function renderBashCall(
 
 	if (!shouldSpin) {
 		stopSpinner(toolCallId, spinnerState);
-		text.setText(buildBashCallText(args, theme, undefined, undefined, toolIntentConfig, toolCallStyle, context));
-		return text;
+		updateBashCallComponent(
+			component,
+			args,
+			theme,
+			context,
+			undefined,
+			undefined,
+			toolIntentConfig,
+			toolCallStyle,
+			commandPreviewRows,
+		);
+		return component;
 	}
 
 	if (spinnerState) {
@@ -213,16 +477,16 @@ export function renderBashCall(
 		if (!spinnerState.timer && typeof context.invalidate === "function") {
 			const timer = setInterval(() => {
 				spinnerState.frameIndex = (spinnerState.frameIndex + 1) % BASH_SPINNER_FRAMES.length;
-				text.setText(
-					buildBashCallText(
-						args,
-						theme,
-						BASH_SPINNER_FRAMES[spinnerState.frameIndex],
-						Date.now() - (spinnerState.startedAt ?? Date.now()),
-						toolIntentConfig,
-						toolCallStyle,
-						context,
-					),
+				updateBashCallComponent(
+					component,
+					args,
+					theme,
+					context,
+					BASH_SPINNER_FRAMES[spinnerState.frameIndex],
+					Date.now() - (spinnerState.startedAt ?? Date.now()),
+					toolIntentConfig,
+					toolCallStyle,
+					commandPreviewRows,
 				);
 				context.invalidate?.();
 			}, BASH_SPINNER_INTERVAL_MS);
@@ -240,6 +504,16 @@ export function renderBashCall(
 	const elapsedMs = spinnerState?.startedAt !== undefined
 		? Date.now() - spinnerState.startedAt
 		: undefined;
-	text.setText(buildBashCallText(args, theme, spinnerFrame, elapsedMs, toolIntentConfig, toolCallStyle, context));
-	return text;
+	updateBashCallComponent(
+		component,
+		args,
+		theme,
+		context,
+		spinnerFrame,
+		elapsedMs,
+		toolIntentConfig,
+		toolCallStyle,
+		commandPreviewRows,
+	);
+	return component;
 }

--- a/packages/pi-tool-display-intent/src/config-modal.ts
+++ b/packages/pi-tool-display-intent/src/config-modal.ts
@@ -23,6 +23,7 @@ interface ModalOverlayOptions {
 }
 
 const PREVIEW_ROW_VALUES = ["4", "8", "12", "20", "40"] as const;
+const BASH_COMMAND_PREVIEW_ROW_VALUES = ["1", "2", "3", "4"] as const;
 const MODE_COMMAND_HINT = RESULT_DISPLAY_MODES.join("|");
 
 function toOnOff(value: boolean): string {
@@ -38,7 +39,7 @@ function summarizeConfig(config: ToolDisplayConfig, capabilities: ToolDisplayCap
 	const parts = [
 		`results=${config.resultMode}/${config.previewRows}rows`,
 		`intent=${toOnOff(config.toolIntent.enabled)}/${config.toolIntent.language}`,
-		`toolCalls=${config.toolCallStyle}`,
+		`toolCalls=${config.toolCallStyle}/bash${config.bashCommandPreviewRows}rows`,
 		`userMessage=${config.enableNativeUserMessageBox ? "boxed" : "default"}`,
 		`thinkingLabel=${toOnOff(config.enableThinkingLabel)}`,
 		`diff=${config.diffViewMode}/${config.diffIndicatorMode}@${config.diffSplitMinWidth}`,
@@ -163,6 +164,26 @@ function buildInspectorSettings(
 			searchTerms: ["tool", "style", "claude", "compact", "status", "shell"],
 		},
 		{
+			id: "bashCommandPreviewRows",
+			label: "Bash command rows",
+			currentValue: String(config.bashCommandPreviewRows),
+			values: BASH_COMMAND_PREVIEW_ROW_VALUES,
+			inspectorTitle: "Bash Command Preview Rows",
+			inspectorSummary: [
+				"Limits collapsed Bash command text after terminal wrapping while leaving short commands unchanged.",
+				"Long Claude-style calls keep intent in the header and move the bounded command preview to its own row.",
+			],
+			inspectorOptions: [
+				"1 — densest transcript and the default",
+				"2–4 — retain more command context before collapsing",
+			],
+			inspectorAdvanced: buildAdvancedNotes(config, capabilities, [
+				"Ctrl+O expands the complete original command; results.previewRows controls output rather than call arguments.",
+			]),
+			inspectorPath: configPath,
+			searchTerms: ["bash", "command", "preview", "rows", "collapse", "expand", "ctrl+o"],
+		},
+		{
 			id: "diffViewMode",
 			label: "Edit diff layout",
 			currentValue: config.diffViewMode,
@@ -254,6 +275,11 @@ function applySetting(config: ToolDisplayConfig, id: string, value: string): Too
 			};
 		case "toolCallStyle":
 			return { ...config, toolCallStyle: value as ToolDisplayConfig["toolCallStyle"] };
+		case "bashCommandPreviewRows":
+			return {
+				...config,
+				bashCommandPreviewRows: parseNumber(value, config.bashCommandPreviewRows),
+			};
 		case "enableThinkingLabel":
 			return { ...config, enableThinkingLabel: value === "on" };
 		case "enableNativeUserMessageBox":

--- a/packages/pi-tool-display-intent/src/config-store.ts
+++ b/packages/pi-tool-display-intent/src/config-store.ts
@@ -300,6 +300,12 @@ export function normalizeToolDisplayConfig(raw: unknown): ToolDisplayConfig {
 		customToolOverrides: normalizeCustomToolOverrides(source.customToolOverrides),
 		toolIntent: normalizeToolIntentConfig(rawToolIntent),
 		toolCallStyle: toToolCallStyle(source.toolCallStyle),
+		bashCommandPreviewRows: clampNumber(
+			source.bashCommandPreviewRows,
+			1,
+			8,
+			DEFAULT_TOOL_DISPLAY_CONFIG.bashCommandPreviewRows,
+		),
 		resultMode: resultResolution.mode,
 		...resultConfig,
 		enableNativeUserMessageBox: toBoolean(
@@ -428,8 +434,9 @@ function validateToolDisplayConfigV2(raw: unknown): string[] {
 	validateOptionalInteger(intent, "maxLength", 16, 256, "intent.", errors);
 
 	const toolCalls = getV2Section(source, "toolCalls", errors);
-	validateKnownKeys(toolCalls, ["style"], "toolCalls.", errors);
+	validateKnownKeys(toolCalls, ["style", "bashCommandPreviewRows"], "toolCalls.", errors);
 	validateOptionalEnum(toolCalls, "style", TOOL_CALL_STYLES, "toolCalls.", errors);
+	validateOptionalInteger(toolCalls, "bashCommandPreviewRows", 1, 8, "toolCalls.", errors);
 
 	if (!hasOwn(source, "results")) errors.push("results: required section");
 	const results = getV2Section(source, "results", errors);
@@ -509,6 +516,7 @@ function normalizeToolDisplayConfigV2(raw: unknown): ToolDisplayConfig {
 		customToolOverrides: tools.custom,
 		toolIntent: source.intent,
 		toolCallStyle: toolCalls.style,
+		bashCommandPreviewRows: toolCalls.bashCommandPreviewRows,
 		enableNativeUserMessageBox:
 			transcript.userMessageStyle === "default"
 				? false
@@ -546,9 +554,12 @@ export function serializeToolDisplayConfigV2(rawConfig: ToolDisplayConfig): Reco
 	if (config.toolIntent.maxLength !== defaults.toolIntent.maxLength) intent.maxLength = config.toolIntent.maxLength;
 	assignSection(output, "intent", intent);
 
-	if (config.toolCallStyle !== defaults.toolCallStyle) {
-		output.toolCalls = { style: config.toolCallStyle };
+	const toolCalls: Record<string, unknown> = {};
+	if (config.toolCallStyle !== defaults.toolCallStyle) toolCalls.style = config.toolCallStyle;
+	if (config.bashCommandPreviewRows !== defaults.bashCommandPreviewRows) {
+		toolCalls.bashCommandPreviewRows = config.bashCommandPreviewRows;
 	}
+	assignSection(output, "toolCalls", toolCalls);
 
 	const results: Record<string, unknown> = { mode: config.resultMode };
 	if (config.previewRows !== defaults.previewRows) results.previewRows = config.previewRows;

--- a/packages/pi-tool-display-intent/src/tool-overrides.ts
+++ b/packages/pi-tool-display-intent/src/tool-overrides.ts
@@ -460,7 +460,7 @@ function formatDisplaySummarySuffix(
     return "";
   }
 
-  const color = summary.source === "model" ? "text" : "muted";
+  const color = summary.source === "model" ? "accent" : "muted";
   return `${theme.fg("muted", " — ")}${theme.fg(color, summary.text)}`;
 }
 
@@ -1203,8 +1203,8 @@ function formatMcpCallLine(
         : toolLabel;
   const intentSuffix = formatDisplaySummarySuffix(args, toolName, theme, config);
   const line = config.toolCallStyle === "claude"
-    ? formatClaudeToolCall("mcp", theme.fg("accent", target), argSuffix, intentSuffix, theme, context)
-    : `${theme.fg("toolTitle", theme.bold("MCP"))} ${theme.fg("accent", target)}${argSuffix}${intentSuffix}`;
+    ? formatClaudeToolCall("mcp", theme.fg("text", target), argSuffix, intentSuffix, theme, context)
+    : `${theme.fg("toolTitle", theme.bold("MCP"))} ${theme.fg("text", target)}${argSuffix}${intentSuffix}`;
 
   return new Text(line, 0, 0);
 }
@@ -1351,7 +1351,7 @@ function formatGenericToolCallLine(
     const metadata = presentation.metadata?.length
       ? theme.fg("muted", ` · ${presentation.metadata.join(" · ")}`)
       : "";
-    const target = `${theme.fg("accent", presentation.target)}${metadata}`;
+    const target = `${theme.fg("text", presentation.target)}${metadata}`;
     const line = config.toolCallStyle === "claude"
       ? formatClaudeToolCall(toolName, target, "", intentSuffix, theme, context)
       : `${theme.fg("toolTitle", theme.bold(toolName))} ${target}${intentSuffix}`;
@@ -1386,7 +1386,7 @@ function formatSearchCallLine(
   config: ToolDisplayConfig,
   context?: ToolRenderContextLike,
 ): Text {
-  const target = `${theme.fg("accent", accent)}${theme.fg("muted", mutedSuffix)}`;
+  const target = `${theme.fg("text", accent)}${theme.fg("muted", mutedSuffix)}`;
   const intentSuffix = formatDisplaySummarySuffix(args, toolName, theme, config);
   const line = config.toolCallStyle === "claude"
     ? formatClaudeToolCall(toolName, target, "", intentSuffix, theme, context)
@@ -1453,7 +1453,7 @@ function renderReadDisplayCall(
     const to = limit !== undefined ? from + limit - 1 : undefined;
     suffix = to ? `:${from}-${to}` : `:${from}`;
   }
-  const target = `${theme.fg("accent", path || "...")}${theme.fg("warning", suffix)}`;
+  const target = `${theme.fg("text", path || "...")}${theme.fg("warning", suffix)}`;
   const intentSuffix = config ? formatDisplaySummarySuffix(args, "read", theme, config) : "";
   const line = config?.toolCallStyle === "claude"
     ? formatClaudeToolCall("read", target, "", intentSuffix, theme, context)
@@ -1515,8 +1515,8 @@ function renderEditDisplayCall(
   const lineCountSuffix = formatLineCountSuffix(lineCount, theme);
   const intentSuffix = formatDisplaySummarySuffix(args, "edit", theme, config);
   const summaryText = config.toolCallStyle === "claude"
-    ? formatClaudeToolCall("edit", theme.fg("accent", path || "..."), lineCountSuffix, intentSuffix, theme, context)
-    : `${theme.fg("toolTitle", theme.bold("edit"))} ${theme.fg("accent", path || "...")}${lineCountSuffix}${intentSuffix}`;
+    ? formatClaudeToolCall("edit", theme.fg("text", path || "..."), lineCountSuffix, intentSuffix, theme, context)
+    : `${theme.fg("toolTitle", theme.bold("edit"))} ${theme.fg("text", path || "...")}${lineCountSuffix}${intentSuffix}`;
   if (!context?.argsComplete || !context.isPartial) {
     return textResult(summaryText);
   }
@@ -1937,8 +1937,8 @@ export function registerToolDisplayOverrides(
       const config = getConfig();
       const intentSuffix = formatDisplaySummarySuffix(args, "write", theme, config);
       const summaryText = config.toolCallStyle === "claude"
-        ? formatClaudeToolCall("write", theme.fg("accent", path || "..."), suffix, intentSuffix, theme, context)
-        : `${theme.fg("toolTitle", theme.bold("write"))} ${theme.fg("accent", path || "...")}${suffix}${intentSuffix}`;
+        ? formatClaudeToolCall("write", theme.fg("text", path || "..."), suffix, intentSuffix, theme, context)
+        : `${theme.fg("toolTitle", theme.bold("write"))} ${theme.fg("text", path || "...")}${suffix}${intentSuffix}`;
       if (!context.argsComplete || !context.isPartial) {
         return textResult(summaryText);
       }
@@ -1988,7 +1988,14 @@ export function registerToolDisplayOverrides(
     ...createBuiltinToolBase("bash"),
     renderCall(args, theme, context) {
       const config = getConfig();
-      return renderBashCall(args, theme, context as never, config.toolIntent, config.toolCallStyle);
+      return renderBashCall(
+        args,
+        theme,
+        context as never,
+        config.toolIntent,
+        config.toolCallStyle,
+        config.bashCommandPreviewRows,
+      );
     },
     renderResult(result, options, theme, context) {
       const config = getConfig();

--- a/packages/pi-tool-display-intent/src/types.ts
+++ b/packages/pi-tool-display-intent/src/types.ts
@@ -65,6 +65,7 @@ export interface ToolDisplayConfig {
 	customToolOverrides: Record<string, CustomToolOverrideConfig>;
 	toolIntent: ToolIntentConfig;
 	toolCallStyle: ToolCallStyle;
+	bashCommandPreviewRows: number;
 	resultMode: ResultDisplayMode;
 	enableNativeUserMessageBox: boolean;
 	enableThinkingLabel: boolean;
@@ -101,6 +102,7 @@ export const DEFAULT_TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
 		maxLength: 96,
 	},
 	toolCallStyle: "compact",
+	bashCommandPreviewRows: 1,
 	resultMode: "compact",
 	enableNativeUserMessageBox: true,
 	enableThinkingLabel: true,

--- a/packages/pi-tool-display-intent/tests/bash-display.test.ts
+++ b/packages/pi-tool-display-intent/tests/bash-display.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { Text } from "@earendil-works/pi-tui";
+import { visibleWidth, type Component } from "@earendil-works/pi-tui";
 import { renderBashCall } from "../src/bash-display.ts";
 
 // ─── Test Helpers ────────────────────────────────────────────────────────────
@@ -14,6 +14,7 @@ interface BashCallRenderTheme {
 
 interface BashCallRenderContextLike {
 	executionStarted: boolean;
+	expanded?: boolean;
 	isPartial: boolean;
 	invalidate(): void;
 	lastComponent?: unknown;
@@ -32,7 +33,7 @@ function createPassThroughTheme(): BashCallRenderTheme {
 function createAnsiTheme(): BashCallRenderTheme {
 	return {
 		fg: (color: string, text: string): string =>
-			`\x1b[${color === "warning" ? "93" : color === "muted" ? "90" : color === "toolTitle" ? "94" : color === "accent" ? "92" : "0"}m${text}\x1b[0m`,
+			`\x1b[${color === "warning" ? "93" : color === "muted" ? "90" : color === "toolTitle" ? "94" : color === "accent" ? "92" : color === "text" ? "97" : "0"}m${text}\x1b[0m`,
 		bold: (text: string): string => `\x1b[1m${text}\x1b[0m`,
 	};
 }
@@ -46,8 +47,8 @@ function makeContext(overrides: Partial<BashCallRenderContextLike> = {}): BashCa
 	};
 }
 
-function renderedText(component: Text): string {
-	return component.render(120).map((line) => line.trimEnd()).join("\n").trim();
+function renderedText(component: Component, width = 120): string {
+	return component.render(width).map((line) => line.trimEnd()).join("\n").trim();
 }
 
 /**
@@ -58,7 +59,7 @@ function createSpinningBashCall(
 	args: { command?: string; timeout?: number },
 	state: Record<string, unknown>,
 	extra?: Partial<BashCallRenderContextLike>,
-): { text: Text; stop(): void } {
+): { text: Component; stop(): void } {
 	const text = renderBashCall(
 		args,
 		createPassThroughTheme(),
@@ -110,7 +111,7 @@ test("renderBashCall displays short command", () => {
 });
 
 test("renderBashCall handles very long commands without crashing", () => {
-	// Text wraps at render width (120), extremely long commands wrap to multiple lines
+	// Long command calls use a width-aware component instead of flooding the transcript
 	const longCmd = "node " + "a".repeat(200);
 	const text = renderBashCall({ command: longCmd }, createPassThroughTheme(), makeContext());
 	const output = renderedText(text);
@@ -121,13 +122,68 @@ test("renderBashCall handles very long commands without crashing", () => {
 	assert.ok(output.length > 10, "output should have content");
 });
 
-test("renderBashCall displays multiline command", () => {
+test("renderBashCall keeps collapsed command rows within narrow CJK-aware widths", () => {
+	const text = renderBashCall(
+		{ command: `printf '${"模型菜单".repeat(20)}'\nprintf done` },
+		createPassThroughTheme(),
+		makeContext(),
+	);
+	const lines = text.render(32);
+	assert.ok(lines.length <= 2);
+	assert.ok(lines.every((line) => visibleWidth(line) <= 32));
+});
+
+test("renderBashCall collapses multiline commands by default", () => {
 	const text = renderBashCall(
 		{ command: "echo hello\necho world" },
 		createPassThroughTheme(),
 		makeContext(),
 	);
+	const output = renderedText(text);
+	assert.match(output, /^\$ echo hello … \(2 lines · \d+B · Ctrl\+O\)$/);
+	assert.doesNotMatch(output, /echo world/);
+});
+
+test("renderBashCall shows the complete multiline command when tools are expanded", () => {
+	const text = renderBashCall(
+		{ command: "echo hello\necho world" },
+		createPassThroughTheme(),
+		makeContext({ expanded: true }),
+	);
 	assert.ok(renderedText(text).includes("echo hello\necho world"));
+});
+
+test("renderBashCall gives collapsed Claude calls an intent-first header and command row", () => {
+	const text = renderBashCall(
+		{
+			command: "set -euo pipefail\nprintf done",
+			displaySummary: "Verifying the model menu",
+			timeout: 20,
+		},
+		createPassThroughTheme(),
+		makeContext(),
+		{ enabled: true, language: "en", maxLength: 96 },
+		"claude",
+	);
+	assert.equal(
+		renderedText(text),
+		"● Bash (timeout 20s) — Verifying the model menu\n  $ set -euo pipefail … (2 lines · 29B · Ctrl+O)",
+	);
+});
+
+test("renderBashCall respects the configured collapsed command row budget", () => {
+	const text = renderBashCall(
+		{ command: "printf one\nprintf two\nprintf three" },
+		createPassThroughTheme(),
+		makeContext(),
+		undefined,
+		"compact",
+		2,
+	);
+	assert.equal(
+		renderedText(text),
+		"$ printf one\n  printf two … (3 lines · 34B · Ctrl+O)",
+	);
 });
 
 test("renderBashCall appends timeout suffix when timeout is provided", () => {
@@ -165,13 +221,13 @@ test("renderBashCall applies ANSI bold to the dollar sign with ANSI theme", () =
 	assert.ok(rendered.includes("\x1b[1m$\x1b[0m"), `expected bold $ in: ${JSON.stringify(rendered)}`);
 });
 
-test("renderBashCall applies ANSI color to command with ANSI theme", () => {
+test("renderBashCall applies text color to commands with ANSI theme", () => {
 	const text = renderBashCall({ command: "ls" }, createAnsiTheme(), makeContext());
 	const rendered = renderedText(text);
-	assert.ok(rendered.includes("\x1b[92mls\x1b[0m"), `expected green ls in: ${JSON.stringify(rendered)}`);
+	assert.ok(rendered.includes("\x1b[97mls\x1b[0m"), `expected text-colored ls in: ${JSON.stringify(rendered)}`);
 });
 
-test("renderBashCall uses text for model intent and muted for fallback intent", () => {
+test("renderBashCall uses accent for model intent and muted for fallback intent", () => {
 	const theme = {
 		fg: (color: string, value: string): string => `<${color}>${value}</${color}>`,
 		bold: (value: string): string => value,
@@ -184,7 +240,7 @@ test("renderBashCall uses text for model intent and muted for fallback intent", 
 		makeContext(),
 		toolIntent,
 	);
-	assert.match(renderedText(modelIntent), /<text>Running the test suite<\/text>/);
+	assert.match(renderedText(modelIntent), /<accent>Running the test suite<\/accent>/);
 
 	const fallbackIntent = renderBashCall(
 		{ command: "pnpm test" },
@@ -425,7 +481,7 @@ test("renderBashCall handles repeated calls without creating multiple timers", (
 
 // ─── lastComponent Preservation ──────────────────────────────────────────────
 
-test("renderBashCall preserves the same Text component reference when lastComponent is a Text", () => {
+test("renderBashCall preserves the same component reference through lastComponent", () => {
 	const initialState: Record<string, unknown> = {};
 	const { text: first, stop } = createSpinningBashCall({ command: "npm test" }, initialState);
 
@@ -440,7 +496,7 @@ test("renderBashCall preserves the same Text component reference when lastCompon
 		}),
 	);
 
-	assert.equal(first, second, "should return the same Text instance via lastComponent");
+	assert.equal(first, second, "should return the same component instance via lastComponent");
 	stop();
 });
 

--- a/packages/pi-tool-display-intent/tests/config-modal.test.ts
+++ b/packages/pi-tool-display-intent/tests/config-modal.test.ts
@@ -101,6 +101,7 @@ test("show reports the simple result mode and independent groups", async () => {
 	assert.match(notifications[0]?.message ?? "", /^tool-display-intent: /);
 	assert.match(notifications[0]?.message ?? "", /results=compact\/8rows/);
 	assert.match(notifications[0]?.message ?? "", /intent=on\/auto/);
+	assert.match(notifications[0]?.message ?? "", /toolCalls=compact\/bash1rows/);
 	assert.match(notifications[0]?.message ?? "", /mcp=available/);
 	assert.match(notifications[0]?.message ?? "", /rtkHints=off/);
 	assert.equal(notifications[0]?.message.includes("profile"), false);

--- a/packages/pi-tool-display-intent/tests/config-schema.test.ts
+++ b/packages/pi-tool-display-intent/tests/config-schema.test.ts
@@ -22,6 +22,7 @@ test("bundled config example is valid simple v2", () => {
 		assert.equal(loaded.config.resultMode, "summary");
 		assert.equal(loaded.config.toolIntent.language, "zh-CN");
 		assert.equal(loaded.config.toolCallStyle, "claude");
+		assert.equal(loaded.config.bashCommandPreviewRows, 1);
 		assert.equal(loaded.config.previewRows, 10);
 		assert.equal(loaded.config.diffCollapsedRows, 24);
 		assert.equal(loaded.config.expandedPreviewMaxRows, 500);
@@ -48,6 +49,7 @@ test("bundled JSON Schema exposes only the reviewed public field names", () => {
 	assert.equal(schema.properties?.results?.properties?.profile, undefined);
 	assert.equal(schema.properties?.results?.properties?.overrides, undefined);
 	assert.ok(schema.properties?.toolCalls?.properties?.style);
+	assert.ok(schema.properties?.toolCalls?.properties?.bashCommandPreviewRows);
 	assert.equal(schema.properties?.toolCalls?.properties?.frame, undefined);
 	assert.ok(schema.properties?.tools?.properties?.passthrough);
 	assert.equal(schema.properties?.tools?.properties?.disabled, undefined);

--- a/packages/pi-tool-display-intent/tests/config-store.test.ts
+++ b/packages/pi-tool-display-intent/tests/config-store.test.ts
@@ -204,7 +204,7 @@ test("v2 grouped config resolves simple result mode and clear field names", () =
 		writeFileSync(configFile, `${JSON.stringify({
 			version: 2,
 			intent: { enabled: false, language: "en", maxLength: 64 },
-			toolCalls: { style: "claude" },
+			toolCalls: { style: "claude", bashCommandPreviewRows: 3 },
 			results: { mode: "summary", previewRows: 20 },
 			diff: {
 				layout: "split",
@@ -236,6 +236,7 @@ test("v2 grouped config resolves simple result mode and clear field names", () =
 		assert.equal(loaded.config.mcpOutputMode, "summary");
 		assert.equal(loaded.config.bashOutputMode, "summary");
 		assert.equal(loaded.config.previewRows, 20);
+		assert.equal(loaded.config.bashCommandPreviewRows, 3);
 		assert.equal(loaded.config.registerToolOverrides.read, false);
 		assert.equal(loaded.config.registerToolOverrides.write, false);
 		assert.deepEqual(loaded.config.customToolOverrides.custom_mcp, {
@@ -256,11 +257,13 @@ test("v2 serialization is sparse and round-trips the effective config", () => {
 		resultMode: "preview",
 		previewRows: 16,
 		toolIntent: { enabled: false, language: "zh-CN", maxLength: 80 },
+		bashCommandPreviewRows: 2,
 		enableThinkingLabel: false,
 	});
 	const serialized = serializeToolDisplayConfigV2(config);
 	assert.deepEqual(serialized.results, { mode: "preview", previewRows: 16 });
 	assert.deepEqual(serialized.intent, { enabled: false, language: "zh-CN", maxLength: 80 });
+	assert.deepEqual(serialized.toolCalls, { bashCommandPreviewRows: 2 });
 	assert.deepEqual(serialized.transcript, { thinkingLabel: false });
 
 	withTempDir("pi-tool-display-config-roundtrip-", (dir) => {
@@ -276,7 +279,7 @@ test("invalid or old v2 fields are reported with paths and never rewritten", () 
 		const original = `${JSON.stringify({
 			version: 2,
 			extension: { enabled: false },
-			toolCalls: { frame: "claude" },
+			toolCalls: { frame: "claude", bashCommandPreviewRows: 9 },
 			results: {
 				profile: "minimal",
 				previewLines: 10,
@@ -288,6 +291,7 @@ test("invalid or old v2 fields are reported with paths and never rewritten", () 
 		assert.deepEqual(loaded.config, DEFAULT_TOOL_DISPLAY_CONFIG);
 		assert.match(loaded.error ?? "", /extension: unknown setting/);
 		assert.match(loaded.error ?? "", /toolCalls\.frame: unknown setting/);
+		assert.match(loaded.error ?? "", /toolCalls\.bashCommandPreviewRows: expected integer from 1 to 8/);
 		assert.match(loaded.error ?? "", /results\.profile: unknown setting/);
 		assert.match(loaded.error ?? "", /results\.mode: required setting/);
 		assert.equal(readFileSync(configFile, "utf8"), original);

--- a/packages/pi-tool-display-intent/tests/reload-behavior.test.ts
+++ b/packages/pi-tool-display-intent/tests/reload-behavior.test.ts
@@ -267,12 +267,10 @@ test("3: bash spinner interval is created during partial execution and cleared o
 
   try {
     // Render context that triggers spinner
-    const textComponent = new Text("", 0, 0);
     const context: Record<string, unknown> = {
       executionStarted: true,
       isPartial: true,
       invalidate: () => {},
-      lastComponent: textComponent,
       state: {},
     };
 
@@ -282,7 +280,7 @@ test("3: bash spinner interval is created during partial execution and cleared o
       stubTheme,
       context as unknown as Parameters<typeof renderBashCall>[2],
     );
-    assert.ok(result1 instanceof Text, "renderBashCall returns a Text");
+    assert.equal(typeof result1.render, "function", "renderBashCall returns a component");
     assert.ok(
       createdIntervals.length > 0,
       "spinner interval was created during partial execution",
@@ -290,12 +288,13 @@ test("3: bash spinner interval is created during partial execution and cleared o
 
     // Simulate execution completing (reload-like: context becomes non-partial)
     context.isPartial = false;
+    context.lastComponent = result1;
     const result2 = renderBashCall(
       { command: "sleep 5" },
       stubTheme,
       context as unknown as Parameters<typeof renderBashCall>[2],
     );
-    assert.ok(result2 instanceof Text, "renderBashCall still returns Text");
+    assert.equal(result2, result1, "renderBashCall reuses its component after completion");
     assert.ok(
       clearedIntervals.length > 0,
       "spinner interval was cleared on execution completion",

--- a/packages/pi-tool-display-intent/tests/tool-overrides-registration.test.ts
+++ b/packages/pi-tool-display-intent/tests/tool-overrides-registration.test.ts
@@ -221,7 +221,7 @@ test("registered built-ins expose intent in schemas and TUI while stripping it b
 	});
 });
 
-test("built-in renderers use text for model intent and muted for fallback intent", () => {
+test("built-in renderers use accent for model intent and muted for fallback intent", () => {
 	const { api, registeredTools } = createExtensionApiStub();
 	registerToolDisplayOverrides(api, () => DEFAULT_TOOL_DISPLAY_CONFIG);
 	const read = registeredTools.find((tool) => tool.name === "read");
@@ -236,7 +236,9 @@ test("built-in renderers use text for model intent and muted for fallback intent
 		theme,
 		{},
 	) as { render(width: number): string[] };
-	assert.match(modelIntent.render(160).join("\n"), /<text>Checking the sample file<\/text>/);
+	const modelIntentText = modelIntent.render(160).join("\n");
+	assert.match(modelIntentText, /<text>sample\.txt<\/text>/);
+	assert.match(modelIntentText, /<accent>Checking the sample file<\/accent>/);
 
 	const fallbackIntent = read.renderCall?.(
 		{ path: "sample.txt" },

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const packagePaths = [
+	".",
+	"./packages/pi-recap",
+	"./packages/pi-tool-display-intent",
+	"./packages/pi-todo",
+	"./packages/pi-search-hub",
+];
+
+const requiredPackFiles = new Map([
+	[".", [
+		"README.md",
+		"README.zh-CN.md",
+		"packages/pi-search-hub/README.md",
+		"packages/pi-search-hub/README.zh-CN.md",
+	]],
+	["./packages/pi-search-hub", ["README.md", "README.zh-CN.md"]],
+]);
+
+async function assertBilingualPair(englishPath, chinesePath) {
+	const [english, chinese] = await Promise.all([
+		readFile(resolve(repositoryRoot, englishPath), "utf8"),
+		readFile(resolve(repositoryRoot, chinesePath), "utf8"),
+	]);
+	const headingLevels = (markdown) => Array.from(
+		markdown.matchAll(/^(#{1,6})\s+.+$/gm),
+		(match) => match[1].length,
+	);
+	assert.deepEqual(
+		headingLevels(chinese),
+		headingLevels(english),
+		`${chinesePath} must keep the same heading structure as ${englishPath}`,
+	);
+	assert.match(english, new RegExp(`\\[简体中文\\]\\(\\./${chinesePath.split("/").pop().replaceAll(".", "\\.")}\\)`));
+	assert.match(chinese, /\[English\]\(\.\/README\.md\)/);
+}
+
+await assertBilingualPair("README.md", "README.zh-CN.md");
+await assertBilingualPair(
+	"packages/pi-search-hub/README.md",
+	"packages/pi-search-hub/README.zh-CN.md",
+);
+
+for (const packagePath of packagePaths) {
+	const result = spawnSync(
+		"npm",
+		["pack", "--dry-run", "--json", packagePath],
+		{
+			cwd: repositoryRoot,
+			encoding: "utf8",
+		},
+	);
+	if (result.error) throw result.error;
+	if (result.status !== 0) {
+		process.stderr.write(result.stderr);
+		process.stderr.write(result.stdout);
+		process.exit(result.status ?? 1);
+	}
+
+	const packResult = JSON.parse(result.stdout);
+	const files = new Set((packResult[0]?.files ?? []).map((file) => file.path));
+	for (const requiredFile of requiredPackFiles.get(packagePath) ?? []) {
+		assert.ok(files.has(requiredFile), `${packagePath} npm pack is missing ${requiredFile}`);
+	}
+	console.log(`${packagePath}: npm pack dry-run passed (${files.size} files)`);
+}

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -6,6 +6,7 @@ const rootPackage = JSON.parse(
 const version = rootPackage.version;
 const readmes = [
 	new URL("../README.md", import.meta.url),
+	new URL("../README.zh-CN.md", import.meta.url),
 	new URL("../packages/pi-recap/README.md", import.meta.url),
 	new URL("../packages/pi-recap/README.zh-CN.md", import.meta.url),
 	new URL("../packages/pi-tool-display-intent/README.md", import.meta.url),


### PR DESCRIPTION
## Summary

- collapse long and multiline Bash call arguments with Ctrl+O expansion
- emphasize model-written intents with the theme accent color
- add `toolCalls.bashCommandPreviewRows` configuration and migration coverage
- refresh bilingual root/Search Hub docs and npm pack assertions
- add a release-plan review gate

## Release plan

Reviewed and approved:
- `@zhcsyncer/pi-extensions`: 0.4.0 → 0.5.0
- `@zhcsyncer/pi-tool-display-intent`: 0.4.0 → 0.5.0

## Validation

- `pnpm --filter @zhcsyncer/pi-tool-display-intent check`
- `pnpm --filter @zhcsyncer/pi-search-hub check`
- `pnpm check`