### PR TITLE
feat: add strict Plan Mode extension

### DIFF
--- a/.changeset/strict-plans-review.md
+++ b/.changeset/strict-plans-review.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": minor
+"@zhcsyncer/pi-plan-mode": minor
+---
+
+Add a temporary read-only Plan Mode with `/plan on|off`, the `--plan` startup flag, keyboard shortcuts, fail-closed tools, revdiff review with word-level revision comparisons, immutable Plan revisions, configurable English or Simplified Chinese Plan content, compact custom-message approval handoff, immediate normal-tool restoration, and collapsible display-only Steps widgets.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A collection of Pi extensions by zhcsyncer.
 - [`@zhcsyncer/pi-tool-display-intent`](./packages/pi-tool-display-intent) — compact tool rendering with model-written intent phrases, RPC-visible summaries, adaptive diffs, and bounded Bash call previews.
 - [`@zhcsyncer/pi-todo`](./packages/pi-todo) — maintained fork of `@juicesharp/rpiv-todo` with a persistent task overlay and no duplicate successful tool nodes.
 - [`@zhcsyncer/pi-glance`](./packages/pi-glance) — maintained `pi-glance` fork with composable extension statuses, bottom-right context progress, and a highlighted auto-compaction marker.
+- [`@zhcsyncer/pi-plan-mode`](./packages/pi-plan-mode) — temporary read-only Plan Mode with word-aware revdiff review, immutable revisions, configurable English/Chinese Plan content, explicit approval, and collapsible TUI Steps.
 - [`@zhcsyncer/pi-search-hub`](./packages/pi-search-hub) — bundle-private `web_search` and `web_read` tools integrated with intent-aware rendering.
 
 ## Bundle-private Search Hub
@@ -34,7 +35,7 @@ pi -e git:github.com/zhcsyncer/pi-extensions
 
 ## Install from npm
 
-Install the complete bundle, including Glance and the private Search Hub fork:
+Install the complete bundle, including Glance, Plan Mode, and the private Search Hub fork:
 
 ```bash
 pi install npm:@zhcsyncer/pi-extensions
@@ -64,6 +65,12 @@ Install only Glance:
 pi install npm:@zhcsyncer/pi-glance
 ```
 
+Install only strict Plan Mode:
+
+```bash
+pi install npm:@zhcsyncer/pi-plan-mode
+```
+
 ## Development
 
 Test the root bundle:
@@ -79,6 +86,7 @@ pi -e ./packages/pi-recap --list-models nope
 pi --no-extensions -e ./packages/pi-tool-display-intent
 pi --no-extensions -e ./packages/pi-todo --list-models nope
 pi --no-extensions -e ./packages/pi-glance
+pi --no-extensions -e ./packages/pi-plan-mode --list-models nope
 pi --no-extensions -e ./packages/pi-search-hub --list-models nope
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,6 +10,7 @@ zhcsyncer 维护的一组 Pi extensions。
 - [`@zhcsyncer/pi-tool-display-intent`](./packages/pi-tool-display-intent) — 紧凑工具展示，支持模型生成的 intent、RPC 可见摘要、自适应 diff 和受限的 Bash 调用预览。
 - [`@zhcsyncer/pi-todo`](./packages/pi-todo) — `@juicesharp/rpiv-todo` 的维护 fork，提供持久 Todo overlay，且不会重复展示成功的工具节点。
 - [`@zhcsyncer/pi-glance`](./packages/pi-glance) — `pi-glance` 的维护 fork，保留扩展状态，支持右下角 context 进度条和高亮自动压缩标记。
+- [`@zhcsyncer/pi-plan-mode`](./packages/pi-plan-mode) — 临时只读 Plan Mode，支持 word-aware revdiff 评审、不可变 revision、中英文 Plan 内容配置、显式批准和可折叠 TUI Steps。
 - [`@zhcsyncer/pi-search-hub`](./packages/pi-search-hub) — bundle 私有的 `web_search` 和 `web_read` 工具，集成 intent-aware 展示。
 
 ## Bundle 私有 Search Hub
@@ -34,7 +35,7 @@ pi -e git:github.com/zhcsyncer/pi-extensions
 
 ## 从 npm 安装
 
-安装包含 Glance 和私有 Search Hub fork 的完整 bundle：
+安装包含 Glance、Plan Mode 和私有 Search Hub fork 的完整 bundle：
 
 ```bash
 pi install npm:@zhcsyncer/pi-extensions
@@ -64,6 +65,12 @@ pi install npm:@zhcsyncer/pi-todo
 pi install npm:@zhcsyncer/pi-glance
 ```
 
+仅安装严格 Plan Mode：
+
+```bash
+pi install npm:@zhcsyncer/pi-plan-mode
+```
+
 ## 开发
 
 测试根 bundle：
@@ -79,6 +86,7 @@ pi -e ./packages/pi-recap --list-models nope
 pi --no-extensions -e ./packages/pi-tool-display-intent
 pi --no-extensions -e ./packages/pi-todo --list-models nope
 pi --no-extensions -e ./packages/pi-glance
+pi --no-extensions -e ./packages/pi-plan-mode --list-models nope
 pi --no-extensions -e ./packages/pi-search-hub --list-models nope
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,13 @@
 # Releasing
 
-This repository publishes five public npm packages:
+This repository publishes seven public npm packages:
 
 - `@zhcsyncer/pi-extensions`
 - `@zhcsyncer/pi-recap`
 - `@zhcsyncer/pi-tool-display-intent`
 - `@zhcsyncer/pi-todo`
+- `@zhcsyncer/pi-glance`
+- `@zhcsyncer/pi-plan-mode`
 - `pi-provider-volcengine-agent-plan`
 
 Packages version independently. Because the aggregate root tarball embeds bundled child sources, every bundled child release must include a root release of at least the same bump level. The standalone `pi-provider-volcengine-agent-plan` package is excluded from the aggregate tarball and may release without the root. Unchanged siblings remain unreleased.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "packages/*/LICENSE",
     "packages/*/UPSTREAM_LICENSE",
     "packages/pi-todo/package.json",
+    "packages/pi-plan-mode/package.json",
     "packages/pi-todo/config.ts",
     "packages/pi-todo/index.ts",
     "packages/pi-todo/todo.ts",
@@ -81,6 +82,7 @@
       "./packages/pi-tool-display-intent/extensions/tool-display-intent.ts",
       "./packages/pi-todo/index.ts",
       "./packages/pi-glance/index.ts",
+      "./packages/pi-plan-mode/extensions/plan-mode.ts",
       "./packages/pi-search-hub/extensions/search-hub.ts"
     ]
   },

--- a/packages/pi-plan-mode/CHANGELOG.md
+++ b/packages/pi-plan-mode/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.0.0
+
+- Added temporary TUI-only Plan Mode with `/plan on|off`, the `--plan` startup flag, command completion, and `Ctrl+Alt+P` mode switching.
+- Added fail-closed read-only planning and revdiff review with explicit approval, Markdown TOC for first revisions, and word-level highlighting for later revision comparisons.
+- Added immutable `rN` Plan revisions, SHA-256 approval records, persistent Session pointers, and temporary no-session storage.
+- Added a Unicode `⏸` read-only mode bar and a persistent Plan summary with display-only English or Simplified Chinese Steps that expand through `Ctrl+Alt+O`; collapsed summaries hide the Plan path.
+- Added user-level `plan-mode.json` configuration for `auto`, `en`, or `zh-CN` Plan content and section headings.
+- Restored normal tools immediately after approval and handed off the full approved Plan through a compact displayed custom context message, without execution phases, user-role handoff turns, run commands, Todo integration, or completion tracking.

