### PR TITLE
feat: add Volcengine Agent Plan provider

### DIFF
--- a/.changeset/bright-plans-flow.md
+++ b/.changeset/bright-plans-flow.md
@@ -1,0 +1,5 @@
+---
+"pi-provider-volcengine-agent-plan": minor
+---
+
+Publish the standalone Volcengine Ark Agent Plan provider with native Pi login, tier-aware static models, mixed Responses and Chat routing, reasoning and tool compatibility hooks, and zero-inference API key validation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - name: Set up npm trusted publishing client
         run: npm install --global npm@11.18.0
@@ -44,9 +45,11 @@ jobs:
       - name: Create version PR or publish packages
         id: changesets
         uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0
+        env:
+          NPM_BOOTSTRAP_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
         with:
           version: pnpm version-packages
-          publish: pnpm release
+          publish: bash scripts/publish-packages.sh
           createGithubReleases: false
           commit: "chore: version packages"
           title: "chore: version packages"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,13 +1,14 @@
 # Releasing
 
-This repository publishes four public npm packages:
+This repository publishes five public npm packages:
 
 - `@zhcsyncer/pi-extensions`
 - `@zhcsyncer/pi-recap`
 - `@zhcsyncer/pi-tool-display-intent`
 - `@zhcsyncer/pi-todo`
+- `pi-provider-volcengine-agent-plan`
 
-Packages version independently. Because the aggregate root tarball embeds child sources, every child release must include a root release of at least the same bump level. Unchanged siblings remain unreleased.
+Packages version independently. Because the aggregate root tarball embeds bundled child sources, every bundled child release must include a root release of at least the same bump level. The standalone `pi-provider-volcengine-agent-plan` package is excluded from the aggregate tarball and may release without the root. Unchanged siblings remain unreleased.
 
 A successful publish creates package-level Git tags and GitHub Releases. The root package also owns the repository `vX.Y.Z` tag and latest release.
 
@@ -27,13 +28,13 @@ The release workflow uses OIDC and does not normally require an `NPM_TOKEN`. npm
 
 ### Bootstrap a new npm package
 
-npm trusted publishing can only be configured after a package exists. A new package such as `@zhcsyncer/pi-todo` must still be published through the Changesets version-PR flow:
+npm trusted publishing can only be configured after a package exists. A new package must still be published through the Changesets version-PR flow:
 
-1. Create or rotate a granular npm token with an explicit expiration, read/write access limited to the `@zhcsyncer` package scope, and CI-compatible 2FA settings; store it as the repository secret `NPM_TOKEN`.
-2. In a reviewed temporary change, expose that secret as `NPM_TOKEN` only to the Changesets publish step.
-3. Merge the generated `chore: version packages` PR and let GitHub Actions perform the first publish. Do not run `npm publish` manually.
-4. Configure the package's trusted publisher immediately after the first publish.
-5. Remove the temporary workflow token wiring. The encrypted repository secret may remain for future package bootstraps, but must stay disconnected from normal releases and be rotated before its npm expiration date.
+1. Create a short-lived granular npm token that can create the new package and publish its first version. An unscoped, not-yet-created package may require temporary read/write access to all packages owned by the account because it cannot yet be selected by name.
+2. Store the token as the repository secret `NPM_BOOTSTRAP_TOKEN`. Do not expose it to pull-request workflows.
+3. Review and merge the generated `chore: version packages` PR. `scripts/publish-packages.sh` detects the bootstrap secret, disables OIDC for that publish command, and lets `changeset publish` perform the first publish. Do not run `npm publish` manually.
+4. Configure the new package's trusted publisher immediately after the first publish, using `release.yml` and the `npm publish` allowed action.
+5. Delete the `NPM_BOOTSTRAP_TOKEN` repository secret and revoke the npm token. With no bootstrap secret, the same script uses trusted publishing (OIDC) for normal releases.
 
 ### Allow Actions to create pull requests
 
@@ -47,7 +48,7 @@ Create a changeset in every user-facing pull request:
 pnpm changeset
 ```
 
-Select each affected public package and its bump type. When selecting a child package, also select `@zhcsyncer/pi-extensions` with an equal or higher bump.
+Select each affected public package and its bump type. When selecting a bundled child package, also select `@zhcsyncer/pi-extensions` with an equal or higher bump. Standalone packages do not require a root release unless root package contents or documentation also change.
 
 Changes that do not need a release, such as CI-only or internal documentation changes, do not need a changeset.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,27 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  providers/pi-provider-volcengine-agent-plan:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: 0.81.1
+        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.81.1
+        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      jiti:
+        specifier: 2.7.0
+        version: 2.7.0
+      tsx:
+        specifier: 4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
 packages:
 
   '@anthropic-ai/sdk@0.91.1':
@@ -286,8 +307,17 @@ packages:
     resolution: {integrity: sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==}
     engines: {node: '>=22.19.0'}
 
+  '@earendil-works/pi-agent-core@0.81.1':
+    resolution: {integrity: sha512-yqbh68CyhqxMov/jUogFJfMqlu2Gd37GAki+tr59YCmAPHfomiCA5ESzusXtpGzABeiZFC/OrRdQ4GwCCOMIHA==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-ai@0.80.3':
     resolution: {integrity: sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-ai@0.81.1':
+    resolution: {integrity: sha512-hzHE7Z8l5mgJk+ke67Lge0rwS2+wbKJrFKl9o5M1R1rh33+cCT7D1AHz1OAtX5wFs90E1/BTGhyJRTUHaMxGvQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -296,8 +326,17 @@ packages:
     engines: {node: '>=22.19.0'}
     hasBin: true
 
+  '@earendil-works/pi-coding-agent@0.81.1':
+    resolution: {integrity: sha512-r6ovAsZOgAqbC/aU6s+/dPnv/sGZBuWyZNvi3pXjpbuX5wvp3XvGkQI7/VLvX2o9XpmpFaPUxKNym1WfkN/P8A==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
   '@earendil-works/pi-tui@0.80.3':
     resolution: {integrity: sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.81.1':
+    resolution: {integrity: sha512-OMEe+Zt8oQYi/rCq3upxsTlIScWL0FPhXwQus34TbQb3EmTx88S7Uzx32JxvQiEeWOw8eDCdJf2PBUBE9r6wIg==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.11.1':
@@ -1685,7 +1724,7 @@ snapshots:
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.2
       '@smithy/fetch-http-handler': 5.6.4
-      '@smithy/node-http-handler': 4.7.3
+      '@smithy/node-http-handler': 4.9.4
       '@smithy/types': 4.16.0
       tslib: 2.8.1
 
@@ -2019,7 +2058,42 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-agent-core@0.81.1(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.81.1(ws@8.21.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-ai@0.80.3(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.81.1(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -2070,7 +2144,42 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-coding-agent@0.81.1(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.81.1(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.81.1(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.81.1
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.1.38
+      undici: 8.5.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-tui@0.80.3':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
+
+  '@earendil-works/pi-tui@0.81.1':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "."
   - "packages/*"
+  - "providers/*"
 
 allowBuilds:
   "@google/genai": false

--- a/providers/pi-provider-volcengine-agent-plan/LICENSE
+++ b/providers/pi-provider-volcengine-agent-plan/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 zhcsyncer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/providers/pi-provider-volcengine-agent-plan/README.md
+++ b/providers/pi-provider-volcengine-agent-plan/README.md
@@ -1,0 +1,107 @@
+# pi-provider-volcengine-agent-plan
+
+[简体中文](./README.zh-CN.md)
+
+Unofficial [Pi](https://github.com/badlogic/pi-mono) provider extension for Volcengine Ark Agent Plan at `https://ark.cn-beijing.volces.com/api/plan/v3`.
+
+This community package is not affiliated with or endorsed by Volcengine.
+
+## Features
+
+- Native Pi provider registration and `/login` integration.
+- Static catalog for the 13 current Agent Plan text models.
+- Tier-aware availability for Small, Medium, Large, and Max plans.
+- OpenAI Responses by default, with Chat Completions routing for Kimi K2.6 and Kimi K2.7 Code.
+- Streaming, reasoning, and tool-call support tested through the Agent Plan gateway.
+- Request compatibility handling for MiniMax M2.7 and Kimi K2.6 thinking controls.
+- Zero-inference API key validation before Pi persists a login credential.
+
+## Requirements
+
+- Node.js 20 or newer.
+- Pi and `@earendil-works/pi-ai` 0.81.1 or a compatible 0.81 release.
+- A dedicated Ark Agent Plan API key. A regular Volcengine Ark API key does not work with the Plan endpoint.
+
+## Install
+
+```bash
+pi install npm:pi-provider-volcengine-agent-plan
+```
+
+Restart Pi or run `/reload`, then verify the catalog:
+
+```bash
+pi --list-models volcengine-agent-plan
+```
+
+## Login and credentials
+
+### Interactive login
+
+Run:
+
+```text
+/login volcengine-agent-plan
+```
+
+Pi prompts for the dedicated Agent Plan API key and the subscribed tier. The login flow sends an authenticated, intentionally incomplete Responses request. A valid key reaches `MissingParameter`; an invalid or unauthorized key returns 401/403 and is requested again. This validation does not start model inference.
+
+Pi stores the API key and selected tier in its standard credential file, normally `~/.pi/agent/auth.json`. The package does not read a custom key file.
+
+### Environment variables
+
+Interactive login is recommended. Ambient credentials remain available for automated environments:
+
+```bash
+export ARK_AGENT_PLAN_API_KEY='...'
+export ARK_AGENT_PLAN_TIER='medium'
+```
+
+`VOLCENGINE_ARK_PLAN_API_KEY` is also accepted as an API key fallback. Supported tier values are `small`, `medium`, `large`, and `max`; the default is `medium` when no tier is configured.
+
+## Models and tiers
+
+The current catalog contains:
+
+- Doubao Seed 2.0 Mini, Lite, Code, and Pro
+- Doubao Seed Evolving
+- DeepSeek V4 Flash and Pro
+- MiniMax M2.7 and M3
+- GLM 5.2
+- Kimi K2.6, Kimi K2.7 Code, and Kimi K3
+
+Small exposes 12 models. Kimi K3 currently requires Medium or higher. Medium, Large, and Max expose all 13 current text models.
+
+## Compatibility
+
+Kimi K2.6 and Kimi K2.7 Code use Chat Completions because their Agent Plan Responses tool-call path returned repeated server errors during compatibility testing. Other catalog entries use Responses.
+
+Kimi K2.7 Code does not support disabling thinking through the current gateway. Selecting Pi's `off` level therefore avoids sending an unsupported disable control but cannot guarantee that the model stops internal reasoning.
+
+## Security
+
+Pi's standard `auth.json` is protected by filesystem permissions but is not an operating-system keychain. Do not commit credentials, paste them into issue reports, or place them in project configuration.
+
+The API key validation request never logs the key or response body. Temporary network or service failures let the user retry, cancel, or explicitly save without validation.
+
+## Development
+
+From the repository root:
+
+```bash
+pnpm --filter pi-provider-volcengine-agent-plan check
+pi --no-extensions -e ./providers/pi-provider-volcengine-agent-plan --list-models volcengine-agent-plan
+npm pack --dry-run --json ./providers/pi-provider-volcengine-agent-plan
+```
+
+Unit tests use mocked credentials and fetch responses. Real-key contract tests are intentionally excluded from normal CI.
+
+## Limitations
+
+Agent Plan does not expose a usable `/models` endpoint, so the catalog and model metadata are versioned statically. Volcengine may change aliases, protocol behavior, limits, or tier availability before this package is updated.
+
+The package currently declares text input only. Image input, extreme context windows, maximum-length output, concurrency, rate limits, and subscription quota reporting are not covered.
+
+## License
+
+MIT

