### PR TITLE
ci: isolate npm bootstrap publishing

### DIFF
--- a/.github/workflows/bootstrap-npm-package.yml
+++ b/.github/workflows/bootstrap-npm-package.yml
@@ -1,0 +1,60 @@
+name: Bootstrap npm package
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Exact public workspace package name to create on npm
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-bootstrap-${{ inputs.package }}
+  cancel-in-progress: false
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: npm-bootstrap
+
+    steps:
+      - name: Require main workflow ref
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Bootstrap npm package must be dispatched from main, not $GITHUB_REF." >&2
+          exit 1
+
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Set up npm publishing client
+        run: npm install --global npm@11.18.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate repository packages
+        run: pnpm check
+
+      - name: Bootstrap exact npm package
+        env:
+          BOOTSTRAP_PACKAGE: ${{ inputs.package }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+        run: node scripts/bootstrap-npm-package.mjs "$BOOTSTRAP_PACKAGE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,6 @@ jobs:
       - name: Create version PR or publish packages
         id: changesets
         uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0
-        env:
-          # Temporary fallback for the first publish of a new package; remove it
-          # after @zhcsyncer/pi-glance has a trusted publisher configured.
-          NPM_BOOTSTRAP_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN || secrets.NPM_TOKEN }}
         with:
           version: pnpm version-packages
           publish: bash scripts/publish-packages.sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,13 +28,20 @@ The release workflow uses OIDC and does not normally require an `NPM_TOKEN`. npm
 
 ### Bootstrap a new npm package
 
-npm trusted publishing can only be configured after a package exists. A new package must still be published through the Changesets version-PR flow:
+npm trusted publishing can only be configured after a package exists. Normal releases never receive an npm token: before publishing, `scripts/check-unbootstrapped-packages.mjs` stops the release if any public workspace package does not yet exist on npm. This happens before `changeset publish`, preventing a partial release.
 
-1. Create a short-lived granular npm token that can create the new package and publish its first version. An unscoped, not-yet-created package may require temporary read/write access to all packages owned by the account because it cannot yet be selected by name.
-2. Store the token as the repository secret `NPM_BOOTSTRAP_TOKEN`. Do not expose it to pull-request workflows.
-3. Review and merge the generated `chore: version packages` PR. `scripts/publish-packages.sh` detects the bootstrap secret, disables OIDC for that publish command, and lets `changeset publish` perform the first publish. Do not run `npm publish` manually.
-4. Configure the new package's trusted publisher immediately after the first publish, using `release.yml` and the `npm publish` allowed action.
-5. Delete the `NPM_BOOTSTRAP_TOKEN` repository secret and revoke the npm token. With no bootstrap secret, the same script uses trusted publishing (OIDC) for normal releases.
+Create a protected GitHub Environment named `npm-bootstrap`, require reviewer approval, and store a short-lived granular token there as `NPM_BOOTSTRAP_TOKEN`. Only `.github/workflows/bootstrap-npm-package.yml` can use it.
+
+A new package must still pass through the Changesets version-PR flow:
+
+1. Merge the package and its changeset into `main`, then review and merge the generated `chore: version packages` PR.
+2. The normal release job stops safely because the package does not exist on npm.
+3. Run **Bootstrap npm package** from `main` and enter the exact workspace package name. The workflow verifies a clean `main` checkout, a public workspace manifest, a non-`0.0.0` version with a matching changelog entry, and that the package name is still absent from npm. It publishes only that exact package.
+4. Configure the new package's npm Trusted Publisher immediately, using `release.yml` and the `npm publish` allowed action.
+5. Re-run the previously failed normal release job. Changesets skips the already-published bootstrap version, publishes any remaining versions through OIDC, and release reconciliation creates the package tag and GitHub Release.
+6. Revoke the short-lived token and clear the `NPM_BOOTSTRAP_TOKEN` Environment secret until another new package needs its first publish.
+
+Do not run `npm publish` locally and do not expose the bootstrap token to the normal release or pull-request workflows.
 
 ### Allow Actions to create pull requests
 
