### PR TITLE
docs: track package discoverability follow-up

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,3 +21,15 @@ Repository-level follow-up work that should remain discoverable across sessions.
   - Both language versions stay structurally aligned and link to one another.
   - Package file lists and pack checks include both language versions where applicable.
   - Add an appropriate changeset if the documentation update accompanies user-visible behavior changes.
+
+## Next related package release
+
+- [ ] Refresh npm / Pi Package Gallery discoverability alongside the next otherwise-needed package change; do not cut a standalone release only to force reindexing.
+
+  Acceptance criteria:
+
+  - Expand `@zhcsyncer/pi-todo` metadata with broader Pi and task-planning search terms such as `pi`, `pi-coding-agent`, `task-management`, and `planning`.
+  - Recheck `@zhcsyncer/pi-glance` and include equivalent metadata improvements if its npm search score is still zero.
+  - Publish the metadata update through the normal Changesets version PR flow together with the next related user-visible release.
+  - After publishing, verify exact-package and keyword queries through the npm registry search API and the `pi.dev/packages` catalog, while retaining working direct package pages and install commands.
+  - If either package remains absent after npm has reindexed the new version, report the indexing issue upstream with the observed zero search score and direct-page evidence.


### PR DESCRIPTION
## Summary

- record the npm / Pi Package Gallery indexing issue for `pi-todo` and potentially `pi-glance`
- explicitly defer metadata changes until the next otherwise-needed package release
- capture verification and upstream-reporting acceptance criteria

No package versions or release metadata are changed.