### PR TITLE
ci: bootstrap new npm packages with token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,9 @@ jobs:
         id: changesets
         uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0
         env:
-          NPM_BOOTSTRAP_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+          # Temporary fallback for the first publish of a new package; remove it
+          # after @zhcsyncer/pi-glance has a trusted publisher configured.
+          NPM_BOOTSTRAP_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN || secrets.NPM_TOKEN }}
         with:
           version: pnpm version-packages
           publish: bash scripts/publish-packages.sh


### PR DESCRIPTION
## Summary

- reuse the existing `NPM_TOKEN` secret as a fallback bootstrap credential
- keep `NPM_BOOTSTRAP_TOKEN` as the preferred explicit credential
- document that the fallback must be removed after the first `@zhcsyncer/pi-glance` publish and trusted publisher setup

The previous Release run was cancelled during validation, before its publish step, because the unpublished package cannot use OIDC until its first npm publish.