@@ -67,7 +74,8 @@ Do not push the release-bearing change to `main`, merge the generated version PR
 1. Changes with one or more changesets land on `main`.
 2. `.github/workflows/release.yml` creates or updates `chore: version packages`.
 3. Review and merge that version PR when ready to release.
-4. The workflow validates and publishes every planned package version not already present on npm.
-5. The workflow reconciles package tags and creates GitHub Releases for the packages published in that plan.
+4. The workflow validates that every public workspace package already exists on npm, then publishes every planned package version through OIDC.
+5. For a new package, follow the protected bootstrap flow above and re-run the stopped release job.
+6. The workflow reconciles package tags and creates GitHub Releases for the packages published in that plan.
 
 Publishing and release reconciliation are idempotent. If npm publishing partially succeeds or GitHub Release creation fails, rerun the failed workflow job.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "version-packages": "changeset version",
     "release": "changeset publish",
     "check": "pnpm check:release-policy && pnpm check:smoke && pnpm check:pack",
-    "check:release-policy": "node --test scripts/release-policy.test.mjs && node scripts/check-release-policy.mjs",
+    "check:release-policy": "node --test scripts/release-policy.test.mjs scripts/npm-bootstrap.test.mjs && node scripts/check-release-policy.mjs",
     "check:smoke": "node scripts/check-smoke.mjs",
     "check:pack": "node scripts/check-pack.mjs"
   },