--- a/packages/pi-plan-mode/LICENSE
+++ b/packages/pi-plan-mode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 zhcsyncer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -1,0 +1,200 @@
+# @zhcsyncer/pi-plan-mode
+
+[简体中文](./README.zh-CN.md)
+
+A strict, TUI-only permission mode for planning in Pi. It combines fail-closed read-only tools, terminal review through [revdiff](https://github.com/umputun/revdiff), immutable Plan revisions, explicit approval, and compact Plan Mode widgets.
+
+Plan Mode is temporary: approval immediately restores the tools that were active before planning and starts ordinary implementation in a fresh agent turn. The extension does not maintain an execution or completion workflow.
+
+## Requirements
+
+- Node.js 22.19 or newer
+- Pi 0.81 or newer
+- `revdiff` available in `PATH`, or `REVDIFF_BIN` pointing to an executable binary
+- Pi TUI mode
+
+The extension checks revdiff when each TUI Session starts. If it is missing or not executable, Pi shows an installation warning and keeps Plan Mode disabled for that Session. Install revdiff and restart Pi.
+
+On macOS with Homebrew:
+
+```bash
+brew install umputun/apps/revdiff
+```
+
+## Behavior
+
+- `/plan on` enters read-only planning; `/plan off` immediately restores the previous normal tools. Starting Pi with `--plan` is equivalent to the initial `/plan on`.
+- `Ctrl+Alt+P` toggles the same mode. `/plan` without an argument shows status and usage instead of toggling implicitly.
+- Planning uses a fail-closed allowlist: `read`, `grep`, `find`, `ls`, approved documentation/search/question tools, and `submit_plan`.
+- `bash`, `edit`, `write`, and unknown custom tools are blocked while Plan Mode is on.
+- The original Pi system prompt, including `AGENTS.md` rules, is preserved and extended rather than replaced.
+- A clean revdiff exit is not approval. Pi asks for an explicit `Approve Plan`, `Keep planning`, or `Cancel review` decision.
+- Every complete submission creates an immutable `rN` Markdown file and SHA-256 hash. Approved revisions are never overwritten.
+- Approval restores normal tools, removes the read-only mode bar, retains the Plan summary, and starts implementation through a displayed custom context message rather than a user-role turn. The transcript renders only a compact approval event while the full approved revision remains in model context.
+- Steps are a display-only projection of `## Execution steps` or `## 执行步骤`. They have no completion state and do not integrate with or inspect Todo extensions.
+- Plan title, prose, lists, and required section headings can use English, Simplified Chinese, or automatically follow the conversation language through a read-only user config file.
+- TUI-only behavior is enforced with `ctx.mode === "tui"`. RPC, JSON, and print modes do not register Plan tools, change active tools, inject prompts, or write Plan state.
+
+This is a capability boundary, not an OS sandbox. Read tools can still access files allowed by the Pi process.
+
+## Workflow
+
+1. Run `/plan on`, press `Ctrl+Alt+P`, or start Pi with `--plan`.
+2. The agent explores with read-only tools.
+3. The agent calls `submit_plan` with a title and the complete Markdown Plan.
+4. Pi pauses its TUI and gives the terminal to revdiff.
+5. Annotations are returned as one feedback package. A complete resubmission creates `rN+1` and opens a revision diff with revdiff word-level highlighting.
+6. A clean review returns to Pi for an explicit approval decision.
+7. Approval records the exact revision and hash, turns Plan Mode off, restores normal tools, and starts ordinary implementation in a fresh turn.
+
+Interrupting implementation has normal Pi semantics. The approved Plan remains available, but this extension does not track execution progress, restart work automatically, or require a completion tool. Re-entering Plan Mode injects the attached revision as planning context; the agent must still inspect the current workspace before revising it.
+
+## Commands and shortcuts
+
+| Interaction | Behavior |
+|---|---|
+| `/plan on` | Enable strict read-only Plan Mode |
+| `/plan off` | Disable Plan Mode and restore normal tools |
+| `/plan` | Show current mode, content language/config path, Plan revision, path, and usage |
+| `--plan` | Start the initial TUI Session with Plan Mode on |
+| `Ctrl+Alt+P` | Toggle Plan Mode |
+| `Ctrl+Alt+O` | Expand or collapse the current Plan Steps |
+
+`on` and `off` support command argument completion.
+
+## Plan content language
+
+Plan Mode reads one optional user-level file from `<agent-dir>/plan-mode.json` (normally `~/.pi/agent/plan-mode.json`):
+
+```json
+{
+  "contentLanguage": "zh-CN"
+}
+```
+
+Supported values:
+
+- `auto` (default): honor higher-priority or explicit user language instructions; otherwise match the current user. Simplified Chinese Plans use Chinese section headings, and other Plans use English headings.
+- `en`: require English title, content, and section headings.
+- `zh-CN`: require Simplified Chinese title, content, and section headings.
+
+The extension only reads this file and never creates or rewrites it. Reload or restart Pi after editing it. Invalid JSON or an unsupported value produces a warning and falls back to `auto`. This setting controls generated Plan content and headings only; Plan Mode UI, revdiff UI, control prompts, and approval events remain English.
+
+## Widgets
+
+While Plan Mode is on, a below-editor widget is rendered with the standard Unicode pause symbol:
+
+```text
+⏸ PLAN MODE · READ-ONLY                    /plan off · Ctrl+Alt+P
+```
+
+The extension uses Unicode `⏸` directly. It does not add a font setting, environment variable, Nerd Font branch, or ASCII fallback.
+
+After a Plan exists, an above-editor summary remains visible independently of whether Plan Mode is on:
+
+```text
+▌ PLAN  OAuth migration                              APPROVED · r2
+6 steps                                             Ctrl+Alt+O expand
+```
+
+The Plan path is intentionally hidden while collapsed. Expanding shows the path and the display-only Steps:
+
+```text
+▌ PLAN  OAuth migration                              APPROVED · r2
+~/.pi/agent/plans/…/revisions/r2.md
+  1. Update the policy
+  2. Run integration tests
+                                              Ctrl+Alt+O collapse
+```
+
+Steps are collapsed by default. `Ctrl+Alt+O` expands up to 30% of terminal height, bounded to 3–10 steps; overflow is shown as `… +N more`. Expansion is TUI-local and resets when the current Plan, revision, Session, or tree branch changes.
+
+Approval adds one compact custom event to the transcript:
+
+```text
+✓ PLAN APPROVED · OAuth migration · r2 · 6 steps
+```
+
+Persistent widgets do not receive focus and Pi's public Widget API has no mouse click callback, so direct clicking is not supported.
+
+## Storage
+
+Persistent Sessions store application data separately from Pi JSONL transcripts. The optional language config is a sibling of the `plans/` directory:
+
+```text
+~/.pi/agent/plan-mode.json
+~/.pi/agent/plans/
+└── <plan-id>/
+    ├── manifest.json
+    ├── revisions/
+    │   ├── r1.md
+    │   └── r2.md
+    └── .review/
+        └── annotations.md
+```
+
+The root is resolved with Pi's `getAgentDir()`, so `PI_CODING_AGENT_DIR` is respected. Directories use mode `0700`; revision and manifest files use `0600` where supported.
+
+Each submission writes a new revision with exclusive creation. The manifest records the stable Plan ID, current and approved revisions, document states (`draft`, `changes_requested`, or `approved`), SHA-256 hashes, extracted display Steps, Session ID, cwd, timestamps, and revision lineage.
+
+With `--no-session`, the extension uses `$TMPDIR/pi-plan-<random>/`, never appends Session state, and removes the directory on Session shutdown. Crash leftovers may remain until the operating system cleans its temporary directory.
+
+## Plan artifact
+
+`submit_plan` accepts the complete artifact, not a file path:
+
+```text
+submit_plan({
+  title: "Add cache invalidation",
+  markdown: "# Goal\n..."
+})
+```
+
+When revising the same Plan, pass the current Plan ID returned by the previous submission:
+
+```text
+submit_plan({
+  planId: "20260723T140506-add-cache-a1b2c3d4",
+  title: "Add cache invalidation",
+  markdown: "# Goal\n... complete revised Plan ..."
+})
+```
+
+Omitting `planId` creates a different Plan. A supplied ID must match the current Session branch Plan; arbitrary or cross-Session adoption is rejected.
+
+Plans are limited to 256 KiB and should cover the nine required sections. English Plans use Goal, Non-goals, Current evidence, Decisions and rationale, Proposed changes, Execution steps, Verification, Risks, and Assumptions. Simplified Chinese Plans use 目标、非目标、当前证据、决策与理由、拟议改动、执行步骤、验证、风险和假设.
+
+## Install
+
+Install only this extension:
+
+```bash
+pi install npm:@zhcsyncer/pi-plan-mode
+```
+
+Try it from this repository:
+
+```bash
+pi --no-extensions -e ./packages/pi-plan-mode
+```
+
+## Failure behavior
+
+- Missing or non-executable revdiff at startup: warn with installation guidance and disable Plan Mode for the Session.
+- revdiff removed, too old for `--word-diff`, or failing after startup: remain in planning and report an error.
+- Invalid `plan-mode.json`: warn, use `contentLanguage: "auto"`, and keep Plan Mode available.
+- Interrupted review: remain in planning without approval.
+- Plan content or current revision changed while revdiff is open: reject approval and require another review.
+- Missing or cross-Session metadata during restore: keep normal mode and do not adopt that Plan pointer.
+- `/plan off`: restore normal tools without deleting or cancelling the current draft.
+
+## Development
+
+```bash
+pnpm --filter @zhcsyncer/pi-plan-mode check
+pi --no-extensions -e ./packages/pi-plan-mode --list-models nope
+```
+
+## License
+
+MIT

--- a/packages/pi-plan-mode/README.zh-CN.md
+++ b/packages/pi-plan-mode/README.zh-CN.md
@@ -1,0 +1,200 @@
+# @zhcsyncer/pi-plan-mode
+
+[English](./README.md)
+
+严格、仅 TUI 启用的 Pi 临时规划权限模式。它组合 fail-closed 只读工具、[revdiff](https://github.com/umputun/revdiff) 终端评审、不可变 Plan revision、显式批准和紧凑的 Plan Mode Widget。
+
+Plan Mode 是临时模式：批准后立即恢复进入规划前的工具，并在新的 Agent turn 中开始普通实现。扩展不维护执行或完成工作流。
+
+## 环境要求
+
+- Node.js 22.19 或更高版本
+- Pi 0.81 或更高版本
+- `revdiff` 位于 `PATH`，或用 `REVDIFF_BIN` 指向具有执行权限的文件
+- Pi TUI 模式
+
+每次 TUI Session 启动时，扩展都会预检 revdiff。若文件缺失或不可执行，Pi 会显示安装提示，并在该 Session 内保持 Plan Mode 禁用。安装完成后需重启 Pi。
+
+macOS Homebrew 安装示例：
+
+```bash
+brew install umputun/apps/revdiff
+```
+
+## 行为
+
+- `/plan on` 进入只读规划；`/plan off` 立即恢复之前的普通工具。用 `--plan` 启动 Pi 等价于首次执行 `/plan on`。
+- `Ctrl+Alt+P` 切换同一模式。`/plan` 不带参数时只显示状态和用法，不做隐式切换。
+- 规划阶段使用 fail-closed 白名单：`read`、`grep`、`find`、`ls`、获准的文档/搜索/提问工具和 `submit_plan`。
+- Plan Mode 开启时会拦截 `bash`、`edit`、`write` 和未知自定义工具。
+- 原始 Pi system prompt（包括 `AGENTS.md` 规则）会被保留并追加约束，而不是被替换。
+- revdiff 无批注退出不等于批准。Pi 会要求明确选择 `Approve Plan`、`Keep planning` 或 `Cancel review`。
+- 每次完整提交都会创建不可变的 `rN` Markdown 文件和 SHA-256 hash；获批 revision 永不覆盖。
+- 批准后恢复普通工具、移除只读模式条、保留 Plan 摘要，并通过 displayed custom context message 开始实现，而不是创建 user-role turn。Transcript 只渲染紧凑批准事件，完整获批 revision 仍保留在模型上下文中。
+- Steps 只是 `## Execution steps` 或 `## 执行步骤` 的展示投影，没有完成状态，也不会集成或探测 Todo 扩展。
+- Plan 标题、正文、列表和必需章节标题可通过只读用户配置选择英文、简体中文或自动跟随会话语言。
+- 通过 `ctx.mode === "tui"` 强制仅 TUI 启用。RPC、JSON、print 模式不会注册 Plan 工具、切换活动工具、注入提示或写入 Plan 状态。
+
+这是能力边界，不是 OS sandbox。只读工具仍可访问 Pi 进程有权读取的文件。
+
+## 工作流程
+
+1. 运行 `/plan on`、按 `Ctrl+Alt+P`，或用 `--plan` 启动 Pi。
+2. Agent 使用只读工具探索。
+3. Agent 调用 `submit_plan`，提交标题和完整 Markdown Plan。
+4. Pi 暂停自己的 TUI，把终端交给 revdiff。
+5. 批注整批返回 Agent；完整重提会创建 `rN+1`，并用 revdiff 词内高亮打开 revision Diff。
+6. 无批注 Review 返回 Pi，要求用户显式决定是否批准。
+7. 批准会记录精确 revision 和 hash、关闭 Plan Mode、恢复普通工具，并在新的 turn 中开始普通实现。
+
+实现中断沿用普通 Pi 语义。获批 Plan 会继续保留，但扩展不跟踪执行进度、不自动重启工作，也不要求完成工具。重新进入 Plan Mode 时，扩展会把关联 revision 注入规划上下文；Agent 仍须先检查当前工作区再修订。
+
+## 命令与快捷键
+
+| 交互 | 行为 |
+|---|---|
+| `/plan on` | 开启严格只读 Plan Mode |
+| `/plan off` | 关闭 Plan Mode 并恢复普通工具 |
+| `/plan` | 显示当前模式、内容语言/配置路径、Plan revision、路径和用法 |
+| `--plan` | 让初始 TUI Session 直接开启 Plan Mode |
+| `Ctrl+Alt+P` | 切换 Plan Mode |
+| `Ctrl+Alt+O` | 展开或收起当前 Plan Steps |
+
+`on` 和 `off` 支持命令参数补全。
+
+## Plan 内容语言
+
+Plan Mode 从 `<agent-dir>/plan-mode.json`（通常是 `~/.pi/agent/plan-mode.json`）读取一个可选用户级配置：
+
+```json
+{
+  "contentLanguage": "zh-CN"
+}
+```
+
+支持值：
+
+- `auto`（默认）：遵循更高优先级或用户明确指定的语言；否则匹配当前用户语言。简体中文 Plan 使用中文章节标题，其他 Plan 使用英文标题。
+- `en`：要求英文标题、内容和章节标题。
+- `zh-CN`：要求简体中文标题、内容和章节标题。
+
+扩展只读取该文件，不会自动创建或改写。编辑后需 reload 或重启 Pi。JSON 无效或值不受支持时会提示 warning 并回退到 `auto`。该设置只控制生成的 Plan 内容和标题；Plan Mode UI、revdiff UI、控制 prompt 和批准事件仍使用英文。
+
+## Widgets
+
+Plan Mode 开启时，编辑器下方显示使用标准 Unicode 暂停符号的 Widget：
+
+```text
+⏸ PLAN MODE · READ-ONLY                    /plan off · Ctrl+Alt+P
+```
+
+扩展直接使用 Unicode `⏸`，不增加字体设置、环境变量、Nerd Font 分支或 ASCII fallback。
+
+存在 Plan 后，编辑器上方的摘要会独立于 Plan Mode 开关持续显示：
+
+```text
+▌ PLAN  OAuth migration                              APPROVED · r2
+6 steps                                             Ctrl+Alt+O expand
+```
+
+收起时刻意隐藏 Plan 路径。展开后显示路径和只用于展示的 Steps：
+
+```text
+▌ PLAN  OAuth migration                              APPROVED · r2
+~/.pi/agent/plans/…/revisions/r2.md
+  1. 更新策略
+  2. 运行集成测试
+                                              Ctrl+Alt+O collapse
+```
+
+Steps 默认收起。`Ctrl+Alt+O` 展开终端高度的最多 30%，并限制在 3–10 个 step；溢出显示 `… +N more`。展开状态只属于当前 TUI，切换当前 Plan、revision、Session 或 tree branch 时重置。
+
+批准后 transcript 增加一条紧凑 custom event：
+
+```text
+✓ PLAN APPROVED · OAuth migration · r2 · 6 steps
+```
+
+持久 Widget 不获取焦点，Pi 公开 Widget API 也没有鼠标点击回调，因此不支持直接点击。
+
+## 存储方式
+
+持久 Session 把应用数据与 Pi JSONL transcript 分开保存。可选语言配置与 `plans/` 目录同级：
+
+```text
+~/.pi/agent/plan-mode.json
+~/.pi/agent/plans/
+└── <plan-id>/
+    ├── manifest.json
+    ├── revisions/
+    │   ├── r1.md
+    │   └── r2.md
+    └── .review/
+        └── annotations.md
+```
+
+根目录通过 Pi 的 `getAgentDir()` 获取，因此会遵循 `PI_CODING_AGENT_DIR`。在平台支持时，目录权限为 `0700`，revision 和 manifest 文件权限为 `0600`。
+
+每次提交都用 exclusive create 写入新 revision。manifest 记录稳定 Plan ID、当前与获批 revision、文档状态（`draft`、`changes_requested` 或 `approved`）、SHA-256 hash、提取出的展示 Steps、Session ID、cwd、时间戳和 revision lineage。
+
+使用 `--no-session` 时，扩展改用 `$TMPDIR/pi-plan-<random>/`，不会向 Session 追加状态，并在 Session shutdown 时删除目录。异常崩溃的残留文件可能要等操作系统清理临时目录。
+
+## Plan 产物
+
+`submit_plan` 接收完整产物，而不是文件路径：
+
+```text
+submit_plan({
+  title: "Add cache invalidation",
+  markdown: "# Goal\n..."
+})
+```
+
+修订同一个 Plan 时，传入上次提交返回的当前 Plan ID：
+
+```text
+submit_plan({
+  planId: "20260723T140506-add-cache-a1b2c3d4",
+  title: "Add cache invalidation",
+  markdown: "# Goal\n... 完整修订 Plan ..."
+})
+```
+
+省略 `planId` 会创建另一个 Plan。传入的 ID 必须匹配当前 Session branch 的 Plan；任意 ID 或跨 Session 接管会被拒绝。
+
+Plan 上限为 256 KiB，并应覆盖九个必需章节。英文 Plan 使用 Goal、Non-goals、Current evidence、Decisions and rationale、Proposed changes、Execution steps、Verification、Risks 和 Assumptions；简体中文 Plan 使用目标、非目标、当前证据、决策与理由、拟议改动、执行步骤、验证、风险和假设。
+
+## 安装
+
+仅安装此扩展：
+
+```bash
+pi install npm:@zhcsyncer/pi-plan-mode
+```
+
+从本仓库试用：
+
+```bash
+pi --no-extensions -e ./packages/pi-plan-mode
+```
+
+## 失败处理
+
+- 启动时找不到 revdiff 或文件不可执行：提示安装，并在当前 Session 禁用 Plan Mode。
+- 启动后 revdiff 被删除、版本过旧而不支持 `--word-diff` 或运行失败：保留 planning 模式并报告错误。
+- `plan-mode.json` 无效：提示 warning、使用 `contentLanguage: "auto"`，并继续允许 Plan Mode。
+- Review 被中断：保留 planning 模式，不产生批准。
+- revdiff 打开期间 Plan 内容或当前 revision 改变：拒绝批准并要求重新 Review。
+- 恢复时元数据缺失或属于另一 Session：保持 normal，不接管该 Plan 指针。
+- `/plan off`：恢复普通工具，但不删除或取消当前草稿。
+
+## 开发
+
+```bash
+pnpm --filter @zhcsyncer/pi-plan-mode check
+pi --no-extensions -e ./packages/pi-plan-mode --list-models nope
+```
+
+## 许可证
+
+MIT

--- a/packages/pi-plan-mode/extensions/plan-mode.ts
+++ b/packages/pi-plan-mode/extensions/plan-mode.ts
@@ -1,0 +1,643 @@
+import path from "node:path";
+import { Buffer } from "node:buffer";
+import { Type } from "typebox";
+import {
+	getAgentDir,
+	withFileMutationQueue,
+	type ExtensionAPI,
+	type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import {
+	DEFAULT_PLAN_MODE_CONFIG,
+	getPlanModeConfigPath,
+	loadPlanModeConfig,
+	type PlanContentLanguage,
+} from "../src/config.ts";
+import {
+	SUBMIT_PLAN_TOOL,
+	getPlanningTools,
+	isPlanningToolAllowed,
+	withoutManagedTools,
+} from "../src/policy.ts";
+import {
+	appendPlanningPrompt,
+	buildImplementationHandoff,
+	buildReviewFeedback,
+} from "../src/prompts.ts";
+import { resolveRevdiffBinary, reviewPlanWithRevdiff } from "../src/review.ts";
+import {
+	approvePlan,
+	cleanupReviewWorkspace,
+	createTemporaryPlanRoot,
+	ensurePersistentPlanRoot,
+	generatePlanId,
+	getPlanPaths,
+	isValidPlanId,
+	readPlanMetadata,
+	removeTemporaryPlanRoot,
+	saveSubmittedPlan,
+	updatePlanStatus,
+	writeReviewAnnotations,
+} from "../src/storage.ts";
+import {
+	SESSION_STATE_VERSION,
+	type PlanMetadata,
+	type PlanMode,
+	type PlanSessionState,
+	type PlanStorageMode,
+} from "../src/types.ts";
+import {
+	renderModeWidget,
+	renderPlanApprovedEvent,
+	renderPlanWidget,
+	type PlanApprovedEventData,
+} from "../src/widgets.ts";
+
+const STATE_ENTRY_TYPE = "zhcsyncer-plan-mode-state";
+export const APPROVED_PLAN_MESSAGE_TYPE = "zhcsyncer-plan-approved";
+const PLAN_WIDGET_KEY = "zhcsyncer-plan-mode-document";
+const MODE_WIDGET_KEY = "zhcsyncer-plan-mode-indicator";
+const MAX_PLAN_BYTES = 256 * 1024;
+const APPROVE_CHOICE = "Approve Plan";
+const KEEP_PLANNING_CHOICE = "Keep planning";
+const CANCEL_REVIEW_CHOICE = "Cancel review";
+
+export const PLAN_MODE_SHORTCUT = "ctrl+alt+p";
+export const PLAN_STEPS_SHORTCUT = "ctrl+alt+o";
+
+interface ToolDetails {
+	kind: string;
+	planId?: string;
+	revision?: number;
+	planPath?: string;
+	approvedHash?: string;
+}
+
+interface ApprovedPlanMessageDetails extends PlanApprovedEventData {
+	title: string;
+	revision: number;
+	stepCount: number;
+	planId: string;
+	approvedHash: string;
+	planPath: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseSessionState(value: unknown): PlanSessionState | undefined {
+	if (!isRecord(value) || value.version !== SESSION_STATE_VERSION) return undefined;
+	if (value.mode !== "normal" && value.mode !== "planning") return undefined;
+	if (!Array.isArray(value.normalTools) || !value.normalTools.every((tool) => typeof tool === "string")) return undefined;
+	if (value.planId !== undefined && (typeof value.planId !== "string" || !isValidPlanId(value.planId))) return undefined;
+	if (value.revision !== undefined && (typeof value.revision !== "number" || !Number.isInteger(value.revision) || value.revision < 1)) {
+		return undefined;
+	}
+	if ((value.planId === undefined) !== (value.revision === undefined)) return undefined;
+	return value as unknown as PlanSessionState;
+}
+
+function findLatestSessionState(ctx: ExtensionContext): PlanSessionState | undefined {
+	let latest: PlanSessionState | undefined;
+	for (const entry of ctx.sessionManager.getBranch()) {
+		if (entry.type !== "custom" || entry.customType !== STATE_ENTRY_TYPE) continue;
+		const parsed = parseSessionState(entry.data);
+		if (parsed) latest = parsed;
+	}
+	return latest;
+}
+
+function textResult(text: string, details: ToolDetails, terminate = false) {
+	return {
+		content: [{ type: "text" as const, text }],
+		details,
+		...(terminate ? { terminate: true } : {}),
+	};
+}
+
+function normalizeMarkdown(markdown: string): string {
+	return markdown.endsWith("\n") ? markdown : `${markdown}\n`;
+}
+
+export function isPersistentSession(ctx: Pick<ExtensionContext, "sessionManager">): boolean {
+	return ctx.sessionManager.getSessionFile() !== undefined;
+}
+
+export default function planModeExtension(pi: ExtensionAPI): void {
+	pi.registerFlag("plan", {
+		description: "Start in strict read-only Plan Mode",
+		type: "boolean",
+		default: false,
+	});
+
+	pi.registerMessageRenderer<ApprovedPlanMessageDetails>(APPROVED_PLAN_MESSAGE_TYPE, (message, _options, theme) => {
+		const details: Record<string, unknown> = isRecord(message.details) ? message.details : {};
+		const eventData: PlanApprovedEventData = {
+			...(typeof details.title === "string" ? { title: details.title } : {}),
+			...(typeof details.revision === "number" ? { revision: details.revision } : {}),
+			...(typeof details.stepCount === "number" ? { stepCount: details.stepCount } : {}),
+		};
+		return {
+			render: (width) => renderPlanApprovedEvent(eventData, width, theme),
+			invalidate() {},
+		};
+	});
+
+	let tuiEnabled = false;
+	let toolsRegistered = false;
+	let mode: PlanMode = "normal";
+	let planId: string | undefined;
+	let currentRevision: number | undefined;
+	let currentMetadata: PlanMetadata | undefined;
+	let planRoot: string | undefined;
+	let normalTools: string[] = [];
+	let temporaryRoot: string | undefined;
+	let disabledReason: string | undefined;
+	let stepsExpanded = false;
+	let contentLanguage: PlanContentLanguage = DEFAULT_PLAN_MODE_CONFIG.contentLanguage;
+	let planConfigPath = getPlanModeConfigPath();
+
+	function persistState(ctx: ExtensionContext): void {
+		if (!isPersistentSession(ctx)) return;
+		const data: PlanSessionState = {
+			version: SESSION_STATE_VERSION,
+			mode,
+			planId,
+			revision: currentRevision,
+			normalTools,
+		};
+		pi.appendEntry(STATE_ENTRY_TYPE, data);
+	}
+
+	function applyNormalTools(fallback?: string[]): void {
+		const restore = normalTools.length > 0 ? normalTools : fallback ?? withoutManagedTools(pi.getActiveTools());
+		normalTools = withoutManagedTools(restore);
+		pi.setActiveTools(normalTools);
+	}
+
+	function applyPlanningTools(): void {
+		pi.setActiveTools(getPlanningTools(normalTools));
+	}
+
+	function refreshWidgets(ctx: ExtensionContext): void {
+		if (ctx.mode !== "tui") return;
+		const revision = currentRevisionMetadata();
+		if (planId && currentMetadata && revision && planRoot) {
+			const planPath = getPlanPaths(planRoot, planId, revision.revision, revision.basedOn).plan;
+			ctx.ui.setWidget(
+				PLAN_WIDGET_KEY,
+				(tui, theme) => ({
+					render: (width) => renderPlanWidget({
+						title: currentMetadata?.title ?? "Plan",
+						status: revision.status,
+						revision: revision.revision,
+						planPath,
+						steps: revision.steps,
+						expanded: stepsExpanded,
+						terminalRows: tui.terminal.rows,
+					}, width, theme),
+					invalidate() {},
+				}),
+				{ placement: "aboveEditor" },
+			);
+		} else {
+			ctx.ui.setWidget(PLAN_WIDGET_KEY, undefined);
+		}
+
+		if (tuiEnabled && mode === "planning") {
+			ctx.ui.setWidget(
+				MODE_WIDGET_KEY,
+				(_tui, theme) => ({
+					render: (width) => renderModeWidget(width, theme),
+					invalidate() {},
+				}),
+				{ placement: "belowEditor" },
+			);
+		} else {
+			ctx.ui.setWidget(MODE_WIDGET_KEY, undefined);
+		}
+	}
+
+	function clearWidgets(ctx: ExtensionContext): void {
+		if (ctx.mode !== "tui") return;
+		ctx.ui.setWidget(PLAN_WIDGET_KEY, undefined);
+		ctx.ui.setWidget(MODE_WIDGET_KEY, undefined);
+	}
+
+	async function ensurePlanRoot(ctx: ExtensionContext): Promise<{ root: string; storage: PlanStorageMode }> {
+		if (isPersistentSession(ctx)) {
+			const root = await ensurePersistentPlanRoot(path.join(getAgentDir(), "plans"));
+			planRoot = root;
+			return { root, storage: "persistent" };
+		}
+		if (!temporaryRoot) temporaryRoot = await createTemporaryPlanRoot();
+		planRoot = temporaryRoot;
+		return { root: temporaryRoot, storage: "temporary" };
+	}
+
+	function setMode(ctx: ExtensionContext, nextMode: PlanMode, notify = true): void {
+		if (nextMode === mode) {
+			if (notify) ctx.ui.notify(`Plan Mode is already ${mode === "planning" ? "on" : "off"}.`, "info");
+			return;
+		}
+		if (nextMode === "planning") {
+			normalTools = withoutManagedTools(pi.getActiveTools());
+			mode = "planning";
+			applyPlanningTools();
+			persistState(ctx);
+			refreshWidgets(ctx);
+			if (notify) ctx.ui.notify("Plan Mode enabled. Tools are restricted to read-only exploration and submit_plan.", "info");
+			return;
+		}
+		applyNormalTools();
+		mode = "normal";
+		persistState(ctx);
+		refreshWidgets(ctx);
+		if (notify) ctx.ui.notify("Plan Mode disabled. Normal tools restored.", "info");
+	}
+
+	function currentRevisionMetadata() {
+		if (!currentMetadata || currentRevision === undefined) return undefined;
+		return currentMetadata.revisions[currentRevision - 1];
+	}
+
+	function showPlanStatus(ctx: ExtensionContext): void {
+		const lines = [
+			`Plan Mode: ${mode === "planning" ? "on" : "off"}`,
+			"Usage: /plan on|off",
+			`Plan content language: ${contentLanguage}`,
+			`Config: ${planConfigPath}`,
+		];
+		const revision = currentRevisionMetadata();
+		if (planId && currentMetadata && revision && planRoot) {
+			lines.push(
+				`Current Plan: ${currentMetadata.title}`,
+				`Document: ${revision.status.toUpperCase()} · r${revision.revision}`,
+				`Path: ${getPlanPaths(planRoot, planId, revision.revision, revision.basedOn).plan}`,
+			);
+		}
+		ctx.ui.notify(lines.join("\n"), "info");
+	}
+
+	function ensureCommandAvailable(ctx: ExtensionContext): boolean {
+		if (ctx.mode !== "tui") return false;
+		if (tuiEnabled) return true;
+		if (disabledReason) ctx.ui.notify(disabledReason, "warning");
+		return false;
+	}
+
+	function registerTools(): void {
+		if (toolsRegistered) return;
+		toolsRegistered = true;
+
+		pi.registerTool({
+			name: SUBMIT_PLAN_TOOL,
+			label: "Submit Plan",
+			description: "Persist a complete Plan revision and open revdiff for explicit user review. Re-submit the full Plan after feedback.",
+			promptSnippet: "Submit a complete Plan revision for terminal review",
+			promptGuidelines: [
+				"Use submit_plan only in Plan Mode after repository exploration is complete.",
+				"Call submit_plan with the entire Plan, never a delta, and as the only tool in its tool-call batch.",
+				"Pass the current planId when revising the same Plan; omit planId only when starting a different Plan.",
+			],
+			parameters: Type.Object({
+				planId: Type.Optional(Type.String({ description: "Current Plan ID when submitting another revision of the same Plan." })),
+				title: Type.String({ minLength: 1, maxLength: 160, description: "Concise Plan title." }),
+				markdown: Type.String({ minLength: 1, description: "Complete decision-ready Markdown Plan." }),
+			}),
+			executionMode: "sequential",
+			async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+				if (!tuiEnabled || ctx.mode !== "tui" || mode !== "planning") {
+					return textResult("submit_plan is available only while TUI Plan Mode is on.", { kind: "unavailable" }, true);
+				}
+
+				const title = params.title.trim();
+				const markdown = normalizeMarkdown(params.markdown);
+				const requestedPlanId = params.planId?.trim() || undefined;
+				if (!title || !markdown.trim()) {
+					return textResult("Plan title and Markdown body must not be empty.", { kind: "invalid" }, true);
+				}
+				if (Buffer.byteLength(markdown, "utf8") > MAX_PLAN_BYTES) {
+					return textResult(`Plan exceeds the ${MAX_PLAN_BYTES} byte limit.`, { kind: "invalid" }, true);
+				}
+				if (requestedPlanId && (!isValidPlanId(requestedPlanId) || requestedPlanId !== planId)) {
+					return textResult(
+						"planId must match the current Session branch Plan. Omit it to create a new Plan.",
+						{ kind: "invalid_plan_id" },
+						true,
+					);
+				}
+
+				const storage = await ensurePlanRoot(ctx);
+				const activePlanId = requestedPlanId ?? generatePlanId(title);
+				const manifestPath = getPlanPaths(storage.root, activePlanId).manifest;
+				let submitted;
+				try {
+					submitted = await withFileMutationQueue(manifestPath, () =>
+						saveSubmittedPlan({
+							root: storage.root,
+							planId: activePlanId,
+							title,
+							markdown,
+							storage: storage.storage,
+							sessionId: ctx.sessionManager.getSessionId(),
+							cwd: ctx.cwd,
+							...(requestedPlanId && currentRevision ? { basedOn: currentRevision } : {}),
+						}),
+					);
+				} catch (error) {
+					return textResult(
+						`Plan revision was not saved: ${error instanceof Error ? error.message : String(error)}`,
+						{ kind: "storage_error", planId: activePlanId },
+						true,
+					);
+				}
+
+				planId = activePlanId;
+				currentRevision = submitted.revision.revision;
+				currentMetadata = submitted.metadata;
+				stepsExpanded = false;
+				persistState(ctx);
+				refreshWidgets(ctx);
+
+				const review = await reviewPlanWithRevdiff(ctx, {
+					paths: submitted.paths,
+					hasPrevious: submitted.hasPrevious,
+					cwd: ctx.cwd,
+				});
+
+				if (review.kind === "changes_requested") {
+					await writeReviewAnnotations(submitted.paths, review.annotations);
+					currentMetadata = await updatePlanStatus(storage.root, activePlanId, "changes_requested");
+					persistState(ctx);
+					refreshWidgets(ctx);
+					return textResult(buildReviewFeedback(activePlanId, submitted.revision.revision, review.annotations), {
+						kind: review.kind,
+						planId: activePlanId,
+						revision: submitted.revision.revision,
+						planPath: submitted.paths.plan,
+					});
+				}
+
+				if (review.kind === "cancelled" || review.kind === "error") {
+					currentMetadata = await updatePlanStatus(storage.root, activePlanId, "draft");
+					persistState(ctx);
+					refreshWidgets(ctx);
+					return textResult(
+						review.kind === "cancelled" ? `Plan review was cancelled: ${review.message}` : `Plan review failed: ${review.message}`,
+						{
+							kind: review.kind,
+							planId: activePlanId,
+							revision: submitted.revision.revision,
+							planPath: submitted.paths.plan,
+						},
+						true,
+					);
+				}
+
+				const decision = await ctx.ui.select("Plan review finished. Choose an explicit decision:", [
+					APPROVE_CHOICE,
+					KEEP_PLANNING_CHOICE,
+					CANCEL_REVIEW_CHOICE,
+				]);
+				if (decision !== APPROVE_CHOICE) {
+					currentMetadata = await updatePlanStatus(storage.root, activePlanId, "draft");
+					persistState(ctx);
+					refreshWidgets(ctx);
+					const keepPlanning = decision === KEEP_PLANNING_CHOICE;
+					return textResult(
+						keepPlanning
+							? "The user kept Plan Mode on. Continue planning or wait for further direction."
+							: "The user cancelled this approval. The revision remains a draft and Plan Mode stays on.",
+						{
+							kind: keepPlanning ? "keep_planning" : "cancelled",
+							planId: activePlanId,
+							revision: submitted.revision.revision,
+							planPath: submitted.paths.plan,
+						},
+						true,
+					);
+				}
+
+				let approved: PlanMetadata;
+				try {
+					approved = await withFileMutationQueue(manifestPath, () =>
+						approvePlan(storage.root, activePlanId, submitted.revision.revision, submitted.submittedHash),
+					);
+				} catch (error) {
+					currentMetadata = await readPlanMetadata(storage.root, activePlanId);
+					refreshWidgets(ctx);
+					return textResult(
+						`Approval was not recorded: ${error instanceof Error ? error.message : String(error)}. Submit the current Plan for review again.`,
+						{
+							kind: "integrity_error",
+							planId: activePlanId,
+							revision: submitted.revision.revision,
+							planPath: submitted.paths.plan,
+						},
+						true,
+					);
+				}
+
+				currentMetadata = approved;
+				currentRevision = submitted.revision.revision;
+				await cleanupReviewWorkspace(storage.root, activePlanId);
+				setMode(ctx, "normal", false);
+				const approvedHash = approved.approvedHash;
+				if (!approvedHash) throw new Error("Approval did not produce an approved hash");
+				pi.sendMessage<ApprovedPlanMessageDetails>(
+					{
+						customType: APPROVED_PLAN_MESSAGE_TYPE,
+						content: buildImplementationHandoff({
+							planId: activePlanId,
+							title: approved.title,
+							revision: submitted.revision.revision,
+							approvedHash,
+							planPath: submitted.paths.plan,
+							markdown,
+						}),
+						display: true,
+						details: {
+							title: approved.title,
+							revision: submitted.revision.revision,
+							stepCount: submitted.revision.steps.length,
+							planId: activePlanId,
+							approvedHash,
+							planPath: submitted.paths.plan,
+						},
+					},
+					{ triggerTurn: true, deliverAs: "followUp" },
+				);
+				ctx.ui.notify(`Plan approved: ${approved.title} · r${submitted.revision.revision}`, "info");
+				return textResult(
+					`The user approved ${activePlanId} r${submitted.revision.revision}. Plan Mode is off and normal implementation will start next.`,
+					{
+						kind: "approved",
+						planId: activePlanId,
+						revision: submitted.revision.revision,
+						planPath: submitted.paths.plan,
+						approvedHash,
+					},
+					true,
+				);
+			},
+		});
+	}
+
+	async function restoreState(ctx: ExtensionContext): Promise<void> {
+		const fallbackTools = normalTools.length > 0 ? normalTools : withoutManagedTools(pi.getActiveTools());
+		const restored = findLatestSessionState(ctx);
+		if (!restored) {
+			mode = "normal";
+			planId = undefined;
+			currentRevision = undefined;
+			currentMetadata = undefined;
+			planRoot = undefined;
+			normalTools = fallbackTools;
+			applyNormalTools(fallbackTools);
+			refreshWidgets(ctx);
+			return;
+		}
+
+		normalTools = withoutManagedTools(restored.normalTools.length > 0 ? restored.normalTools : fallbackTools);
+		mode = restored.mode;
+		planId = restored.planId;
+		currentRevision = restored.revision;
+		currentMetadata = undefined;
+		planRoot = undefined;
+
+		if (planId && currentRevision) {
+			const root = await ensurePersistentPlanRoot(path.join(getAgentDir(), "plans"));
+			const metadata = await readPlanMetadata(root, planId);
+			const revision = metadata?.revisions[currentRevision - 1];
+			if (metadata && revision && metadata.sessionId === ctx.sessionManager.getSessionId()) {
+				planRoot = root;
+				currentMetadata = metadata;
+			} else {
+				planId = undefined;
+				currentRevision = undefined;
+			}
+		}
+
+		if (mode === "planning") applyPlanningTools();
+		else applyNormalTools(fallbackTools);
+		refreshWidgets(ctx);
+	}
+
+	pi.on("session_start", async (event, ctx) => {
+		if (ctx.mode !== "tui") return;
+		stepsExpanded = false;
+		const loadedConfig = await loadPlanModeConfig();
+		contentLanguage = loadedConfig.config.contentLanguage;
+		planConfigPath = loadedConfig.path;
+		if (loadedConfig.warning) ctx.ui.notify(loadedConfig.warning, "warning");
+		if (!resolveRevdiffBinary()) {
+			tuiEnabled = false;
+			disabledReason = "Plan Mode is disabled because revdiff is not installed. Install it, then restart Pi. macOS: brew install umputun/apps/revdiff";
+			if (toolsRegistered) pi.setActiveTools(withoutManagedTools(pi.getActiveTools()));
+			clearWidgets(ctx);
+			ctx.ui.notify(disabledReason, "warning");
+			return;
+		}
+		disabledReason = undefined;
+		tuiEnabled = true;
+		registerTools();
+		await restoreState(ctx);
+		if (event.reason === "startup" && pi.getFlag("plan") === true && mode === "normal") {
+			setMode(ctx, "planning", false);
+		}
+	});
+
+	pi.on("session_tree", async (_event, ctx) => {
+		if (!tuiEnabled || ctx.mode !== "tui") return;
+		stepsExpanded = false;
+		await restoreState(ctx);
+	});
+
+	pi.on("session_shutdown", async (_event, ctx) => {
+		clearWidgets(ctx);
+		tuiEnabled = false;
+		await removeTemporaryPlanRoot(temporaryRoot).catch(() => undefined);
+		temporaryRoot = undefined;
+		if (!isPersistentSession(ctx)) {
+			mode = "normal";
+			planId = undefined;
+			currentRevision = undefined;
+			currentMetadata = undefined;
+			planRoot = undefined;
+			normalTools = [];
+		}
+	});
+
+	pi.on("tool_call", async (event, ctx) => {
+		if (!tuiEnabled || ctx.mode !== "tui" || mode !== "planning") return;
+		if (isPlanningToolAllowed(event.toolName)) return;
+		const reason = `Plan Mode blocked non-read-only tool: ${event.toolName}`;
+		ctx.ui.notify(reason, "warning");
+		return { block: true, reason };
+	});
+
+	pi.on("before_agent_start", async (event, ctx) => {
+		if (!tuiEnabled || ctx.mode !== "tui" || mode !== "planning") return;
+		const revision = currentRevisionMetadata();
+		if (!planRoot || !planId || !currentMetadata || !revision) {
+			return { systemPrompt: appendPlanningPrompt(event.systemPrompt, undefined, contentLanguage) };
+		}
+		return {
+			systemPrompt: appendPlanningPrompt(event.systemPrompt, {
+				planId,
+				title: currentMetadata.title,
+				revision: revision.revision,
+				status: revision.status,
+				planPath: getPlanPaths(planRoot, planId, revision.revision, revision.basedOn).plan,
+			}, contentLanguage),
+		};
+	});
+
+	pi.registerCommand("plan", {
+		description: "Turn strict read-only Plan Mode on or off",
+		getArgumentCompletions: (argumentPrefix) => {
+			const prefix = argumentPrefix.trim().toLowerCase();
+			const options = [
+				{ value: "on", label: "on", description: "Enable read-only Plan Mode" },
+				{ value: "off", label: "off", description: "Disable Plan Mode and restore normal tools" },
+			];
+			return options.filter((option) => option.value.startsWith(prefix));
+		},
+		handler: async (args, ctx) => {
+			if (!ensureCommandAvailable(ctx)) return;
+			const action = args.trim().toLowerCase();
+			if (!action) {
+				showPlanStatus(ctx);
+				return;
+			}
+			if (action !== "on" && action !== "off") {
+				ctx.ui.notify("Usage: /plan on|off", "warning");
+				return;
+			}
+			setMode(ctx, action === "on" ? "planning" : "normal");
+		},
+	});
+
+	pi.registerShortcut(PLAN_MODE_SHORTCUT, {
+		description: "Toggle Plan Mode",
+		handler: (ctx) => {
+			if (!ensureCommandAvailable(ctx)) return;
+			setMode(ctx, mode === "planning" ? "normal" : "planning");
+		},
+	});
+
+	pi.registerShortcut(PLAN_STEPS_SHORTCUT, {
+		description: "Expand or collapse current Plan steps",
+		handler: (ctx) => {
+			if (!ensureCommandAvailable(ctx)) return;
+			if (!currentRevisionMetadata()) {
+				ctx.ui.notify("No current Plan.", "info");
+				return;
+			}
+			stepsExpanded = !stepsExpanded;
+			refreshWidgets(ctx);
+		},
+	});
+}

--- a/packages/pi-plan-mode/package.json
+++ b/packages/pi-plan-mode/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@zhcsyncer/pi-plan-mode",
+  "version": "0.0.0",
+  "description": "Temporary read-only Plan Mode for Pi with revdiff review and immutable revisions.",
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi",
+    "pi-coding-agent",
+    "coding-agent",
+    "plan-mode",
+    "planning",
+    "read-only",
+    "approval-workflow",
+    "revdiff"
+  ],
+  "type": "module",
+  "license": "MIT",
+  "author": "zhcsyncer",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zhcsyncer/pi-extensions.git",
+    "directory": "packages/pi-plan-mode"
+  },
+  "homepage": "https://github.com/zhcsyncer/pi-extensions/tree/main/packages/pi-plan-mode#readme",
+  "bugs": {
+    "url": "https://github.com/zhcsyncer/pi-extensions/issues"
+  },
+  "engines": {
+    "node": ">=22.19.0"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "check": "pnpm typecheck && pnpm test"
+  },
+  "files": [
+    "extensions/",
+    "src/",
+    "README.md",
+    "README.zh-CN.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "pi": {
+    "extensions": [
+      "./extensions/plan-mode.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.81.0",
+    "@earendil-works/pi-tui": "^0.80.3",
+    "typebox": "^1.1.24"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "0.81.1",
+    "@earendil-works/pi-tui": "0.80.3",
+    "@types/node": "25.6.0",
+    "typescript": "6.0.3",
+    "vitest": "4.1.7"
+  }
+}

--- a/packages/pi-plan-mode/src/config.ts
+++ b/packages/pi-plan-mode/src/config.ts
@@ -1,0 +1,67 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export type PlanContentLanguage = "auto" | "en" | "zh-CN";
+
+export interface PlanModeConfig {
+	contentLanguage: PlanContentLanguage;
+}
+
+export interface LoadedPlanModeConfig {
+	config: PlanModeConfig;
+	path: string;
+	warning?: string;
+}
+
+export const DEFAULT_PLAN_MODE_CONFIG: PlanModeConfig = {
+	contentLanguage: "auto",
+};
+
+const CONTENT_LANGUAGES = new Set<PlanContentLanguage>(["auto", "en", "zh-CN"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMissingFile(error: unknown): boolean {
+	return isRecord(error) && error.code === "ENOENT";
+}
+
+export function getPlanModeConfigPath(agentDir = getAgentDir()): string {
+	return path.join(agentDir, "plan-mode.json");
+}
+
+export function parsePlanModeConfig(value: unknown): PlanModeConfig {
+	if (!isRecord(value)) throw new Error("the root value must be a JSON object");
+	if (value.contentLanguage === undefined) return { ...DEFAULT_PLAN_MODE_CONFIG };
+	if (typeof value.contentLanguage !== "string" || !CONTENT_LANGUAGES.has(value.contentLanguage as PlanContentLanguage)) {
+		throw new Error('contentLanguage must be one of "auto", "en", or "zh-CN"');
+	}
+	return { contentLanguage: value.contentLanguage as PlanContentLanguage };
+}
+
+export async function loadPlanModeConfig(agentDir = getAgentDir()): Promise<LoadedPlanModeConfig> {
+	const configPath = getPlanModeConfigPath(agentDir);
+	let raw: string;
+	try {
+		raw = await readFile(configPath, "utf8");
+	} catch (error) {
+		if (isMissingFile(error)) return { config: { ...DEFAULT_PLAN_MODE_CONFIG }, path: configPath };
+		return {
+			config: { ...DEFAULT_PLAN_MODE_CONFIG },
+			path: configPath,
+			warning: `Failed to read Plan Mode config at ${configPath}: ${error instanceof Error ? error.message : String(error)}. Using contentLanguage "auto".`,
+		};
+	}
+
+	try {
+		return { config: parsePlanModeConfig(JSON.parse(raw) as unknown), path: configPath };
+	} catch (error) {
+		return {
+			config: { ...DEFAULT_PLAN_MODE_CONFIG },
+			path: configPath,
+			warning: `Invalid Plan Mode config at ${configPath}: ${error instanceof Error ? error.message : String(error)}. Using contentLanguage "auto".`,
+		};
+	}
+}

--- a/packages/pi-plan-mode/src/policy.ts
+++ b/packages/pi-plan-mode/src/policy.ts
@@ -1,0 +1,33 @@
+export const SUBMIT_PLAN_TOOL = "submit_plan";
+
+const READ_ONLY_PLANNING_TOOLS = new Set([
+	"read",
+	"grep",
+	"find",
+	"ls",
+	"web_search",
+	"web_read",
+	"resolve-library-id",
+	"query-docs",
+	"ask_user_question",
+	"questionnaire",
+]);
+
+const MANAGED_TOOLS = new Set([SUBMIT_PLAN_TOOL]);
+
+export function withoutManagedTools(toolNames: string[]): string[] {
+	return [...new Set(toolNames.filter((name) => !MANAGED_TOOLS.has(name)))];
+}
+
+export function getPlanningTools(previouslyActive: string[]): string[] {
+	return [
+		...new Set([
+			...previouslyActive.filter((name) => READ_ONLY_PLANNING_TOOLS.has(name)),
+			SUBMIT_PLAN_TOOL,
+		]),
+	];
+}
+
+export function isPlanningToolAllowed(toolName: string): boolean {
+	return toolName === SUBMIT_PLAN_TOOL || READ_ONLY_PLANNING_TOOLS.has(toolName);
+}

--- a/packages/pi-plan-mode/src/prompts.ts
+++ b/packages/pi-plan-mode/src/prompts.ts
@@ -1,0 +1,118 @@
+import type { PlanContentLanguage } from "./config.ts";
+
+const ENGLISH_PLAN_HEADINGS = [
+	"Goal",
+	"Non-goals",
+	"Current evidence",
+	"Decisions and rationale",
+	"Proposed changes",
+	"Execution steps",
+	"Verification",
+	"Risks",
+	"Assumptions",
+] as const;
+
+const CHINESE_PLAN_HEADINGS = [
+	"目标",
+	"非目标",
+	"当前证据",
+	"决策与理由",
+	"拟议改动",
+	"执行步骤",
+	"验证",
+	"风险",
+	"假设",
+] as const;
+
+function headingList(headings: readonly string[]): string {
+	return headings.map((heading) => `  - ## ${heading}`).join("\n");
+}
+
+function planLanguageRules(contentLanguage: PlanContentLanguage): string {
+	if (contentLanguage === "en") {
+		return `[PLAN CONTENT LANGUAGE]\nConfigured content language: en.\n- Write the Plan title, section headings, prose, and list items in English.\n- Use these required section headings exactly:\n${headingList(ENGLISH_PLAN_HEADINGS)}`;
+	}
+	if (contentLanguage === "zh-CN") {
+		return `[PLAN CONTENT LANGUAGE]\nConfigured content language: zh-CN.\n- Write the Plan title, section headings, prose, and list items in Simplified Chinese.\n- Use these required section headings exactly:\n${headingList(CHINESE_PLAN_HEADINGS)}`;
+	}
+	return `[PLAN CONTENT LANGUAGE]\nConfigured content language: auto.\n- Follow higher-priority language instructions and any explicit language requested by the user. If neither specifies a language, match the current user's language.\n- When writing the Plan in Simplified Chinese, use these required section headings exactly:\n${headingList(CHINESE_PLAN_HEADINGS)}\n- Otherwise, use these required section headings exactly:\n${headingList(ENGLISH_PLAN_HEADINGS)}`;
+}
+
+export function buildPlanningPrompt(contentLanguage: PlanContentLanguage = "auto"): string {
+	return `[PLAN MODE ACTIVE]
+You are in a strictly read-only planning mode. The harness enforces a fail-closed tool allowlist.
+
+Rules:
+- Inspect facts before proposing changes.
+- Do not modify source code, project documentation, Git state, dependencies, generated files, or external mutable systems.
+- Do not attempt to bypass the tool policy or ask the user to make changes on your behalf.
+- Ask only high-impact questions whose answers cannot be discovered from the repository or environment.
+- Produce a decision-complete plan, not an implementation.
+- The plan must include all nine required sections specified below.
+- When ready, call submit_plan with the complete title and complete Markdown body. Do not write a plan file directly.
+- Call submit_plan as the only tool call in its tool batch.
+- If review feedback is returned, revise the full plan and call submit_plan again with the current planId.
+
+${planLanguageRules(contentLanguage)}
+
+The user must explicitly approve the reviewed content before normal tools are restored.`;
+}
+
+export const PLANNING_PROMPT = buildPlanningPrompt();
+
+export interface CurrentPlanReferenceInput {
+	planId: string;
+	title: string;
+	revision: number;
+	status: string;
+	planPath: string;
+}
+
+export function appendPlanningPrompt(
+	systemPrompt: string,
+	currentPlan?: CurrentPlanReferenceInput,
+	contentLanguage: PlanContentLanguage = "auto",
+): string {
+	const base = `${systemPrompt}\n\n${buildPlanningPrompt(contentLanguage)}`;
+	if (!currentPlan) return base;
+	return `${base}\n\n[CURRENT PLAN REFERENCE]
+A Plan is attached to the current Session branch. Use it as context and inspect the current workspace before deciding whether it still applies. Pass this planId to submit_plan only when revising the same goal; omit planId to create a different Plan.
+
+Plan: ${currentPlan.title}
+Plan ID: ${currentPlan.planId}
+Revision: r${currentPlan.revision}
+Document status: ${currentPlan.status}
+Plan path: ${currentPlan.planPath}
+
+Read that revision with the read tool before revising or replacing it.`;
+}
+
+export interface ImplementationHandoffInput {
+	planId: string;
+	title: string;
+	revision: number;
+	approvedHash: string;
+	planPath: string;
+	markdown: string;
+}
+
+export function buildImplementationHandoff(input: ImplementationHandoffInput): string {
+	return `[APPROVED PLAN]
+The user approved the exact Plan revision below. Plan Mode is now off and normal tools are restored.
+
+Plan: ${input.title}
+Plan ID: ${input.planId}
+Revision: r${input.revision}
+Approved hash: ${input.approvedHash}
+Plan path: ${input.planPath}
+
+Implement the approved Plan using the current workspace as the source of truth. If repository facts invalidate a decision, stop and ask the user rather than silently changing scope.
+
+--- BEGIN APPROVED PLAN ---
+${input.markdown}
+--- END APPROVED PLAN ---`;
+}
+
+export function buildReviewFeedback(planId: string, revision: number, annotations: string): string {
+	return `The user reviewed plan ${planId} r${revision} and requested changes. Address every annotation, then submit the complete revised plan with submit_plan and planId ${planId}.\n\n${annotations}`;
+}

--- a/packages/pi-plan-mode/src/review.ts
+++ b/packages/pi-plan-mode/src/review.ts
@@ -1,0 +1,120 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { accessSync, constants, existsSync } from "node:fs";
+import { chmod, readFile } from "node:fs/promises";
+import path from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { PlanPaths, RevdiffReviewResult } from "./types.ts";
+
+const EXIT_CODE_ANNOTATIONS = 10;
+
+export interface RevdiffRequest {
+	paths: PlanPaths;
+	hasPrevious: boolean;
+	cwd: string;
+}
+
+function isExecutable(file: string): boolean {
+	if (!existsSync(file)) return false;
+	if (process.platform === "win32") return true;
+	try {
+		accessSync(file, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function resolveRevdiffBinary(env: NodeJS.ProcessEnv = process.env): string | undefined {
+	const configured = env.REVDIFF_BIN?.trim();
+	if (configured) return isExecutable(configured) ? configured : undefined;
+	for (const directory of (env.PATH ?? "").split(path.delimiter)) {
+		if (!directory) continue;
+		const candidate = path.join(directory, process.platform === "win32" ? "revdiff.exe" : "revdiff");
+		if (isExecutable(candidate)) return candidate;
+	}
+	return undefined;
+}
+
+export function buildRevdiffArguments(request: RevdiffRequest): string[] {
+	const reviewArguments = request.hasPrevious
+		? ["--compare-old", request.paths.previous, "--compare-new", request.paths.plan, "--word-diff"]
+		: ["--only", request.paths.plan];
+	return [...reviewArguments, `--output=${request.paths.annotations}`];
+}
+
+interface ProcessResult {
+	status: number | null;
+	signal: NodeJS.Signals | null;
+	error?: Error;
+}
+
+export function classifyRevdiffResult(result: ProcessResult, annotations: string): RevdiffReviewResult {
+	const output = annotations.trim();
+	if (result.error) return { kind: "error", message: `Failed to launch revdiff: ${result.error.message}` };
+	if (result.signal || result.status === 130) {
+		return { kind: "cancelled", message: `revdiff was interrupted${result.signal ? ` (${result.signal})` : ""}` };
+	}
+	if (result.status !== 0 && result.status !== EXIT_CODE_ANNOTATIONS) {
+		return { kind: "error", message: `revdiff exited with code ${result.status ?? "unknown"}` };
+	}
+	if (output) return { kind: "changes_requested", annotations: output };
+	if (result.status === EXIT_CODE_ANNOTATIONS) {
+		return { kind: "error", message: "revdiff reported annotations but produced no annotation output" };
+	}
+	return { kind: "clean" };
+}
+
+function processResult(result: SpawnSyncReturns<Buffer>): ProcessResult {
+	return {
+		status: result.status,
+		signal: result.signal,
+		error: result.error,
+	};
+}
+
+export async function reviewPlanWithRevdiff(
+	ctx: ExtensionContext,
+	request: RevdiffRequest,
+): Promise<RevdiffReviewResult> {
+	if (ctx.mode !== "tui") return { kind: "error", message: "Plan review requires Pi TUI mode" };
+	const binary = resolveRevdiffBinary();
+	if (!binary) {
+		return {
+			kind: "error",
+			message: "revdiff was not found. Install it with `brew install umputun/apps/revdiff` or set REVDIFF_BIN.",
+		};
+	}
+
+	let result: ProcessResult | undefined;
+	try {
+		result = await ctx.ui.custom<ProcessResult>((tui, _theme, _keybindings, done) => {
+			tui.stop();
+			process.stdout.write("\x1b[2J\x1b[H");
+			let spawned: SpawnSyncReturns<Buffer>;
+			try {
+				spawned = spawnSync(binary, buildRevdiffArguments(request), {
+					cwd: request.cwd,
+					env: { ...process.env, REVDIFF_EXIT_CODE_ON_ANNOTATIONS: "true" },
+					stdio: "inherit",
+				});
+			} finally {
+				tui.start();
+				tui.requestRender(true);
+			}
+			const outcome = processResult(spawned!);
+			done(outcome);
+			return { render: () => [], invalidate() {} };
+		});
+	} catch (error) {
+		return { kind: "error", message: `Failed to hand the terminal to revdiff: ${error instanceof Error ? error.message : String(error)}` };
+	}
+
+	let annotations = "";
+	try {
+		annotations = await readFile(request.paths.annotations, "utf8");
+		await chmod(request.paths.annotations, 0o600);
+	} catch (error) {
+		if (!(typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT")) throw error;
+	}
+	return classifyRevdiffResult(result, annotations);
+}

--- a/packages/pi-plan-mode/src/storage.ts
+++ b/packages/pi-plan-mode/src/storage.ts
@@ -1,0 +1,423 @@
+import { createHash, randomUUID } from "node:crypto";
+import { chmod, mkdir, mkdtemp, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+	PLAN_METADATA_VERSION,
+	type PlanMetadata,
+	type PlanPaths,
+	type PlanRevision,
+	type PlanStatus,
+	type PlanStorageMode,
+	type SubmitPlanResult,
+} from "./types.ts";
+
+const PLAN_ID_PATTERN = /^\d{8}T\d{6}-[a-z0-9][a-z0-9-]{0,47}-[a-f0-9]{8}$/;
+const APPROVED_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const PLAN_STATUSES = new Set<PlanStatus>(["draft", "changes_requested", "approved"]);
+const MAX_TITLE_SLUG_LENGTH = 48;
+const EXECUTION_STEP_HEADINGS = new Set(["execution steps", "执行步骤"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMissingFile(error: unknown): boolean {
+	return isRecord(error) && error.code === "ENOENT";
+}
+
+function normalizeSlug(title: string): string {
+	const slug = title
+		.normalize("NFKD")
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, MAX_TITLE_SLUG_LENGTH)
+		.replace(/-+$/g, "");
+	return slug || "plan";
+}
+
+function revisionRelativePath(revision: number): string {
+	return `revisions/r${revision}.md`;
+}
+
+function normalizeStepSummary(value: string): string {
+	return value
+		.replace(/^\[[ xX]\]\s*/, "")
+		.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+		.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+		.replace(/\*\*([^*]+)\*\*/g, "$1")
+		.replace(/__([^_]+)__/g, "$1")
+		.replace(/~~([^~]+)~~/g, "$1")
+		.replace(/`([^`]+)`/g, "$1")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+export function extractPlanSteps(markdown: string): string[] {
+	const lines = markdown.split(/\r?\n/);
+	let sectionLevel: number | undefined;
+	const steps: string[] = [];
+
+	for (const line of lines) {
+		const heading = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(line);
+		if (heading) {
+			const level = heading[1].length;
+			const title = heading[2].trim().toLowerCase();
+			if (sectionLevel === undefined && EXECUTION_STEP_HEADINGS.has(title)) {
+				sectionLevel = level;
+				continue;
+			}
+			if (sectionLevel !== undefined && level <= sectionLevel) break;
+		}
+		if (sectionLevel === undefined) continue;
+
+		const item = /^ {0,3}\d+[.)]\s+(.+?)\s*$/.exec(line);
+		if (!item) continue;
+		const summary = normalizeStepSummary(item[1]);
+		if (summary) steps.push(summary);
+	}
+
+	return steps;
+}
+
+export function generatePlanId(title: string, now = new Date(), random: string = randomUUID()): string {
+	const timestamp = now.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "");
+	const suffix = createHash("sha256").update(random).digest("hex").slice(0, 8);
+	return `${timestamp}-${normalizeSlug(title)}-${suffix}`;
+}
+
+export function isValidPlanId(planId: string): boolean {
+	return PLAN_ID_PATTERN.test(planId);
+}
+
+export function hashPlanContent(markdown: string): string {
+	return `sha256:${createHash("sha256").update(markdown, "utf8").digest("hex")}`;
+}
+
+export function getPlanPaths(
+	root: string,
+	planId: string,
+	revision = 1,
+	previousRevision = Math.max(1, revision - 1),
+): PlanPaths {
+	if (!isValidPlanId(planId)) throw new Error(`Invalid plan id: ${planId}`);
+	if (!Number.isInteger(revision) || revision < 1) throw new Error(`Invalid plan revision: ${revision}`);
+	if (!Number.isInteger(previousRevision) || previousRevision < 1) {
+		throw new Error(`Invalid previous Plan revision: ${previousRevision}`);
+	}
+	const planDir = path.join(root, planId);
+	const revisionsDir = path.join(planDir, "revisions");
+	const reviewDir = path.join(planDir, ".review");
+	return {
+		root,
+		planDir,
+		manifest: path.join(planDir, "manifest.json"),
+		revisionsDir,
+		plan: path.join(revisionsDir, `r${revision}.md`),
+		reviewDir,
+		previous: path.join(revisionsDir, `r${previousRevision}.md`),
+		annotations: path.join(reviewDir, "annotations.md"),
+	};
+}
+
+async function ensurePrivateDirectory(directory: string): Promise<void> {
+	await mkdir(directory, { recursive: true, mode: 0o700 });
+	await chmod(directory, 0o700);
+}
+
+async function atomicWrite(file: string, content: string): Promise<void> {
+	await ensurePrivateDirectory(path.dirname(file));
+	const temporary = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${randomUUID()}.tmp`);
+	try {
+		await writeFile(temporary, content, { encoding: "utf8", mode: 0o600, flag: "wx" });
+		await rename(temporary, file);
+		await chmod(file, 0o600);
+	} finally {
+		await rm(temporary, { force: true }).catch(() => undefined);
+	}
+}
+
+async function createImmutableFile(file: string, content: string): Promise<void> {
+	await ensurePrivateDirectory(path.dirname(file));
+	await writeFile(file, content, { encoding: "utf8", mode: 0o600, flag: "wx" });
+	await chmod(file, 0o600);
+}
+
+async function readTextIfExists(file: string): Promise<string | undefined> {
+	try {
+		return await readFile(file, "utf8");
+	} catch (error) {
+		if (isMissingFile(error)) return undefined;
+		throw error;
+	}
+}
+
+export async function pathExists(file: string): Promise<boolean> {
+	try {
+		await stat(file);
+		return true;
+	} catch (error) {
+		if (isMissingFile(error)) return false;
+		throw error;
+	}
+}
+
+export async function createTemporaryPlanRoot(baseDirectory = tmpdir()): Promise<string> {
+	const root = await mkdtemp(path.join(baseDirectory, "pi-plan-"));
+	await chmod(root, 0o700);
+	return root;
+}
+
+export async function ensurePersistentPlanRoot(root: string): Promise<string> {
+	await ensurePrivateDirectory(root);
+	return root;
+}
+
+export async function removeTemporaryPlanRoot(root: string | undefined): Promise<void> {
+	if (!root) return;
+	await rm(root, { recursive: true, force: true });
+}
+
+function parseRevision(value: unknown): PlanRevision | undefined {
+	if (!isRecord(value)) return undefined;
+	if (typeof value.revision !== "number" || !Number.isInteger(value.revision) || value.revision < 1) return undefined;
+	if (typeof value.status !== "string" || !PLAN_STATUSES.has(value.status as PlanStatus)) return undefined;
+	if (value.path !== revisionRelativePath(value.revision)) return undefined;
+	if (typeof value.hash !== "string" || !APPROVED_HASH_PATTERN.test(value.hash)) return undefined;
+	if (typeof value.createdAt !== "string") return undefined;
+	if (value.basedOn !== undefined && (typeof value.basedOn !== "number" || !Number.isInteger(value.basedOn) || value.basedOn < 1)) return undefined;
+	if (!Array.isArray(value.steps) || !value.steps.every((step) => typeof step === "string")) return undefined;
+	if (value.approvedAt !== undefined && typeof value.approvedAt !== "string") return undefined;
+	return value as unknown as PlanRevision;
+}
+
+function parseMetadata(value: unknown): PlanMetadata | undefined {
+	if (!isRecord(value) || value.version !== PLAN_METADATA_VERSION) return undefined;
+	if (typeof value.planId !== "string" || !isValidPlanId(value.planId)) return undefined;
+	if (typeof value.title !== "string" || typeof value.status !== "string" || !PLAN_STATUSES.has(value.status as PlanStatus)) return undefined;
+	if (value.storage !== "persistent" && value.storage !== "temporary") return undefined;
+	if (typeof value.sessionId !== "string" || typeof value.cwd !== "string") return undefined;
+	if (typeof value.createdAt !== "string" || typeof value.updatedAt !== "string") return undefined;
+	if (typeof value.currentRevision !== "number" || !Number.isInteger(value.currentRevision) || value.currentRevision < 1) return undefined;
+	if (value.approvedRevision !== undefined && (typeof value.approvedRevision !== "number" || !Number.isInteger(value.approvedRevision) || value.approvedRevision < 1)) return undefined;
+	if (value.approvedHash !== undefined && (typeof value.approvedHash !== "string" || !APPROVED_HASH_PATTERN.test(value.approvedHash))) return undefined;
+	if (!Array.isArray(value.revisions)) return undefined;
+	const revisions = value.revisions.map(parseRevision);
+	if (revisions.some((revision) => revision === undefined)) return undefined;
+	const parsedRevisions = revisions as PlanRevision[];
+	if (parsedRevisions.length !== value.currentRevision) return undefined;
+	if (!parsedRevisions.every((revision, index) => revision.revision === index + 1)) return undefined;
+	const current = parsedRevisions.at(-1);
+	if (!current || current.status !== value.status) return undefined;
+	if ((value.approvedRevision === undefined) !== (value.approvedHash === undefined)) return undefined;
+	if (value.approvedRevision !== undefined) {
+		const approved = parsedRevisions[value.approvedRevision - 1];
+		if (!approved || approved.status !== "approved" || approved.hash !== value.approvedHash) return undefined;
+	}
+	return value as unknown as PlanMetadata;
+}
+
+export async function readPlanMetadata(root: string, planId: string): Promise<PlanMetadata | undefined> {
+	const raw = await readTextIfExists(getPlanPaths(root, planId).manifest);
+	if (raw === undefined) return undefined;
+	try {
+		return parseMetadata(JSON.parse(raw) as unknown);
+	} catch {
+		return undefined;
+	}
+}
+
+export async function readPlanContent(root: string, planId: string, revision?: number): Promise<string | undefined> {
+	let targetRevision = revision;
+	if (targetRevision === undefined) {
+		const metadata = await readPlanMetadata(root, planId);
+		if (!metadata) return undefined;
+		targetRevision = metadata.currentRevision;
+	}
+	return readTextIfExists(getPlanPaths(root, planId, targetRevision).plan);
+}
+
+export async function writePlanMetadata(root: string, metadata: PlanMetadata): Promise<void> {
+	if (!isValidPlanId(metadata.planId)) throw new Error(`Invalid plan id: ${metadata.planId}`);
+	await atomicWrite(getPlanPaths(root, metadata.planId).manifest, `${JSON.stringify(metadata, null, 2)}\n`);
+}
+
+export interface SubmitPlanInput {
+	root: string;
+	planId: string;
+	title: string;
+	markdown: string;
+	storage: PlanStorageMode;
+	sessionId: string;
+	cwd: string;
+	basedOn?: number;
+	now?: Date;
+}
+
+export async function saveSubmittedPlan(input: SubmitPlanInput): Promise<SubmitPlanResult> {
+	await ensurePrivateDirectory(input.root);
+	const existing = await readPlanMetadata(input.root, input.planId);
+	if (existing && existing.sessionId !== input.sessionId) {
+		throw new Error(`Plan ${input.planId} belongs to another Session`);
+	}
+	if (input.basedOn !== undefined && (!existing || !existing.revisions[input.basedOn - 1])) {
+		throw new Error(`Base revision does not exist: r${input.basedOn}`);
+	}
+
+	const revisionNumber = (existing?.currentRevision ?? 0) + 1;
+	const basedOn = existing ? (input.basedOn ?? existing.currentRevision) : undefined;
+	const paths = getPlanPaths(input.root, input.planId, revisionNumber, basedOn ?? 1);
+	await ensurePrivateDirectory(paths.planDir);
+	await ensurePrivateDirectory(paths.revisionsDir);
+	await ensurePrivateDirectory(paths.reviewDir);
+	await rm(paths.annotations, { force: true });
+
+	const timestamp = (input.now ?? new Date()).toISOString();
+	const revision: PlanRevision = {
+		revision: revisionNumber,
+		status: "draft",
+		path: revisionRelativePath(revisionNumber),
+		hash: hashPlanContent(input.markdown),
+		createdAt: timestamp,
+		...(basedOn ? { basedOn } : {}),
+		steps: extractPlanSteps(input.markdown),
+	};
+	const metadata: PlanMetadata = {
+		version: PLAN_METADATA_VERSION,
+		planId: input.planId,
+		title: input.title.trim(),
+		status: "draft",
+		storage: input.storage,
+		sessionId: input.sessionId,
+		cwd: input.cwd,
+		createdAt: existing?.createdAt ?? timestamp,
+		updatedAt: timestamp,
+		currentRevision: revisionNumber,
+		...(existing?.approvedRevision ? { approvedRevision: existing.approvedRevision } : {}),
+		...(existing?.approvedHash ? { approvedHash: existing.approvedHash } : {}),
+		revisions: [...(existing?.revisions ?? []), revision],
+	};
+
+	await createImmutableFile(paths.plan, input.markdown);
+	try {
+		await writePlanMetadata(input.root, metadata);
+	} catch (error) {
+		await rm(paths.plan, { force: true }).catch(() => undefined);
+		throw error;
+	}
+
+	return {
+		metadata,
+		paths,
+		revision,
+		submittedHash: revision.hash,
+		hasPrevious: existing !== undefined,
+	};
+}
+
+export async function writeReviewAnnotations(paths: PlanPaths, annotations: string): Promise<void> {
+	await atomicWrite(paths.annotations, annotations.trimEnd() ? `${annotations.trimEnd()}\n` : "");
+}
+
+export async function updatePlanStatus(
+	root: string,
+	planId: string,
+	status: Exclude<PlanStatus, "approved">,
+	now = new Date(),
+): Promise<PlanMetadata> {
+	const current = await readPlanMetadata(root, planId);
+	if (!current) throw new Error(`Plan metadata not found: ${planId}`);
+	if (current.revisions[current.currentRevision - 1]?.status === "approved") {
+		throw new Error(`Approved Plan revision r${current.currentRevision} is immutable`);
+	}
+	const revisions = current.revisions.map((revision) =>
+		revision.revision === current.currentRevision ? { ...revision, status } : revision,
+	);
+	const metadata: PlanMetadata = {
+		...current,
+		status,
+		updatedAt: now.toISOString(),
+		revisions,
+	};
+	await writePlanMetadata(root, metadata);
+	return metadata;
+}
+
+export async function approvePlan(
+	root: string,
+	planId: string,
+	revision: number,
+	expectedHash: string,
+	now = new Date(),
+): Promise<PlanMetadata> {
+	const metadata = await readPlanMetadata(root, planId);
+	if (!metadata) throw new Error(`Plan metadata not found: ${planId}`);
+	if (metadata.currentRevision !== revision) throw new Error("Plan revision changed during review; approval was not recorded");
+	const content = await readPlanContent(root, planId, revision);
+	if (content === undefined) throw new Error(`Plan revision not found: ${planId} r${revision}`);
+	const actualHash = hashPlanContent(content);
+	if (actualHash !== expectedHash) throw new Error("Plan content changed during review; approval was not recorded");
+	const approvedAt = now.toISOString();
+	const revisions = metadata.revisions.map((entry) =>
+		entry.revision === revision ? { ...entry, status: "approved" as const, approvedAt } : entry,
+	);
+	const approved: PlanMetadata = {
+		...metadata,
+		status: "approved",
+		updatedAt: approvedAt,
+		currentRevision: revision,
+		approvedRevision: revision,
+		approvedHash: actualHash,
+		revisions,
+	};
+	await writePlanMetadata(root, approved);
+	return approved;
+}
+
+export interface IntegrityResult {
+	ok: boolean;
+	expectedHash?: string;
+	actualHash?: string;
+	content?: string;
+	metadata?: PlanMetadata;
+	reason?: string;
+}
+
+export async function verifyApprovedPlan(
+	root: string,
+	planId: string,
+	revision?: number,
+	expectedHash?: string,
+): Promise<IntegrityResult> {
+	const metadata = await readPlanMetadata(root, planId);
+	if (!metadata) return { ok: false, reason: "Plan metadata is missing" };
+	const approvedRevision = revision ?? metadata.approvedRevision;
+	if (!approvedRevision) return { ok: false, metadata, reason: "Plan has no approved revision" };
+	const approved = metadata.revisions[approvedRevision - 1];
+	if (!approved || approved.status !== "approved") {
+		return { ok: false, metadata, reason: `Plan revision r${approvedRevision} is not approved` };
+	}
+	const content = await readPlanContent(root, planId, approvedRevision);
+	if (content === undefined) return { ok: false, metadata, reason: "Approved Plan revision is missing" };
+	const approvedHash = expectedHash ?? metadata.approvedHash;
+	if (!approvedHash || approved.hash !== approvedHash || metadata.approvedRevision !== approvedRevision) {
+		return { ok: false, metadata, content, reason: "Plan metadata does not match the approved revision" };
+	}
+	const actualHash = hashPlanContent(content);
+	if (actualHash !== approvedHash) {
+		return {
+			ok: false,
+			metadata,
+			content,
+			expectedHash: approvedHash,
+			actualHash,
+			reason: "Plan content no longer matches the approved hash",
+		};
+	}
+	return { ok: true, metadata, content, expectedHash: approvedHash, actualHash };
+}
+
+export async function cleanupReviewWorkspace(root: string, planId: string): Promise<void> {
+	await rm(getPlanPaths(root, planId).reviewDir, { recursive: true, force: true });
+}

--- a/packages/pi-plan-mode/src/types.ts
+++ b/packages/pi-plan-mode/src/types.ts
@@ -1,0 +1,66 @@
+export const PLAN_METADATA_VERSION = 2 as const;
+export const SESSION_STATE_VERSION = 2 as const;
+
+export type PlanMode = "normal" | "planning";
+export type PlanStatus = "draft" | "changes_requested" | "approved";
+export type PlanStorageMode = "persistent" | "temporary";
+
+export interface PlanRevision {
+	revision: number;
+	status: PlanStatus;
+	path: string;
+	hash: string;
+	createdAt: string;
+	basedOn?: number;
+	steps: string[];
+	approvedAt?: string;
+}
+
+export interface PlanMetadata {
+	version: typeof PLAN_METADATA_VERSION;
+	planId: string;
+	title: string;
+	status: PlanStatus;
+	storage: PlanStorageMode;
+	sessionId: string;
+	cwd: string;
+	createdAt: string;
+	updatedAt: string;
+	currentRevision: number;
+	approvedRevision?: number;
+	approvedHash?: string;
+	revisions: PlanRevision[];
+}
+
+export interface PlanPaths {
+	root: string;
+	planDir: string;
+	manifest: string;
+	revisionsDir: string;
+	plan: string;
+	reviewDir: string;
+	previous: string;
+	annotations: string;
+}
+
+export interface PlanSessionState {
+	version: typeof SESSION_STATE_VERSION;
+	mode: PlanMode;
+	planId?: string;
+	revision?: number;
+	normalTools: string[];
+}
+
+export type RevdiffReviewResult =
+	| { kind: "clean" }
+	| { kind: "changes_requested"; annotations: string }
+	| { kind: "cancelled"; message: string }
+	| { kind: "error"; message: string };
+
+export interface SubmitPlanResult {
+	metadata: PlanMetadata;
+	paths: PlanPaths;
+	revision: PlanRevision;
+	submittedHash: string;
+	hasPrevious: boolean;
+}

--- a/packages/pi-plan-mode/src/widgets.ts
+++ b/packages/pi-plan-mode/src/widgets.ts
@@ -1,0 +1,133 @@
+import { homedir } from "node:os";
+import path from "node:path";
+import { type Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { PlanStatus } from "./types.ts";
+
+const PLAN_PREFIX = "▌ PLAN  ";
+const MODE_LABEL = "⏸ PLAN MODE · READ-ONLY";
+const MODE_HINT = "/plan off · Ctrl+Alt+P";
+const STEPS_HINT = "Ctrl+Alt+O";
+
+export interface PlanWidgetData {
+	title: string;
+	status: PlanStatus;
+	revision: number;
+	planPath: string;
+	steps: string[];
+	expanded: boolean;
+	terminalRows: number;
+}
+
+export interface PlanApprovedEventData {
+	title?: string;
+	revision?: number;
+	stepCount?: number;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	return Math.min(maximum, Math.max(minimum, value));
+}
+
+function statusLabel(status: PlanStatus): string {
+	return status === "changes_requested" ? "CHANGES REQUESTED" : status.toUpperCase();
+}
+
+function statusColor(status: PlanStatus): "success" | "warning" | "accent" {
+	if (status === "approved") return "success";
+	if (status === "changes_requested") return "warning";
+	return "accent";
+}
+
+function alignRight(left: string, right: string, width: number, minimumGap = 2): string {
+	if (width <= 0) return "";
+	if (!right) return truncateToWidth(left, width);
+	const rightWidth = visibleWidth(right);
+	if (rightWidth >= width) return truncateToWidth(left, width);
+	const leftWidth = visibleWidth(left);
+	if (leftWidth + minimumGap + rightWidth <= width) {
+		return `${left}${" ".repeat(width - leftWidth - rightWidth)}${right}`;
+	}
+	const availableLeft = width - rightWidth - minimumGap;
+	if (availableLeft < 8) return truncateToWidth(left, width);
+	const fittedLeft = truncateToWidth(left, availableLeft);
+	return `${fittedLeft}${" ".repeat(width - visibleWidth(fittedLeft) - rightWidth)}${right}`;
+}
+
+function rightAligned(text: string, width: number): string {
+	const fitted = truncateToWidth(text, width);
+	return `${" ".repeat(Math.max(0, width - visibleWidth(fitted)))}${fitted}`;
+}
+
+export function compactPlanPath(planPath: string, home = homedir()): string {
+	const normalizedHome = path.resolve(home);
+	const normalizedPath = path.resolve(planPath);
+	if (normalizedPath === normalizedHome) return "~";
+	if (normalizedPath.startsWith(`${normalizedHome}${path.sep}`)) {
+		return `~${normalizedPath.slice(normalizedHome.length)}`;
+	}
+	return planPath;
+}
+
+export function renderPlanWidget(data: PlanWidgetData, width: number, theme: Theme): string[] {
+	if (width <= 0) return [];
+	const title = `${theme.fg("accent", PLAN_PREFIX)}${theme.bold(data.title)}`;
+	const state = theme.fg(statusColor(data.status), `${statusLabel(data.status)} · r${data.revision}`);
+	const lines = [alignRight(title, state, width)];
+
+	if (!data.expanded) {
+		const count = theme.fg("muted", `${data.steps.length} ${data.steps.length === 1 ? "step" : "steps"}`);
+		const hint = theme.fg("dim", `${STEPS_HINT} expand`);
+		lines.push(alignRight(count, hint, width));
+		return lines.map((line) => truncateToWidth(line, width));
+	}
+
+	const planPath = theme.fg("dim", compactPlanPath(data.planPath));
+	lines.push(truncateToWidth(planPath, width));
+	if (data.steps.length === 0) {
+		lines.push(truncateToWidth(theme.fg("muted", "  No execution steps"), width));
+	} else {
+		const budget = clamp(Math.floor(data.terminalRows * 0.3), 3, 10);
+		const visibleSteps = data.steps.slice(0, budget);
+		for (const [index, step] of visibleSteps.entries()) {
+			const prefix = theme.fg("accent", `  ${index + 1}. `);
+			lines.push(truncateToWidth(`${prefix}${step}`, width));
+		}
+		const remaining = data.steps.length - visibleSteps.length;
+		if (remaining > 0) lines.push(truncateToWidth(theme.fg("muted", `  … +${remaining} more`), width));
+	}
+	lines.push(rightAligned(theme.fg("dim", `${STEPS_HINT} collapse`), width));
+	return lines.map((line) => truncateToWidth(line, width));
+}
+
+export function renderPlanApprovedEvent(data: PlanApprovedEventData, width: number, theme: Theme): string[] {
+	if (width <= 0) return [];
+	const status = theme.fg("success", "✓ PLAN APPROVED");
+	const metadata: string[] = [];
+	if (data.title?.trim()) metadata.push(data.title.trim());
+	if (Number.isInteger(data.revision) && data.revision! > 0) metadata.push(`r${data.revision}`);
+	if (Number.isInteger(data.stepCount) && data.stepCount! >= 0) {
+		metadata.push(`${data.stepCount} ${data.stepCount === 1 ? "step" : "steps"}`);
+	}
+	if (metadata.length === 0) return [truncateToWidth(status, width)];
+	const statusWidth = visibleWidth(status);
+	if (width - statusWidth < 3) return [truncateToWidth(status, width)];
+	const suffix = theme.fg("dim", ` · ${metadata.join(" · ")}`);
+	return [`${status}${truncateToWidth(suffix, width - statusWidth)}`];
+}
+
+export function renderModeWidget(width: number, theme: Theme): string[] {
+	if (width <= 0) return [];
+	const label = theme.fg("warning", MODE_LABEL);
+	const fullHint = theme.fg("dim", MODE_HINT);
+	const commandOnly = theme.fg("dim", "/plan off");
+	let line: string;
+	if (visibleWidth(label) + 2 + visibleWidth(fullHint) <= width) {
+		line = alignRight(label, fullHint, width);
+	} else if (visibleWidth(label) + 2 + visibleWidth(commandOnly) <= width) {
+		line = alignRight(label, commandOnly, width);
+	} else {
+		line = truncateToWidth(label, width);
+	}
+	return [truncateToWidth(line, width)];
+}

--- a/packages/pi-plan-mode/tests/config.test.ts
+++ b/packages/pi-plan-mode/tests/config.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	DEFAULT_PLAN_MODE_CONFIG,
+	getPlanModeConfigPath,
+	loadPlanModeConfig,
+	parsePlanModeConfig,
+} from "../src/config.ts";
+
+const cleanup = new Set<string>();
+
+afterEach(async () => {
+	await Promise.all([...cleanup].map((directory) => rm(directory, { recursive: true, force: true })));
+	cleanup.clear();
+});
+
+async function agentDir(): Promise<string> {
+	const directory = await mkdtemp(path.join(tmpdir(), "pi-plan-config-test-"));
+	cleanup.add(directory);
+	return directory;
+}
+
+describe("Plan Mode config", () => {
+	it("defaults to auto when the config file or field is missing", async () => {
+		const directory = await agentDir();
+		expect(await loadPlanModeConfig(directory)).toEqual({
+			config: DEFAULT_PLAN_MODE_CONFIG,
+			path: getPlanModeConfigPath(directory),
+		});
+		expect(parsePlanModeConfig({})).toEqual({ contentLanguage: "auto" });
+	});
+
+	it.each(["auto", "en", "zh-CN"] as const)("loads supported content language %s", async (contentLanguage) => {
+		const directory = await agentDir();
+		await writeFile(getPlanModeConfigPath(directory), `${JSON.stringify({ contentLanguage })}\n`, "utf8");
+		expect(await loadPlanModeConfig(directory)).toEqual({
+			config: { contentLanguage },
+			path: getPlanModeConfigPath(directory),
+		});
+	});
+
+	it.each([
+		["malformed JSON", "{"],
+		["non-object root", "[]"],
+		["unsupported language", '{"contentLanguage":"fr"}'],
+	])("warns and falls back for %s", async (_label, content) => {
+		const directory = await agentDir();
+		await writeFile(getPlanModeConfigPath(directory), content, "utf8");
+		const loaded = await loadPlanModeConfig(directory);
+		expect(loaded.config).toEqual({ contentLanguage: "auto" });
+		expect(loaded.warning).toContain("Invalid Plan Mode config");
+		expect(loaded.warning).toContain('Using contentLanguage "auto"');
+	});
+});

--- a/packages/pi-plan-mode/tests/extension.test.ts
+++ b/packages/pi-plan-mode/tests/extension.test.ts
@@ -1,0 +1,504 @@
+import { chmod, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import planModeExtension, {
+	APPROVED_PLAN_MESSAGE_TYPE,
+	PLAN_MODE_SHORTCUT,
+	PLAN_STEPS_SHORTCUT,
+	isPersistentSession,
+} from "../extensions/plan-mode.ts";
+import { SUBMIT_PLAN_TOOL } from "../src/policy.ts";
+
+interface CustomEntry {
+	type: "custom";
+	customType: string;
+	data: unknown;
+}
+
+type EventHandler = (event: any, ctx: ExtensionContext) => unknown | Promise<unknown>;
+
+class FakePi {
+	activeTools = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+	readonly activeToolHistory: string[][] = [];
+	readonly tools = new Map<string, any>();
+	readonly commands = new Map<string, any>();
+	readonly shortcuts = new Map<string, any>();
+	readonly handlers = new Map<string, EventHandler[]>();
+	readonly entries: CustomEntry[];
+	readonly sentUserMessages: Array<{ content: string; options?: unknown }> = [];
+	readonly sentMessages: Array<{ message: any; options?: unknown; activeTools: string[] }> = [];
+	readonly messageRenderers = new Map<string, any>();
+	readonly flags = new Map<string, unknown>();
+	onSendMessage?: () => void;
+
+	constructor(entries: CustomEntry[] = []) {
+		this.entries = entries;
+	}
+
+	api(): ExtensionAPI {
+		return this as unknown as ExtensionAPI;
+	}
+
+	on(name: string, handler: EventHandler): void {
+		const handlers = this.handlers.get(name) ?? [];
+		handlers.push(handler);
+		this.handlers.set(name, handlers);
+	}
+
+	registerTool(definition: { name: string }): void {
+		this.tools.set(definition.name, definition);
+		this.activeTools = [...new Set([...this.activeTools, definition.name])];
+	}
+
+	registerFlag(name: string, definition: { default?: unknown }): void {
+		if (!this.flags.has(name)) this.flags.set(name, definition.default);
+	}
+
+	getFlag(name: string): unknown {
+		return this.flags.get(name);
+	}
+
+	registerCommand(name: string, definition: unknown): void {
+		this.commands.set(name, definition);
+	}
+
+	registerMessageRenderer(customType: string, renderer: unknown): void {
+		this.messageRenderers.set(customType, renderer);
+	}
+
+	registerShortcut(shortcut: string, definition: unknown): void {
+		this.shortcuts.set(shortcut, definition);
+	}
+
+	getActiveTools(): string[] {
+		return [...this.activeTools];
+	}
+
+	setActiveTools(tools: string[]): void {
+		this.activeTools = [...tools];
+		this.activeToolHistory.push([...tools]);
+	}
+
+	appendEntry(customType: string, data: unknown): void {
+		this.entries.push({ type: "custom", customType, data });
+	}
+
+	sendUserMessage(content: string, options?: unknown): void {
+		this.sentUserMessages.push({ content, options });
+	}
+
+	sendMessage(message: unknown, options?: unknown): void {
+		this.onSendMessage?.();
+		this.sentMessages.push({ message, options, activeTools: [...this.activeTools] });
+	}
+
+	async emit(name: string, event: unknown, ctx: ExtensionContext): Promise<unknown> {
+		let result: unknown;
+		for (const handler of this.handlers.get(name) ?? []) {
+			const next = await handler(event, ctx);
+			if (next !== undefined) result = next;
+		}
+		return result;
+	}
+}
+
+interface FakeContextOptions {
+	mode?: "tui" | "rpc" | "json" | "print";
+	sessionFile?: string;
+	sessionId?: string;
+	cwd?: string;
+	entries?: CustomEntry[];
+	choices?: Array<string | undefined>;
+}
+
+interface FakeContextHarness {
+	ctx: ExtensionContext;
+	notifications: Array<{ message: string; type?: string }>;
+	terminal: { stops: number; starts: number; renders: number };
+	widgets: Map<string, { content: any; placement?: string }>;
+	renderWidget(key: string, width?: number): string[] | undefined;
+}
+
+function fakeContext(options: FakeContextOptions = {}): FakeContextHarness {
+	const mode = options.mode ?? "tui";
+	const notifications: Array<{ message: string; type?: string }> = [];
+	const terminal = { stops: 0, starts: 0, renders: 0 };
+	const widgets = new Map<string, { content: any; placement?: string }>();
+	const choices = [...(options.choices ?? [])];
+	const entries = options.entries ?? [];
+	const theme = {
+		fg: (_color: string, text: string) => text,
+		bold: (text: string) => text,
+		strikethrough: (text: string) => text,
+	};
+
+	const ctx = {
+		mode,
+		hasUI: mode === "tui" || mode === "rpc",
+		cwd: options.cwd ?? process.cwd(),
+		sessionManager: {
+			getBranch: () => entries,
+			getSessionFile: () => options.sessionFile,
+			getSessionId: () => options.sessionId ?? "session-test",
+		},
+		ui: {
+			theme,
+			notify: (message: string, type?: string) => notifications.push({ message, type }),
+			setWidget: (key: string, content: any, widgetOptions?: { placement?: string }) => {
+				if (content === undefined) widgets.delete(key);
+				else widgets.set(key, { content, placement: widgetOptions?.placement });
+			},
+			select: async () => choices.shift(),
+			custom: async (factory: any) => {
+				let completed = false;
+				let value: unknown;
+				await factory(
+					{
+						stop: () => terminal.stops++,
+						start: () => terminal.starts++,
+						requestRender: () => terminal.renders++,
+					},
+					theme,
+					{},
+					(result: unknown) => {
+						completed = true;
+						value = result;
+					},
+				);
+				if (!completed) throw new Error("Custom UI did not complete synchronously in the test harness");
+				return value;
+			},
+		},
+	} as unknown as ExtensionContext;
+	return {
+		ctx,
+		notifications,
+		terminal,
+		widgets,
+		renderWidget: (key, width = 100) => {
+			const widget = widgets.get(key);
+			if (!widget) return undefined;
+			const component = typeof widget.content === "function"
+				? widget.content({ terminal: { rows: 40 } }, theme)
+				: { render: () => widget.content };
+			return component.render(width);
+		},
+	};
+}
+
+function plain(text: string | undefined): string {
+	return (text ?? "").replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+const cleanup = new Set<string>();
+
+afterEach(async () => {
+	vi.unstubAllEnvs();
+	await Promise.all([...cleanup].map(async (directory) => {
+		const { rm } = await import("node:fs/promises");
+		await rm(directory, { recursive: true, force: true });
+	}));
+	cleanup.clear();
+});
+
+async function fakeRevdiff(): Promise<string> {
+	const directory = await mkdtemp(path.join(tmpdir(), "pi-plan-revdiff-test-"));
+	cleanup.add(directory);
+	const executable = path.join(directory, "revdiff-test.mjs");
+	await writeFile(
+		executable,
+		`#!/usr/bin/env node\nimport { writeFileSync } from "node:fs";\nconst out = process.argv.find((arg) => arg.startsWith("--output="))?.slice(9);\nconst annotations = process.env.PLAN_MODE_TEST_ANNOTATIONS ?? "";\nif (out && annotations) writeFileSync(out, annotations);\nprocess.exit(Number(process.env.PLAN_MODE_TEST_EXIT ?? (annotations ? 10 : 0)));\n`,
+		"utf8",
+	);
+	await chmod(executable, 0o700);
+	vi.stubEnv("PI_CODING_AGENT_DIR", directory);
+	vi.stubEnv("REVDIFF_BIN", executable);
+	vi.stubEnv("PLAN_MODE_TEST_ANNOTATIONS", "");
+	vi.stubEnv("PLAN_MODE_TEST_EXIT", "0");
+	return executable;
+}
+
+async function turnPlanOn(pi: FakePi, ctx: ExtensionContext): Promise<void> {
+	const command = pi.commands.get("plan") as { handler: (args: string, ctx: ExtensionContext) => Promise<void> };
+	await command.handler("on", ctx);
+}
+
+async function submitPlan(pi: FakePi, ctx: ExtensionContext, planId?: string) {
+	const tool = pi.tools.get(SUBMIT_PLAN_TOOL);
+	expect(tool).toBeDefined();
+	return tool.execute(
+		"submit-1",
+		{
+			...(planId ? { planId } : {}),
+			title: "Implement simple Plan Mode",
+			markdown: "# Goal\n\nImplement it.\n\n## Execution steps\n\n1. Change code\n2. Run tests\n\n## Verification\n\nRun tests.\n",
+		},
+		undefined,
+		undefined,
+		ctx,
+	);
+}
+
+describe("Plan Mode extension lifecycle", () => {
+	it("is completely inert outside TUI mode even when --plan is set", async () => {
+		const agentDir = await mkdtemp(path.join(tmpdir(), "pi-plan-non-tui-test-"));
+		cleanup.add(agentDir);
+		await writeFile(path.join(agentDir, "plan-mode.json"), "{", "utf8");
+		vi.stubEnv("PI_CODING_AGENT_DIR", agentDir);
+		const pi = new FakePi();
+		planModeExtension(pi.api());
+		pi.flags.set("plan", true);
+		const originalTools = [...pi.activeTools];
+		const { ctx, notifications } = fakeContext({ mode: "print", entries: pi.entries });
+
+		await pi.emit("session_start", { reason: "startup" }, ctx);
+
+		expect(pi.tools.size).toBe(0);
+		expect(pi.activeToolHistory).toHaveLength(0);
+		expect(pi.activeTools).toEqual(originalTools);
+		expect(pi.entries).toHaveLength(0);
+		expect(notifications).toHaveLength(0);
+		expect(await pi.emit("before_agent_start", { systemPrompt: "base" }, ctx)).toBeUndefined();
+	});
+
+	it("warns at TUI startup and keeps Plan Mode disabled when revdiff is missing", async () => {
+		const agentDir = await mkdtemp(path.join(tmpdir(), "pi-plan-agent-config-test-"));
+		cleanup.add(agentDir);
+		vi.stubEnv("PI_CODING_AGENT_DIR", agentDir);
+		vi.stubEnv("REVDIFF_BIN", path.join(tmpdir(), "missing-revdiff"));
+		const pi = new FakePi();
+		planModeExtension(pi.api());
+		const originalTools = [...pi.activeTools];
+		const harness = fakeContext({ entries: pi.entries });
+
+		await pi.emit("session_start", { reason: "startup" }, harness.ctx);
+
+		expect(pi.tools.size).toBe(0);
+		expect(pi.activeTools).toEqual(originalTools);
+		expect(harness.notifications.some(({ message }) => message.includes("revdiff is not installed"))).toBe(true);
+		const command = pi.commands.get("plan") as { handler: (args: string, ctx: ExtensionContext) => Promise<void> };
+		await command.handler("on", harness.ctx);
+		expect(pi.activeTools).toEqual(originalTools);
+	});
+
+	it("maps --plan to Plan Mode on during initial TUI startup", async () => {
+		await fakeRevdiff();
+		const pi = new FakePi();
+		planModeExtension(pi.api());
+		pi.flags.set("plan", true);
+		const harness = fakeContext({ entries: pi.entries });
+
+		await pi.emit("session_start", { reason: "startup" }, harness.ctx);
+
+		expect(pi.activeTools).toEqual(["read", "grep", "find", "ls", SUBMIT_PLAN_TOOL]);
+		const belowEntry = [...harness.widgets.entries()].find(([, widget]) => widget.placement === "belowEditor");
+		expect(belowEntry).toBeDefined();
+		expect(harness.renderWidget(belowEntry![0])?.join("\n")).toContain("⏸ PLAN MODE · READ-ONLY");
+	});
+
+	it("loads zh-CN Plan content language into status and the planning prompt", async () => {
+		const revdiff = await fakeRevdiff();
+		const configPath = path.join(path.dirname(revdiff), "plan-mode.json");
+		await writeFile(configPath, '{"contentLanguage":"zh-CN"}\n', "utf8");
+		const pi = new FakePi();
+		planModeExtension(pi.api());
+		const harness = fakeContext({ entries: pi.entries });
+		await pi.emit("session_start", { reason: "startup" }, harness.ctx);
+		const command = pi.commands.get("plan") as { handler: (args: string, ctx: ExtensionContext) => Promise<void> };
+		await command.handler("", harness.ctx);
+		expect(harness.notifications.at(-1)?.message).toContain("Plan content language: zh-CN");
+		expect(harness.notifications.at(-1)?.message).toContain(`Config: ${configPath}`);
+		await turnPlanOn(pi, harness.ctx);
+		const prompt = await pi.emit("before_agent_start", { systemPrompt: "BASE" }, harness.ctx) as { systemPrompt: string };
+		expect(prompt.systemPrompt).toContain("Configured content language: zh-CN");
+		expect(prompt.systemPrompt).toContain("## 执行步骤");
+		expect(prompt.systemPrompt).not.toContain("## Execution steps");
+	});
+
+	it("warns and falls back to auto for an invalid Plan Mode config", async () => {
+		const revdiff = await fakeRevdiff();
+		await writeFile(path.join(path.dirname(revdiff), "plan-mode.json"), '{"contentLanguage":"fr"}\n', "utf8");
+		const pi = new FakePi();
+		planModeExtension(pi.api());
+		const harness = fakeContext({ entries: pi.entries });
+		await pi.emit("session_start", { reason: "startup" }, harness.ctx);
+		expect(harness.notifications.some(({ message, type }) => type === "warning" && message.includes("Invalid Plan Mode config"))).toBe(true);
+		await turnPlanOn(pi, harness.ctx);
+		const prompt = await pi.emit("before_agent_start", { systemPrompt: "BASE" }, harness.ctx) as { systemPrompt: string };
+		expect(prompt.systemPrompt).toContain("Configured content language: auto");
+	});
+
+	it("supports /plan on|off, autocomplete, and the mode shortcut", async () => {
+		await fakeRevdiff();
+		const pi = new FakePi();
+		planModeExtension(pi.api());
+		const harness = fakeContext({ entries: pi.entries });
+		const { ctx, notifications } = harness;
+		await pi.emit("session_start", { reason: "startup" }, ctx);
+		const command = pi.commands.get("plan") as any;
+
+		expect(command.getArgumentCompletions("").map((item: any) => item.value)).toEqual(["on", "off"]);
+		expect(command.getArgumentCompletions("o").map((item: any) => item.value)).toEqual(["on", "off"]);
+		await command.handler("", ctx);
+		expect(notifications.at(-1)?.message).toContain("Plan Mode: off");
+		const stepsShortcut = pi.shortcuts.get(PLAN_STEPS_SHORTCUT) as { handler: (ctx: ExtensionContext) => void };
+		stepsShortcut.handler(ctx);
+		expect(notifications.at(-1)?.message).toBe("No current Plan.");
+
+		await command.handler("on", ctx);
+		expect(pi.activeTools).toEqual(["read", "grep", "find", "ls", SUBMIT_PLAN_TOOL]);
+		const belowEntry = [...harness.widgets.entries()].find(([, widget]) => widget.placement === "belowEditor");
+		expect(belowEntry).toBeDefined();
+		expect(harness.renderWidget(belowEntry![0])?.join("\n")).toContain("⏸ PLAN MODE · READ-ONLY");
+		expect(await pi.emit("tool_call", { toolName: "read", input: {} }, ctx)).toBeUndefined();
+		expect(await pi.emit("tool_call", { toolName: "unknown_custom_tool", input: {} }, ctx)).toMatchObject({ block: true });
+		const prompt = await pi.emit("before_agent_start", { systemPrompt: "BASE RULES" }, ctx) as { systemPrompt: string };
+		expect(prompt.systemPrompt).toContain("BASE RULES");
+		expect(prompt.systemPrompt).toContain("[PLAN MODE ACTIVE]");
+
+		const shortcut = pi.shortcuts.get(PLAN_MODE_SHORTCUT) as { handler: (ctx: ExtensionContext) => void };
+		shortcut.handler(ctx);
+		expect(pi.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls"]);
+		expect([...harness.widgets.values()].some((widget) => widget.placement === "belowEditor")).toBe(false);
+		await command.handler("bad", ctx);
+		expect(notifications.at(-1)?.message).toBe("Usage: /plan on|off");
+	});
+
+	it("uses temporary revision storage, exits Plan Mode on approval, and cleans up", async () => {
+		await fakeRevdiff();
+		const pi = new FakePi();
+		planModeExtension(pi.api());
+		const harness = fakeContext({ entries: pi.entries, choices: ["Approve Plan"] });
+		await pi.emit("session_start", { reason: "startup" }, harness.ctx);
+		await turnPlanOn(pi, harness.ctx);
+		expect(isPersistentSession(harness.ctx)).toBe(false);
+		expect(pi.entries).toHaveLength(0);
+		pi.onSendMessage = () => {
+			expect(pi.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls"]);
+			expect([...harness.widgets.values()].some((widget) => widget.placement === "belowEditor")).toBe(false);
+		};
+
+		const result = await submitPlan(pi, harness.ctx) as { details: { planId: string; planPath: string; approvedHash: string; revision: number } };
+		const planRoot = path.dirname(path.dirname(path.dirname(result.details.planPath)));
+		expect(planRoot).toMatch(new RegExp(`${path.sep.replace("\\", "\\\\")}pi-plan-`));
+		expect(result.details.revision).toBe(1);
+		expect(result.details.planPath).toMatch(/revisions[/\\]r1\.md$/);
+		expect(await readFile(result.details.planPath, "utf8")).toContain("Implement it");
+		expect(pi.entries).toHaveLength(0);
+		expect(pi.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls"]);
+		expect(harness.terminal).toMatchObject({ stops: 1, starts: 1 });
+		expect(pi.sentUserMessages).toHaveLength(0);
+		expect(pi.sentMessages).toHaveLength(1);
+		const sent = pi.sentMessages[0];
+		expect(sent.options).toEqual({ triggerTurn: true, deliverAs: "followUp" });
+		expect(sent.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls"]);
+		expect(sent.message).toMatchObject({
+			customType: APPROVED_PLAN_MESSAGE_TYPE,
+			display: true,
+			details: {
+				title: "Implement simple Plan Mode",
+				revision: 1,
+				stepCount: 2,
+				planId: result.details.planId,
+				approvedHash: result.details.approvedHash,
+				planPath: result.details.planPath,
+			},
+		});
+		expect(sent.message.content).toContain(result.details.approvedHash);
+		expect(sent.message.content).toContain("Revision: r1");
+		expect(sent.message.content).toContain("# Goal\n\nImplement it.");
+		const renderer = pi.messageRenderers.get(APPROVED_PLAN_MESSAGE_TYPE);
+		expect(renderer).toBeDefined();
+		const renderedMessage = renderer(
+			{ details: sent.message.details },
+			{ expanded: true },
+			(harness.ctx.ui as any).theme,
+		).render(100);
+		expect(renderedMessage).toHaveLength(1);
+		expect(plain(renderedMessage[0])).toBe("✓ PLAN APPROVED · Implement simple Plan Mode · r1 · 2 steps");
+		const fallbackMessage = renderer(
+			{ details: "corrupted" },
+			{ expanded: false },
+			(harness.ctx.ui as any).theme,
+		).render(100);
+		expect(plain(fallbackMessage[0])).toBe("✓ PLAN APPROVED");
+		const aboveEntry = [...harness.widgets.entries()].find(([, widget]) => widget.placement === "aboveEditor");
+		expect(aboveEntry).toBeDefined();
+		expect(plain(harness.renderWidget(aboveEntry![0])?.join("\n"))).toContain("APPROVED · r1");
+		expect(plain(harness.renderWidget(aboveEntry![0])?.join("\n"))).toContain("2 steps");
+		expect([...harness.widgets.values()].some((widget) => widget.placement === "belowEditor")).toBe(false);
+		const stepsShortcut = pi.shortcuts.get(PLAN_STEPS_SHORTCUT) as { handler: (ctx: ExtensionContext) => void };
+		stepsShortcut.handler(harness.ctx);
+		expect(plain(harness.renderWidget(aboveEntry![0])?.join("\n"))).toContain("1. Change code");
+		expect(plain(harness.renderWidget(aboveEntry![0])?.join("\n"))).toContain("Ctrl+Alt+O collapse");
+
+		await turnPlanOn(pi, harness.ctx);
+		const replanningPrompt = await pi.emit("before_agent_start", { systemPrompt: "BASE" }, harness.ctx) as { systemPrompt: string };
+		expect(replanningPrompt.systemPrompt).toContain("[CURRENT PLAN REFERENCE]");
+		expect(replanningPrompt.systemPrompt).toContain(`Plan ID: ${result.details.planId}`);
+		expect(replanningPrompt.systemPrompt).toContain("Revision: r1");
+		expect(replanningPrompt.systemPrompt).toContain(`Plan path: ${result.details.planPath}`);
+
+		await pi.emit("session_shutdown", { reason: "quit" }, harness.ctx);
+		await expect(stat(planRoot)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("creates immutable revisions after requested changes", async () => {
+		await fakeRevdiff();
+		vi.stubEnv("PLAN_MODE_TEST_ANNOTATIONS", "Step 1: add a rollback check");
+		vi.stubEnv("PLAN_MODE_TEST_EXIT", "10");
+		const pi = new FakePi();
+		planModeExtension(pi.api());
+		const harness = fakeContext({ entries: pi.entries, choices: ["Approve Plan"] });
+		await pi.emit("session_start", { reason: "startup" }, harness.ctx);
+		await turnPlanOn(pi, harness.ctx);
+
+		const first = await submitPlan(pi, harness.ctx) as { details: { planId: string; planPath: string; revision: number } };
+		expect(first.details.revision).toBe(1);
+		expect(await readFile(first.details.planPath, "utf8")).toContain("Change code");
+		const stepsShortcut = pi.shortcuts.get(PLAN_STEPS_SHORTCUT) as { handler: (ctx: ExtensionContext) => void };
+		stepsShortcut.handler(harness.ctx);
+		const aboveKey = [...harness.widgets.entries()].find(([, widget]) => widget.placement === "aboveEditor")?.[0];
+		expect(aboveKey).toBeDefined();
+		expect(plain(harness.renderWidget(aboveKey!)?.join("\n"))).toContain("1. Change code");
+
+		vi.stubEnv("PLAN_MODE_TEST_ANNOTATIONS", "");
+		vi.stubEnv("PLAN_MODE_TEST_EXIT", "0");
+		const second = await submitPlan(pi, harness.ctx, first.details.planId) as { details: { planPath: string; revision: number } };
+		expect(second.details.revision).toBe(2);
+		expect(second.details.planPath).toMatch(/r2\.md$/);
+		expect(await readFile(first.details.planPath, "utf8")).toContain("Change code");
+		expect(plain(harness.renderWidget(aboveKey!)?.join("\n"))).toContain("Ctrl+Alt+O expand");
+		expect(plain(harness.renderWidget(aboveKey!)?.join("\n"))).not.toContain("1. Change code");
+		expect(pi.activeTools).toContain("edit");
+	});
+
+	it("restores normal mode and the current Plan pointer from persistent Session state", async () => {
+		await fakeRevdiff();
+		const agentDir = await mkdtemp(path.join(tmpdir(), "pi-plan-agent-test-"));
+		cleanup.add(agentDir);
+		vi.stubEnv("PI_CODING_AGENT_DIR", agentDir);
+		const sessionFile = path.join(agentDir, "sessions", "session.jsonl");
+		const entries: CustomEntry[] = [];
+
+		const firstPi = new FakePi(entries);
+		planModeExtension(firstPi.api());
+		const first = fakeContext({ sessionFile, sessionId: "persistent-session", entries, choices: ["Approve Plan"] });
+		await firstPi.emit("session_start", { reason: "startup" }, first.ctx);
+		await turnPlanOn(firstPi, first.ctx);
+		const approved = await submitPlan(firstPi, first.ctx) as { details: { planPath: string } };
+		expect(entries.some((entry) => (entry.data as any).mode === "normal" && (entry.data as any).revision === 1)).toBe(true);
+
+		const resumedPi = new FakePi(entries);
+		planModeExtension(resumedPi.api());
+		const resumed = fakeContext({ sessionFile, sessionId: "persistent-session", entries });
+		await resumedPi.emit("session_start", { reason: "resume" }, resumed.ctx);
+		expect(resumedPi.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls"]);
+		const command = resumedPi.commands.get("plan") as { handler: (args: string, ctx: ExtensionContext) => Promise<void> };
+		await command.handler("", resumed.ctx);
+		expect(resumed.notifications.at(-1)?.message).toContain("APPROVED · r1");
+		expect(resumed.notifications.at(-1)?.message).toContain(approved.details.planPath);
+	});
+});

--- a/packages/pi-plan-mode/tests/policy.test.ts
+++ b/packages/pi-plan-mode/tests/policy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+	SUBMIT_PLAN_TOOL,
+	getPlanningTools,
+	isPlanningToolAllowed,
+	withoutManagedTools,
+} from "../src/policy.ts";
+
+describe("strict planning tool policy", () => {
+	it("keeps known read-only tools and fails closed for everything else", () => {
+		const active = ["read", "bash", "edit", "write", "grep", "web_search", "custom_mutator"];
+		expect(getPlanningTools(active)).toEqual(["read", "grep", "web_search", SUBMIT_PLAN_TOOL]);
+		expect(isPlanningToolAllowed("read")).toBe(true);
+		expect(isPlanningToolAllowed("query-docs")).toBe(true);
+		expect(isPlanningToolAllowed(SUBMIT_PLAN_TOOL)).toBe(true);
+		for (const tool of ["bash", "edit", "write", "custom_mutator"]) {
+			expect(isPlanningToolAllowed(tool)).toBe(false);
+		}
+	});
+
+	it("restores the previous normal tools without leaking submit_plan", () => {
+		const saved = ["read", "bash", "edit", SUBMIT_PLAN_TOOL, "read"];
+		expect(withoutManagedTools(saved)).toEqual(["read", "bash", "edit"]);
+	});
+});

--- a/packages/pi-plan-mode/tests/prompts.test.ts
+++ b/packages/pi-plan-mode/tests/prompts.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { appendPlanningPrompt, buildPlanningPrompt } from "../src/prompts.ts";
+
+describe("Plan Mode prompts", () => {
+	it("requires English content and section headings for en", () => {
+		const prompt = buildPlanningPrompt("en");
+		expect(prompt).toContain("Configured content language: en");
+		expect(prompt).toContain("title, section headings, prose, and list items in English");
+		expect(prompt).toContain("## Goal");
+		expect(prompt).toContain("## Execution steps");
+		expect(prompt).not.toContain("## 执行步骤");
+	});
+
+	it("requires Simplified Chinese content and section headings for zh-CN", () => {
+		const prompt = buildPlanningPrompt("zh-CN");
+		expect(prompt).toContain("Configured content language: zh-CN");
+		expect(prompt).toContain("title, section headings, prose, and list items in Simplified Chinese");
+		expect(prompt).toContain("## 目标");
+		expect(prompt).toContain("## 执行步骤");
+		expect(prompt).not.toContain("## Execution steps");
+	});
+
+	it("documents language following and both heading sets for auto", () => {
+		const prompt = buildPlanningPrompt("auto");
+		expect(prompt).toContain("Configured content language: auto");
+		expect(prompt).toContain("match the current user's language");
+		expect(prompt).toContain("## Execution steps");
+		expect(prompt).toContain("## 执行步骤");
+	});
+
+	it("keeps the current Plan reference when applying a configured language", () => {
+		const prompt = appendPlanningPrompt("BASE", {
+			planId: "plan-1",
+			title: "现有计划",
+			revision: 2,
+			status: "draft",
+			planPath: "/plans/plan-1/revisions/r2.md",
+		}, "zh-CN");
+		expect(prompt).toContain("BASE");
+		expect(prompt).toContain("Configured content language: zh-CN");
+		expect(prompt).toContain("Plan ID: plan-1");
+		expect(prompt).toContain("Revision: r2");
+	});
+});

--- a/packages/pi-plan-mode/tests/review.test.ts
+++ b/packages/pi-plan-mode/tests/review.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { buildRevdiffArguments, classifyRevdiffResult } from "../src/review.ts";
+import type { PlanPaths } from "../src/types.ts";
+
+const paths: PlanPaths = {
+	root: "/plans",
+	planDir: "/plans/test",
+	manifest: "/plans/test/manifest.json",
+	revisionsDir: "/plans/test/revisions",
+	plan: "/plans/test/revisions/r2.md",
+	reviewDir: "/plans/test/.review",
+	previous: "/plans/test/revisions/r1.md",
+	annotations: "/plans/test/.review/annotations.md",
+};
+
+describe("revdiff adapter", () => {
+	it("reviews the first submission as one file", () => {
+		expect(buildRevdiffArguments({ paths, hasPrevious: false, cwd: "/repo" })).toEqual([
+			"--only",
+			paths.plan,
+			`--output=${paths.annotations}`,
+		]);
+	});
+
+	it("reviews later immutable revisions as previous-to-current diffs", () => {
+		expect(buildRevdiffArguments({ paths, hasPrevious: true, cwd: "/repo" })).toEqual([
+			"--compare-old",
+			paths.previous,
+			"--compare-new",
+			paths.plan,
+			"--word-diff",
+			`--output=${paths.annotations}`,
+		]);
+	});
+
+	it("distinguishes clean review, requested changes, cancellation, and errors", () => {
+		expect(classifyRevdiffResult({ status: 0, signal: null }, "")).toEqual({ kind: "clean" });
+		expect(classifyRevdiffResult({ status: 10, signal: null }, "line 4: revise")).toEqual({
+			kind: "changes_requested",
+			annotations: "line 4: revise",
+		});
+		expect(classifyRevdiffResult({ status: null, signal: "SIGINT" }, "")).toMatchObject({ kind: "cancelled" });
+		expect(classifyRevdiffResult({ status: 2, signal: null }, "")).toEqual({ kind: "error", message: "revdiff exited with code 2" });
+		expect(classifyRevdiffResult({ status: 10, signal: null }, "")).toMatchObject({ kind: "error" });
+	});
+});

--- a/packages/pi-plan-mode/tests/storage.test.ts
+++ b/packages/pi-plan-mode/tests/storage.test.ts
@@ -1,0 +1,197 @@
+import { chmod, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	approvePlan,
+	cleanupReviewWorkspace,
+	createTemporaryPlanRoot,
+	extractPlanSteps,
+	generatePlanId,
+	getPlanPaths,
+	hashPlanContent,
+	isValidPlanId,
+	readPlanMetadata,
+	removeTemporaryPlanRoot,
+	saveSubmittedPlan,
+	updatePlanStatus,
+	verifyApprovedPlan,
+	writeReviewAnnotations,
+} from "../src/storage.ts";
+
+const cleanup = new Set<string>();
+
+afterEach(async () => {
+	await Promise.all([...cleanup].map((directory) => removeTemporaryPlanRoot(directory)));
+	cleanup.clear();
+});
+
+async function root(): Promise<string> {
+	const directory = await mkdtemp(path.join(tmpdir(), "pi-plan-storage-test-"));
+	cleanup.add(directory);
+	return directory;
+}
+
+describe("plan storage", () => {
+	it("generates sortable traversal-safe plan ids", () => {
+		const id = generatePlanId("Add OAuth / 登录", new Date("2026-07-23T14:05:06.000Z"), "fixed-random");
+		expect(id).toMatch(/^20260723T140506-add-oauth-[a-f0-9]{8}$/);
+		expect(isValidPlanId(id)).toBe(true);
+		expect(isValidPlanId("../escape")).toBe(false);
+	});
+
+	it("extracts display-only top-level execution steps", () => {
+		expect(extractPlanSteps(`# Plan\n\n## Execution steps\n\n1. **Change** [policy](./policy.ts) in \`policy_file.ts\`\n   - nested detail\n2) [ ] Run tests\n\n### Notes\n\n3. Still part of the section\n\n## Verification\n\n1. Not a step\n`)).toEqual([
+			"Change policy in policy_file.ts",
+			"Run tests",
+			"Still part of the section",
+		]);
+		expect(extractPlanSteps(`# 计划\n\n## 执行步骤\n\n1. 修改策略\n2. 运行测试\n\n## 验证\n\n1. 不应提取\n`)).toEqual([
+			"修改策略",
+			"运行测试",
+		]);
+		expect(extractPlanSteps("# Plan\n\n## Goal\n\nNo steps.\n")).toEqual([]);
+		expect(extractPlanSteps("# 计划\n\n## 实施步骤\n\n1. 不受支持的近似标题\n")).toEqual([]);
+	});
+
+	it("creates immutable revisions and points revdiff at the selected base", async () => {
+		const directory = await root();
+		const planId = generatePlanId("Storage test", new Date("2026-01-01T00:00:00.000Z"), "storage");
+		const first = await saveSubmittedPlan({
+			root: directory,
+			planId,
+			title: "Storage test",
+			markdown: "# First\n\n## Execution steps\n\n1. First step\n",
+			storage: "persistent",
+			sessionId: "session-1",
+			cwd: "/repo",
+			now: new Date("2026-01-01T00:00:00.000Z"),
+		});
+		expect(first.hasPrevious).toBe(false);
+		expect(first.revision).toMatchObject({ revision: 1, status: "draft", steps: ["First step"] });
+
+		await writeReviewAnnotations(first.paths, "Change the title");
+		await updatePlanStatus(directory, planId, "changes_requested");
+		const second = await saveSubmittedPlan({
+			root: directory,
+			planId,
+			title: "Storage test revised",
+			markdown: "# Second\n\n## Execution steps\n\n1. Second step\n",
+			storage: "persistent",
+			sessionId: "session-1",
+			cwd: "/repo",
+			basedOn: 1,
+			now: new Date("2026-01-01T00:01:00.000Z"),
+		});
+
+		expect(second.hasPrevious).toBe(true);
+		expect(second.paths.previous).toBe(first.paths.plan);
+		expect(await readFile(first.paths.plan, "utf8")).toContain("# First");
+		expect(await readFile(second.paths.plan, "utf8")).toContain("# Second");
+		expect(await readFile(second.paths.annotations, "utf8").catch(() => undefined)).toBeUndefined();
+		const metadata = await readPlanMetadata(directory, planId);
+		expect(metadata).toMatchObject({ currentRevision: 2, status: "draft", title: "Storage test revised" });
+		expect(metadata?.revisions).toHaveLength(2);
+		expect(metadata?.revisions[1]).toMatchObject({ basedOn: 1, path: "revisions/r2.md", steps: ["Second step"] });
+		await expect(saveSubmittedPlan({
+			root: directory,
+			planId,
+			title: "Wrong Session",
+			markdown: "# Third\n",
+			storage: "persistent",
+			sessionId: "another-session",
+			cwd: "/repo",
+		})).rejects.toThrow("another Session");
+	});
+
+	it("binds approval to an exact immutable revision and detects tampering", async () => {
+		const directory = await root();
+		const planId = generatePlanId("Hash test", new Date("2026-01-02T00:00:00.000Z"), "hash");
+		const submitted = await saveSubmittedPlan({
+			root: directory,
+			planId,
+			title: "Hash test",
+			markdown: "# Approved\n",
+			storage: "persistent",
+			sessionId: "session-2",
+			cwd: "/repo",
+		});
+		const approved = await approvePlan(directory, planId, 1, submitted.submittedHash);
+		expect(approved.approvedRevision).toBe(1);
+		expect(approved.approvedHash).toBe(hashPlanContent("# Approved\n"));
+		expect((await verifyApprovedPlan(directory, planId)).ok).toBe(true);
+		await expect(updatePlanStatus(directory, planId, "draft")).rejects.toThrow("is immutable");
+
+		await writeFile(submitted.paths.plan, "# Tampered\n", "utf8");
+		const integrity = await verifyApprovedPlan(directory, planId);
+		expect(integrity).toMatchObject({ ok: false, reason: "Plan content no longer matches the approved hash" });
+	});
+
+	it("refuses approval if content or current revision changes during review", async () => {
+		const directory = await root();
+		const planId = generatePlanId("Race test", new Date("2026-01-03T00:00:00.000Z"), "race");
+		const first = await saveSubmittedPlan({
+			root: directory,
+			planId,
+			title: "Race test",
+			markdown: "# Reviewed\n",
+			storage: "persistent",
+			sessionId: "session-3",
+			cwd: "/repo",
+		});
+		await writeFile(first.paths.plan, "# Changed while open\n", "utf8");
+		await expect(approvePlan(directory, planId, 1, first.submittedHash)).rejects.toThrow("changed during review");
+
+		const otherPlanId = generatePlanId("Revision race", new Date("2026-01-03T00:01:00.000Z"), "revision-race");
+		const base = await saveSubmittedPlan({
+			root: directory,
+			planId: otherPlanId,
+			title: "Revision race",
+			markdown: "# r1\n",
+			storage: "persistent",
+			sessionId: "session-3",
+			cwd: "/repo",
+		});
+		await saveSubmittedPlan({
+			root: directory,
+			planId: otherPlanId,
+			title: "Revision race",
+			markdown: "# r2\n",
+			storage: "persistent",
+			sessionId: "session-3",
+			cwd: "/repo",
+		});
+		await expect(approvePlan(directory, otherPlanId, 1, base.submittedHash)).rejects.toThrow("revision changed");
+	});
+
+	it("uses private permissions for no-session roots and removes them on shutdown", async () => {
+		const parent = await root();
+		await chmod(parent, 0o700);
+		const temporary = await createTemporaryPlanRoot(parent);
+		cleanup.add(temporary);
+		expect((await stat(temporary)).mode & 0o777).toBe(0o700);
+
+		const planId = generatePlanId("Temporary", new Date("2026-01-04T00:00:00.000Z"), "temporary");
+		const submitted = await saveSubmittedPlan({
+			root: temporary,
+			planId,
+			title: "Temporary",
+			markdown: "# Temp\n",
+			storage: "temporary",
+			sessionId: "memory-session",
+			cwd: "/repo",
+		});
+		expect((await stat(submitted.paths.plan)).mode & 0o777).toBe(0o600);
+		expect((await stat(submitted.paths.manifest)).mode & 0o777).toBe(0o600);
+		await cleanupReviewWorkspace(temporary, planId);
+		await removeTemporaryPlanRoot(temporary);
+		cleanup.delete(temporary);
+		await expect(stat(temporary)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("rejects invalid ids and revisions before constructing paths", () => {
+		expect(() => getPlanPaths("/tmp/plans", "../../etc/passwd")).toThrow("Invalid plan id");
+		const planId = generatePlanId("Path test", new Date("2026-01-05T00:00:00.000Z"), "path");
+		expect(() => getPlanPaths("/tmp/plans", planId, 0)).toThrow("Invalid plan revision");
+	});
+});

--- a/packages/pi-plan-mode/tests/widgets.test.ts
+++ b/packages/pi-plan-mode/tests/widgets.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+	compactPlanPath,
+	renderModeWidget,
+	renderPlanApprovedEvent,
+	renderPlanWidget,
+} from "../src/widgets.ts";
+
+const theme = {
+	fg: (_color: string, text: string) => `\x1b[36m${text}\x1b[39m`,
+	bold: (text: string) => `\x1b[1m${text}\x1b[22m`,
+} as unknown as Theme;
+
+function plain(text: string): string {
+	return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+const plan = {
+	title: "OAuth migration",
+	status: "approved" as const,
+	revision: 2,
+	planPath: "/home/test/.pi/agent/plans/oauth/revisions/r2.md",
+	steps: [
+		"Add OAuth configuration",
+		"Implement callback validation",
+		"Add session integration tests",
+		"Document rollback behavior",
+		"Run the full verification suite",
+	],
+	terminalRows: 10,
+};
+
+describe("Plan Mode widgets", () => {
+	it("renders the Unicode read-only mode label and progressively drops the hint", () => {
+		const wide = plain(renderModeWidget(80, theme).join("\n"));
+		expect(wide).toContain("⏸ PLAN MODE · READ-ONLY");
+		expect(wide).toContain("/plan off · Ctrl+Alt+P");
+
+		const narrow = plain(renderModeWidget(24, theme).join("\n"));
+		expect(narrow).toContain("⏸ PLAN MODE");
+		expect(narrow).not.toContain("Ctrl+Alt+P");
+	});
+
+	it("keeps steps collapsed by default", () => {
+		const rendered = plain(renderPlanWidget({ ...plan, expanded: false }, 100, theme).join("\n"));
+		expect(rendered).toContain("APPROVED · r2");
+		expect(rendered).toContain("5 steps");
+		expect(rendered).toContain("Ctrl+Alt+O expand");
+		expect(rendered).not.toContain(plan.planPath);
+		expect(rendered).not.toContain("1. Add OAuth configuration");
+	});
+
+	it("caps expanded steps from terminal height and reports overflow", () => {
+		const rendered = plain(renderPlanWidget({ ...plan, expanded: true }, 100, theme).join("\n"));
+		expect(rendered).toContain(plan.planPath);
+		expect(rendered).toContain("1. Add OAuth configuration");
+		expect(rendered).toContain("3. Add session integration tests");
+		expect(rendered).not.toContain("4. Document rollback behavior");
+		expect(rendered).toContain("… +2 more");
+		expect(rendered).toContain("Ctrl+Alt+O collapse");
+	});
+
+	it("renders a compact width-safe approval event", () => {
+		const wide = plain(renderPlanApprovedEvent({ title: plan.title, revision: 2, stepCount: 5 }, 100, theme).join("\n"));
+		expect(wide).toBe("✓ PLAN APPROVED · OAuth migration · r2 · 5 steps");
+		const narrow = plain(renderPlanApprovedEvent({ title: plan.title, revision: 2, stepCount: 5 }, 16, theme).join("\n"));
+		expect(narrow).toContain("PLAN APPROVED");
+		expect(narrow).not.toContain("OAuth migration");
+	});
+
+	it("never renders a line wider than the supplied viewport", () => {
+		for (const width of [8, 16, 24, 40, 80]) {
+			for (const line of renderModeWidget(width, theme)) expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+			for (const line of renderPlanWidget({ ...plan, expanded: true }, width, theme)) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+			}
+			for (const line of renderPlanApprovedEvent({ title: plan.title, revision: 2, stepCount: 5 }, width, theme)) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+			}
+		}
+	});
+
+	it("compacts only paths inside the supplied home directory", () => {
+		expect(compactPlanPath("/home/test/.pi/agent/plans/p/r1.md", "/home/test")).toBe("~/.pi/agent/plans/p/r1.md");
+		expect(compactPlanPath("/workspace/plans/p/r1.md", "/home/test")).toBe("/workspace/plans/p/r1.md");
+	});
+});

--- a/packages/pi-plan-mode/tsconfig.json
+++ b/packages/pi-plan-mode/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["extensions/**/*.ts", "src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,28 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  packages/pi-plan-mode:
+    dependencies:
+      typebox:
+        specifier: ^1.1.24
+        version: 1.1.24
+    devDependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.81.1
+        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.80.3
+        version: 0.80.3
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/pi-recap:
     dependencies:
       '@earendil-works/pi-ai':

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -11,6 +11,7 @@ const packagePaths = [
 	"./packages/pi-tool-display-intent",
 	"./packages/pi-todo",
 	"./packages/pi-glance",
+	"./packages/pi-plan-mode",
 	"./packages/pi-search-hub",
 	"./providers/pi-provider-volcengine-agent-plan",
 ];
@@ -23,6 +24,13 @@ const requiredPackFiles = new Map([
 		"packages/pi-glance/footer.ts",
 		"packages/pi-glance/README.md",
 		"packages/pi-glance/README.zh-CN.md",
+		"packages/pi-plan-mode/package.json",
+		"packages/pi-plan-mode/extensions/plan-mode.ts",
+		"packages/pi-plan-mode/src/config.ts",
+		"packages/pi-plan-mode/src/storage.ts",
+		"packages/pi-plan-mode/src/widgets.ts",
+		"packages/pi-plan-mode/README.md",
+		"packages/pi-plan-mode/README.zh-CN.md",
 		"packages/pi-search-hub/README.md",
 		"packages/pi-search-hub/README.zh-CN.md",
 	]],
@@ -35,6 +43,16 @@ const requiredPackFiles = new Map([
 		"LICENSE",
 		"UPSTREAM_LICENSE",
 		"UPSTREAM_SOURCE.md",
+	]],
+	["./packages/pi-plan-mode", [
+		"extensions/plan-mode.ts",
+		"src/config.ts",
+		"src/storage.ts",
+		"src/widgets.ts",
+		"README.md",
+		"README.zh-CN.md",
+		"CHANGELOG.md",
+		"LICENSE",
 	]],
 	["./packages/pi-search-hub", ["README.md", "README.zh-CN.md"]],
 	["./providers/pi-provider-volcengine-agent-plan", [
@@ -52,6 +70,8 @@ const maintainedReadmes = [
 	"packages/pi-recap/README.zh-CN.md",
 	"packages/pi-glance/README.md",
 	"packages/pi-glance/README.zh-CN.md",
+	"packages/pi-plan-mode/README.md",
+	"packages/pi-plan-mode/README.zh-CN.md",
 	"packages/pi-search-hub/README.md",
 	"packages/pi-search-hub/README.zh-CN.md",
 	"providers/pi-provider-volcengine-agent-plan/README.md",
@@ -84,6 +104,10 @@ await assertBilingualPair("README.md", "README.zh-CN.md");
 await assertBilingualPair(
 	"packages/pi-glance/README.md",
 	"packages/pi-glance/README.zh-CN.md",
+);
+await assertBilingualPair(
+	"packages/pi-plan-mode/README.md",
+	"packages/pi-plan-mode/README.zh-CN.md",
 );
 await assertBilingualPair(
 	"packages/pi-search-hub/README.md",

--- a/scripts/check-smoke.mjs
+++ b/scripts/check-smoke.mjs
@@ -10,6 +10,7 @@ const packagePaths = [
 	"./packages/pi-tool-display-intent",
 	"./packages/pi-todo",
 	"./packages/pi-glance",
+	"./packages/pi-plan-mode",
 	"./packages/pi-search-hub",
 	"./providers/pi-provider-volcengine-agent-plan",
 ];

--- a/scripts/reconcile-release.sh
+++ b/scripts/reconcile-release.sh
@@ -7,6 +7,7 @@ PACKAGES=(
   "@zhcsyncer/pi-tool-display-intent|packages/pi-tool-display-intent/package.json|packages/pi-tool-display-intent/CHANGELOG.md|pi-tool-display-intent|child"
   "@zhcsyncer/pi-todo|packages/pi-todo/package.json|packages/pi-todo/CHANGELOG.md|pi-todo|child"
   "@zhcsyncer/pi-glance|packages/pi-glance/package.json|packages/pi-glance/CHANGELOG.md|pi-glance|child"
+  "@zhcsyncer/pi-plan-mode|packages/pi-plan-mode/package.json|packages/pi-plan-mode/CHANGELOG.md|pi-plan-mode|child"
   "pi-provider-volcengine-agent-plan|providers/pi-provider-volcengine-agent-plan/package.json|providers/pi-provider-volcengine-agent-plan/CHANGELOG.md|pi-provider-volcengine-agent-plan|child"
 )
 

--- a/scripts/release-policy.mjs
+++ b/scripts/release-policy.mjs
@@ -10,6 +10,7 @@ export const CHILD_PACKAGES = Object.freeze([
 	"@zhcsyncer/pi-tool-display-intent",
 	"@zhcsyncer/pi-todo",
 	"@zhcsyncer/pi-glance",
+	"@zhcsyncer/pi-plan-mode",
 ]);
 
 /**

--- a/scripts/release-policy.test.mjs
+++ b/scripts/release-policy.test.mjs
@@ -8,6 +8,7 @@ const RECAP = "@zhcsyncer/pi-recap";
 const INTENT = "@zhcsyncer/pi-tool-display-intent";
 const TODO = "@zhcsyncer/pi-todo";
 const GLANCE = "@zhcsyncer/pi-glance";
+const PLAN_MODE = "@zhcsyncer/pi-plan-mode";
 const AGENT_PLAN = "pi-provider-volcengine-agent-plan";
 
 function releases(...entries) {
@@ -52,6 +53,12 @@ test("requires the root package when Glance releases", () => {
 	]);
 });
 
+test("requires the root package when Plan Mode releases", () => {
+	assert.deepEqual(validateReleasePolicy(releases([PLAN_MODE, "minor"])), [
+		`${PLAN_MODE} has a minor release, but ${ROOT} is missing from the release plan.`,
+	]);
+});
+
 test("allows unchanged sibling packages to remain unreleased", () => {
 	assert.deepEqual(
 		validateReleasePolicy(releases([ROOT, "minor"], [INTENT, "minor"])),
@@ -78,7 +85,7 @@ test("rejects a root bump lower than a child bump", () => {
 test("compares the root against every changed child", () => {
 	assert.deepEqual(
 		validateReleasePolicy(
-			releases([ROOT, "minor"], [RECAP, "patch"], [INTENT, "major"], [TODO, "minor"]),
+			releases([ROOT, "minor"], [RECAP, "patch"], [INTENT, "major"], [TODO, "minor"], [PLAN_MODE, "patch"]),
 		),
 		[
 			`${ROOT} has a minor release, which is lower than ${INTENT}'s major release.`,


### PR DESCRIPTION
## Summary

- add `@zhcsyncer/pi-plan-mode`, a temporary read-only planning mode for Pi
- support `/plan on|off`, `--plan`, keyboard switching, fail-closed tools, immutable revisions, and explicit revdiff approval
- include configurable English/Simplified Chinese Plan content and collapsible display-only Steps widgets
- bundle Plan Mode in `@zhcsyncer/pi-extensions` and include it in pack, smoke, release-policy, tag, and GitHub Release reconciliation checks
- add npm/Pi discovery keywords before the package's first publish

## Release plan

- `@zhcsyncer/pi-extensions`: `0.6.0` → `0.7.0` (minor)
- `@zhcsyncer/pi-plan-mode`: `0.0.0` → `0.1.0` (minor, first publish)

## First-publish flow

After the Changesets version PR is reviewed and merged, the normal release will stop before publishing because Plan Mode does not yet exist on npm. Then:

1. run **Bootstrap npm package** for `@zhcsyncer/pi-plan-mode`
2. configure its npm Trusted Publisher for `release.yml`
3. re-run the stopped normal release job to publish the aggregate root through OIDC and reconcile tags/releases

## Validation

- Plan Mode: 7 test files, 38 tests passed
- root release-policy/bootstrap tests: 19 passed
- root smoke checks passed, including Plan Mode loading and Agent Plan provider validation
- npm pack dry-run passed for the root and all standalone packages; Plan Mode tarball contains 13 files
- live npm preflight correctly reports only `@zhcsyncer/pi-plan-mode@0.0.0` as requiring bootstrap
