### PR TITLE
perf: deduplicate tool intent prompt guidance

### DIFF
--- a/.changeset/calm-tools-summarize.md
+++ b/.changeset/calm-tools-summarize.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-tool-display-intent": patch
+---
+
+Reduce prompt overhead for model-written tool intents. Wrapped tools now share one Pi-deduplicatable guideline, preserve their original descriptions, and retain detailed `displaySummary` field guidance in each schema. This trims the initial bundle prompt without changing execution, RPC, fallback, or rendering semantics.

--- a/packages/pi-search-hub/tests/integration.test.ts
+++ b/packages/pi-search-hub/tests/integration.test.ts
@@ -99,6 +99,7 @@ describe("tool display integration", () => {
 				"Set web_read objective only to a valid CSS selector for Jina targeted extraction; do not pass a natural-language question",
 			);
 
+			const intentGuidelines = registeredTools.map((tool) => tool.promptGuidelines.at(-1));
 			for (const tool of registeredTools) {
 				const schema = tool.parameters as {
 					properties: Record<string, unknown>;
@@ -106,8 +107,11 @@ describe("tool display integration", () => {
 				};
 				expect(schema.properties.displaySummary).toBeDefined();
 				expect(schema.required).toContain("displaySummary");
-				expect(tool.promptGuidelines.at(-1)).toContain(`Every ${tool.name} call must include displaySummary`);
+				expect(tool.promptGuidelines.at(-1)).toContain(
+					"Every tool call whose schema defines displaySummary must include it",
+				);
 			}
+			expect(new Set(intentGuidelines).size).toBe(1);
 		} finally {
 			if (previousApi === undefined) {
 				delete globalWithApi[apiKey];

--- a/packages/pi-tool-display-intent/README.md
+++ b/packages/pi-tool-display-intent/README.md
@@ -17,6 +17,7 @@ The model writes `displaySummary` as part of the normal tool call. The extension
 ## Features
 
 - Adds `displaySummary` to the owned `read`, `grep`, `find`, `ls`, `bash`, `edit`, and `write` schemas.
+- Uses one Pi-deduplicated system-prompt guideline while keeping field-specific intent guidance in each tool schema.
 - Shows the intent beside deterministic metadata such as paths, commands, patterns, and diff information.
 - Strips the presentation field before calling the original tool implementation.
 - Keeps the raw field available to Pi RPC consumers and retains it in later model context so follow-up calls keep producing intent.

--- a/packages/pi-tool-display-intent/README.zh-CN.md
+++ b/packages/pi-tool-display-intent/README.zh-CN.md
@@ -17,6 +17,7 @@ $ pnpm test — 验证 extension 测试套件
 ## 功能
 
 - 为持有的 `read`、`grep`、`find`、`ls`、`bash`、`edit`、`write` Schema 添加 `displaySummary`。
+- 使用一条可由 Pi 去重的 system prompt guideline，同时在各工具 Schema 中保留字段级意图说明。
 - 在 TUI 中同时展示模型意图与路径、命令、pattern、diff 等确定性信息。
 - 调用原始工具前剥离纯展示字段，保持工具执行语义不变。
 - 在 Pi RPC 原始事件及后续模型上下文中保留该字段，让 follow-up 调用继续生成意图。

--- a/packages/pi-tool-display-intent/src/display-summary.js
+++ b/packages/pi-tool-display-intent/src/display-summary.js
@@ -173,12 +173,12 @@ export function withDisplaySummary(tool, rawOptions = {}) {
     : undefined;
   const originalGuidelines = Array.isArray(tool.promptGuidelines) ? tool.promptGuidelines : [];
   const languageGuideline = languageInstruction(options.language);
-  const toolName = typeof tool.name === "string" && tool.name.trim() ? tool.name.trim() : "tool";
-  const intentGuideline = `Every ${toolName} call must include ${DISPLAY_SUMMARY_FIELD}, including follow-up calls in the same agent run. Set it to a concise user-facing phrase describing that call's intent. ${languageGuideline} Never include secrets or credentials.`;
+  // Keep this tool-name agnostic so Pi deduplicates the guideline across active
+  // wrapped tools. Per-tool semantics remain next to the field in its schema.
+  const intentGuideline = `Every tool call whose schema defines ${DISPLAY_SUMMARY_FIELD} must include it, including follow-up calls in the same agent run. Set it to a concise user-facing phrase describing that call's intent. ${languageGuideline} Never include secrets or credentials.`;
 
   const wrapped = {
     ...tool,
-    description: `${typeof tool.description === "string" ? tool.description : ""}\n\nEvery call includes ${DISPLAY_SUMMARY_FIELD}, a short user-facing phrase explaining what the tool is doing and why.`.trim(),
     promptGuidelines: [...originalGuidelines, intentGuideline],
     parameters: addDisplaySummaryParameter(tool.parameters, options),
     prepareArguments(args) {

--- a/packages/pi-tool-display-intent/tests/display-summary.test.ts
+++ b/packages/pi-tool-display-intent/tests/display-summary.test.ts
@@ -49,6 +49,21 @@ test("adds a required displaySummary without mutating the original schema", () =
 	assert.equal("displaySummary" in originalParameters.properties, false);
 });
 
+test("shares one deduplicatable guideline without rewriting tool descriptions", () => {
+	const first = withDisplaySummary(createTool());
+	const second = withDisplaySummary(createTool({
+		name: "other_probe",
+		description: "Inspect another value.",
+	}));
+	const firstGuideline = (first as { promptGuidelines?: string[] }).promptGuidelines?.at(-1);
+	const secondGuideline = (second as { promptGuidelines?: string[] }).promptGuidelines?.at(-1);
+
+	assert.equal(first.description, "Inspect a value.");
+	assert.equal(second.description, "Inspect another value.");
+	assert.match(firstGuideline ?? "", /Every tool call whose schema defines displaySummary must include it/);
+	assert.equal(secondGuideline, firstGuideline);
+});
+
 test("refuses to hijack a custom tool's existing displaySummary parameter", () => {
 	assert.throws(
 		() => addDisplaySummaryParameter({

--- a/packages/pi-tool-display-intent/tests/tool-overrides-registration.test.ts
+++ b/packages/pi-tool-display-intent/tests/tool-overrides-registration.test.ts
@@ -122,15 +122,20 @@ test("registerToolDisplayOverrides copies built-in prompt metadata onto overridd
 		const registeredTool = byName.get(name);
 		const builtInMetadata = builtInTool as unknown as RegisteredToolLike;
 		assert.ok(registeredTool, `expected '${name}' to be registered`);
+		assert.equal(registeredTool.description, builtInMetadata.description);
 		assert.equal(registeredTool.promptSnippet, builtInMetadata.promptSnippet);
 	}
 
+	const intentGuidelines = new Set<string>();
 	for (const [name, builtInTool] of Object.entries(builtInTools)) {
 		const registeredGuidelines = byName.get(name)?.promptGuidelines ?? [];
 		const builtInGuidelines = (builtInTool as unknown as RegisteredToolLike).promptGuidelines ?? [];
 		assert.deepEqual(registeredGuidelines.slice(0, -1), builtInGuidelines);
-		assert.match(registeredGuidelines.at(-1) ?? "", /displaySummary/);
+		const intentGuideline = registeredGuidelines.at(-1) ?? "";
+		assert.match(intentGuideline, /displaySummary/);
+		intentGuidelines.add(intentGuideline);
 	}
+	assert.equal(intentGuidelines.size, 1);
 });
 
 test("registerToolDisplayOverrides registers built-in display renderers during extension load for pre-bind history rendering", () => {


### PR DESCRIPTION
## Summary

- replace per-tool `displaySummary` prompt guidelines with one Pi-deduplicatable shared rule
- preserve each tool's original description while retaining detailed field guidance in its parameter schema
- update built-in and Search Hub integration tests plus bilingual package docs

## Prompt impact

For the root bundle's default nine intent-aware tools, this removes about 2,041 characters from the initial system prompt and another 945 characters from tool descriptions, while keeping execution, RPC, fallback, and rendering behavior unchanged.

## Release plan

- `@zhcsyncer/pi-extensions`: `0.5.0` → `0.5.1`
- `@zhcsyncer/pi-tool-display-intent`: `0.5.0` → `0.5.1`
- private `@zhcsyncer/pi-search-hub`: no standalone release

## Validation

- `pnpm --filter @zhcsyncer/pi-tool-display-intent check`
- `pnpm --filter @zhcsyncer/pi-search-hub check`
- `pnpm check`