--- a/scripts/bootstrap-npm-package.mjs
+++ b/scripts/bootstrap-npm-package.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import {
+	assertVersionPrApplied,
+	discoverWorkspacePackages,
+	packageExistsOnRegistry,
+	selectBootstrapPackage,
+} from "./npm-bootstrap-lib.mjs";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const requestedName = process.argv[2];
+
+function run(command, args, options = {}) {
+	const result = spawnSync(command, args, {
+		cwd: options.cwd ?? repositoryRoot,
+		encoding: options.capture ? "utf8" : undefined,
+		stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+		env: process.env,
+	});
+	if (result.error) throw result.error;
+	if (result.status !== 0) {
+		const detail = options.capture ? `: ${(result.stderr || result.stdout || "").trim()}` : "";
+		throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status}${detail}`);
+	}
+	return options.capture ? result.stdout.trim() : "";
+}
+
+if (!process.env.NODE_AUTH_TOKEN?.trim()) {
+	throw new Error("NODE_AUTH_TOKEN is missing. Configure NPM_BOOTSTRAP_TOKEN in the protected npm-bootstrap environment.");
+}
+if (process.env.GITHUB_ACTIONS === "true" && process.env.GITHUB_REF !== "refs/heads/main") {
+	throw new Error(`Bootstrap publishing must run from main, not ${process.env.GITHUB_REF || "an unknown ref"}.`);
+}
+
+const status = run("git", ["status", "--porcelain"], { capture: true });
+if (status) throw new Error("Bootstrap checkout is not clean; refusing to publish.");
+const head = run("git", ["rev-parse", "HEAD"], { capture: true });
+const remoteMain = run("git", ["rev-parse", "origin/main"], { capture: true });
+if (head !== remoteMain) throw new Error("Bootstrap checkout does not match origin/main.");
+
+const packages = await discoverWorkspacePackages(repositoryRoot);
+const selected = selectBootstrapPackage(packages, requestedName);
+if (await packageExistsOnRegistry(selected.name)) {
+	throw new Error(`${selected.name} already exists on npm. Publish future versions through the normal OIDC release workflow.`);
+}
+
+let changelog;
+try {
+	changelog = await readFile(join(selected.directory, "CHANGELOG.md"), "utf8");
+} catch (error) {
+	throw new Error(`${selected.name} must have a CHANGELOG.md produced by the Changesets version PR.`);
+}
+assertVersionPrApplied(selected, changelog);
+
+console.log(`Bootstrap publishing ${selected.name}@${selected.version} from ${selected.directory}`);
+run("npm", ["pack", "--dry-run"], { cwd: selected.directory });
+run("npm", ["publish", "--access", "public"], { cwd: selected.directory });
+
+console.log("");
+console.log(`Bootstrap publish completed for ${selected.name}@${selected.version}.`);
+console.log("Next steps:");
+console.log("1. Configure this package's npm Trusted Publisher for .github/workflows/release.yml.");
+console.log("2. Re-run the previously failed normal release job so OIDC publishing and release reconciliation can finish.");

--- a/scripts/check-unbootstrapped-packages.mjs
+++ b/scripts/check-unbootstrapped-packages.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { discoverWorkspacePackages, findUnbootstrappedPackages } from "./npm-bootstrap-lib.mjs";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const packages = await discoverWorkspacePackages(repositoryRoot);
+const missing = await findUnbootstrappedPackages(packages);
+
+if (missing.length === 0) {
+	console.log("All public workspace packages already exist on npm; continuing with OIDC publishing.");
+} else {
+	console.error("Normal OIDC publishing stopped before any package was published.");
+	console.error("The following public workspace packages need a one-time npm bootstrap publish:");
+	for (const pkg of missing) console.error(`- ${pkg.name}@${pkg.version}`);
+	console.error("");
+	console.error("For each package:");
+	console.error('1. Run the GitHub Actions workflow "Bootstrap npm package" from main.');
+	console.error("2. Configure that package's npm Trusted Publisher for .github/workflows/release.yml.");
+	console.error("3. Re-run this failed release job; normal publishing will then use OIDC.");
+	process.exitCode = 1;
+}

--- a/scripts/npm-bootstrap-lib.mjs
+++ b/scripts/npm-bootstrap-lib.mjs
@@ -1,0 +1,95 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const WORKSPACE_PARENT_DIRECTORIES = ["packages", "providers"];
+
+async function readManifest(directory) {
+	const manifestPath = join(directory, "package.json");
+	try {
+		const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+		if (!manifest.name || !manifest.version) return undefined;
+		return {
+			name: manifest.name,
+			version: manifest.version,
+			private: manifest.private === true,
+			publishConfig: manifest.publishConfig,
+			directory,
+			manifestPath,
+		};
+	} catch (error) {
+		if (error?.code === "ENOENT") return undefined;
+		throw new Error(`Failed to read ${manifestPath}: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+export async function discoverWorkspacePackages(repositoryRoot) {
+	const root = resolve(repositoryRoot);
+	const directories = [root];
+	for (const parentName of WORKSPACE_PARENT_DIRECTORIES) {
+		const parent = join(root, parentName);
+		let entries;
+		try {
+			entries = await readdir(parent, { withFileTypes: true });
+		} catch (error) {
+			if (error?.code === "ENOENT") continue;
+			throw error;
+		}
+		for (const entry of entries) {
+			if (entry.isDirectory()) directories.push(join(parent, entry.name));
+		}
+	}
+
+	const packages = (await Promise.all(directories.map(readManifest))).filter(Boolean);
+	return packages.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function selectBootstrapPackage(packages, requestedName) {
+	if (!requestedName?.trim() || requestedName !== requestedName.trim()) {
+		throw new Error("Provide one exact workspace package name.");
+	}
+	const selected = packages.find((pkg) => pkg.name === requestedName);
+	if (!selected) throw new Error(`Unknown workspace package: ${requestedName}`);
+	if (selected.private) throw new Error(`${requestedName} is private and cannot be published.`);
+	return selected;
+}
+
+export function registryPackageUrl(packageName, registry = process.env.npm_config_registry || "https://registry.npmjs.org") {
+	const base = registry.endsWith("/") ? registry : `${registry}/`;
+	return new URL(encodeURIComponent(packageName), base).toString();
+}
+
+export async function packageExistsOnRegistry(packageName, options = {}) {
+	const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+	if (typeof fetchImpl !== "function") throw new Error("A fetch implementation is required.");
+	const response = await fetchImpl(registryPackageUrl(packageName, options.registry), {
+		headers: { Accept: "application/json", "User-Agent": "pi-extensions-release-check" },
+	});
+	if (response.status === 200) return true;
+	if (response.status === 404) return false;
+	const body = await response.text().catch(() => "");
+	throw new Error(
+		`npm registry lookup failed for ${packageName}: HTTP ${response.status}${body ? ` ${body.slice(0, 200)}` : ""}`,
+	);
+}
+
+export async function findUnbootstrappedPackages(packages, options = {}) {
+	const publicPackages = packages.filter((pkg) => !pkg.private);
+	const states = await Promise.all(publicPackages.map(async (pkg) => ({
+		pkg,
+		exists: await packageExistsOnRegistry(pkg.name, options),
+	})));
+	return states.filter((state) => !state.exists).map((state) => state.pkg);
+}
+
+export function assertVersionPrApplied(pkg, changelogContent) {
+	if (pkg.version === "0.0.0") {
+		throw new Error(`${pkg.name} is still at 0.0.0. Merge its Changesets version PR before bootstrap publishing.`);
+	}
+	const escapedVersion = pkg.version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const heading = new RegExp(`^## ${escapedVersion}(?:\\s|$)`, "m");
+	if (!heading.test(changelogContent)) {
+		throw new Error(
+			`${pkg.name}@${pkg.version} is missing a matching CHANGELOG.md entry. Merge its Changesets version PR first.`,
+		);
+	}
+}

--- a/scripts/npm-bootstrap.test.mjs
+++ b/scripts/npm-bootstrap.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import {
+	assertVersionPrApplied,
+	discoverWorkspacePackages,
+	findUnbootstrappedPackages,
+	packageExistsOnRegistry,
+	registryPackageUrl,
+	selectBootstrapPackage,
+} from "./npm-bootstrap-lib.mjs";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+async function writeManifest(directory, manifest) {
+	await mkdir(directory, { recursive: true });
+	await writeFile(join(directory, "package.json"), JSON.stringify(manifest));
+}
+
+test("discovers root, package, and provider manifests while retaining private state", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-bootstrap-discovery-"));
+	try {
+		await writeManifest(root, { name: "root-package", version: "1.0.0" });
+		await writeManifest(join(root, "packages", "public"), { name: "public-package", version: "0.1.0" });
+		await writeManifest(join(root, "packages", "private"), { name: "private-package", version: "0.1.0", private: true });
+		await writeManifest(join(root, "providers", "provider"), { name: "provider-package", version: "0.2.0" });
+		await mkdir(join(root, "packages", "without-manifest"), { recursive: true });
+
+		const packages = await discoverWorkspacePackages(root);
+		assert.deepEqual(packages.map((pkg) => [pkg.name, pkg.private]), [
+			["private-package", true],
+			["provider-package", false],
+			["public-package", false],
+			["root-package", false],
+		]);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("selects only an exact public workspace package", () => {
+	const packages = [
+		{ name: "public-package", private: false },
+		{ name: "private-package", private: true },
+	];
+	assert.equal(selectBootstrapPackage(packages, "public-package").name, "public-package");
+	assert.throws(() => selectBootstrapPackage(packages, " public-package"), /exact workspace package name/);
+	assert.throws(() => selectBootstrapPackage(packages, "missing"), /Unknown workspace package/);
+	assert.throws(() => selectBootstrapPackage(packages, "private-package"), /private/);
+});
+
+test("encodes scoped package names for registry lookup", () => {
+	assert.equal(
+		registryPackageUrl("@scope/package", "https://registry.example.test"),
+		"https://registry.example.test/%40scope%2Fpackage",
+	);
+});
+
+test("distinguishes existing, missing, and failed registry lookups", async () => {
+	assert.equal(await packageExistsOnRegistry("exists", {
+		fetchImpl: async () => ({ status: 200 }),
+	}), true);
+	assert.equal(await packageExistsOnRegistry("missing", {
+		fetchImpl: async () => ({ status: 404 }),
+	}), false);
+	await assert.rejects(
+		packageExistsOnRegistry("broken", {
+			fetchImpl: async () => ({ status: 503, text: async () => "unavailable" }),
+		}),
+		/HTTP 503 unavailable/,
+	);
+});
+
+test("preflight reports only missing public packages", async () => {
+	const packages = [
+		{ name: "existing", private: false },
+		{ name: "missing", private: false },
+		{ name: "private", private: true },
+	];
+	const missing = await findUnbootstrappedPackages(packages, {
+		fetchImpl: async (url) => ({ status: url.endsWith("missing") ? 404 : 200 }),
+		registry: "https://registry.example.test",
+	});
+	assert.deepEqual(missing.map((pkg) => pkg.name), ["missing"]);
+});
+
+test("isolates token auth to the protected manual bootstrap workflow", async () => {
+	const releaseWorkflow = await readFile(join(repositoryRoot, ".github", "workflows", "release.yml"), "utf8");
+	const bootstrapWorkflow = await readFile(
+		join(repositoryRoot, ".github", "workflows", "bootstrap-npm-package.yml"),
+		"utf8",
+	);
+	const publishScript = await readFile(join(repositoryRoot, "scripts", "publish-packages.sh"), "utf8");
+
+	assert.doesNotMatch(releaseWorkflow, /NPM_(?:BOOTSTRAP_)?TOKEN|NODE_AUTH_TOKEN/);
+	assert.match(bootstrapWorkflow, /environment: npm-bootstrap/);
+	assert.match(bootstrapWorkflow, /secrets\.NPM_BOOTSTRAP_TOKEN/);
+	assert.match(publishScript, /check-unbootstrapped-packages\.mjs/);
+	assert.doesNotMatch(publishScript, /NPM_BOOTSTRAP_TOKEN|ACTIONS_ID_TOKEN_REQUEST/);
+});
+
+test("requires a Changesets-produced version and matching changelog entry", () => {
+	assert.throws(
+		() => assertVersionPrApplied({ name: "new-package", version: "0.0.0" }, "## 0.0.0\n"),
+		/Merge its Changesets version PR/,
+	);
+	assert.throws(
+		() => assertVersionPrApplied({ name: "new-package", version: "0.1.0" }, "## 0.0.0\n"),
+		/missing a matching CHANGELOG/,
+	);
+	assert.doesNotThrow(() => assertVersionPrApplied(
+		{ name: "new-package", version: "0.1.0" },
+		"# Changelog\n\n## 0.1.0\n\n- Initial release\n",
+	));
+});

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -1,17 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ -n "${NPM_BOOTSTRAP_TOKEN:-}" ]]; then
-  echo "Publishing with the one-time npm bootstrap token."
-  export NODE_AUTH_TOKEN="$NPM_BOOTSTRAP_TOKEN"
-  # npm prefers GitHub OIDC when these variables are present. A package cannot
-  # configure a trusted publisher until after its first publish, so force token
-  # auth only for the explicitly configured bootstrap run.
-  unset ACTIONS_ID_TOKEN_REQUEST_TOKEN
-  unset ACTIONS_ID_TOKEN_REQUEST_URL
-else
-  echo "Publishing with npm trusted publishing (OIDC)."
-  unset NODE_AUTH_TOKEN
-fi
+echo "Publishing with npm trusted publishing (OIDC)."
+unset NODE_AUTH_TOKEN
+
+# Fail before changeset publish can partially release a plan that contains a
+# package npm does not know yet. New package creation is intentionally isolated
+# in the manually approved Bootstrap npm package workflow.
+node scripts/check-unbootstrapped-packages.mjs
 
 pnpm release


### PR DESCRIPTION
## Summary

- keep the normal Changesets release path OIDC-only and remove its npm-token fallback
- stop normal publishing before any partial release when a public workspace package does not exist on npm
- add a protected, manual workflow that can bootstrap exactly one versioned public workspace package from `main`
- document the first-publish handoff back to OIDC and release reconciliation

## Safety

- the bootstrap job uses the protected `npm-bootstrap` Environment and only its `NPM_BOOTSTRAP_TOKEN`
- package selection is an exact workspace package name, not a path
- bootstrap requires a clean checkout matching `origin/main`, a post-version-PR version/changelog, and an npm-absent package name
- bootstrap does not create tags or GitHub Releases

## Validation

- `pnpm check`
- `node scripts/check-unbootstrapped-packages.mjs` against the live npm registry
- workflow YAML parsing
- Plan Mode worktree is detected as `@zhcsyncer/pi-plan-mode@0.0.0`, ready to be blocked until its version PR is merged

No changeset: CI/release-process-only change.