--- a/providers/pi-provider-volcengine-agent-plan/README.zh-CN.md
+++ b/providers/pi-provider-volcengine-agent-plan/README.zh-CN.md
@@ -1,0 +1,107 @@
+# pi-provider-volcengine-agent-plan
+
+[English](./README.md)
+
+用于火山方舟 Agent Plan `https://ark.cn-beijing.volces.com/api/plan/v3` 的非官方 [Pi](https://github.com/badlogic/pi-mono) provider 扩展。
+
+这是社区包，与火山引擎无隶属关系，也未获得火山引擎官方背书。
+
+## 功能
+
+- 原生注册 Pi provider，并集成 `/login`。
+- 静态维护当前 13 个 Agent Plan 文本模型。
+- 按 Small、Medium、Large 和 Max 套餐过滤可用模型。
+- 默认使用 OpenAI Responses；Kimi K2.6 和 Kimi K2.7 Code 路由到 Chat Completions。
+- 已通过 Agent Plan 网关验证流式、reasoning 和工具调用。
+- 处理 MiniMax M2.7 和 Kimi K2.6 的 thinking 请求兼容性。
+- Pi 持久化登录凭证前执行零推理 API Key 校验。
+
+## 要求
+
+- Node.js 20 或更高版本。
+- Pi 和 `@earendil-works/pi-ai` 0.81.1，或兼容的 0.81 版本。
+- Agent Plan 专属 API Key。普通火山方舟 API Key 不能用于 Plan 端点。
+
+## 安装
+
+```bash
+pi install npm:pi-provider-volcengine-agent-plan
+```
+
+重启 Pi 或执行 `/reload`，然后检查模型目录：
+
+```bash
+pi --list-models volcengine-agent-plan
+```
+
+## 登录与凭证
+
+### 交互登录
+
+执行：
+
+```text
+/login volcengine-agent-plan
+```
+
+Pi 会提示输入 Agent Plan 专属 API Key 和已订阅套餐。登录流程会发送一个已鉴权但故意缺少参数的 Responses 请求：有效 Key 会到达 `MissingParameter`，无效或无权限的 Key 返回 401/403，并提示重新输入。该校验不会启动模型推理。
+
+Pi 将 API Key 和套餐保存到标准凭证文件，通常为 `~/.pi/agent/auth.json`。本包不会读取自定义 Key 文件。
+
+### 环境变量
+
+推荐使用交互登录。自动化环境也可以提供环境凭证：
+
+```bash
+export ARK_AGENT_PLAN_API_KEY='...'
+export ARK_AGENT_PLAN_TIER='medium'
+```
+
+也支持使用 `VOLCENGINE_ARK_PLAN_API_KEY` 作为 API Key fallback。套餐可取 `small`、`medium`、`large` 或 `max`；未配置套餐时默认使用 `medium`。
+
+## 模型与套餐
+
+当前目录包含：
+
+- Doubao Seed 2.0 Mini、Lite、Code 和 Pro
+- Doubao Seed Evolving
+- DeepSeek V4 Flash 和 Pro
+- MiniMax M2.7 和 M3
+- GLM 5.2
+- Kimi K2.6、Kimi K2.7 Code 和 Kimi K3
+
+Small 展示 12 个模型。Kimi K3 当前要求 Medium 或更高套餐。Medium、Large 和 Max 展示当前全部 13 个文本模型。
+
+## 兼容性
+
+Kimi K2.6 和 Kimi K2.7 Code 使用 Chat Completions，因为兼容性测试中它们通过 Agent Plan Responses 执行工具调用会重复返回服务端错误。其余目录模型使用 Responses。
+
+当前网关不支持关闭 Kimi K2.7 Code 的 thinking。Pi 选择 `off` 时，本包不会发送不受支持的禁用参数，但无法保证模型停止内部推理。
+
+## 安全
+
+Pi 标准 `auth.json` 由文件系统权限保护，但不是操作系统 Keychain。请勿提交凭证、将凭证粘贴到 issue，或把凭证写入项目配置。
+
+API Key 校验请求不会记录 Key 或响应正文。遇到临时网络或服务错误时，用户可以重试、取消，或明确选择未经验证仍然保存。
+
+## 开发
+
+在仓库根目录运行：
+
+```bash
+pnpm --filter pi-provider-volcengine-agent-plan check
+pi --no-extensions -e ./providers/pi-provider-volcengine-agent-plan --list-models volcengine-agent-plan
+npm pack --dry-run --json ./providers/pi-provider-volcengine-agent-plan
+```
+
+单元测试使用模拟凭证和 fetch 响应。需要真实 Key 的契约测试不会进入普通 CI。
+
+## 限制
+
+Agent Plan 没有可用的 `/models` 端点，因此模型目录和元数据采用静态版本维护。火山引擎可能在本包更新前修改别名、协议行为、限制或套餐权限。
+
+本包目前只声明文本输入。图片输入、极限上下文、最大长度输出、并发、限流和套餐余量展示不在当前覆盖范围内。
+
+## 许可证
+
+MIT

--- a/providers/pi-provider-volcengine-agent-plan/docs/quota-auto-refresh-design.md
+++ b/providers/pi-provider-volcengine-agent-plan/docs/quota-auto-refresh-design.md
@@ -1,0 +1,207 @@
+# Volcengine Agent Plan 扩展 · 套餐余量与 tier 自动刷新方案
+
+> 当前实现：[`../index.ts`](../index.ts)（独立 npm 子包的单文件扩展入口）。
+> 本文档仅描述尚未实现的可选增量方案，不代表当前已发布能力。
+
+## 1. 目标
+
+在现有 provider 扩展上做到"配置一次"：
+
+1. 推理照常使用 Agent Plan 专属 API Key（Bearer，数据面）。
+2. 可选配置火山引擎 Access Key（AK/SK）后：
+   - 通过管控面接口 `GetAFPUsage` **自动刷新当前订阅 tier**（替代登录时手动选择）；
+   - 在 TUI 状态栏 / 命令中展示套餐余量（5 小时 / 日 / 周 / 月四个 AFP 窗口）。
+3. 不配 AK/SK 时维持现状：tier 由用户在登录流程中手动提供。
+4. **不新增任何环境变量分支**（避免额外逻辑分支）；既有环境变量行为保持不动。
+
+## 2. 认证调研结论（为什么必须双凭证）
+
+方舟 API 分数据面与管控面（[Base URL及鉴权](https://www.volcengine.com/docs/82379/1298459)）：
+
+| 面 | 端点 | 鉴权 |
+| --- | --- | --- |
+| 数据面（推理：Chat/Responses 等） | `https://ark.cn-beijing.volces.com/api/v3`（Agent Plan 为 `/api/plan/v3`） | API Key（Bearer）或 AK/SK 签名 |
+| 管控面（`GetAFPUsage`、接入点/API Key 管理等） | `https://ark.cn-beijing.volcengineapi.com/` | **仅 AK/SK HMAC-SHA256 签名** |
+
+已排除的"单凭证"路线：
+
+| 路线 | 结论 |
+| --- | --- |
+| Agent Plan API Key（Bearer）直调管控面 | ❌ 已实测：`ark.cn-beijing.volces.com` → 404；`ark.cn-beijing.volcengineapi.com` → `InvalidAuthorization` |
+| 只用 AK/SK 签名调推理 | ❌ AK 鉴权时 `model` 必须是 `ep-xxx` 接入点 ID；Agent Plan 按模型名直调、无接入点概念，且不计入套餐额度 |
+| AK/SK 调 `GetApiKey` 换临时 key 再推理 | ❌ [GetApiKey](https://www.volcengine.com/docs/82379/1262825) 产出的是**资源绑定临时 key**（`endpoint`/`bot`/`presetendpoint`），计费走接入点按量付费（`GetUsageDetails` 中的 `OutsideOfPlan`），不走套餐 |
+| 管控面读回个人版 key 明文 | ❌ 无读回接口；仅 `RegeneratePersonalApiKey`（轮换，会使在用 key 立即失效，禁止使用） |
+
+**结论：套餐额度只认"个人版 API Key"，余量查询只认 AK/SK，两者不可互替，必须双凭证。**
+
+## 3. 依赖的管控面接口
+
+### 3.1 GetAFPUsage —— 获取套餐 AFP 额度（核心）
+
+文档：<https://docs.volcengine.com/docs/82379/2479847>
+
+```http
+POST /?Action=GetAFPUsage&Version=2024-01-01 HTTP/1.1
+Host: ark.cn-beijing.volcengineapi.com
+Content-Type: application/json; charset=UTF-8
+X-Date: 20260511T034034Z
+X-Content-Sha256: <hex>
+Authorization: HMAC-SHA256 Credential=<AK>/<yyyymmdd>/cn-beijing/ark/request, SignedHeaders=host;x-content-sha256;x-date, Signature=<hex>
+
+{}
+```
+
+无业务请求参数。响应 `Result`：
+
+| 字段 | 说明 |
+| --- | --- |
+| `PlanType` | 套餐档位：`Small` / `Medium` / `Large` / `Max`（注意首字母大写，映射到扩展内部的小写 `PlanTier`） |
+| `AFPFiveHour` / `AFPDaily` / `AFPWeekly` / `AFPMonthly` | 四个窗口，各含 `Quota`（总配额）、`Used`（已用）、`SubscribeTime`（窗口开始，epoch ms）、`ResetTime`（下次重置，epoch ms） |
+
+签名参数固定：`Service: ark`、`Region: cn-beijing`。
+
+### 3.2 签名算法要点（火山 v4，类 AWS SigV4）
+
+文档：<https://www.volcengine.com/docs/6369/67269>
+
+与 AWS SigV4 的差异：算法名 `HMAC-SHA256`；签名密钥链以 `HMAC(SK, shortDate)` 起手（无 `AWS4` 前缀），末端为字面量 `request`。
+
+```
+CanonicalRequest = METHOD \n "/" \n sortedQuery \n canonicalHeaders \n signedHeaders \n sha256hex(body)
+canonicalHeaders = "host:<host>\nx-content-sha256:<payloadHash>\nx-date:<xDate>\n"
+signedHeaders    = "host;x-content-sha256;x-date"
+StringToSign     = HMAC-SHA256 \n xDate \n "<shortDate>/cn-beijing/ark/request" \n sha256hex(CanonicalRequest)
+kSigning         = HMAC(HMAC(HMAC(HMAC(SK, shortDate), "cn-beijing"), "ark"), "request")
+Signature        = hex(HMAC(kSigning, StringToSign))
+xDate 格式        = 20260511T034034Z（ISO8601 去 - : 和毫秒）
+```
+
+Node 内置 `crypto` 即可实现（约 80 行），无需引入 `@volcengine/openapi`。
+
+### 3.3 可选接口
+
+- `GetUsageDetails`（<https://docs.volcengine.com/docs/82379/2479849>）：按模型/时间段拉用量明细，`BillingType` 区分套餐内（`WithinPlan`）/套餐外（`OutsideOfPlan`）。适合后续做按模型的用量视图，本期不实现。
+- `ListArkAgentPlanModel`：套餐支持的模型列表。可作为 `refreshModels` 的数据源替代手工维护的 CATALOG，但返回字段与模型元数据（contextWindow 等）未验证，**先不动 CATALOG**。
+
+## 4. 改造设计
+
+### 4.1 目录结构
+
+如实现本方案，将当前单文件包入口拆成以下模块：
+
+```
+providers/pi-provider-volcengine-agent-plan/
+├── docs/quota-auto-refresh-design.md  # 本文档
+├── index.ts                           # provider 注册与扩展事件
+├── volc-sign.ts                       # 火山 v4 签名（纯函数，无 IO）
+├── ark-api.ts                         # GetAFPUsage 调用与响应解析（可注入 fetch）
+└── quota-store.ts                     # 套餐信息缓存读写（见 4.4）
+```
+
+`package.json` 的 `pi.extensions` 继续只注册 `./index.ts`，避免重复加载 provider。
+
+### 4.2 AK/SK 的配置存储：复用 auth.json 的 credential.env
+
+不新增配置文件、不读环境变量，与现有 key/tier 同一体系：
+
+- 现有 login 已把 tier 存进 `credential.env[ARK_AGENT_PLAN_TIER]`；
+- 新增两个键：`ARK_AGENT_PLAN_ACCESS_KEY_ID`、`ARK_AGENT_PLAN_SECRET_ACCESS_KEY`（仅作为 credential.env 的键名，**不读取 process.env**）；
+- 事件/命令中通过 `ctx.modelRegistry.getProviderAuth(PROVIDER_ID)` 解析 provider-scoped env 取回 AK/SK（该 API 不需要已加载模型）。
+
+### 4.3 login 流程变更（auth.apiKey.login）
+
+```
+1. prompt secret：Agent Plan API Key（现状）
+2. confirm：是否配置火山 Access Key 以自动刷新套餐信息与余量？
+   ├─ 是 → prompt AK → prompt SK → 不再询问 tier（由首次自动刷新填充；
+   │        刷新失败前回退默认 medium）
+   └─ 否 → select tier（现状：small/medium/large/max）
+3. 存 credential：{ type: "api_key", key, env: { TIER_ENV?: tier, AK?: ak, SK?: sk } }
+```
+
+注意：重新执行 `/login volcengine-agent-plan` 会覆盖旧 credential，属预期行为（更新 AK/SK 的唯一入口，无需单独的"改配置"命令）。
+
+### 4.4 tier 解析优先级与缓存
+
+新增缓存文件 `<agentDir>/volcengine-agent-plan-cache.json`：
+
+```jsonc
+{
+  "planType": "Large",        // 最近一次 GetAFPUsage 返回值
+  "fetchedAt": 1778806800000, // epoch ms
+  "windows": {                 // 原样缓存四个窗口，供 status/命令渲染
+    "fiveHour": { "quota": 50, "used": 12.5, "subscribeTime": 0, "resetTime": 0 },
+    "daily":    { "quota": 100, "used": 22.5, "subscribeTime": 0, "resetTime": 0 }
+    // ...
+  }
+}
+```
+
+`<agentDir>` = `process.env.PI_CODING_AGENT_DIR ?? ~/.pi/agent`（尊重 pi 的目录覆盖，冒烟测试隔离需要）。
+
+`credentialPlanTier()`（filterModels 用，必须同步）优先级：
+
+1. 缓存文件的 `planType`（映射 `Large→large` 等，非法值忽略）；
+2. `credential.env[ARK_AGENT_PLAN_TIER]`（手动，现状）；
+3. `process.env[ARK_AGENT_PLAN_TIER]`（现状，保留不动）；
+4. 默认 `"medium"`（现状）。
+
+同步读取策略：模块级内存缓存 + mtime 检查；`refreshQuota()` 写文件后同步更新内存，保证同进程即时生效。首次加载文件不存在时直接落到 2/3/4，不报错。
+
+### 4.5 余量刷新与展示
+
+`refreshQuota(ctx, { force?: boolean })`：
+
+1. `getProviderAuth(PROVIDER_ID)` 取 env 中的 AK/SK，缺一即返回（静默，维持手动 tier 展示）；
+2. TTL 节流：距上次成功调用 < 60s 且非 `force` 则复用缓存；
+3. 调 `fetchAfpUsage()` → 写缓存文件 → 更新 status；
+4. 失败时保留旧缓存，status 显示 `Ark <tier> · quota: <错误摘要>`（下一次触发再重试，不弹窗打扰）。
+
+触发点：
+
+| 时机 | 行为 |
+| --- | --- |
+| `session_start` | 有 AK/SK 则后台刷新（不阻塞启动） |
+| `agent_settled` | TTL 节流刷新（每轮对话结束后余量已变化） |
+| `/ark-plan-quota` 命令 | `force: true` 强刷并展示详情 |
+
+Status 文案（`ctx.ui.setStatus("volcengine-agent-plan", ...)`）：
+
+- 有数据：`Ark Large · 5h 25% · D 22% · W 30% · M 42%`（百分比 = Used/Quota，已用量）
+- 仅手动 tier：`Ark Large`
+- 未配置：`Ark: /login volcengine-agent-plan`（仅当前模型属于本 provider 时显示）
+
+Status 仅在 `ctx.model?.provider === PROVIDER_ID` 时设置，切走模型时 `setStatus(id, undefined)` 清除，避免污染其他 provider 的会话。可在 `model_select` 事件里处理切换。
+
+`/ark-plan-quota` 详情输出（`ctx.ui.notify`，无 UI 模式打印）：
+
+```
+Agent Plan: Large (auto · updated 12:03)
+5h    12.5 / 50    (25%) · resets 14:30
+Day   22.5 / 100   (22%) · resets 00:00
+Week  150 / 500    (30%) · resets Mon 00:00
+Month 850.5 / 2000 (42%) · resets 06-01
+```
+
+未配 AK/SK 时命令输出当前生效 tier 及来源（manual/env/default），并提示重新 `/login` 可配置 AK/SK。
+
+### 4.6 不改动清单
+
+- CATALOG 与 `minimumTier` 过滤逻辑（`ListArkAgentPlanModel` 动态化留作后续）；
+- `before_provider_request` 中 minimax-m2.7 / kimi-k2.6 的 thinking hack；
+- 既有环境变量（`ARK_AGENT_PLAN_TIER`、`KEY_ENV_NAMES`）读取分支；
+- baseUrl、authHeader、两种 API（responses/completions）的注册方式。
+
+## 5. 验证计划
+
+1. **签名正确性**：用真实 AK/SK 对 `GetAFPUsage` 发起一次调用（或先在 [API Explorer](https://api.volcengine.com/api-docs?serviceCode=ark) 用同参数在线调试对照），确认不再 `InvalidAuthorization`；本地可用 `node --test` 对 `volc-sign.ts` 做确定性测试（固定 date 快照比对）。
+2. **加载冒烟**：`pi --no-extensions -e .pi/extensions/volcengine-agent-plan --list-models`（沿用仓库 `scripts/check-smoke.mjs` 的方式，`PI_CODING_AGENT_DIR` 指向临时目录）。
+3. **tier 联动**：配置 AK/SK 后 `/reload`，确认 `/model` 列表按 API 返回 tier 过滤（如 Large 出现 Kimi K3）；删除缓存文件后回退手动 tier。
+4. **余量渲染**：`/ark-plan-quota` 强刷，核对四个窗口数值与控制台"套餐概览"页一致。
+
+## 6. 风险与备注
+
+- **IAM 权限**：建议用子账号 AK/SK 并仅授予方舟只读类权限；`GetAFPUsage` 所需的最小 action 权限未在文档中单列，若子账号被拒，需回主账号在 IAM 中补充 `ark:GetAFPUsage`（及后续 `GetUsageDetails`）授权。
+- **文档不一致**：`GetAFPUsage` 接口文档示例 Host 写的是数据面域名 `ark.cn-beijing.volces.com`（实测 404），管控面域名 `ark.cn-beijing.volcengineapi.com` 才是正确入口。
+- **接口稳定性**：Agent Plan / Coding Plan API 是 2026 年新上的接口组，字段可能调整；`ark-api.ts` 解析应保持防御性（缺字段降级而非抛错）。
+- **多账号**：缓存文件为单账号设计；同一 agentDir 切换不同账号的 key 时，缓存会在下一次刷新时被覆盖，无需处理多账号并存。

--- a/providers/pi-provider-volcengine-agent-plan/index.ts
+++ b/providers/pi-provider-volcengine-agent-plan/index.ts
@@ -1,0 +1,515 @@
+import {
+	createProvider,
+	openAICompletionsApi,
+	openAIResponsesApi,
+	type ApiKeyCredential,
+	type AuthContext,
+	type AuthInteraction,
+	type Credential,
+	type Model,
+} from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const PROVIDER_ID = "volcengine-agent-plan";
+const BASE_URL = "https://ark.cn-beijing.volces.com/api/plan/v3";
+const TIER_ENV = "ARK_AGENT_PLAN_TIER";
+const KEY_ENV_NAMES = ["ARK_AGENT_PLAN_API_KEY", "VOLCENGINE_ARK_PLAN_API_KEY"] as const;
+const KEY_VALIDATION_URL = `${BASE_URL}/responses`;
+const KEY_VALIDATION_TIMEOUT_MS = 12_000;
+
+const ZERO_COST = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+};
+
+const RESPONSES_COMPAT = {
+	supportsDeveloperRole: true,
+	supportsLongCacheRetention: true,
+};
+
+const KIMI_CHAT_COMPAT = {
+	supportsDeveloperRole: false,
+	supportsReasoningEffort: true,
+	supportsStore: true,
+	supportsUsageInStreaming: true,
+	supportsLongCacheRetention: false,
+	maxTokensField: "max_completion_tokens" as const,
+	requiresReasoningContentOnAssistantMessages: true,
+};
+
+type ArkApi = "openai-responses" | "openai-completions";
+type PlanTier = "small" | "medium" | "large" | "max";
+
+type CatalogEntry = Omit<Model<ArkApi>, "provider" | "baseUrl"> & {
+	minimumTier: PlanTier;
+};
+
+const TIER_RANK: Record<PlanTier, number> = {
+	small: 0,
+	medium: 1,
+	large: 2,
+	max: 3,
+};
+
+const CATALOG: CatalogEntry[] = [
+	{
+		id: "doubao-seed-2.0-mini",
+		name: "Doubao Seed 2.0 Mini",
+		api: "openai-responses",
+		minimumTier: "small",
+		reasoning: true,
+		input: ["text"],
+		contextWindow: 256_000,
+		maxTokens: 128_000,
+		cost: ZERO_COST,
+		compat: RESPONSES_COMPAT,
+	},
+	{
+		id: "doubao-seed-2.0-lite",
+		name: "Doubao Seed 2.0 Lite",
+		api: "openai-responses",
+		minimumTier: "small",
+		reasoning: true,
+		input: ["text"],
+		contextWindow: 256_000,
+		maxTokens: 128_000,
+		cost: ZERO_COST,
+		compat: RESPONSES_COMPAT,
+	},
+	{
+		id: "deepseek-v4-flash",
+		name: "DeepSeek V4 Flash",
+		api: "openai-responses",
+		minimumTier: "small",
+		reasoning: true,
+		input: ["text"],
+		contextWindow: 1_024_000,
+		maxTokens: 384_000,
+		cost: ZERO_COST,
+		compat: RESPONSES_COMPAT,
+	},
+	{
+		id: "doubao-seed-evolving",
+		name: "Doubao Seed Evolving",
+		api: "openai-responses",
+		minimumTier: "small",
+		reasoning: true,
+		input: ["text"],
+		contextWindow: 1_024_000,
+		maxTokens: 256_000,
+		cost: ZERO_COST,
+		compat: RESPONSES_COMPAT,
+	},
+	{
+		id: "doubao-seed-2.0-code",
+		name: "Doubao Seed 2.0 Code",
+		api: "openai-responses",
+		minimumTier: "small",
+		reasoning: true,
+		input: ["text"],
+		contextWindow: 256_000,
+		maxTokens: 128_000,
+		cost: ZERO_COST,
+		compat: RESPONSES_COMPAT,
+	},
+	{
+		id: "doubao-seed-2.0-pro",
+		name: "Doubao Seed 2.0 Pro",
+		api: "openai-responses",
+		minimumTier: "small",
+		reasoning: true,
+		input: ["text"],
+		contextWindow: 256_000,
+		maxTokens: 128_000,
+		cost: ZERO_COST,
+		compat: RESPONSES_COMPAT,
+	},
+	{
+		id: "minimax-m2.7",
+		name: "MiniMax M2.7",
+		api: "openai-responses",
+		minimumTier: "small",
+		reasoning: true,
+		thinkingLevelMap: { off: null },
+		input: ["text"],
+		contextWindow: 200_000,
+		maxTokens: 128_000,
+		cost: ZERO_COST,
+		compat: RESPONSES_COMPAT,
+	},
+	{
+		id: "minimax-m3",
+		name: "MiniMax M3",
+		api: "openai-responses",
+		minimumTier: "small",
+		reasoning: true,
+		input: ["text"],
+		contextWindow: 512_000,
+		maxTokens: 128_000,
+		cost: ZERO_COST,
+		compat: RESPONSES_COMPAT,
+	},
+	{
+		id: "glm-5.2",
+		name: "GLM 5.2",
+		api: "openai-responses",
+		minimumTier: "small",
+		reasoning: true,
+		input: ["text"],
+		contextWindow: 1_024_000,
+		maxTokens: 128_000,
+		cost: ZERO_COST,
+		compat: RESPONSES_COMPAT,
+	},
+	{
+		id: "kimi-k2.6",
+		name: "Kimi K2.6",
+		api: "openai-completions",
+		minimumTier: "small",
+		reasoning: true,
+		thinkingLevelMap: { off: "minimal" },
+		input: ["text"],
+		contextWindow: 256_000,
+		maxTokens: 32_000,
+		cost: ZERO_COST,
+		compat: KIMI_CHAT_COMPAT,
+	},
+	{
+		id: "kimi-k2.7-code",
+		name: "Kimi K2.7 Code",
+		api: "openai-completions",
+		minimumTier: "small",
+		reasoning: true,
+		thinkingLevelMap: { off: null },
+		input: ["text"],
+		contextWindow: 256_000,
+		maxTokens: 32_000,
+		cost: ZERO_COST,
+		compat: KIMI_CHAT_COMPAT,
+	},
+	{
+		id: "deepseek-v4-pro",
+		name: "DeepSeek V4 Pro",
+		api: "openai-responses",
+		minimumTier: "small",
+		reasoning: true,
+		input: ["text"],
+		contextWindow: 1_024_000,
+		maxTokens: 384_000,
+		cost: ZERO_COST,
+		compat: RESPONSES_COMPAT,
+	},
+	{
+		id: "kimi-k3",
+		name: "Kimi K3",
+		api: "openai-responses",
+		minimumTier: "medium",
+		reasoning: true,
+		input: ["text"],
+		contextWindow: 1_024_000,
+		maxTokens: 128_000,
+		cost: ZERO_COST,
+		compat: RESPONSES_COMPAT,
+	},
+];
+
+const MINIMUM_TIER = new Map(CATALOG.map((model) => [model.id, model.minimumTier]));
+const MODELS: Model<ArkApi>[] = CATALOG.map(({ minimumTier: _minimumTier, ...model }) => ({
+	...model,
+	provider: PROVIDER_ID,
+	baseUrl: BASE_URL,
+}));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type KeyValidationResult =
+	| { status: "valid" }
+	| { status: "invalid" }
+	| { status: "unavailable"; reason: string };
+
+interface KeyValidationOptions {
+	fetchImpl?: typeof fetch;
+	signal?: AbortSignal;
+	timeoutMs?: number;
+}
+
+async function responseErrorCode(response: Response): Promise<string | undefined> {
+	try {
+		const payload: unknown = await response.json();
+		if (!isRecord(payload)) return undefined;
+		const error = payload.error;
+		if (isRecord(error) && typeof error.code === "string") return error.code;
+		return typeof payload.code === "string" ? payload.code : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export async function validateAgentPlanKey(
+	key: string,
+	options: KeyValidationOptions = {},
+): Promise<KeyValidationResult> {
+	const fetchImpl = options.fetchImpl ?? fetch;
+	const controller = new AbortController();
+	let timedOut = false;
+	const timeout = setTimeout(() => {
+		timedOut = true;
+		controller.abort();
+	}, options.timeoutMs ?? KEY_VALIDATION_TIMEOUT_MS);
+	const abortFromLogin = () => controller.abort(options.signal?.reason);
+	if (options.signal?.aborted) abortFromLogin();
+	else options.signal?.addEventListener("abort", abortFromLogin, { once: true });
+
+	try {
+		// An authenticated empty request is rejected as MissingParameter before any
+		// model inference. Invalid credentials fail earlier with 401/403, allowing
+		// login validation without consuming Agent Plan tokens.
+		const response = await fetchImpl(KEY_VALIDATION_URL, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${key}`,
+				"Content-Type": "application/json",
+			},
+			body: "{}",
+			signal: controller.signal,
+		});
+		const errorCode = await responseErrorCode(response);
+
+		if (response.status === 401 || response.status === 403) return { status: "invalid" };
+		if (response.ok || (response.status === 400 && errorCode === "MissingParameter")) {
+			return { status: "valid" };
+		}
+		return {
+			status: "unavailable",
+			reason: `HTTP ${response.status}${errorCode ? ` (${errorCode})` : ""}`,
+		};
+	} catch (error) {
+		if (options.signal?.aborted) {
+			throw options.signal.reason instanceof Error
+				? options.signal.reason
+				: new Error("Agent Plan 登录已取消");
+		}
+		return {
+			status: "unavailable",
+			reason: timedOut
+				? "请求超时"
+				: error instanceof Error
+					? error.message
+					: "未知网络错误",
+		};
+	} finally {
+		clearTimeout(timeout);
+		options.signal?.removeEventListener("abort", abortFromLogin);
+	}
+}
+
+async function promptValidatedAgentPlanKey(
+	interaction: AuthInteraction,
+	fetchImpl: typeof fetch,
+): Promise<string> {
+	keyPrompt: while (true) {
+		const key = (
+			await interaction.prompt({
+				type: "secret",
+				message: "Agent Plan API Key",
+				placeholder: "输入后将安全保存到 Pi auth.json",
+			})
+		).trim();
+		if (!key) throw new Error("Agent Plan API Key 不能为空");
+
+		while (true) {
+			interaction.notify({ type: "progress", message: "正在验证 Agent Plan API Key…" });
+			const result = await validateAgentPlanKey(key, {
+				fetchImpl,
+				signal: interaction.signal,
+			});
+			if (result.status === "valid") {
+				interaction.notify({ type: "info", message: "Agent Plan API Key 验证通过。" });
+				return key;
+			}
+			if (result.status === "invalid") {
+				interaction.notify({
+					type: "info",
+					message: "API Key 无效或无权访问 Agent Plan，请重新输入。",
+				});
+				continue keyPrompt;
+			}
+
+			const action = await interaction.prompt({
+				type: "select",
+				message: `暂时无法验证 API Key：${result.reason}`,
+				options: [
+					{ id: "retry", label: "重试", description: "再次连接 Agent Plan 验证" },
+					{ id: "save", label: "仍然保存", description: "跳过验证并在首次请求时确认" },
+				],
+			});
+			if (action === "retry") continue;
+			return key;
+		}
+	}
+}
+
+function parsePlanTier(value: unknown): PlanTier | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim().toLowerCase();
+	return normalized === "small" || normalized === "medium" || normalized === "large" || normalized === "max"
+		? normalized
+		: undefined;
+}
+
+function processPlanTier(): PlanTier {
+	return parsePlanTier(process.env[TIER_ENV]) ?? "medium";
+}
+
+function credentialPlanTier(credential: Credential | undefined): PlanTier {
+	if (credential?.type === "api_key") {
+		const stored = parsePlanTier(credential.env?.[TIER_ENV]);
+		if (stored) return stored;
+	}
+	return processPlanTier();
+}
+
+interface ResolvedKey {
+	key: string;
+	source: string;
+}
+
+async function resolveKey(ctx: AuthContext, credential?: ApiKeyCredential): Promise<ResolvedKey | undefined> {
+	const stored = credential?.key?.trim();
+	if (stored) return { key: stored, source: "Pi auth.json" };
+
+	for (const variable of KEY_ENV_NAMES) {
+		const value = (await ctx.env(variable))?.trim();
+		if (value) return { key: value, source: variable };
+	}
+
+	return undefined;
+}
+
+async function resolveTier(ctx: AuthContext, credential?: ApiKeyCredential): Promise<PlanTier> {
+	return (
+		parsePlanTier(credential?.env?.[TIER_ENV]) ??
+		parsePlanTier(await ctx.env(TIER_ENV)) ??
+		"medium"
+	);
+}
+
+function filterModelsByTier(models: readonly Model<ArkApi>[], tier: PlanTier): readonly Model<ArkApi>[] {
+	return models.filter((model) => {
+		const minimum = MINIMUM_TIER.get(model.id) ?? "small";
+		return TIER_RANK[tier] >= TIER_RANK[minimum];
+	});
+}
+
+export interface AgentPlanProviderOptions {
+	fetchImpl?: typeof fetch;
+}
+
+export function createAgentPlanProvider(options: AgentPlanProviderOptions = {}) {
+	return createProvider<ArkApi>({
+		id: PROVIDER_ID,
+		name: "Volcengine Ark Agent Plan",
+		baseUrl: BASE_URL,
+		auth: {
+			apiKey: {
+				name: "Ark Agent Plan API key",
+				async login(interaction) {
+					interaction.notify({
+						type: "info",
+						message: "请使用 Agent Plan 专属 API Key；普通方舟 API Key 不适用于该端点。",
+					});
+					const key = await promptValidatedAgentPlanKey(
+						interaction,
+						options.fetchImpl ?? fetch,
+					);
+
+					const tier = parsePlanTier(
+						await interaction.prompt({
+							type: "select",
+							message: "选择 Agent Plan 订阅级别",
+							options: [
+								{ id: "small", label: "Small", description: "隐藏 Medium 起可用的 Kimi K3" },
+								{ id: "medium", label: "Medium", description: "当前套餐；显示全部文本模型" },
+								{ id: "large", label: "Large", description: "显示全部文本模型" },
+								{ id: "max", label: "Max", description: "显示全部文本模型" },
+							],
+						}),
+					);
+					if (!tier) throw new Error("无效的 Agent Plan 订阅级别");
+
+					interaction.notify({
+						type: "progress",
+						message: "正在保存凭证并刷新 provider 状态，请稍候…",
+					});
+					return {
+						type: "api_key",
+						key,
+						env: { [TIER_ENV]: tier },
+					};
+				},
+				async check({ ctx, credential }) {
+					const resolved = await resolveKey(ctx, credential);
+					return resolved ? { type: "api_key", source: resolved.source } : undefined;
+				},
+				async resolve({ ctx, credential }) {
+					const resolved = await resolveKey(ctx, credential);
+					if (!resolved) return undefined;
+					const tier = await resolveTier(ctx, credential);
+					return {
+						auth: { apiKey: resolved.key },
+						env: { [TIER_ENV]: tier },
+						source: resolved.source,
+					};
+				},
+		},
+		},
+		models: MODELS,
+		filterModels(models, credential) {
+			return filterModelsByTier(models, credentialPlanTier(credential));
+		},
+		api: {
+			"openai-responses": openAIResponsesApi(),
+			"openai-completions": openAICompletionsApi(),
+		},
+	});
+}
+
+export default function volcengineAgentPlan(pi: ExtensionAPI) {
+	pi.registerProvider(createAgentPlanProvider());
+
+	pi.on("before_provider_request", (event, ctx) => {
+		if (ctx.model?.provider !== PROVIDER_ID || !isRecord(event.payload)) return;
+		const payload = { ...event.payload };
+
+		if (ctx.model.id === "minimax-m2.7") {
+			// The model emits standard Responses reasoning events but rejects the OpenAI
+			// `reasoning` request object. Keep reasoning enabled on the model card so Pi
+			// can render returned thinking blocks, while removing unsupported controls.
+			delete payload.reasoning;
+			if (Array.isArray(payload.include)) {
+				const include = payload.include.filter(
+					(item) => item !== "reasoning.encrypted_content",
+				);
+				if (include.length > 0) payload.include = include;
+				else delete payload.include;
+			}
+			payload.thinking = {
+				type: pi.getThinkingLevel() === "off" ? "disabled" : "enabled",
+			};
+		}
+
+		if (ctx.model.id === "kimi-k2.6") {
+			// `reasoning_effort: minimal` alone does not disable thinking through the
+			// Agent Plan gateway; this provider field is required for a real off state.
+			payload.thinking = {
+				type: pi.getThinkingLevel() === "off" ? "disabled" : "enabled",
+			};
+		}
+
+		return payload;
+	});
+}

--- a/providers/pi-provider-volcengine-agent-plan/package.json
+++ b/providers/pi-provider-volcengine-agent-plan/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "pi-provider-volcengine-agent-plan",
+  "version": "0.0.0",
+  "description": "Unofficial Pi provider extension for Volcengine Ark Agent Plan.",
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi-provider",
+    "volcengine",
+    "ark",
+    "agent-plan"
+  ],
+  "author": "zhcsyncer",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zhcsyncer/pi-extensions.git",
+    "directory": "providers/pi-provider-volcengine-agent-plan"
+  },
+  "homepage": "https://github.com/zhcsyncer/pi-extensions/tree/main/providers/pi-provider-volcengine-agent-plan#readme",
+  "bugs": {
+    "url": "https://github.com/zhcsyncer/pi-extensions/issues"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json",
+    "test": "tsx --test test/**/*.test.ts",
+    "check": "pnpm typecheck && pnpm test"
+  },
+  "files": [
+    "index.ts",
+    "README.md",
+    "README.zh-CN.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-ai": "0.81.1",
+    "@earendil-works/pi-coding-agent": "0.81.1",
+    "@types/node": "25.6.0",
+    "jiti": "2.7.0",
+    "tsx": "4.22.4",
+    "typescript": "6.0.3"
+  }
+}

--- a/providers/pi-provider-volcengine-agent-plan/test/provider.test.ts
+++ b/providers/pi-provider-volcengine-agent-plan/test/provider.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+	moduleCache: false,
+	alias: {
+		"@earendil-works/pi-ai": fileURLToPath(
+			new URL("../node_modules/@earendil-works/pi-ai/dist/compat.js", import.meta.url),
+		),
+	},
+});
+const extension = await jiti.import<typeof import("../index.ts")>(
+	fileURLToPath(new URL("../index.ts", import.meta.url)),
+);
+const {
+	default: volcengineAgentPlan,
+	createAgentPlanProvider,
+	validateAgentPlanKey,
+} = extension;
+
+function errorResponse(status: number, code: string): Response {
+	return new Response(JSON.stringify({ error: { code } }), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+test("validates keys without starting inference", async () => {
+	const valid = await validateAgentPlanKey("valid", {
+		fetchImpl: async (_input, init) => {
+			assert.equal(init?.method, "POST");
+			assert.equal(init?.body, "{}");
+			assert.equal(new Headers(init?.headers).get("Authorization"), "Bearer valid");
+			return errorResponse(400, "MissingParameter");
+		},
+	});
+	assert.deepEqual(valid, { status: "valid" });
+
+	const invalid = await validateAgentPlanKey("invalid", {
+		fetchImpl: async () => errorResponse(401, "AuthenticationError"),
+	});
+	assert.deepEqual(invalid, { status: "invalid" });
+
+	const forbidden = await validateAgentPlanKey("forbidden", {
+		fetchImpl: async () => errorResponse(403, "Forbidden"),
+	});
+	assert.deepEqual(forbidden, { status: "invalid" });
+});
+
+test("reports temporary validation failures without exposing the key", async () => {
+	const result = await validateAgentPlanKey("never-log-this", {
+		fetchImpl: async () => {
+			throw new Error("network unavailable");
+		},
+	});
+	assert.deepEqual(result, {
+		status: "unavailable",
+		reason: "network unavailable",
+	});
+	assert.doesNotMatch(JSON.stringify(result), /never-log-this/);
+});
+
+test("re-prompts an invalid key and stores the selected tier", async () => {
+	const provider = createAgentPlanProvider({
+		fetchImpl: async (_input, init) => {
+			const authorization = new Headers(init?.headers).get("Authorization");
+			return authorization === "Bearer valid-key"
+				? errorResponse(400, "MissingParameter")
+				: errorResponse(401, "AuthenticationError");
+		},
+	});
+	const login = provider.auth.apiKey?.login;
+	assert.ok(login);
+
+	let secretPrompts = 0;
+	const notifications: string[] = [];
+	const credential = await login({
+		async prompt(prompt) {
+			if (prompt.type === "secret") {
+				secretPrompts += 1;
+				return secretPrompts === 1 ? "invalid-key" : "valid-key";
+			}
+			if (prompt.type === "select") return "medium";
+			throw new Error(`Unexpected prompt type: ${prompt.type}`);
+		},
+		notify(event) {
+			if ("message" in event) notifications.push(event.message);
+		},
+	});
+
+	assert.equal(secretPrompts, 2);
+	assert.equal(credential.type, "api_key");
+	assert.equal(credential.key, "valid-key");
+	assert.equal(credential.env?.ARK_AGENT_PLAN_TIER, "medium");
+	assert.ok(notifications.some((message) => message.includes("请重新输入")));
+	assert.ok(notifications.some((message) => message.includes("验证通过")));
+});
+
+test("allows an explicit save when validation is temporarily unavailable", async () => {
+	const provider = createAgentPlanProvider({
+		fetchImpl: async () => {
+			throw new Error("temporary outage");
+		},
+	});
+	const login = provider.auth.apiKey?.login;
+	assert.ok(login);
+
+	const prompts: string[] = [];
+	const credential = await login({
+		async prompt(prompt) {
+			prompts.push(prompt.type);
+			if (prompt.type === "secret") return "unchecked-key";
+			if (prompt.type === "select" && prompt.message.startsWith("暂时无法验证")) return "save";
+			if (prompt.type === "select") return "small";
+			throw new Error(`Unexpected prompt type: ${prompt.type}`);
+		},
+		notify() {},
+	});
+
+	assert.deepEqual(prompts, ["secret", "select", "select"]);
+	assert.equal(credential.key, "unchecked-key");
+	assert.equal(credential.env?.ARK_AGENT_PLAN_TIER, "small");
+});
+
+test("filters the static catalog by tier and resolves standard auth", async () => {
+	const provider = createAgentPlanProvider();
+	const models = provider.getModels();
+	assert.equal(models.length, 13);
+	assert.equal(models.filter((model) => model.api === "openai-completions").length, 2);
+	assert.equal(models.filter((model) => model.api === "openai-responses").length, 11);
+
+	const smallCredential = {
+		type: "api_key" as const,
+		key: "stored-key",
+		env: { ARK_AGENT_PLAN_TIER: "small" },
+	};
+	const mediumCredential = {
+		type: "api_key" as const,
+		key: "stored-key",
+		env: { ARK_AGENT_PLAN_TIER: "medium" },
+	};
+	const smallModels = provider.filterModels?.(models, smallCredential) ?? [];
+	const mediumModels = provider.filterModels?.(models, mediumCredential) ?? [];
+	assert.equal(smallModels.length, 12);
+	assert.equal(smallModels.some((model) => model.id === "kimi-k3"), false);
+	assert.equal(mediumModels.length, 13);
+
+	const ctx = {
+		async env() { return undefined; },
+		async fileExists() { return false; },
+	};
+	const auth = await provider.auth.apiKey?.resolve({ ctx, credential: mediumCredential });
+	assert.equal(auth?.auth.apiKey, "stored-key");
+	assert.equal(auth?.env?.ARK_AGENT_PLAN_TIER, "medium");
+	assert.equal(auth?.source, "Pi auth.json");
+	assert.equal(await provider.auth.apiKey?.check?.({ ctx }), undefined);
+});
+
+test("applies MiniMax and Kimi request compatibility hooks", () => {
+	let requestHook: ((event: any, ctx: any) => unknown) | undefined;
+	const pi = {
+		registerProvider() {},
+		on(event: string, handler: (event: any, ctx: any) => unknown) {
+			if (event === "before_provider_request") requestHook = handler;
+		},
+		getThinkingLevel() { return "off"; },
+	} as unknown as ExtensionAPI;
+	volcengineAgentPlan(pi);
+	assert.ok(requestHook);
+
+	const minimax = requestHook(
+		{
+			payload: {
+				reasoning: { effort: "high" },
+				include: ["reasoning.encrypted_content", "message.output_text.logprobs"],
+			},
+		},
+		{ model: { provider: "volcengine-agent-plan", id: "minimax-m2.7" } },
+	) as Record<string, unknown>;
+	assert.equal("reasoning" in minimax, false);
+	assert.deepEqual(minimax.include, ["message.output_text.logprobs"]);
+	assert.deepEqual(minimax.thinking, { type: "disabled" });
+
+	const kimi = requestHook(
+		{ payload: { reasoning_effort: "minimal" } },
+		{ model: { provider: "volcengine-agent-plan", id: "kimi-k2.6" } },
+	) as Record<string, unknown>;
+	assert.deepEqual(kimi.thinking, { type: "disabled" });
+});

--- a/providers/pi-provider-volcengine-agent-plan/tsconfig.json
+++ b/providers/pi-provider-volcengine-agent-plan/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "paths": {
+      "@earendil-works/pi-ai": ["./node_modules/@earendil-works/pi-ai/dist/compat.d.ts"]
+    },
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["index.ts", "test/**/*.ts"]
+}

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -11,6 +11,7 @@ const packagePaths = [
 	"./packages/pi-tool-display-intent",
 	"./packages/pi-todo",
 	"./packages/pi-search-hub",
+	"./providers/pi-provider-volcengine-agent-plan",
 ];
 
 const requiredPackFiles = new Map([
@@ -21,6 +22,12 @@ const requiredPackFiles = new Map([
 		"packages/pi-search-hub/README.zh-CN.md",
 	]],
 	["./packages/pi-search-hub", ["README.md", "README.zh-CN.md"]],
+	["./providers/pi-provider-volcengine-agent-plan", [
+		"index.ts",
+		"README.md",
+		"README.zh-CN.md",
+		"LICENSE",
+	]],
 ]);
 const maintainedReadmes = [
 	".changeset/README.md",
@@ -30,6 +37,8 @@ const maintainedReadmes = [
 	"packages/pi-recap/README.zh-CN.md",
 	"packages/pi-search-hub/README.md",
 	"packages/pi-search-hub/README.zh-CN.md",
+	"providers/pi-provider-volcengine-agent-plan/README.md",
+	"providers/pi-provider-volcengine-agent-plan/README.zh-CN.md",
 	"packages/pi-todo/README.md",
 	"packages/pi-tool-display-intent/README.md",
 	"packages/pi-tool-display-intent/README.zh-CN.md",
@@ -58,6 +67,10 @@ await assertBilingualPair("README.md", "README.zh-CN.md");
 await assertBilingualPair(
 	"packages/pi-search-hub/README.md",
 	"packages/pi-search-hub/README.zh-CN.md",
+);
+await assertBilingualPair(
+	"providers/pi-provider-volcengine-agent-plan/README.md",
+	"providers/pi-provider-volcengine-agent-plan/README.zh-CN.md",
 );
 for (const readmePath of maintainedReadmes) {
 	const readme = await readFile(resolve(repositoryRoot, readmePath), "utf8");

--- a/scripts/check-smoke.mjs
+++ b/scripts/check-smoke.mjs
@@ -10,23 +10,66 @@ const packagePaths = [
 	"./packages/pi-tool-display-intent",
 	"./packages/pi-todo",
 	"./packages/pi-search-hub",
+	"./providers/pi-provider-volcengine-agent-plan",
 ];
 
 try {
+	const providerCheck = spawnSync(
+		"pnpm",
+		["--filter", "pi-provider-volcengine-agent-plan", "check"],
+		{ stdio: "inherit" },
+	);
+	if (providerCheck.error) throw providerCheck.error;
+	if (providerCheck.status !== 0) process.exit(providerCheck.status ?? 1);
+
 	for (const packagePath of packagePaths) {
+		const isAgentPlan = packagePath === "./providers/pi-provider-volcengine-agent-plan";
+		const piArgs = [
+			"--no-extensions",
+			"-e",
+			isAgentPlan ? "." : packagePath,
+			"--list-models",
+			isAgentPlan ? "volcengine-agent-plan" : "__pi_release_check__",
+		];
 		const result = spawnSync(
-			"pi",
-			["--no-extensions", "-e", packagePath, "--list-models", "__pi_release_check__"],
+			isAgentPlan ? "pnpm" : "pi",
+			isAgentPlan
+				? ["--filter", "pi-provider-volcengine-agent-plan", "exec", "pi", ...piArgs]
+				: piArgs,
 			{
 				env: {
 					...process.env,
 					PI_CODING_AGENT_DIR: isolatedAgentDir,
+					...(isAgentPlan
+						? {
+							ARK_AGENT_PLAN_API_KEY: "release-smoke-test-key",
+							ARK_AGENT_PLAN_TIER: "small",
+						}
+						: {}),
 				},
-				stdio: "inherit",
+				stdio: isAgentPlan ? "pipe" : "inherit",
+				encoding: isAgentPlan ? "utf8" : undefined,
 			},
 		);
 		if (result.error) throw result.error;
-		if (result.status !== 0) process.exit(result.status ?? 1);
+		if (result.status !== 0) {
+			if (isAgentPlan) {
+				process.stderr.write(result.stderr ?? "");
+				process.stderr.write(result.stdout ?? "");
+			}
+			process.exit(result.status ?? 1);
+		}
+		if (isAgentPlan) {
+			const modelCount = (result.stdout ?? "")
+				.split("\n")
+				.filter((line) => line.startsWith("volcengine-agent-plan ")).length;
+			if (modelCount !== 12) {
+				process.stderr.write(result.stderr ?? "");
+				process.stderr.write(result.stdout ?? "");
+				throw new Error(`Agent Plan Small smoke expected 12 models, received ${modelCount}`);
+			}
+			console.log(`${packagePath}: Pi 0.81 Small catalog smoke passed (${modelCount} models)`);
+		}
 	}
 } finally {
 	rmSync(isolatedAgentDir, { recursive: true, force: true });

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${NPM_BOOTSTRAP_TOKEN:-}" ]]; then
+  echo "Publishing with the one-time npm bootstrap token."
+  export NODE_AUTH_TOKEN="$NPM_BOOTSTRAP_TOKEN"
+  # npm prefers GitHub OIDC when these variables are present. A package cannot
+  # configure a trusted publisher until after its first publish, so force token
+  # auth only for the explicitly configured bootstrap run.
+  unset ACTIONS_ID_TOKEN_REQUEST_TOKEN
+  unset ACTIONS_ID_TOKEN_REQUEST_URL
+else
+  echo "Publishing with npm trusted publishing (OIDC)."
+  unset NODE_AUTH_TOKEN
+fi
+
+pnpm release

--- a/scripts/reconcile-release.sh
+++ b/scripts/reconcile-release.sh
@@ -6,6 +6,7 @@ PACKAGES=(
   "@zhcsyncer/pi-recap|packages/pi-recap/package.json|packages/pi-recap/CHANGELOG.md|pi-recap|child"
   "@zhcsyncer/pi-tool-display-intent|packages/pi-tool-display-intent/package.json|packages/pi-tool-display-intent/CHANGELOG.md|pi-tool-display-intent|child"
   "@zhcsyncer/pi-todo|packages/pi-todo/package.json|packages/pi-todo/CHANGELOG.md|pi-todo|child"
+  "pi-provider-volcengine-agent-plan|providers/pi-provider-volcengine-agent-plan/package.json|providers/pi-provider-volcengine-agent-plan/CHANGELOG.md|pi-provider-volcengine-agent-plan|child"
 )
 
 wait_for_package() {

--- a/scripts/release-policy.test.mjs
+++ b/scripts/release-policy.test.mjs
@@ -7,6 +7,7 @@ const ROOT = "@zhcsyncer/pi-extensions";
 const RECAP = "@zhcsyncer/pi-recap";
 const INTENT = "@zhcsyncer/pi-tool-display-intent";
 const TODO = "@zhcsyncer/pi-todo";
+const AGENT_PLAN = "pi-provider-volcengine-agent-plan";
 
 function releases(...entries) {
 	return {
@@ -20,6 +21,10 @@ test("allows an empty release plan", () => {
 
 test("allows the root package to release independently", () => {
 	assert.deepEqual(validateReleasePolicy(releases([ROOT, "patch"])), []);
+});
+
+test("allows the standalone Agent Plan provider to release without the root", () => {
+	assert.deepEqual(validateReleasePolicy(releases([AGENT_PLAN, "patch"])), []);
 });
 
 test("requires the root package when recap releases", () => {


### PR DESCRIPTION
## Summary

- publish `pi-provider-volcengine-agent-plan` as a standalone, unscoped Pi package
- register 13 tier-aware Agent Plan text models with Responses/Chat routing and compatibility hooks
- add native `/login`, standard `auth.json` persistence, and zero-inference API key validation
- add mocked unit tests, Pi 0.81 catalog smoke, npm pack checks, and first-publish token/OIDC workflow support
- keep the provider outside the aggregate root npm tarball under `providers/`

## Release plan

- `pi-provider-volcengine-agent-plan`: `0.0.0` → `0.1.0` (minor)
- no `@zhcsyncer/pi-extensions` release

## Validation

- `pnpm check`
- 6 provider unit tests
- Pi 0.81 Small catalog smoke: 12 models
- npm pack dry run: 5 files
- root tarball provider files: 0
- real Responses smoke through standard Pi `auth.json`
- credential leakage scan
