### PR TITLE
feat: batch plugin updates for release

### DIFF
--- a/.changeset/calm-model-catalog.md
+++ b/.changeset/calm-model-catalog.md
@@ -1,0 +1,5 @@
+---
+"pi-provider-volcengine-agent-plan": patch
+---
+
+Correct Agent Plan model metadata by reporting public API reference cost estimates and exposing only the thinking levels supported by Kimi K3.

--- a/.changeset/fresh-search-controls.md
+++ b/.changeset/fresh-search-controls.md
@@ -1,0 +1,5 @@
+---
+"@zhcsyncer/pi-extensions": minor
+---
+
+Turn `/search-setup` into Search Hub's combined status and configuration dashboard, remove the separate `/search-status` command and footer activity, add ordered default-reader fallback, simplify search routing into fallback/targeted/all modes, and remove the unused local search-result cache and cache settings. Backend rows now expose switch, unified resolved-auth readiness, URL, and project-override status up front; unresolved references display as no credential. Detail menus separate credential management from enablement and show global versus effective state, while Codex search resolves its credential through the current Pi model registry. Backends now live on a dedicated second-level page. All setup pages share one in-memory draft, and `Save & apply` validates and atomically writes once; closing with dirty state offers save, discard, or continued editing. Backend disablement remains reversible, and blank required credentials cannot enable a backend.

--- a/.changeset/fuzzy-wolves-recap.md
+++ b/.changeset/fuzzy-wolves-recap.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-recap": minor
+"@zhcsyncer/pi-extensions": minor
+---
+
+Add automatic nearest-layer terminal multiplexer naming to recap: Herdr pane labels now take precedence over inherited tmux windows, legacy `tmux` config migrates to `multiplexer`, and ownership-aware restore avoids clobbering later manual renames while handling disable, reload, and shutdown lifecycles.

--- a/.changeset/strict-todos-rest.md
+++ b/.changeset/strict-todos-rest.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": minor
+"@zhcsyncer/pi-todo": minor
+---
+
+Make Todo reliable for multi-stage work: isolate state per SDK session runtime, enforce lifecycle and dependency contracts, add atomic batch mutations, report validation failures as tool errors, and expose hidden successful calls in expanded audit views. Single-step work is now explicitly excluded from Todo guidance.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of Pi extensions by zhcsyncer.
 
 ## Packages
 
-- [`@zhcsyncer/pi-recap`](./packages/pi-recap) — recent activity recap extension with optional session title and tmux window sync.
+- [`@zhcsyncer/pi-recap`](./packages/pi-recap) — recent activity recap extension with optional session title and nearest-layer Herdr pane or tmux window naming.
 - [`@zhcsyncer/pi-tool-display-intent`](./packages/pi-tool-display-intent) — compact tool rendering with model-written intent phrases, RPC-visible summaries, adaptive diffs, and bounded Bash call previews.
 - [`@zhcsyncer/pi-todo`](./packages/pi-todo) — maintained fork of `@juicesharp/rpiv-todo` with a persistent task overlay and no duplicate successful tool nodes.
 - [`@zhcsyncer/pi-glance`](./packages/pi-glance) — maintained `pi-glance` fork with composable extension statuses, bottom-right context progress, and a highlighted auto-compaction marker.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A collection of Pi extensions by zhcsyncer.
 
 - [`@zhcsyncer/pi-recap`](./packages/pi-recap) — recent activity recap extension with optional session title and tmux window sync.
 - [`@zhcsyncer/pi-tool-display-intent`](./packages/pi-tool-display-intent) — compact tool rendering with model-written intent phrases, RPC-visible summaries, adaptive diffs, and bounded Bash call previews.
-- [`@zhcsyncer/pi-todo`](./packages/pi-todo) — maintained fork of `@juicesharp/rpiv-todo` with a persistent task overlay and no duplicate successful tool nodes.
+- [`@zhcsyncer/pi-todo`](./packages/pi-todo) — branch-aware task overlay with strict lifecycle rules, atomic batches, isolated SDK session state, and expandable audit summaries.
 - [`@zhcsyncer/pi-glance`](./packages/pi-glance) — maintained `pi-glance` fork with composable extension statuses, bottom-right context progress, and a highlighted auto-compaction marker.
 - [`@zhcsyncer/pi-plan-mode`](./packages/pi-plan-mode) — temporary read-only Plan Mode with word-aware revdiff review, immutable revisions, configurable English/Chinese Plan content, explicit approval, and collapsible TUI Steps.
 - [`@zhcsyncer/pi-search-hub`](./packages/pi-search-hub) — bundle-private `web_search` and `web_read` tools integrated with intent-aware rendering.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@ zhcsyncer 维护的一组 Pi extensions。
 
 ## 包列表
 
-- [`@zhcsyncer/pi-recap`](./packages/pi-recap) — 最近活动回顾扩展，可选同步 Session 标题和 tmux 窗口名。
+- [`@zhcsyncer/pi-recap`](./packages/pi-recap) — 最近活动回顾扩展，可选同步 Session 标题，并自动命名最近一层 Herdr pane 或 tmux window。
 - [`@zhcsyncer/pi-tool-display-intent`](./packages/pi-tool-display-intent) — 紧凑工具展示，支持模型生成的 intent、RPC 可见摘要、自适应 diff 和受限的 Bash 调用预览。
 - [`@zhcsyncer/pi-todo`](./packages/pi-todo) — `@juicesharp/rpiv-todo` 的维护 fork，提供持久 Todo overlay，且不会重复展示成功的工具节点。
 - [`@zhcsyncer/pi-glance`](./packages/pi-glance) — `pi-glance` 的维护 fork，保留扩展状态，支持右下角 context 进度条和高亮自动压缩标记。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@ zhcsyncer 维护的一组 Pi extensions。
 
 - [`@zhcsyncer/pi-recap`](./packages/pi-recap) — 最近活动回顾扩展，可选同步 Session 标题和 tmux 窗口名。
 - [`@zhcsyncer/pi-tool-display-intent`](./packages/pi-tool-display-intent) — 紧凑工具展示，支持模型生成的 intent、RPC 可见摘要、自适应 diff 和受限的 Bash 调用预览。
-- [`@zhcsyncer/pi-todo`](./packages/pi-todo) — `@juicesharp/rpiv-todo` 的维护 fork，提供持久 Todo overlay，且不会重复展示成功的工具节点。
+- [`@zhcsyncer/pi-todo`](./packages/pi-todo) — 分支感知的 Todo overlay，提供严格生命周期、原子批量操作、SDK Session 状态隔离和可展开审计摘要。
 - [`@zhcsyncer/pi-glance`](./packages/pi-glance) — `pi-glance` 的维护 fork，保留扩展状态，支持右下角 context 进度条和高亮自动压缩标记。
 - [`@zhcsyncer/pi-plan-mode`](./packages/pi-plan-mode) — 临时只读 Plan Mode，支持 word-aware revdiff 评审、不可变 revision、中英文 Plan 内容配置、显式批准和可折叠 TUI Steps。
 - [`@zhcsyncer/pi-search-hub`](./packages/pi-search-hub) — bundle 私有的 `web_search` 和 `web_read` 工具，集成 intent-aware 展示。

--- a/package.json
+++ b/package.json
@@ -70,8 +70,9 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset publish",
-    "check": "pnpm check:release-policy && pnpm check:smoke && pnpm check:pack",
+    "check": "pnpm check:release-policy && pnpm check:recap && pnpm check:smoke && pnpm check:pack",
     "check:release-policy": "node --test scripts/release-policy.test.mjs && node scripts/check-release-policy.mjs",
+    "check:recap": "pnpm --filter @zhcsyncer/pi-recap check",
     "check:smoke": "node scripts/check-smoke.mjs",
     "check:pack": "node scripts/check-pack.mjs"
   },

--- a/packages/pi-recap/CHANGELOG.md
+++ b/packages/pi-recap/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added automatic Herdr pane-label synchronization through Herdr's CLI, with Herdr taking precedence over inherited tmux sessions.
+- Added ownership-aware restoration, serialized naming updates, failure warnings, and fake-runner contract tests for both supported multiplexers.
+
+### Changed
+
+- Replaced the public `tmux` config group with the shared `multiplexer` group; legacy config migrates automatically and explicit new fields take precedence.
+- Restore owned multiplexer names on extension reload and preserve later manual renames during shutdown or runtime disablement.
+
 ## 0.2.0
 
 ## 0.1.4

--- a/packages/pi-recap/README.md
+++ b/packages/pi-recap/README.md
@@ -12,7 +12,7 @@ Features:
 - Display automatic recap progress plus recap results and errors in an editor widget, without duplicating successful results in chat notifications.
 - Generate a short title as a recap side effect.
 - Optionally apply the title to the Pi session name.
-- Optionally sync Pi session name changes to the current tmux window name.
+- Optionally sync Pi session name changes to the nearest terminal multiplexer: a Herdr pane label or tmux window name.
 - Configure common options with `/recap-config`.
 - Edit full JSON config with `/recap-config json`.
 
@@ -56,7 +56,7 @@ Generate a recent activity recap. It will:
 4. persist state with `pi.appendEntry("recap", ...)`;
 5. display the recap in an editor widget;
 6. optionally apply the title to the Pi session name;
-7. optionally sync the session name to the current tmux window.
+7. optionally sync the session name to the nearest Herdr pane or tmux window.
 
 ```text
 /recap-config
@@ -121,7 +121,7 @@ Default config:
     "applyPolicy": "if-empty-or-auto",
     "maxLength": 50
   },
-  "tmux": {
+  "multiplexer": {
     "enabled": true,
     "template": "π {session} · {project}",
     "maxLength": 48,
@@ -176,13 +176,13 @@ Choose widget placement:
 
 Recap display always uses an editor widget; the display surface is not configurable. Automatic recap progress is replaced by the result in that widget. Manual `/recap` uses a cancellable loader while generating, then shows the result in the widget. The widget is cleared when the next message starts. If an automatic recap is still running, it is cancelled and cannot later store or redisplay a stale result.
 
-When an older config is loaded, obsolete `display.notify`, `display.mode`, `display.widget`, and `display.clearWidgetOnNextAgentStart` fields are removed and the source config file is updated. `display.widgetPlacement` is preserved.
+When an older config is loaded, obsolete `display.notify`, `display.mode`, `display.widget`, and `display.clearWidgetOnNextAgentStart` fields are removed and the source config file is updated. `display.widgetPlacement` is preserved. Legacy `tmux` settings are migrated to `multiplexer`; when both exist, explicitly configured `multiplexer` fields take precedence.
 
-Customize tmux window name:
+Customize the Herdr pane label or tmux window name:
 
 ```json
 {
-  "tmux": {
+  "multiplexer": {
     "template": "π {project} · {session}",
     "maxLength": 60
   }
@@ -232,16 +232,19 @@ or:
 
 Note: Pi currently does not expose a user language or locale field to extensions. This is an extension-level setting.
 
-### tmux behavior
+### Terminal multiplexer behavior
 
-When `tmux.enabled` is true:
+When `multiplexer.enabled` is true, recap automatically selects the directly hosting layer:
 
-- It only runs when `process.env.TMUX` exists.
-- It disables `automatic-rename` for the current tmux window to avoid shell-command overwrites.
-- It renames the current tmux window when Pi session name changes.
-- If `restoreOnShutdown` is true, it restores the previous window name and `automatic-rename` setting when Pi exits.
+1. `HERDR_ENV=1` with a non-empty `HERDR_PANE_ID` selects the current Herdr pane label. The `herdr` CLI must be available; Herdr may provide its absolute path through `HERDR_BIN_PATH`.
+2. If Herdr is not detected and `TMUX` exists, recap selects the current tmux window name.
+3. Otherwise, naming is a no-op.
 
-All of these trigger tmux sync:
+In nested Herdr-inside-tmux sessions, recap only updates the Herdr pane. If Herdr is detected but its pane identity is incomplete or its CLI is unavailable, recap warns once and does not fall back to the inherited tmux layer.
+
+For tmux, recap keeps the original behavior of disabling `automatic-rename` while it owns the window name. The original pane/window name is restored only if the current name still equals recap's last successful write, so a later manual rename is preserved. Disabling sync or reloading the extension releases ownership immediately; reload always restores before the new extension instance reapplies the name. On ordinary Pi exit, `restoreOnShutdown` controls restoration. tmux's captured `automatic-rename` setting is restored whenever owned sync is restored or disabled.
+
+All of these trigger multiplexer sync:
 
 ```bash
 pi --name "auth refresh"
@@ -251,7 +254,7 @@ pi --name "auth refresh"
 /name auth refresh
 ```
 
-and recap calling `pi.setSessionName(title)` when enabled by config.
+and recap calling `pi.setSessionName(title)` when enabled by config. Recap does not modify Herdr's Pi agent-state integration.
 
 ### Privacy and cost
 

--- a/packages/pi-recap/README.zh-CN.md
+++ b/packages/pi-recap/README.zh-CN.md
@@ -12,7 +12,7 @@
 - 使用 editor widget 展示自动 recap 的进度以及 recap 结果和错误，成功结果不会再重复显示为聊天区通知；
 - recap 时顺便生成短 title；
 - 是否用 title 更新 Pi session name 由配置控制；
-- session name 变化时可选同步 tmux window name；
+- session name 变化时可选同步最近一层终端复用器：Herdr pane label 或 tmux window name；
 - `/recap-config` 提供 TUI 常用配置；
 - `/recap-config json` 编辑完整 JSON 配置。
 
@@ -56,7 +56,7 @@ pi -e ./packages/pi-recap
 4. 使用 `pi.appendEntry("recap", ...)` 保存状态；
 5. 在 editor widget 中展示 recap；
 6. 如果配置允许，用 title 更新 Pi session name；
-7. 如果启用 tmux 同步，session name 变化会同步到当前 tmux window。
+7. 如果启用终端复用器同步，session name 变化会同步到最近一层 Herdr pane 或 tmux window。
 
 ```text
 /recap-config
@@ -121,7 +121,7 @@ examples/recap.json
     "applyPolicy": "if-empty-or-auto",
     "maxLength": 50
   },
-  "tmux": {
+  "multiplexer": {
     "enabled": true,
     "template": "π {session} · {project}",
     "maxLength": 48,
@@ -176,13 +176,13 @@ examples/recap.json
 
 recap 始终使用 editor widget，展示区域不再支持配置。自动 recap 的生成进度会在同一个 widget 中被最终结果替换；手动 `/recap` 生成时使用可取消 Loader，完成后在 widget 中显示结果。下一条消息开始时会清除 widget；如果自动 recap 仍在生成，该任务也会被取消，并且不会在稍后写入或重新展示过期结果。
 
-读取旧配置时，插件会移除已废弃的 `display.notify`、`display.mode`、`display.widget` 和 `display.clearWidgetOnNextAgentStart`，并更新原配置文件；`display.widgetPlacement` 会保留。
+读取旧配置时，插件会移除已废弃的 `display.notify`、`display.mode`、`display.widget` 和 `display.clearWidgetOnNextAgentStart`，并更新原配置文件；`display.widgetPlacement` 会保留。旧的 `tmux` 配置会自动迁移到 `multiplexer`；两者同时存在时，显式设置的 `multiplexer` 字段优先。
 
-自定义 tmux window 名称：
+自定义 Herdr pane label 或 tmux window 名称：
 
 ```json
 {
-  "tmux": {
+  "multiplexer": {
     "template": "π {project} · {session}",
     "maxLength": 60
   }
@@ -232,16 +232,19 @@ recap 始终使用 editor widget，展示区域不再支持配置。自动 recap
 
 注意：Pi 当前不会向 extension 提供用户语言/locale 字段；这是插件自己的配置。
 
-### tmux 行为
+### 终端复用器行为
 
-启用 `tmux.enabled` 后：
+启用 `multiplexer.enabled` 后，recap 会自动选择直接承载当前 Pi 的最近一层：
 
-- 仅在检测到 `process.env.TMUX` 时生效；
-- 会关闭当前 tmux window 的 `automatic-rename`，避免被 shell 命令覆盖；
-- session name 变化时重命名当前 tmux window；
-- `restoreOnShutdown` 为 `true` 时，Pi 退出会恢复原 window name 和 `automatic-rename` 设置。
+1. `HERDR_ENV=1` 且 `HERDR_PANE_ID` 非空时，选择当前 Herdr pane label。系统需要能执行 `herdr` CLI；Herdr 也可以通过 `HERDR_BIN_PATH` 提供绝对路径。
+2. 未检测到 Herdr、但存在 `TMUX` 时，选择当前 tmux window name。
+3. 两者都没有时，不执行任何命名操作。
 
-这些都会触发 tmux 同步：
+Herdr 嵌套在 tmux 中时，recap 只更新 Herdr pane。如果检测到了 Herdr，但 pane 身份不完整或 CLI 不可用，recap 只警告一次，不会回退修改继承的外层 tmux。
+
+对于 tmux，recap 延续原行为：持有 window name 期间关闭 `automatic-rename`。仅当当前名称仍等于 recap 最近一次成功写入的值时，才恢复原 pane/window 名称，因此后续手动改名不会被覆盖。运行时关闭同步或 reload 会立即释放持有状态；reload 会先恢复，再由新 extension 实例重新应用。普通 Pi 退出时是否恢复由 `restoreOnShutdown` 控制。同步被恢复或关闭时，tmux 捕获到的 `automatic-rename` 设置会一并恢复。
+
+以下操作都会触发复用器同步：
 
 ```bash
 pi --name "auth refresh"
@@ -251,7 +254,7 @@ pi --name "auth refresh"
 /name auth refresh
 ```
 
-以及 recap 根据配置调用 `pi.setSessionName(title)`。
+以及 recap 根据配置调用 `pi.setSessionName(title)`。recap 不会修改 Herdr 官方的 Pi agent-state integration。
 
 ### 隐私与费用
 

--- a/packages/pi-recap/examples/recap.json
+++ b/packages/pi-recap/examples/recap.json
@@ -21,7 +21,7 @@
     "applyPolicy": "if-empty-or-auto",
     "maxLength": 50
   },
-  "tmux": {
+  "multiplexer": {
     "enabled": true,
     "template": "π {session} · {project}",
     "maxLength": 48,

--- a/packages/pi-recap/extensions/multiplexer.ts
+++ b/packages/pi-recap/extensions/multiplexer.ts
@@ -1,0 +1,403 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type MultiplexerConfig = {
+	enabled: boolean;
+	template: string;
+	maxLength: number;
+	restoreOnShutdown: boolean;
+};
+
+export type MultiplexerNameContext = {
+	sessionName?: string;
+	cwd: string;
+	sessionId: string;
+};
+
+export type MultiplexerEnvironment = Record<string, string | undefined>;
+
+export type CommandOutput = {
+	stdout: string;
+	stderr?: string;
+};
+
+export type CommandRunner = (command: string, args: string[]) => Promise<CommandOutput>;
+
+export type MultiplexerHooks = {
+	setTitle(name: string): void;
+	warn(message: string): void;
+};
+
+export type MultiplexerDetection =
+	| { kind: "herdr"; paneId: string }
+	| { kind: "herdr-invalid" }
+	| { kind: "tmux" }
+	| { kind: "none" };
+
+type TmuxSnapshot = {
+	windowId: string;
+	originalName: string;
+	originalAutomaticRename: string;
+};
+
+type HerdrSnapshot = {
+	paneId: string;
+	originalLabel?: string;
+};
+
+type SnapshotByKind = {
+	tmux: TmuxSnapshot;
+	herdr: HerdrSnapshot;
+};
+
+type MultiplexerKind = keyof SnapshotByKind;
+
+type MultiplexerAdapter<K extends MultiplexerKind = MultiplexerKind> = {
+	kind: K;
+	capture(): Promise<SnapshotByKind[K]>;
+	apply(snapshot: SnapshotByKind[K], name: string): Promise<void>;
+	readCurrent(snapshot: SnapshotByKind[K]): Promise<string | undefined>;
+	restore(snapshot: SnapshotByKind[K], restoreName: boolean): Promise<void>;
+};
+
+type ActiveMultiplexer<K extends MultiplexerKind = MultiplexerKind> = {
+	adapter: MultiplexerAdapter<K>;
+	snapshot: SnapshotByKind[K];
+	lastAppliedName?: string;
+};
+
+export type ConfigMigration = {
+	value: unknown;
+	changed: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function migrateMultiplexerConfig(value: unknown): ConfigMigration {
+	if (!isRecord(value) || !("tmux" in value)) return { value, changed: false };
+
+	const next = { ...value };
+	const legacyTmux = isRecord(value.tmux) ? value.tmux : undefined;
+	const currentMultiplexer = isRecord(value.multiplexer) ? value.multiplexer : undefined;
+
+	if (legacyTmux) {
+		next.multiplexer = {
+			...legacyTmux,
+			...currentMultiplexer,
+		};
+	}
+	delete next.tmux;
+
+	return { value: next, changed: true };
+}
+
+export function detectMultiplexer(environment: MultiplexerEnvironment): MultiplexerDetection {
+	if (environment.HERDR_ENV === "1") {
+		const paneId = environment.HERDR_PANE_ID?.trim();
+		return paneId ? { kind: "herdr", paneId } : { kind: "herdr-invalid" };
+	}
+	if (environment.TMUX) return { kind: "tmux" };
+	return { kind: "none" };
+}
+
+export function cleanMultiplexerName(name: string, maxLength: number): string {
+	const cleaned = name
+		.replace(/[\x00-\x1f\x7f]/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+	if (cleaned.length <= maxLength) return cleaned;
+	return `${cleaned.slice(0, Math.max(1, maxLength - 1))}…`;
+}
+
+export function buildMultiplexerName(config: MultiplexerConfig, context: MultiplexerNameContext): string {
+	const project = path.basename(context.cwd) || "project";
+	const session = (context.sessionName ?? context.sessionId.slice(0, 8)) || "session";
+	const raw = config.template
+		.replaceAll("{session}", session)
+		.replaceAll("{project}", project)
+		.replaceAll("{cwd}", context.cwd)
+		.replaceAll("{id}", context.sessionId);
+	return cleanMultiplexerName(raw, config.maxLength);
+}
+
+export const defaultCommandRunner: CommandRunner = async (command, args) => {
+	const { stdout, stderr } = await execFileAsync(command, args, {
+		encoding: "utf8",
+		timeout: 1_000,
+	});
+	return { stdout: String(stdout), stderr: String(stderr) };
+};
+
+function requireOutput(output: CommandOutput, description: string): string {
+	const value = output.stdout.trim();
+	if (!value) throw new Error(`${description} returned empty output`);
+	return value;
+}
+
+function commandError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function parseHerdrPane(output: CommandOutput, expectedPaneId: string): { paneId: string; label?: string } {
+	let response: unknown;
+	try {
+		response = JSON.parse(output.stdout);
+	} catch {
+		throw new Error("Herdr pane get returned invalid JSON");
+	}
+
+	if (!isRecord(response) || !isRecord(response.result) || !isRecord(response.result.pane)) {
+		throw new Error("Herdr pane get returned an unexpected response");
+	}
+	const pane = response.result.pane;
+	if (pane.pane_id !== expectedPaneId) {
+		throw new Error(`Herdr pane get returned ${String(pane.pane_id)} instead of ${expectedPaneId}`);
+	}
+	if (pane.label !== undefined && pane.label !== null && typeof pane.label !== "string") {
+		throw new Error("Herdr pane get returned an invalid label");
+	}
+	return {
+		paneId: expectedPaneId,
+		label: typeof pane.label === "string" ? pane.label : undefined,
+	};
+}
+
+function createHerdrAdapter(runner: CommandRunner, paneId: string, command: string): MultiplexerAdapter<"herdr"> {
+	async function getPane() {
+		return parseHerdrPane(await runner(command, ["pane", "get", paneId]), paneId);
+	}
+
+	return {
+		kind: "herdr",
+		async capture() {
+			const pane = await getPane();
+			return { paneId: pane.paneId, originalLabel: pane.label };
+		},
+		async apply(snapshot, name) {
+			await runner(command, ["pane", "rename", snapshot.paneId, name]);
+		},
+		async readCurrent(snapshot) {
+			return (await getPane()).label;
+		},
+		async restore(snapshot, restoreName) {
+			if (!restoreName) return;
+			await runner(
+				command,
+				snapshot.originalLabel === undefined
+					? ["pane", "rename", snapshot.paneId, "--clear"]
+					: ["pane", "rename", snapshot.paneId, snapshot.originalLabel],
+			);
+		},
+	};
+}
+
+function createTmuxAdapter(runner: CommandRunner): MultiplexerAdapter<"tmux"> {
+	return {
+		kind: "tmux",
+		async capture() {
+			const windowId = requireOutput(
+				await runner("tmux", ["display-message", "-p", "#{window_id}"]),
+				"tmux window id query",
+			);
+			const originalName = requireOutput(
+				await runner("tmux", ["display-message", "-p", "-t", windowId, "#{window_name}"]),
+				"tmux window name query",
+			);
+			const originalAutomaticRename = requireOutput(
+				await runner("tmux", ["show-window-options", "-qv", "-t", windowId, "automatic-rename"]),
+				"tmux automatic-rename query",
+			);
+			await runner("tmux", ["set-window-option", "-q", "-t", windowId, "automatic-rename", "off"]);
+			return { windowId, originalName, originalAutomaticRename };
+		},
+		async apply(snapshot, name) {
+			await runner("tmux", ["rename-window", "-t", snapshot.windowId, name]);
+		},
+		async readCurrent(snapshot) {
+			return requireOutput(
+				await runner("tmux", ["display-message", "-p", "-t", snapshot.windowId, "#{window_name}"]),
+				"tmux window name query",
+			);
+		},
+		async restore(snapshot, restoreName) {
+			let firstError: unknown;
+			if (restoreName) {
+				try {
+					await runner("tmux", ["rename-window", "-t", snapshot.windowId, snapshot.originalName]);
+				} catch (error) {
+					firstError = error;
+				}
+			}
+			try {
+				await runner("tmux", [
+					"set-window-option",
+					"-q",
+					"-t",
+					snapshot.windowId,
+					"automatic-rename",
+					snapshot.originalAutomaticRename,
+				]);
+			} catch (error) {
+				firstError ??= error;
+			}
+			if (firstError) throw firstError;
+		},
+	};
+}
+
+export type MultiplexerManagerOptions = {
+	environment?: MultiplexerEnvironment;
+	runner?: CommandRunner;
+};
+
+export class MultiplexerManager {
+	private readonly environment: MultiplexerEnvironment;
+	private readonly runner: CommandRunner;
+	private active?: ActiveMultiplexer;
+	private operation: Promise<void> = Promise.resolve();
+	private readonly warned = new Set<string>();
+
+	constructor(options: MultiplexerManagerOptions = {}) {
+		this.environment = options.environment ?? process.env;
+		this.runner = options.runner ?? defaultCommandRunner;
+	}
+
+	sync(config: MultiplexerConfig, context: MultiplexerNameContext, hooks: MultiplexerHooks): Promise<void> {
+		return this.enqueue(() => this.syncNow(config, context, hooks));
+	}
+
+	shutdown(config: MultiplexerConfig, reason: string, hooks: MultiplexerHooks): Promise<void> {
+		return this.enqueue(async () => {
+			if (reason === "reload" || config.restoreOnShutdown) {
+				await this.release(true, hooks);
+			} else {
+				this.active = undefined;
+			}
+		});
+	}
+
+	private enqueue(operation: () => Promise<void>): Promise<void> {
+		const next = this.operation.then(operation, operation);
+		this.operation = next.catch(() => undefined);
+		return next;
+	}
+
+	private async syncNow(config: MultiplexerConfig, context: MultiplexerNameContext, hooks: MultiplexerHooks): Promise<void> {
+		if (!config.enabled) {
+			await this.release(true, hooks);
+			return;
+		}
+
+		const detection = detectMultiplexer(this.environment);
+		if (detection.kind === "herdr-invalid") {
+			await this.release(true, hooks);
+			this.warnOnce(
+				"herdr-invalid",
+				"Recap detected Herdr, but HERDR_PANE_ID is missing; outer multiplexers will not be modified.",
+				hooks,
+			);
+			return;
+		}
+		if (detection.kind === "none") {
+			await this.release(true, hooks);
+			return;
+		}
+
+		if (this.active && this.active.adapter.kind !== detection.kind) {
+			await this.release(true, hooks);
+		}
+
+		if (!this.active) {
+			const adapter = detection.kind === "herdr"
+				? createHerdrAdapter(
+					this.runner,
+					detection.paneId,
+					this.environment.HERDR_BIN_PATH?.trim() || "herdr",
+				)
+				: createTmuxAdapter(this.runner);
+			try {
+				const snapshot = await adapter.capture();
+				this.active = { adapter, snapshot } as ActiveMultiplexer;
+			} catch (error) {
+				this.warnOnce(
+					`${detection.kind}:capture`,
+					`Recap could not initialize ${detection.kind} name sync: ${commandError(error)}`,
+					hooks,
+				);
+				return;
+			}
+		}
+
+		const name = buildMultiplexerName(config, context);
+		if (this.active.lastAppliedName === name) return;
+
+		try {
+			await this.applyActive(name);
+			this.active.lastAppliedName = name;
+			hooks.setTitle(name);
+		} catch (error) {
+			this.warnOnce(
+				`${this.active.adapter.kind}:apply`,
+				`Recap could not update ${this.active.adapter.kind} name: ${commandError(error)}`,
+				hooks,
+			);
+		}
+	}
+
+	private async applyActive(name: string): Promise<void> {
+		const active = this.active;
+		if (!active) return;
+		if (active.adapter.kind === "herdr") {
+			await active.adapter.apply(active.snapshot as HerdrSnapshot, name);
+			return;
+		}
+		await active.adapter.apply(active.snapshot as TmuxSnapshot, name);
+	}
+
+	private async release(restoreOwnedName: boolean, hooks: MultiplexerHooks): Promise<void> {
+		const active = this.active;
+		if (!active) return;
+		this.active = undefined;
+
+		let restoreName = false;
+		if (restoreOwnedName && active.lastAppliedName !== undefined) {
+			try {
+				const current = active.adapter.kind === "herdr"
+					? await active.adapter.readCurrent(active.snapshot as HerdrSnapshot)
+					: await active.adapter.readCurrent(active.snapshot as TmuxSnapshot);
+				restoreName = current === active.lastAppliedName;
+			} catch (error) {
+				this.warnOnce(
+					`${active.adapter.kind}:read-current`,
+					`Recap could not verify the current ${active.adapter.kind} name before restore: ${commandError(error)}`,
+					hooks,
+				);
+			}
+		}
+
+		try {
+			if (active.adapter.kind === "herdr") {
+				await active.adapter.restore(active.snapshot as HerdrSnapshot, restoreName);
+			} else {
+				await active.adapter.restore(active.snapshot as TmuxSnapshot, restoreName);
+			}
+		} catch (error) {
+			this.warnOnce(
+				`${active.adapter.kind}:restore`,
+				`Recap could not restore ${active.adapter.kind} state: ${commandError(error)}`,
+				hooks,
+			);
+		}
+	}
+
+	private warnOnce(key: string, message: string, hooks: MultiplexerHooks) {
+		if (this.warned.has(key)) return;
+		this.warned.add(key);
+		hooks.warn(message);
+	}
+}

--- a/packages/pi-recap/extensions/recap.ts
+++ b/packages/pi-recap/extensions/recap.ts
@@ -3,17 +3,15 @@
  *
  * - Generate a recent activity recap. This is NOT compaction.
  * - Optionally apply the generated title to the Pi session name.
- * - Optionally sync Pi session name to the current tmux window name.
+ * - Optionally sync Pi session name to the nearest terminal multiplexer.
  *
  * Config:
  *   ~/.pi/agent/recap.json
  *   .pi/recap.json          (only read when the project is trusted)
  */
 
-import { execFile } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
 import { complete } from "@earendil-works/pi-ai/compat";
 import {
 	CONFIG_DIR_NAME,
@@ -25,8 +23,14 @@ import {
 	type SessionEntry,
 } from "@earendil-works/pi-coding-agent";
 import { CancellableLoader, Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
+import {
+	migrateMultiplexerConfig,
+	MultiplexerManager,
+	type MultiplexerConfig,
+	type MultiplexerHooks,
+	type MultiplexerNameContext,
+} from "./multiplexer.ts";
 
-const execFileAsync = promisify(execFile);
 const CUSTOM_TYPE = "recap";
 const WIDGET_KEY = "recap";
 const LEGACY_STATUS_KEY = "recap";
@@ -58,12 +62,7 @@ type RecapConfig = {
 		applyPolicy: TitleApplyPolicy;
 		maxLength: number;
 	};
-	tmux: {
-		enabled: boolean;
-		template: string;
-		maxLength: number;
-		restoreOnShutdown: boolean;
-	};
+	multiplexer: MultiplexerConfig;
 };
 
 type RecapEntryData = {
@@ -78,12 +77,6 @@ type RecapEntryData = {
 	generatedAt: number;
 	appliedSessionName: boolean;
 	sessionNamePolicy: TitleApplyPolicy;
-};
-
-type TmuxSnapshot = {
-	windowId: string;
-	originalName?: string;
-	originalAutomaticRename?: string;
 };
 
 const DEFAULT_CONFIG: RecapConfig = {
@@ -109,7 +102,7 @@ const DEFAULT_CONFIG: RecapConfig = {
 		applyPolicy: "if-empty-or-auto",
 		maxLength: 50,
 	},
-	tmux: {
+	multiplexer: {
 		enabled: true,
 		template: "π {session} · {project}",
 		maxLength: 48,
@@ -142,10 +135,14 @@ type ConfigMigration = {
 };
 
 function migrateLegacyConfig(value: unknown): ConfigMigration {
-	if (!isRecord(value) || !isRecord(value.display)) return { value, changed: false };
+	const multiplexerMigration = migrateMultiplexerConfig(value);
+	const migrated = multiplexerMigration.value;
+	if (!isRecord(migrated) || !isRecord(migrated.display)) {
+		return multiplexerMigration;
+	}
 
-	const display = { ...value.display };
-	let changed = false;
+	const display = { ...migrated.display };
+	let changed = multiplexerMigration.changed;
 	for (const key of ["notify", "mode", "widget", "clearWidgetOnNextAgentStart"]) {
 		if (key in display) {
 			delete display[key];
@@ -154,7 +151,7 @@ function migrateLegacyConfig(value: unknown): ConfigMigration {
 	}
 
 	return {
-		value: changed ? { ...value, display } : value,
+		value: changed ? { ...migrated, display } : migrated,
 		changed,
 	};
 }
@@ -231,10 +228,10 @@ function normalizeConfig(config: RecapConfig): RecapConfig {
 			applyPolicy: normalizeTitlePolicy(config.title?.applyPolicy),
 			maxLength: positiveNumber(config.title?.maxLength, DEFAULT_CONFIG.title.maxLength),
 		},
-		tmux: {
-			...DEFAULT_CONFIG.tmux,
-			...config.tmux,
-			maxLength: positiveNumber(config.tmux?.maxLength, DEFAULT_CONFIG.tmux.maxLength),
+		multiplexer: {
+			...DEFAULT_CONFIG.multiplexer,
+			...config.multiplexer,
+			maxLength: positiveNumber(config.multiplexer?.maxLength, DEFAULT_CONFIG.multiplexer.maxLength),
 		},
 	};
 
@@ -715,17 +712,17 @@ function settingItems(config: RecapConfig): SettingItem[] {
 			values: ["aboveEditor", "belowEditor"],
 		},
 		{
-			id: "tmux.enabled",
-			label: "Sync tmux window",
-			description: "Rename current tmux window when Pi session name changes.",
-			currentValue: boolValue(config.tmux.enabled),
+			id: "multiplexer.enabled",
+			label: "Sync multiplexer name",
+			description: "Rename the nearest Herdr pane or tmux window when Pi session name changes.",
+			currentValue: boolValue(config.multiplexer.enabled),
 			values: ["on", "off"],
 		},
 		{
-			id: "tmux.restoreOnShutdown",
-			label: "Restore tmux on shutdown",
-			description: "Restore previous tmux window name when Pi exits.",
-			currentValue: boolValue(config.tmux.restoreOnShutdown),
+			id: "multiplexer.restoreOnShutdown",
+			label: "Restore multiplexer on shutdown",
+			description: "Restore the previous pane or window name when Pi exits.",
+			currentValue: boolValue(config.multiplexer.restoreOnShutdown),
 			values: ["on", "off"],
 		},
 	];
@@ -751,11 +748,11 @@ function applyConfigSetting(config: RecapConfig, id: string, value: string): Rec
 		case "display.widgetPlacement":
 			next.display.widgetPlacement = value === "belowEditor" ? "belowEditor" : "aboveEditor";
 			break;
-		case "tmux.enabled":
-			next.tmux.enabled = on;
+		case "multiplexer.enabled":
+			next.multiplexer.enabled = on;
 			break;
-		case "tmux.restoreOnShutdown":
-			next.tmux.restoreOnShutdown = on;
+		case "multiplexer.restoreOnShutdown":
+			next.multiplexer.restoreOnShutdown = on;
 			break;
 	}
 
@@ -778,7 +775,7 @@ async function editConfigJson(pi: ExtensionAPI, ctx: ExtensionContext, state: Re
 		if (!next.recap.enabled || !next.recap.auto) stopAutomaticRecap(ctx, state);
 		refreshRecapDisplay(ctx, state);
 		await saveGlobalConfig(next);
-		await updateTmuxWindow(pi, ctx, next, state);
+		await syncMultiplexer(pi, ctx, state);
 		ctx.ui.notify(`Saved recap config: ${getGlobalConfigPath()}`, "info");
 	} catch (error) {
 		ctx.ui.notify(`Invalid recap config JSON: ${error instanceof Error ? error.message : String(error)}`, "error");
@@ -811,7 +808,7 @@ async function openConfigUi(pi: ExtensionAPI, ctx: ExtensionContext, state: Reca
 				refreshRecapDisplay(ctx, state);
 				void saveGlobalConfig(next)
 					.then(async () => {
-						await updateTmuxWindow(pi, ctx, next, state);
+						await syncMultiplexer(pi, ctx, state);
 					})
 					.catch((error) => {
 						ctx.ui.notify(`Failed to save recap config: ${error instanceof Error ? error.message : String(error)}`, "error");
@@ -837,75 +834,26 @@ async function openConfigUi(pi: ExtensionAPI, ctx: ExtensionContext, state: Reca
 	});
 }
 
-async function tmux(args: string[]): Promise<string | undefined> {
-	if (!process.env.TMUX) return undefined;
-	try {
-		const { stdout } = await execFileAsync("tmux", args, { encoding: "utf8", timeout: 1000 });
-		return String(stdout).trim();
-	} catch {
-		return undefined;
-	}
-}
-
-async function ensureTmuxSnapshot(state: RecapState): Promise<TmuxSnapshot | undefined> {
-	if (state.tmuxSnapshot) return state.tmuxSnapshot;
-
-	const windowId = await tmux(["display-message", "-p", "#{window_id}"]);
-	if (!windowId) return undefined;
-
-	state.tmuxSnapshot = {
-		windowId,
-		originalName: await tmux(["display-message", "-p", "-t", windowId, "#{window_name}"]),
-		originalAutomaticRename: await tmux(["show-window-options", "-qv", "-t", windowId, "automatic-rename"]),
+function multiplexerHooks(ctx: ExtensionContext): MultiplexerHooks {
+	return {
+		setTitle: (name) => ctx.ui.setTitle(name),
+		warn: (message) => ctx.ui.notify(message, "warning"),
 	};
-
-	await tmux(["set-window-option", "-q", "-t", windowId, "automatic-rename", "off"]);
-	return state.tmuxSnapshot;
 }
 
-function cleanTmuxName(name: string, maxLength: number): string {
-	const cleaned = name
-		.replace(/[\x00-\x1f\x7f]/g, "")
-		.replace(/\s+/g, " ")
-		.trim();
-	if (cleaned.length <= maxLength) return cleaned;
-	return `${cleaned.slice(0, Math.max(1, maxLength - 1))}…`;
+function multiplexerNameContext(pi: ExtensionAPI, ctx: ExtensionContext): MultiplexerNameContext {
+	return {
+		sessionName: currentSessionName(pi, ctx),
+		cwd: ctx.cwd,
+		sessionId: ctx.sessionManager.getSessionId(),
+	};
 }
 
-function buildTmuxWindowName(pi: ExtensionAPI, ctx: ExtensionContext, config: RecapConfig): string {
-	const project = path.basename(ctx.cwd) || "project";
-	const session = currentSessionName(pi, ctx) ?? ctx.sessionManager.getSessionId().slice(0, 8) ?? "session";
-	const raw = config.tmux.template
-		.replaceAll("{session}", session)
-		.replaceAll("{project}", project)
-		.replaceAll("{cwd}", ctx.cwd)
-		.replaceAll("{id}", ctx.sessionManager.getSessionId());
-	return cleanTmuxName(raw, config.tmux.maxLength);
-}
-
-async function updateTmuxWindow(pi: ExtensionAPI, ctx: ExtensionContext, config: RecapConfig, state: RecapState) {
-	if (!config.tmux.enabled) return;
-	if (ctx.mode !== "tui") return;
-	if (!process.env.TMUX) return;
-
-	const snapshot = await ensureTmuxSnapshot(state);
-	if (!snapshot) return;
-
-	const name = buildTmuxWindowName(pi, ctx, config);
-	await tmux(["rename-window", "-t", snapshot.windowId, name]);
-	ctx.ui.setTitle(name);
-}
-
-async function restoreTmuxWindow(state: RecapState) {
-	const snapshot = state.tmuxSnapshot;
-	if (!snapshot) return;
-
-	if (snapshot.originalName) {
-		await tmux(["rename-window", "-t", snapshot.windowId, snapshot.originalName]);
-	}
-	if (snapshot.originalAutomaticRename) {
-		await tmux(["set-window-option", "-q", "-t", snapshot.windowId, "automatic-rename", snapshot.originalAutomaticRename]);
-	}
+async function syncMultiplexer(pi: ExtensionAPI, ctx: ExtensionContext, state: RecapState) {
+	const config = ctx.mode === "tui"
+		? state.config.multiplexer
+		: { ...state.config.multiplexer, enabled: false };
+	await state.multiplexer.sync(config, multiplexerNameContext(pi, ctx), multiplexerHooks(ctx));
 }
 
 type ActiveRecapRun = {
@@ -927,7 +875,7 @@ type RecapState = {
 	lastAppliedSessionName: boolean;
 	lastAppliedTitle?: string;
 	autoTimer?: ReturnType<typeof setTimeout>;
-	tmuxSnapshot?: TmuxSnapshot;
+	multiplexer: MultiplexerManager;
 };
 
 function clearAutoTimer(state: RecapState) {
@@ -995,6 +943,7 @@ export default function (pi: ExtensionAPI) {
 		nextRunId: 0,
 		applyingSessionName: false,
 		lastAppliedSessionName: false,
+		multiplexer: new MultiplexerManager(),
 	};
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -1007,7 +956,7 @@ export default function (pi: ExtensionAPI) {
 
 		await refreshStateFromSession(ctx, state);
 		refreshRecapDisplay(ctx, state);
-		await updateTmuxWindow(pi, ctx, state.config, state);
+		await syncMultiplexer(pi, ctx, state);
 	});
 
 	pi.on("session_info_changed", async (event, ctx) => {
@@ -1015,7 +964,7 @@ export default function (pi: ExtensionAPI) {
 			state.lastAppliedSessionName = false;
 			state.lastAppliedTitle = undefined;
 		}
-		await updateTmuxWindow(pi, ctx, state.config, state);
+		await syncMultiplexer(pi, ctx, state);
 	});
 
 	pi.on("input", async (_event, ctx) => {
@@ -1032,9 +981,7 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_shutdown", async (event, ctx) => {
 		stopAutomaticRecap(ctx, state);
-		if (state.config.tmux.restoreOnShutdown && event.reason !== "reload") {
-			await restoreTmuxWindow(state);
-		}
+		await state.multiplexer.shutdown(state.config.multiplexer, event.reason, multiplexerHooks(ctx));
 	});
 
 	pi.registerCommand("recap", {

--- a/packages/pi-recap/package.json
+++ b/packages/pi-recap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zhcsyncer/pi-recap",
   "version": "0.2.0",
-  "description": "Recent activity recap extension for Pi with optional session title and tmux window sync.",
+  "description": "Recent activity recap extension for Pi with optional session title and Herdr/tmux name sync.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/zhcsyncer/pi-extensions.git",
@@ -16,10 +16,17 @@
     "pi-extension",
     "recap",
     "session-title",
+    "terminal-multiplexer",
+    "herdr",
     "tmux"
   ],
   "license": "MIT",
   "type": "module",
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json",
+    "test": "tsx --test tests/*.test.ts",
+    "check": "pnpm typecheck && pnpm test"
+  },
   "files": [
     "extensions",
     "examples",
@@ -40,5 +47,10 @@
     "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*"
+  },
+  "devDependencies": {
+    "@types/node": "25.6.0",
+    "tsx": "4.22.4",
+    "typescript": "6.0.3"
   }
 }

--- a/packages/pi-recap/tests/multiplexer.test.ts
+++ b/packages/pi-recap/tests/multiplexer.test.ts
@@ -1,0 +1,525 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	buildMultiplexerName,
+	cleanMultiplexerName,
+	detectMultiplexer,
+	migrateMultiplexerConfig,
+	MultiplexerManager,
+	type CommandRunner,
+	type MultiplexerConfig,
+	type MultiplexerHooks,
+	type MultiplexerNameContext,
+} from "../extensions/multiplexer.ts";
+
+const CONFIG: MultiplexerConfig = {
+	enabled: true,
+	template: "{session}",
+	maxLength: 48,
+	restoreOnShutdown: true,
+};
+
+const CONTEXT: MultiplexerNameContext = {
+	sessionName: "auth refresh",
+	cwd: "/work/project",
+	sessionId: "session-1234567890",
+};
+
+type Call = { command: string; args: string[] };
+
+function createHooks(): {
+	hooks: MultiplexerHooks;
+	titles: string[];
+	warnings: string[];
+} {
+	const titles: string[] = [];
+	const warnings: string[] = [];
+	return {
+		hooks: {
+			setTitle: (name) => titles.push(name),
+			warn: (message) => warnings.push(message),
+		},
+		titles,
+		warnings,
+	};
+}
+
+function paneJson(paneId: string, label: string | undefined): string {
+	return JSON.stringify({
+		id: "test",
+		result: {
+			type: "pane_info",
+			pane: {
+				pane_id: paneId,
+				...(label === undefined ? {} : { label }),
+			},
+		},
+	});
+}
+
+function createHerdrRunner(initialLabel: string | null = "shell") {
+	let label: string | undefined = initialLabel ?? undefined;
+	const calls: Call[] = [];
+	const runner: CommandRunner = async (command, args) => {
+		calls.push({ command, args: [...args] });
+		assert.equal(command, "herdr");
+		assert.equal(args[0], "pane");
+		if (args[1] === "get") {
+			return { stdout: paneJson(args[2]!, label) };
+		}
+		if (args[1] === "rename") {
+			label = args[3] === "--clear" ? undefined : args[3]!;
+			return { stdout: "{}" };
+		}
+		throw new Error(`Unexpected Herdr command: ${args.join(" ")}`);
+	};
+	return {
+		runner,
+		calls,
+		get label() {
+			return label;
+		},
+		set label(value: string | undefined) {
+			label = value;
+		},
+	};
+}
+
+function createTmuxRunner() {
+	let currentName = "shell";
+	let automaticRename = "on";
+	const calls: Call[] = [];
+	const runner: CommandRunner = async (command, args) => {
+		calls.push({ command, args: [...args] });
+		assert.equal(command, "tmux");
+		if (args[0] === "display-message" && args.at(-1) === "#{window_id}") {
+			return { stdout: "@7\n" };
+		}
+		if (args[0] === "display-message" && args.at(-1) === "#{window_name}") {
+			return { stdout: `${currentName}\n` };
+		}
+		if (args[0] === "show-window-options") {
+			return { stdout: `${automaticRename}\n` };
+		}
+		if (args[0] === "set-window-option") {
+			automaticRename = args.at(-1)!;
+			return { stdout: "" };
+		}
+		if (args[0] === "rename-window") {
+			currentName = args.at(-1)!;
+			return { stdout: "" };
+		}
+		throw new Error(`Unexpected tmux command: ${args.join(" ")}`);
+	};
+	return {
+		runner,
+		calls,
+		get currentName() {
+			return currentName;
+		},
+		set currentName(value: string) {
+			currentName = value;
+		},
+		get automaticRename() {
+			return automaticRename;
+		},
+	};
+}
+
+test("detects no multiplexer without environment markers", () => {
+	assert.deepEqual(detectMultiplexer({}), { kind: "none" });
+});
+
+test("detects tmux when it is the nearest multiplexer", () => {
+	assert.deepEqual(detectMultiplexer({ TMUX: "/tmp/tmux,1,0" }), { kind: "tmux" });
+});
+
+test("detects Herdr pane before inherited tmux", () => {
+	assert.deepEqual(
+		detectMultiplexer({ HERDR_ENV: "1", HERDR_PANE_ID: "w1:p2", TMUX: "/tmp/tmux,1,0" }),
+		{ kind: "herdr", paneId: "w1:p2" },
+	);
+});
+
+test("treats Herdr without a pane id as an invalid nearest layer", () => {
+	assert.deepEqual(detectMultiplexer({ HERDR_ENV: "1", TMUX: "/tmp/tmux,1,0" }), {
+		kind: "herdr-invalid",
+	});
+});
+
+test("ignores stray Herdr pane ids without the Herdr marker", () => {
+	assert.deepEqual(detectMultiplexer({ HERDR_PANE_ID: "w1:p2", TMUX: "tmux" }), { kind: "tmux" });
+});
+
+test("builds one shared name for either multiplexer", () => {
+	assert.equal(
+		buildMultiplexerName(
+			{ ...CONFIG, template: "π {session} · {project} · {cwd} · {id}" },
+			CONTEXT,
+		),
+		"π auth refresh · project · /work/project · sess…",
+	);
+});
+
+test("uses the short session id when Pi has no session name", () => {
+	assert.equal(
+		buildMultiplexerName({ ...CONFIG, template: "{session}" }, { ...CONTEXT, sessionName: undefined }),
+		"session-",
+	);
+});
+
+test("cleans control characters, whitespace, and long labels", () => {
+	assert.equal(cleanMultiplexerName("  auth\n\trefresh\u0000 now  ", 16), "authrefresh now");
+	assert.equal(cleanMultiplexerName("1234567890", 6), "12345…");
+});
+
+test("migrates legacy tmux config to multiplexer config", () => {
+	assert.deepEqual(
+		migrateMultiplexerConfig({
+			recap: { auto: false },
+			tmux: { enabled: false, template: "old", maxLength: 60, restoreOnShutdown: false },
+		}),
+		{
+			changed: true,
+			value: {
+				recap: { auto: false },
+				multiplexer: { enabled: false, template: "old", maxLength: 60, restoreOnShutdown: false },
+			},
+		},
+	);
+});
+
+test("new multiplexer fields win while legacy tmux fills missing fields", () => {
+	assert.deepEqual(
+		migrateMultiplexerConfig({
+			tmux: { enabled: false, template: "old", maxLength: 60 },
+			multiplexer: { template: "new", restoreOnShutdown: true },
+		}).value,
+		{
+			multiplexer: {
+				enabled: false,
+				template: "new",
+				maxLength: 60,
+				restoreOnShutdown: true,
+			},
+		},
+	);
+});
+
+test("removes malformed legacy tmux config without inventing values", () => {
+	assert.deepEqual(migrateMultiplexerConfig({ tmux: false, recap: {} }), {
+		changed: true,
+		value: { recap: {} },
+	});
+});
+
+test("Herdr sync renames the fixed pane and restores its original label", async () => {
+	const herdr = createHerdrRunner("shell");
+	const ui = createHooks();
+	const manager = new MultiplexerManager({
+		environment: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p2" },
+		runner: herdr.runner,
+	});
+
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+	assert.equal(herdr.label, "auth refresh");
+	assert.deepEqual(ui.titles, ["auth refresh"]);
+
+	await manager.shutdown(CONFIG, "quit", ui.hooks);
+	assert.equal(herdr.label, "shell");
+	assert.equal(ui.warnings.length, 0);
+	assert.ok(herdr.calls.every((call) => call.command === "herdr"));
+});
+
+test("Herdr restore clears a pane that originally had no manual label", async () => {
+	const herdr = createHerdrRunner(null);
+	const ui = createHooks();
+	const manager = new MultiplexerManager({
+		environment: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p2" },
+		runner: herdr.runner,
+	});
+
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+	await manager.shutdown(CONFIG, "quit", ui.hooks);
+
+	assert.equal(herdr.label, undefined);
+	assert.ok(
+		herdr.calls.some((call) => call.args.join(" ") === "pane rename w1:p2 --clear"),
+		"shutdown should clear the label",
+	);
+});
+
+test("nested Herdr never calls tmux", async () => {
+	const herdr = createHerdrRunner();
+	const ui = createHooks();
+	const manager = new MultiplexerManager({
+		environment: {
+			HERDR_ENV: "1",
+			HERDR_PANE_ID: "w1:p2",
+			TMUX: "/tmp/tmux,1,0",
+		},
+		runner: herdr.runner,
+	});
+
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+	assert.ok(herdr.calls.length > 0);
+	assert.ok(herdr.calls.every((call) => call.command === "herdr"));
+});
+
+test("uses HERDR_BIN_PATH when Herdr provides a CLI path", async () => {
+	const commands: string[] = [];
+	let label = "shell";
+	const runner: CommandRunner = async (command, args) => {
+		commands.push(command);
+		if (args[1] === "get") return { stdout: paneJson("w1:p2", label) };
+		label = args[3]!;
+		return { stdout: "{}" };
+	};
+	const manager = new MultiplexerManager({
+		environment: {
+			HERDR_ENV: "1",
+			HERDR_PANE_ID: "w1:p2",
+			HERDR_BIN_PATH: "/opt/herdr/bin/herdr",
+		},
+		runner,
+	});
+
+	await manager.sync(CONFIG, CONTEXT, createHooks().hooks);
+	assert.equal(label, "auth refresh");
+	assert.ok(commands.every((command) => command === "/opt/herdr/bin/herdr"));
+});
+
+test("invalid Herdr identity warns once and never falls back to tmux", async () => {
+	const calls: Call[] = [];
+	const ui = createHooks();
+	const manager = new MultiplexerManager({
+		environment: { HERDR_ENV: "1", TMUX: "/tmp/tmux,1,0" },
+		runner: async (command, args) => {
+			calls.push({ command, args });
+			return { stdout: "" };
+		},
+	});
+
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+
+	assert.deepEqual(calls, []);
+	assert.equal(ui.warnings.length, 1);
+	assert.match(ui.warnings[0]!, /HERDR_PANE_ID/);
+});
+
+test("Herdr capture failure retries safely, warns once, and never calls tmux", async () => {
+	const calls: Call[] = [];
+	const ui = createHooks();
+	const manager = new MultiplexerManager({
+		environment: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p2", TMUX: "tmux" },
+		runner: async (command, args) => {
+			calls.push({ command, args });
+			throw new Error("server unavailable");
+		},
+	});
+
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+
+	assert.equal(calls.length, 2);
+	assert.ok(calls.every((call) => call.command === "herdr"));
+	assert.equal(ui.warnings.length, 1);
+});
+
+test("Herdr rejects invalid JSON and mismatched pane ids", async () => {
+	for (const stdout of ["not-json", paneJson("w9:p9", "other")]) {
+		const ui = createHooks();
+		const manager = new MultiplexerManager({
+			environment: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p2" },
+			runner: async () => ({ stdout }),
+		});
+		await manager.sync(CONFIG, CONTEXT, ui.hooks);
+		assert.equal(ui.titles.length, 0);
+		assert.equal(ui.warnings.length, 1);
+	}
+});
+
+test("same generated name is applied only once", async () => {
+	const herdr = createHerdrRunner();
+	const ui = createHooks();
+	const manager = new MultiplexerManager({
+		environment: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p2" },
+		runner: herdr.runner,
+	});
+
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+
+	assert.equal(
+		herdr.calls.filter((call) => call.args[1] === "rename").length,
+		1,
+	);
+	assert.deepEqual(ui.titles, ["auth refresh"]);
+});
+
+test("queued session-name changes are applied in order", async () => {
+	let label = "shell";
+	let releaseFirstRename: (() => void) | undefined;
+	const firstRenameBlocked = new Promise<void>((resolve) => {
+		releaseFirstRename = resolve;
+	});
+	const renamed: string[] = [];
+	const runner: CommandRunner = async (_command, args) => {
+		if (args[1] === "get") return { stdout: paneJson("w1:p2", label) };
+		if (args[1] === "rename") {
+			const next = args[3]!;
+			renamed.push(next);
+			if (renamed.length === 1) await firstRenameBlocked;
+			label = next;
+			return { stdout: "{}" };
+		}
+		throw new Error("unexpected command");
+	};
+	const manager = new MultiplexerManager({
+		environment: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p2" },
+		runner,
+	});
+	const ui = createHooks();
+
+	const first = manager.sync(CONFIG, { ...CONTEXT, sessionName: "first" }, ui.hooks);
+	await new Promise((resolve) => setImmediate(resolve));
+	const second = manager.sync(CONFIG, { ...CONTEXT, sessionName: "second" }, ui.hooks);
+	assert.deepEqual(renamed, ["first"]);
+	releaseFirstRename?.();
+	await Promise.all([first, second]);
+
+	assert.deepEqual(renamed, ["first", "second"]);
+	assert.equal(label, "second");
+});
+
+test("disabling sync immediately restores an owned Herdr label", async () => {
+	const herdr = createHerdrRunner("shell");
+	const manager = new MultiplexerManager({
+		environment: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p2" },
+		runner: herdr.runner,
+	});
+	const ui = createHooks();
+
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+	await manager.sync({ ...CONFIG, enabled: false }, CONTEXT, ui.hooks);
+	assert.equal(herdr.label, "shell");
+});
+
+test("reload restores even when ordinary shutdown restoration is disabled", async () => {
+	const herdr = createHerdrRunner("shell");
+	const config = { ...CONFIG, restoreOnShutdown: false };
+	const ui = createHooks();
+	const first = new MultiplexerManager({
+		environment: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p2" },
+		runner: herdr.runner,
+	});
+
+	await first.sync(config, CONTEXT, ui.hooks);
+	await first.shutdown(config, "reload", ui.hooks);
+	assert.equal(herdr.label, "shell");
+
+	const reloaded = new MultiplexerManager({
+		environment: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p2" },
+		runner: herdr.runner,
+	});
+	await reloaded.sync(config, CONTEXT, ui.hooks);
+	assert.equal(herdr.label, "auth refresh");
+});
+
+test("ordinary shutdown honors restoreOnShutdown false", async () => {
+	const herdr = createHerdrRunner("shell");
+	const config = { ...CONFIG, restoreOnShutdown: false };
+	const manager = new MultiplexerManager({
+		environment: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p2" },
+		runner: herdr.runner,
+	});
+	const ui = createHooks();
+
+	await manager.sync(config, CONTEXT, ui.hooks);
+	await manager.shutdown(config, "quit", ui.hooks);
+	assert.equal(herdr.label, "auth refresh");
+});
+
+test("manual Herdr rename is preserved on shutdown", async () => {
+	const herdr = createHerdrRunner("shell");
+	const manager = new MultiplexerManager({
+		environment: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p2" },
+		runner: herdr.runner,
+	});
+	const ui = createHooks();
+
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+	herdr.label = "manual label";
+	await manager.shutdown(CONFIG, "quit", ui.hooks);
+	assert.equal(herdr.label, "manual label");
+});
+
+test("tmux sync preserves window behavior and restores automatic rename", async () => {
+	const tmux = createTmuxRunner();
+	const ui = createHooks();
+	const manager = new MultiplexerManager({
+		environment: { TMUX: "/tmp/tmux,1,0" },
+		runner: tmux.runner,
+	});
+
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+	assert.equal(tmux.currentName, "auth refresh");
+	assert.equal(tmux.automaticRename, "off");
+	assert.deepEqual(ui.titles, ["auth refresh"]);
+
+	await manager.shutdown(CONFIG, "quit", ui.hooks);
+	assert.equal(tmux.currentName, "shell");
+	assert.equal(tmux.automaticRename, "on");
+});
+
+test("manual tmux rename is preserved while automatic rename is restored", async () => {
+	const tmux = createTmuxRunner();
+	const ui = createHooks();
+	const manager = new MultiplexerManager({
+		environment: { TMUX: "/tmp/tmux,1,0" },
+		runner: tmux.runner,
+	});
+
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+	tmux.currentName = "manual window";
+	await manager.shutdown(CONFIG, "quit", ui.hooks);
+
+	assert.equal(tmux.currentName, "manual window");
+	assert.equal(tmux.automaticRename, "on");
+});
+
+test("tmux apply failure does not set terminal title and still releases automatic rename", async () => {
+	const tmux = createTmuxRunner();
+	const ui = createHooks();
+	const runner: CommandRunner = async (command, args) => {
+		if (args[0] === "rename-window") throw new Error("rename failed");
+		return tmux.runner(command, args);
+	};
+	const manager = new MultiplexerManager({ environment: { TMUX: "tmux" }, runner });
+
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+	assert.deepEqual(ui.titles, []);
+	assert.equal(ui.warnings.length, 1);
+	assert.equal(tmux.automaticRename, "off");
+
+	await manager.sync({ ...CONFIG, enabled: false }, CONTEXT, ui.hooks);
+	assert.equal(tmux.automaticRename, "on");
+});
+
+test("no multiplexer environment performs no command or title side effect", async () => {
+	const calls: Call[] = [];
+	const ui = createHooks();
+	const manager = new MultiplexerManager({
+		environment: {},
+		runner: async (command, args) => {
+			calls.push({ command, args });
+			return { stdout: "" };
+		},
+	});
+
+	await manager.sync(CONFIG, CONTEXT, ui.hooks);
+	assert.deepEqual(calls, []);
+	assert.deepEqual(ui.titles, []);
+	assert.deepEqual(ui.warnings, []);
+});

--- a/packages/pi-recap/tsconfig.json
+++ b/packages/pi-recap/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": [
+    "extensions/**/*.ts",
+    "tests/**/*.ts"
+  ]
+}

--- a/packages/pi-search-hub/README.md
+++ b/packages/pi-search-hub/README.md
@@ -10,7 +10,7 @@ This package is private and is not published separately. Install `@zhcsyncer/pi-
 
 ### `web_search`
 
-Searches the web through an explicitly selected backend or through automatic fallback. `combine=true` queries multiple enabled backends and merges/deduplicates their results; `combineMode: "targeted"` in `search.json` limits fan-out while still collecting multiple usable result sets.
+Searches the web through an explicitly selected backend or through automatic routing. Fallback mode tries enabled backends in order and stops at the first success. `combine=true` queries multiple enabled backends and merges/deduplicates their results: `combineMode: "targeted"` collects up to three usable backend result sets, while `combineMode: "all"` queries every enabled backend. Combine is ignored when a call explicitly selects one backend.
 
 Important call options include:
 
@@ -24,7 +24,7 @@ DuckDuckGo is the keyless fallback when no backend is explicitly enabled. Other 
 
 ### `web_read`
 
-Fetches a URL and returns extracted Markdown. The default Jina reader supports cache bypass, keywords, `rush`/`smart` modes, and targeted extraction. Sofya, Firecrawl, Exa, and Exa MCP readers are also available.
+Fetches a URL and returns extracted Markdown. The configured `reader` is the default reader and is independent of the default search backend. When a call omits `reader`, Search Hub tries the default followed by `readerFallback` in order; an explicit `reader` uses only that reader. Readers fail over sequentially and are never queried or merged in parallel. The default Jina reader supports remote cache bypass, keywords, `rush`/`smart` modes, and targeted extraction. Sofya, Firecrawl, Exa, and Exa MCP readers are also available.
 
 Important call options include:
 
@@ -32,7 +32,7 @@ Important call options include:
 - `fresh` — bypass reader caches where supported;
 - `keywords` — terms used to focus long-page extraction;
 - `mode` — `rush` for speed or `smart` for better narrowing;
-- `reader` — override the configured reader;
+- `reader` — use only the specified reader, bypassing configured reader fallback;
 - `objective` — a Jina CSS target selector.
 
 > `web_read.objective` is a CSS selector passed to Jina as `x-target-selector`. It is not a natural-language question or extraction instruction. Use values such as `main`, `article`, or `#pricing`, and use `keywords` for semantic focus.
@@ -53,7 +53,7 @@ Semantic call metadata includes:
 | `web_search` | Search query | Requested backend, combine mode, result limit, compact mode |
 | `web_read` | Shortened URL | Reader, rush/smart mode, keyword count, fresh mode, selector presence |
 
-Semantic result status includes:
+Search and read progress is emitted through the active tool call rather than a persistent footer status. Semantic result status includes:
 
 | Tool | Status |
 |---|---|
@@ -71,15 +71,27 @@ Search Hub reads configuration from:
 1. `$PI_CODING_AGENT_DIR/extensions/search.json` for global settings;
 2. `.pi/search.json` in the current project.
 
-Project settings win. Backend maps are merged per backend, so a project can override one backend without repeating every global entry. Configuration is refreshed during use, with a short in-process cache.
+Project settings win. Backend maps are merged per backend, so a project can override one backend without repeating every global entry. Configuration is refreshed during use; interactive edits are staged until `Save & apply`.
+
+### Interactive setup
+
+Run `/search-setup` to view effective Search Hub status and edit the global configuration from one place. The top-level page summarizes search routing, web reading, backend and credential counts, and output, then opens dedicated `Search routing`, `Web reading`, `Backends`, and `Output` pages. The long backend list lives only on the Backends page; there is no separate `/search-status` command.
+
+Each concise backend row starts with `[ON]`, `[OFF]`, or `[AUTO]` and uses one `auth` vocabulary across API keys and Pi credentials: `auth ✓ saved key`, `auth ✓ env <name>`, `auth ✓ Pi /login`, `auth ✗ missing`, `auth — optional`, or `auth — not required`. An unset reference is treated as no resolved credential. A shell-command credential is marked `auth ? shell command` because setup does not execute it merely to render status. Selecting a backend compares the global draft with the effective configuration after project overrides, and offers separate switch, credential, URL, and Pi-auth actions. Disabling retains credentials; re-enabling reuses a still-resolvable credential. The bulk action enables only ready keyless hosted backends, leaving SearXNG off until an instance URL is configured.
+
+All pages edit one in-memory global draft. `Back` never writes, and the home page marks unsaved changes. `Save & apply` normalizes the draft, removes obsolete fields, writes the global file atomically with mode `0600`, refreshes runtime configuration once, and emits one result notification. Closing with pending edits offers `Save & apply`, `Discard changes`, or `Continue editing`. After a successful save, `/reload` or a new session is not required.
+
+`/search-setup` changes only the global file. A project `.pi/search.json` can override that change for the current project; Search Hub reports this after saving. Disabling a backend does not delete a stored credential; use `Remove saved API key or reference` in that backend's detail menu when it must also be removed from disk. Search Hub does not cache search results locally; `web_read.fresh` only asks supported remote readers to bypass their own caches.
 
 Minimal example:
 
 ```json
 {
-  "defaultBackend": "auto",
+  "defaultBackend": "duckduckgo",
+  "combine": false,
   "combineMode": "targeted",
   "reader": "jina",
+  "readerFallback": ["firecrawl", "exa_mcp"],
   "backends": {
     "duckduckgo": { "enabled": true },
     "serper": { "enabled": true, "apiKey": "SERPER_API_KEY" }
@@ -87,7 +99,7 @@ Minimal example:
 }
 ```
 
-Copy [`search.json.example`](./search.json.example) for a larger backend matrix. Credential values may be environment-variable names such as `SERPER_API_KEY`, shell commands prefixed with `!`, or literal keys. Prefer environment variables or a secret manager, and never commit credentials.
+Copy [`search.json.example`](./search.json.example) for a larger backend matrix. Search-service credentials (including Jina's optional key) may be environment-variable names such as `JINA_API_KEY`, shell commands prefixed with `!`, or key values saved directly in the configuration. Prefer environment variables or a secret manager, and never commit credentials. OpenAI Codex is the exception: it resolves the existing `openai-codex` provider credential from the current Pi model registry, so `/login openai-codex` remains the single source of truth. Other search services are not Pi model providers, and Pi currently exposes no generic extension secret store, so Search Hub does not register fake providers merely to place their keys in `auth.json`.
 
 See [`UPSTREAM_README.md`](./UPSTREAM_README.md) for the upstream backend-specific reference. Local behavior described in this README takes precedence for the bundled fork.
 

--- a/packages/pi-search-hub/README.zh-CN.md
+++ b/packages/pi-search-hub/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 ### `web_search`
 
-通过明确指定的 backend 搜索，或使用自动 fallback。`combine=true` 会并行查询多个已启用 backend，并合并、去重结果；在 `search.json` 中设置 `combineMode: "targeted"` 可以限制 fan-out，同时仍收集多个可用结果集。
+通过明确指定的 backend 搜索，或使用自动路由。Fallback 模式会按顺序尝试已启用 backend，并在首个成功结果处停止。`combine=true` 会查询多个已启用 backend，并合并、去重结果：`combineMode: "targeted"` 最多收集三个可用 backend 的结果集，`combineMode: "all"` 则查询全部已启用 backend。调用明确指定单个 backend 时会忽略 combine。
 
 主要调用参数：
 
@@ -24,7 +24,7 @@
 
 ### `web_read`
 
-读取 URL 并返回提取后的 Markdown。默认 Jina reader 支持绕过缓存、keywords、`rush`/`smart` 模式和定向提取，也可以使用 Sofya、Firecrawl、Exa 与 Exa MCP reader。
+读取 URL 并返回提取后的 Markdown。配置中的 `reader` 是 default reader，与默认搜索 backend 相互独立。调用未传 `reader` 时，Search Hub 会依次尝试 default reader 和 `readerFallback`；显式传入 `reader` 时只使用该 reader。Reader 只做顺序 fallback，不会并行查询或合并多份内容。默认 Jina reader 支持绕过远端缓存、keywords、`rush`/`smart` 模式和定向提取，也可以使用 Sofya、Firecrawl、Exa 与 Exa MCP reader。
 
 主要调用参数：
 
@@ -32,7 +32,7 @@
 - `fresh` — 在 reader 支持时绕过缓存；
 - `keywords` — 聚焦长页面提取的关键词；
 - `mode` — `rush` 优先速度，`smart` 提高筛选质量；
-- `reader` — 覆盖配置的 reader；
+- `reader` — 仅使用指定 reader，并跳过配置的 reader fallback；
 - `objective` — Jina CSS target selector。
 
 > `web_read.objective` 是通过 `x-target-selector` 传给 Jina 的 CSS selector，不是自然语言问题或提取指令。应使用 `main`、`article`、`#pricing` 等值；语义聚焦请使用 `keywords`。
@@ -53,7 +53,7 @@
 | `web_search` | 搜索词 | 请求的 backend、combine 模式、结果上限、compact 模式 |
 | `web_read` | 缩短后的 URL | reader、rush/smart 模式、keyword 数量、fresh 模式、是否使用 selector |
 
-语义化结果状态包括：
+搜索与读取进度通过当前 tool call 展示，不再写入常驻 footer 状态。语义化结果状态包括：
 
 | 工具 | 状态 |
 |---|---|
@@ -71,15 +71,27 @@ Search Hub 从以下位置读取配置：
 1. `$PI_CODING_AGENT_DIR/extensions/search.json`：全局设置；
 2. 当前项目的 `.pi/search.json`。
 
-项目设置优先。backend map 会按单个 backend 合并，因此项目可以只覆盖一个 backend，无需重复全部全局条目。配置会在使用过程中刷新，并带有较短的进程内缓存。
+项目设置优先。backend map 会按单个 backend 合并，因此项目可以只覆盖一个 backend，无需重复全部全局条目。配置会在使用过程中刷新；交互式修改会暂存在草稿中，直到选择 `Save & apply`。
+
+### 交互式配置
+
+运行 `/search-setup` 可在同一入口查看 Search Hub 的有效状态并编辑全局配置。一级页面只汇总搜索路由、网页读取、backend/credential 数量和输出设置，再进入独立的 `Search routing`、`Web reading`、`Backends` 与 `Output` 页面。较长的 backend 列表只出现在 Backends 二级页；不再提供独立的 `/search-status` 命令。
+
+每个简洁 backend 行都以前置 `[ON]`、`[OFF]` 或 `[AUTO]` 开头，并对 API key 与 Pi credential 统一使用 `auth` 口径：`auth ✓ saved key`、`auth ✓ env <名称>`、`auth ✓ Pi /login`、`auth ✗ missing`、`auth — optional` 或 `auth — not required`。无法解析的引用按“当前没有 credential”展示。Shell command credential 会标成 `auth ? shell command`，因为 setup 不会仅为渲染状态而执行它。选择 backend 后会对比全局草稿与经过项目覆盖后的有效配置，并分别提供开关、credential、URL 和 Pi auth 操作。禁用会保留 credential；只要保留的 credential 仍可解析，重新启用时无需再次输入。批量操作只启用可直接使用的 keyless hosted backend，SearXNG 会保持关闭直到配置实例 URL。
+
+所有页面共同编辑一份内存中的全局草稿。`Back` 不会写盘，一级页面会标记未保存修改。`Save & apply` 会归一化草稿、清理废弃字段、以 `0600` 权限原子写入全局文件，只刷新一次运行时配置，并只发一条结果通知。带未保存修改关闭时，可选择 `Save & apply`、`Discard changes` 或 `Continue editing`。保存成功后无需 `/reload` 或新建会话。
+
+`/search-setup` 只修改全局文件。项目 `.pi/search.json` 可以在当前项目中覆盖这次修改，Search Hub 会在保存后提示。禁用 backend 不会删除已保存的 credential；如果还需要从磁盘移除，请在该 backend 的详情菜单选择 `Remove saved API key or reference`。Search Hub 不在本地缓存搜索结果；`web_read.fresh` 只要求支持它的远端 reader 绕过自身缓存。
 
 最小示例：
 
 ```json
 {
-  "defaultBackend": "auto",
+  "defaultBackend": "duckduckgo",
+  "combine": false,
   "combineMode": "targeted",
   "reader": "jina",
+  "readerFallback": ["firecrawl", "exa_mcp"],
   "backends": {
     "duckduckgo": { "enabled": true },
     "serper": { "enabled": true, "apiKey": "SERPER_API_KEY" }
@@ -87,7 +99,7 @@ Search Hub 从以下位置读取配置：
 }
 ```
 
-可以复制 [`search.json.example`](./search.json.example) 获取更完整的 backend 配置矩阵。Credential 可以是 `SERPER_API_KEY` 这样的环境变量名、以 `!` 开头的 shell command，或 literal key。优先使用环境变量或 secret manager，绝不要提交凭据。
+可以复制 [`search.json.example`](./search.json.example) 获取更完整的 backend 配置矩阵。搜索服务 credential（包括 Jina 的可选 key）可以是 `JINA_API_KEY` 这样的环境变量名、以 `!` 开头的 shell command，或直接保存在配置中的 key 值。优先使用环境变量或 secret manager，绝不要提交凭据。OpenAI Codex 是例外：它从当前 Pi model registry 解析已有的 `openai-codex` provider credential，因此 `/login openai-codex` 是唯一凭据来源。其他搜索服务不是 Pi model provider，而 Pi 目前没有公开通用的 extension secret store，所以 Search Hub 不会为了把 key 放进 `auth.json` 而注册伪 provider。
 
 上游 backend 专属参考见 [`UPSTREAM_README.md`](./UPSTREAM_README.md)。对于 bundle fork，本 README 描述的本地行为优先。
 

--- a/packages/pi-search-hub/extensions/backends/jina.ts
+++ b/packages/pi-search-hub/extensions/backends/jina.ts
@@ -1,6 +1,6 @@
 /**
- * Jina AI backend — search via s.jina.ai (needs free API key).
- * Note: web_read uses Jina Reader (r.jina.ai) which is free and needs no key.
+ * Jina AI backend — search via s.jina.ai with anonymous access or an optional API key.
+ * Authenticated requests receive higher quotas; web_read uses the separate r.jina.ai Reader endpoint.
  */
 
 import { timeoutSignal, sanitizeError } from "../utils.js";

--- a/packages/pi-search-hub/extensions/backends/openai-codex.ts
+++ b/packages/pi-search-hub/extensions/backends/openai-codex.ts
@@ -1,4 +1,3 @@
-import { AuthStorage } from "@earendil-works/pi-coding-agent";
 import {
 	getModel,
 	streamOpenAICodexResponses,
@@ -41,14 +40,16 @@ const SUBMIT_SEARCH_RESULTS_TOOL = {
 export async function searchOpenAICodex(
 	query: string,
 	numResults: number,
+	apiKey: string | undefined,
 	signal?: AbortSignal,
 	backendConfig?: BackendConfig,
 ): Promise<{ results: SearchResult[] }> {
 	if (signal?.aborted) {
 		throw new Error("OpenAI Codex search cancelled");
 	}
-
-	const apiKey = await resolveOpenAICodexAccessToken();
+	if (!apiKey) {
+		throw new Error("OpenAI Codex authentication not found. Run /login openai-codex.");
+	}
 	const modelId = backendConfig?.model?.trim() || DEFAULT_MODEL_ID;
 	const lookupModel = getModel as unknown as (
 		provider: string,
@@ -100,19 +101,6 @@ export async function searchOpenAICodex(
 	}
 
 	return { results };
-}
-
-async function resolveOpenAICodexAccessToken(): Promise<string> {
-	const authStorage = AuthStorage.create();
-	const apiKey = await authStorage.getApiKey("openai-codex", {
-		includeFallback: false,
-	});
-
-	if (!apiKey) {
-		throw new Error("OpenAI Codex authentication not found. Run /login and select OpenAI Codex.");
-	}
-
-	return apiKey;
 }
 
 function buildSystemPrompt(numResults: number): string {

--- a/packages/pi-search-hub/extensions/backends/registry.ts
+++ b/packages/pi-search-hub/extensions/backends/registry.ts
@@ -3,7 +3,7 @@
  */
 
 import type { BackendRunner, BackendConfig, SearchResult } from "../types.js";
-import { MISSING_KEY_HELP, waitForCooldown, markCooldown, searchCache, cacheKey } from "../utils.js";
+import { MISSING_KEY_HELP, waitForCooldown, markCooldown } from "../utils.js";
 import { resolveBackendKey } from "../credentials.js";
 import { config } from "../config.js";
 import { recordBackendSuccess, recordBackendFailure } from "../scoring.js";
@@ -123,14 +123,15 @@ export const BACKEND_DEFS: Record<string, BackendRunner> = {
 		},
 	},
 	"openai-codex": {
+		providerAuth: "openai-codex",
 		needsKey: false,
 		needsKeyFromConfig: false,
 		optionalKey: false,
 		needsInstanceUrl: false,
 		label: "OpenAI Codex",
 		setupLabel: "OpenAI Codex (draws from subscription)",
-		search: async (query, numResults, { signal, backendConfig }) => {
-			const result = await searchOpenAICodex(query, numResults, signal, backendConfig);
+		search: async (query, numResults, { key, signal, backendConfig }) => {
+			const result = await searchOpenAICodex(query, numResults, key, signal, backendConfig);
 			return { results: result.results };
 		},
 	},
@@ -279,25 +280,28 @@ export const BACKEND_DEFS: Record<string, BackendRunner> = {
 // Backend dispatcher
 // ---------------------------------------------------------------------------
 
+export interface BackendRuntime {
+	getProviderApiKey(provider: string): Promise<string | undefined>;
+}
+
 export async function runBackend(
 	backend: string,
 	query: string,
 	numResults: number,
 	signal?: AbortSignal,
-	options?: { skipCache?: boolean },
+	runtime?: BackendRuntime,
 ): Promise<SearchResult[]> {
-	// Check cache first (inline — no persistent key var needed here)
-	if (!options?.skipCache) {
-		const cached = searchCache.get(cacheKey(query, backend, numResults));
-		if (cached) return cached;
-	}
-
 	await waitForCooldown(backend);
 	const def = BACKEND_DEFS[backend];
 	if (!def) throw new Error(`Unknown backend: ${backend}`);
 
 	let key: string | undefined;
-	if (def.needsKeyFromConfig) {
+	if (def.providerAuth) {
+		key = await runtime?.getProviderApiKey(def.providerAuth);
+		if (!key) {
+			throw new Error(`${def.label} authentication not found. Run /login ${def.providerAuth}.`);
+		}
+	} else if (def.needsKeyFromConfig) {
 		const bc = (config.backends as Record<string, BackendConfig> | undefined)?.[backend];
 		key = bc?.apiKey;
 	} else if (def.needsKey) {
@@ -325,8 +329,6 @@ export async function runBackend(
 	try {
 		const result = await def.search(query, numResults, { key, instanceUrl, signal, backendConfig: bc });
 		const latencyMs = Date.now() - startTime;
-		// Cache the result
-		searchCache.set(cacheKey(query, backend, numResults), result.results);
 		recordBackendSuccess(backend, latencyMs, result.results.length, numResults);
 		return result.results;
 	} catch (err) {

--- a/packages/pi-search-hub/extensions/credentials.ts
+++ b/packages/pi-search-hub/extensions/credentials.ts
@@ -33,40 +33,44 @@ export function clearCredentialCache(): void {
  *   • otherwise     → return as literal string (actual key)
  */
 export function resolveConfigValue(reference: string | undefined): string | undefined {
-	if (!reference) return undefined;
+	if (!reference || reference.trim().length === 0) return undefined;
+	const normalizedReference = reference.trim();
 
 	// !command — execute shell command, cache result
-	if (reference.startsWith("!")) {
-		const cached = commandValueCache.get(reference);
+	if (normalizedReference.startsWith("!")) {
+		const cached = commandValueCache.get(normalizedReference);
 		if (cached) {
 			if (cached.errorMessage) throw new Error(cached.errorMessage);
 			return cached.value;
 		}
 		try {
-			const output = execSync(reference.slice(1), {
+			const output = execSync(normalizedReference.slice(1), {
 				encoding: "utf-8",
 				stdio: ["ignore", "pipe", "pipe"],
 				timeout: COMMAND_TIMEOUT_MS,
 			})
 				.trim();
 			const value = output.length > 0 ? output : undefined;
-			commandValueCache.set(reference, { value });
+			commandValueCache.set(normalizedReference, { value });
 			return value;
 		} catch (error) {
 			const errorMessage = (error as Error).message;
-			commandValueCache.set(reference, { errorMessage });
+			commandValueCache.set(normalizedReference, { errorMessage });
 			throw error;
 		}
 	}
 
 	// ALL_CAPS → env var lookup
-	const envValue = process.env[reference];
-	if (envValue !== undefined) return envValue;
-	if (/^[A-Z][A-Z0-9_]*$/.test(reference)) {
+	const envValue = process.env[normalizedReference];
+	if (envValue !== undefined) {
+		const normalizedEnvValue = envValue.trim();
+		return normalizedEnvValue.length > 0 ? normalizedEnvValue : undefined;
+	}
+	if (/^[A-Z][A-Z0-9_]*$/.test(normalizedReference)) {
 		// Warn: value looks like an env var reference but the env var is unset.
 		// If this was intended as a literal key, rename it or set the env var.
-		console.warn(`[pi-search] Credential reference "${reference}" matches ALL_CAPS env-var pattern ` +
-			`but process.env.${reference} is not set. If this is a literal key, ` +
+		console.warn(`[pi-search] Credential reference "${normalizedReference}" matches ALL_CAPS env-var pattern ` +
+			`but process.env.${normalizedReference} is not set. If this is a literal key, ` +
 			`use a different name to avoid confusion.`);
 		return undefined;
 	}
@@ -74,10 +78,10 @@ export function resolveConfigValue(reference: string | undefined): string | unde
 	// Otherwise → literal string (actual key in config)
 	// Reject common accidental non-key literals that would otherwise leak into
 	// Authorization headers as "Bearer null" / "Bearer undefined".
-	if (reference === "null" || reference === "undefined" || reference === "none") {
+	if (normalizedReference === "null" || normalizedReference === "undefined" || normalizedReference === "none") {
 		return undefined;
 	}
-	return reference;
+	return normalizedReference;
 }
 
 // ---------------------------------------------------------------------------
@@ -117,22 +121,25 @@ export function resolveBackendKey(backend: string, config: SearchConfig): string
 	return undefined;
 }
 
-/** Describe where a backend's key comes from (for search-status display). */
+/** Describe where a backend's key comes from for setup and readiness display. */
 export function getKeySource(backend: string, config: SearchConfig): { configured: boolean; source: string } {
 	const bc = config.backends?.[backend as keyof typeof config.backends];
-	if (!bc?.apiKey) {
+	const ref = bc?.apiKey?.trim();
+	if (!ref) {
 		const fallbackEnv = FALLBACK_ENV_MAP[backend];
-		if (fallbackEnv && process.env[fallbackEnv]) {
+		if (fallbackEnv && process.env[fallbackEnv]?.trim()) {
 			return { configured: true, source: `env:${fallbackEnv}` };
 		}
 		return { configured: false, source: "" };
 	}
-	const ref = bc.apiKey;
 	if (ref.startsWith("!")) {
 		return { configured: true, source: `shell:${ref.slice(0, 40)}...` };
 	}
+	if (ref === "null" || ref === "undefined" || ref === "none") {
+		return { configured: false, source: "" };
+	}
 	if (/^[A-Z][A-Z0-9_]*$/.test(ref)) {
-		const envValue = process.env[ref];
+		const envValue = process.env[ref]?.trim();
 		if (envValue) return { configured: true, source: `env:${ref}` };
 		return { configured: false, source: `env:${ref} (unset)` };
 	}

--- a/packages/pi-search-hub/extensions/openai-codex.test.ts
+++ b/packages/pi-search-hub/extensions/openai-codex.test.ts
@@ -4,14 +4,6 @@ const { streamOpenAICodexResponsesMock } = vi.hoisted(() => ({
 	streamOpenAICodexResponsesMock: vi.fn(),
 }));
 
-vi.mock("@earendil-works/pi-coding-agent", () => ({
-	AuthStorage: {
-		create: () => ({
-			getApiKey: async () => "test-api-key",
-		}),
-	},
-}));
-
 vi.mock("@earendil-works/pi-ai/compat", () => ({
 	getModel: () => ({ id: "gpt-5.4-mini" }),
 	streamOpenAICodexResponses: streamOpenAICodexResponsesMock,
@@ -37,7 +29,7 @@ describe("openai-codex helpers", () => {
 	it("searchOpenAICodex asks Codex for rich source-grounded snippets", async () => {
 		const { searchOpenAICodex } = await import("./backends/openai-codex.ts");
 
-		await expect(searchOpenAICodex("test query", 3)).rejects.toThrow("not used in helper tests");
+		await expect(searchOpenAICodex("test query", 3, "test-api-key")).rejects.toThrow("not used in helper tests");
 
 		const [, context] = streamOpenAICodexResponsesMock.mock.calls[0];
 		const submitTool = context.tools[0];
@@ -49,6 +41,15 @@ describe("openai-codex helpers", () => {
 		expect(resultSchema.snippet.description).toContain("450-500 character");
 		expect(resultSchema.snippet.description).toContain("Prefer completeness and concrete details over brevity");
 		expect("content" in resultSchema).toBe(false);
+	});
+
+	it("rejects a missing injected Pi provider credential before inference", async () => {
+		const { searchOpenAICodex } = await import("./backends/openai-codex.ts");
+
+		await expect(searchOpenAICodex("test query", 3, undefined)).rejects.toThrow(
+			"Run /login openai-codex",
+		);
+		expect(streamOpenAICodexResponsesMock).not.toHaveBeenCalled();
 	});
 
 	it("injectCodexSearchPayload prepends hosted search and preserves function tools", async () => {

--- a/packages/pi-search-hub/extensions/search-hub.ts
+++ b/packages/pi-search-hub/extensions/search-hub.ts
@@ -19,8 +19,6 @@
  * Config: ~/.pi/agent/extensions/search.json + .pi/search.json (project wins)
  * Credentials: env var refs (ALL_CAPS), shell commands (!command), or literal keys
  *
- * Statusline activity: Shows "search" status during search operations
- *
  * Example .pi/search.json:
  *   {
  *     "defaultBackend": "auto",
@@ -39,7 +37,7 @@
  *   }
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { defineTool, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { StringEnum } from "@earendil-works/pi-ai";
@@ -49,9 +47,9 @@ import {
 	withDisplaySummary,
 } from "../../pi-tool-display-intent/tool-display-api-consumer.js";
 
-import type { BackendConfig, SearchConfig, SearchResult, SearchResultWithBackend } from "./types.js";
+import type { BackendConfig, ReaderName, SearchConfig, SearchResult, SearchResultWithBackend } from "./types.js";
 import { getAgentDir, timeoutSignal, sanitizeError, clearCooldowns, MISSING_KEY_HELP, validateUrl } from "./utils.js";
-import { resolveBackendKey, getKeySource } from "./credentials.js";
+import { resolveBackendKey, getKeySource, FALLBACK_ENV_MAP } from "./credentials.js";
 import { fetchSofya } from "./backends/sofya.js";
 import { fetchFirecrawl } from "./backends/firecrawl.js";
 import { fetchExaContents } from "./backends/exa.js";
@@ -70,6 +68,26 @@ import {
 
 /** Cap on a single web_read response body, in bytes, to bound memory use on heavy pages. */
 const READ_MAX_BYTES = 2 * 1024 * 1024; // 2 MB
+const READER_NAMES = ["jina", "sofya", "firecrawl", "exa", "exa_mcp"] as const;
+const READER_LABELS: Record<ReaderName, string> = {
+	jina: "Jina",
+	sofya: "Sofya",
+	firecrawl: "Firecrawl",
+	exa: "Exa",
+	exa_mcp: "Exa MCP",
+};
+
+function configuredReaderOrder(searchConfig: SearchConfig): ReaderName[] {
+	const configuredDefault = READER_NAMES.includes(searchConfig.reader as ReaderName)
+		? searchConfig.reader as ReaderName
+		: "jina";
+	const configuredFallback = Array.isArray(searchConfig.readerFallback)
+		? searchConfig.readerFallback
+		: [];
+	return Array.from(new Set([configuredDefault, ...configuredFallback].filter(
+		(reader): reader is ReaderName => READER_NAMES.includes(reader as ReaderName),
+	)));
+}
 
 // ---------------------------------------------------------------------------
 // Extension
@@ -173,25 +191,34 @@ export default function (pi: ExtensionAPI) {
 			const forceCombine = config.combine === true;
 			const effectiveCombine = forceCombine || combine;
 
-			// Helper to update statusline
-			const setStatus = (status: string) => {
-				ctx.ui.setStatus("search", status);
-				onUpdate?.({ content: [{ type: "text", text: `*${status}*` }], details: undefined });
+			const updateActivity = (status: string) => {
+				onUpdate?.({
+					content: [{ type: "text", text: `*${status}*` }],
+					details: { activity: status },
+				});
 			};
+			const runSearchBackend = (
+				backend: string,
+				query: string,
+				limit: number,
+				backendSignal?: AbortSignal,
+			) => runBackend(backend, query, limit, backendSignal, {
+				getProviderApiKey: (provider) => ctx.modelRegistry.getApiKeyForProvider(provider),
+			});
 
 			if (requestedBackend !== "auto") {
 				// Specific backend requested — try it directly
 				const backendLabel = BACKEND_DEFS[requestedBackend]?.label || requestedBackend;
-				setStatus(`🔍 ${backendLabel}: searching...`);
+				updateActivity(`🔍 ${backendLabel}: searching...`);
 				try {
-					const results = await runBackend(requestedBackend, params.query, numResults, signal);
-					setStatus(`🔍 ${backendLabel}: ${results.length} results`);
+					const results = await runSearchBackend(requestedBackend, params.query, numResults, signal);
+					updateActivity(`🔍 ${backendLabel}: ${results.length} results`);
 					return {
 						content: [{ type: "text", text: compact ? formatResultsCompact(results) : formatResults(params.query, requestedBackend, results) }],
 						details: { backend: requestedBackend, resultCount: results.length },
 					};
 				} catch (err) {
-					setStatus(`❌ ${backendLabel}: failed`);
+					updateActivity(`❌ ${backendLabel}: failed`);
 					throw err;
 				}
 			}
@@ -205,7 +232,7 @@ export default function (pi: ExtensionAPI) {
 						config.selectionStrategy ?? "sequential",
 						activeBackends,
 					);
-					setStatus(`🔍 targeted combine: up to 3 of ${activeBackends.length} backends...`);
+					updateActivity(`🔍 targeted combine: up to 3 of ${activeBackends.length} backends...`);
 					const {
 						results: combined,
 						backendStats,
@@ -215,11 +242,11 @@ export default function (pi: ExtensionAPI) {
 						query: params.query,
 						numResults,
 						signal,
-						runBackend,
+						runBackend: runSearchBackend,
 					});
 
 					if (usableBackendCount === 0) {
-						setStatus(`❌ targeted combine: no usable backends`);
+						updateActivity(`❌ targeted combine: no usable backends`);
 						const errors = Array.from(backendStats.entries()).map(([backend, stats]) => (
 							stats.success
 								? `${backend}: 0 results`
@@ -230,7 +257,7 @@ export default function (pi: ExtensionAPI) {
 
 					const attemptedCount = backendStats.size;
 					const incomplete = usableBackendCount < 3 ? `, exhausted after ${usableBackendCount} usable` : "";
-					setStatus(`🔍 targeted combined: ${combined.length} results (${usableBackendCount}/${attemptedCount} usable${incomplete})`);
+					updateActivity(`🔍 targeted combined: ${combined.length} results (${usableBackendCount}/${attemptedCount} usable${incomplete})`);
 
 					return {
 						content: [
@@ -251,11 +278,11 @@ export default function (pi: ExtensionAPI) {
 				}
 
 				// Combine mode: query all enabled backends in parallel
-				setStatus(`🔍 combine: ${activeBackends.length} backends...`);
+				updateActivity(`🔍 combine: ${activeBackends.length} backends...`);
 				const resultsPerBackend = await Promise.all(
 					activeBackends.map(async (backend) => {
 						try {
-							const results = await runBackend(
+							const results = await runSearchBackend(
 								backend,
 								params.query,
 								Math.ceil(numResults / activeBackends.length),
@@ -302,7 +329,7 @@ export default function (pi: ExtensionAPI) {
 
 				const successCount = successfulBackends.length;
 				const failCount = activeBackends.length - successCount;
-				setStatus(`🔍 combined: ${combined.length} results (${successCount} ok${failCount > 0 ? `, ${failCount} failed` : ""})`);
+				updateActivity(`🔍 combined: ${combined.length} results (${successCount} ok${failCount > 0 ? `, ${failCount} failed` : ""})`);
 
 				return {
 					content: [
@@ -329,11 +356,11 @@ export default function (pi: ExtensionAPI) {
 				for (const backend of orderedBackends) {
 					const backendLabel = BACKEND_DEFS[backend]?.label || backend;
 					const t0 = Date.now();
-					setStatus(`🔍 ${backendLabel}: searching...`);
+					updateActivity(`🔍 ${backendLabel}: searching...`);
 					try {
-						const results = await runBackend(backend, params.query, numResults, signal);
+						const results = await runSearchBackend(backend, params.query, numResults, signal);
 						recordLatency(backend, Date.now() - t0);
-						setStatus(`🔍 ${backendLabel}: ${results.length} results`);
+						updateActivity(`🔍 ${backendLabel}: ${results.length} results`);
 						return {
 							content: [
 								{
@@ -351,11 +378,11 @@ export default function (pi: ExtensionAPI) {
 						};
 					} catch (err) {
 						errors.push(`${backend}: ${(err as Error).message}`);
-						setStatus(`❌ ${backendLabel}: failed, trying next...`);
+						updateActivity(`❌ ${backendLabel}: failed, trying next...`);
 					}
 				}
 
-				setStatus(`❌ all backends failed`);
+				updateActivity(`❌ all backends failed`);
 				throw new Error(`All backends failed: ${errors.join("; ")}`);
 			}
 		},
@@ -373,8 +400,8 @@ export default function (pi: ExtensionAPI) {
 		label: "Read Web Page",
 		description:
 			"Fetch a URL as markdown. Use keywords for long pages and objective only for a Jina CSS target selector, " +
-			"rush for speed, smart for better narrowing. Use reader param to switch between " +
-			"Jina (default, free) and Sofya (250+ site parsers, needs API key).",
+			"rush for speed, smart for better narrowing. When reader is omitted, Search Hub tries the configured " +
+			"default reader and ordered fallbacks. An explicit reader disables fallback for that call.",
 		promptSnippet: "Read content from a web page (supports markdown extraction)",
 		promptGuidelines: [
 			"Use web_read when you need to read the content of a specific URL",
@@ -408,32 +435,29 @@ export default function (pi: ExtensionAPI) {
 				}),
 			),
 			reader: Type.Optional(
-				StringEnum(["jina", "sofya", "firecrawl", "exa", "exa_mcp"] as const, {
+				StringEnum(READER_NAMES, {
 					description:
 						"Reader backend: 'jina' (default, free, supports keywords/mode/objective), " +
 						"'sofya' (250+ site-specific parsers, needs API key), " +
 						"'firecrawl' (keyless, 1000 credits/mo), " +
 						"'exa' (needs API key, 1000 req/mo), or " +
-						"'exa_mcp' (zero-config, rate-limited). Overrides the configured default.",
+						"'exa_mcp' (zero-config, rate-limited). Explicit selection skips configured fallback readers.",
 				}),
 			),
 		}),
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
 			refreshConfig(ctx.cwd);
 
-			// Helper to update statusline for web_read
-			const setStatus = (status: string) => {
-				ctx.ui.setStatus("read", status);
-				onUpdate?.({ content: [{ type: "text", text: `*${status}*` }], details: undefined });
+			const updateActivity = (status: string, reader: ReaderName) => {
+				onUpdate?.({
+					content: [{ type: "text", text: `*${status}*` }],
+					details: { activity: status, reader },
+				});
 			};
 
 			const url = params.url.startsWith("https://") || params.url.startsWith("http://")
 				? params.url
 				: `https://${params.url}`;
-
-			const reader = params.reader ?? config.reader ?? "jina";
-			const readerLabel = reader === "sofya" ? "Sofya" : reader === "firecrawl" ? "Firecrawl" : reader === "exa" ? "Exa" : reader === "exa_mcp" ? "Exa MCP" : "Jina";
-			setStatus(`📄 ${readerLabel}: fetching...`);
 
 			// SSRF guard — block private/internal addresses regardless of reader.
 			const ssrfError = validateUrl(url);
@@ -441,83 +465,86 @@ export default function (pi: ExtensionAPI) {
 				throw new Error(ssrfError);
 			}
 
-			let content: string;
-			if (reader === "sofya") {
-				// Sofya Fetch: clean markdown via 250+ site-specific parsers.
-				const sofyaKey = resolveBackendKey("sofya", config);
-				if (!sofyaKey) {
-					throw new Error(`Sofya reader selected but no API key configured. ${MISSING_KEY_HELP}`);
+			const explicitReader = params.reader as ReaderName | undefined;
+			const readers = explicitReader ? [explicitReader] : configuredReaderOrder(config);
+
+			const fetchWithReader = async (reader: ReaderName): Promise<string> => {
+				if (reader === "sofya") {
+					const sofyaKey = resolveBackendKey("sofya", config);
+					if (!sofyaKey) {
+						throw new Error(`Sofya reader selected but no API key configured. ${MISSING_KEY_HELP}`);
+					}
+					return (await fetchSofya(url, sofyaKey, signal)).content;
 				}
-				const result = await fetchSofya(url, sofyaKey, signal);
-				content = result.content;
-			} else if (reader === "firecrawl") {
-				// Firecrawl Scrape: keyless mode (1000 free credits/mo).
-				const firecrawlKey = resolveBackendKey("firecrawl", config);
-				const result = await fetchFirecrawl(url, firecrawlKey, signal);
-				content = result.content;
-			} else if (reader === "exa") {
-				// Exa Contents API: needs API key (1000 req/mo, shared with search).
-				const exaKey = resolveBackendKey("exa", config);
-				if (!exaKey) {
-					throw new Error(`Exa reader selected but no API key configured. ${MISSING_KEY_HELP}`);
+				if (reader === "firecrawl") {
+					const firecrawlKey = resolveBackendKey("firecrawl", config);
+					return (await fetchFirecrawl(url, firecrawlKey, signal)).content;
 				}
-				const result = await fetchExaContents(url, exaKey, signal);
-				if (result.warning) {
-					ctx.ui.notify(result.warning, "warning");
+				if (reader === "exa") {
+					const exaKey = resolveBackendKey("exa", config);
+					if (!exaKey) {
+						throw new Error(`Exa reader selected but no API key configured. ${MISSING_KEY_HELP}`);
+					}
+					const result = await fetchExaContents(url, exaKey, signal);
+					if (result.warning) ctx.ui.notify(result.warning, "warning");
+					return result.content;
 				}
-				content = result.content;
-			} else if (reader === "exa_mcp") {
-				// Exa MCP web_fetch: zero-config, no API key needed.
-				const result = await fetchExaMCP(url, signal);
-				content = result.content;
-			} else {
-				// Jina Reader: free, supports keywords / mode / objective hints.
+				if (reader === "exa_mcp") {
+					return (await fetchExaMCP(url, signal)).content;
+				}
+
 				const readerUrl = new URL("https://r.jina.ai/" + url);
-
-				const headers: Record<string, string> = {
-					"Accept": "text/plain",
-				};
-
-				// Optional Jina API key for higher rate limits (fallback to no-auth)
+				const headers: Record<string, string> = { "Accept": "text/plain" };
 				const jinaKey = resolveBackendKey("jina", config);
-				if (jinaKey) {
-					headers["Authorization"] = `Bearer ${jinaKey}`;
-				}
-
-				if (params.fresh) {
-					headers["x-no-cache"] = "true";
-				}
+				if (jinaKey) headers["Authorization"] = `Bearer ${jinaKey}`;
+				if (params.fresh) headers["x-no-cache"] = "true";
 				if (params.keywords && params.keywords.length > 0) {
 					headers["x-keywords"] = params.keywords.join(", ");
 				}
-				if (params.mode) {
-					headers["x-respond-with"] = params.mode === "rush" ? "text" : "markdown";
-				}
-				if (params.objective) {
-					headers["x-target-selector"] = params.objective;
-				}
+				if (params.mode) headers["x-respond-with"] = params.mode === "rush" ? "text" : "markdown";
+				if (params.objective) headers["x-target-selector"] = params.objective;
 
 				const response = await fetch(readerUrl.toString(), {
 					signal: timeoutSignal(signal),
 					headers,
 				});
-
 				if (!response.ok) {
 					const text = await response.text().catch(() => "");
 					throw new Error(`Failed to read ${url}: ${sanitizeError(response.status, text)}`);
 				}
 
-				// Size guard — refuse oversized payloads before buffering into memory.
 				const contentLength = parseInt(response.headers.get("content-length") ?? "", 10);
 				if (Number.isFinite(contentLength) && contentLength > READ_MAX_BYTES) {
 					throw new Error(`Failed to read ${url}: response too large (${contentLength} bytes, limit ${READ_MAX_BYTES})`);
 				}
+				return response.text();
+			};
 
-				content = await response.text();
+			const errors: string[] = [];
+			let content: string | undefined;
+			let reader: ReaderName | undefined;
+			for (const [index, candidate] of readers.entries()) {
+				const label = READER_LABELS[candidate];
+				updateActivity(`📄 ${label}: fetching...`, candidate);
+				try {
+					content = await fetchWithReader(candidate);
+					reader = candidate;
+					break;
+				} catch (error) {
+					if (signal?.aborted || explicitReader) throw error;
+					errors.push(`${candidate}: ${(error as Error).message}`);
+					const next = readers[index + 1];
+					if (next) {
+						updateActivity(`❌ ${label}: failed; trying ${READER_LABELS[next]}...`, candidate);
+					}
+				}
 			}
 
-			setStatus(`📄 ${readerLabel}: ${content.length} chars`);
+			if (content === undefined || reader === undefined) {
+				throw new Error(`All configured readers failed: ${errors.join("; ")}`);
+			}
 
+			updateActivity(`📄 ${READER_LABELS[reader]}: ${content.length} chars`, reader);
 			const truncated = content.length > WEB_READ_RESULT_MAX_CHARS
 				? content.slice(0, WEB_READ_RESULT_MAX_CHARS) + `\n\n[... truncated, full length: ${content.length} chars]`
 				: content;
@@ -529,11 +556,12 @@ export default function (pi: ExtensionAPI) {
 					reader,
 					length: content.length,
 					truncated: content.length > WEB_READ_RESULT_MAX_CHARS,
+					fallbackErrors: errors.length > 0 ? errors : undefined,
 				},
 			};
 		},
 	}), {
-		getCallPresentation: (args) => getWebReadCallPresentation(args, config.reader ?? "jina"),
+		getCallPresentation: (args) => getWebReadCallPresentation(args, configuredReaderOrder(config)[0]),
 		getResultPresentation: getWebReadResultPresentation,
 	}));
 
@@ -541,423 +569,608 @@ export default function (pi: ExtensionAPI) {
 	// Commands
 	// -----------------------------------------------------------------------
 
+	const getGlobalConfigPath = () => join(getAgentDir(), "extensions", "search.json");
+
+	function readGlobalConfig(): SearchConfig {
+		const configPath = getGlobalConfigPath();
+		if (!existsSync(configPath)) return {};
+		try {
+			return JSON.parse(readFileSync(configPath, "utf-8")) as SearchConfig;
+		} catch {
+			return {};
+		}
+	}
+
+	function writeGlobalConfig(nextConfig: SearchConfig): void {
+		const configPath = getGlobalConfigPath();
+		const tempPath = `${configPath}.${process.pid}.${Date.now()}.tmp`;
+		const serialized = { ...nextConfig } as SearchConfig & Record<string, unknown>;
+		delete serialized.showStatus;
+		delete serialized.cacheTtl;
+		delete serialized.cacheMax;
+		mkdirSync(join(getAgentDir(), "extensions"), { recursive: true });
+		try {
+			writeFileSync(tempPath, JSON.stringify(serialized, null, 2) + "\n", { mode: 0o600 });
+			renameSync(tempPath, configPath);
+		} catch (error) {
+			rmSync(tempPath, { force: true });
+			throw error;
+		}
+	}
+
+	function cloneConfig(value: SearchConfig): SearchConfig {
+		return JSON.parse(JSON.stringify(value)) as SearchConfig;
+	}
+
+	function readProjectConfig(cwd: string): SearchConfig {
+		const projectPath = join(cwd, ".pi", "search.json");
+		if (!existsSync(projectPath)) return {};
+		try {
+			return JSON.parse(readFileSync(projectPath, "utf-8")) as SearchConfig;
+		} catch {
+			return {};
+		}
+	}
+
+	function effectiveDraftConfig(globalDraft: SearchConfig, cwd: string): SearchConfig {
+		const project = readProjectConfig(cwd);
+		const globalBackends = { ...(globalDraft.backends ?? {}) } as Record<string, BackendConfig | undefined>;
+		const projectBackends = project.backends && typeof project.backends === "object"
+			? project.backends as Record<string, BackendConfig | undefined>
+			: undefined;
+		const merged: SearchConfig = {
+			defaultBackend: "duckduckgo",
+			backends: globalBackends,
+			...cloneConfig(globalDraft),
+			...cloneConfig(project),
+		};
+		if (projectBackends) {
+			const backends = { ...globalBackends };
+			for (const [backend, projectBackend] of Object.entries(projectBackends)) {
+				backends[backend] = projectBackend
+					? { ...(globalBackends[backend] ?? {}), ...projectBackend }
+					: projectBackend;
+			}
+			merged.backends = backends;
+		} else {
+			merged.backends = globalBackends;
+		}
+		for (const [backend, envName] of Object.entries(FALLBACK_ENV_MAP)) {
+			if (!process.env[envName]?.trim()) continue;
+			const current = (merged.backends as Record<string, BackendConfig | undefined>)[backend];
+			if (!current || current.enabled === undefined) {
+				(merged.backends as Record<string, BackendConfig | undefined>)[backend] = {
+					...current,
+					enabled: true,
+				};
+			}
+		}
+		return merged;
+	}
+
+	function activeBackendsFor(stateConfig: SearchConfig): string[] {
+		const enabled = Object.entries(stateConfig.backends ?? {})
+			.filter(([, backendConfig]) => backendConfig?.enabled)
+			.map(([backend]) => backend);
+		const active = enabled.length > 0 ? enabled : ["duckduckgo"];
+		return stateConfig.defaultBackend && active.includes(stateConfig.defaultBackend)
+			? [stateConfig.defaultBackend, ...active.filter((backend) => backend !== stateConfig.defaultBackend)]
+			: active;
+	}
+
+	type SetupDraftState = {
+		original: SearchConfig;
+		draft: SearchConfig;
+	};
+
+	function refreshRuntimeConfig(ctx: ExtensionContext): void {
+		refreshConfig(ctx.cwd, true);
+	}
+
+	function authSourceLabel(source: string): string {
+		if (source.startsWith("env:")) return `env ${source.slice(4)}`;
+		if (source.startsWith("shell:")) return "shell command";
+		if (source === "literal") return "saved key";
+		return source || "configured";
+	}
+
+	function configuredAuthDetail(source: string, optional = false): string {
+		const suffix = optional ? " (optional)" : "";
+		return source.startsWith("shell:")
+			? `auth ? shell command${suffix}`
+			: `auth ✓ ${authSourceLabel(source)}${suffix}`;
+	}
+
+	function piAuthDetail(ctx: ExtensionContext): string {
+		try {
+			const auth = ctx.modelRegistry.getProviderAuthStatus("openai-codex");
+			if (!auth.configured) return "auth ✗ run /login openai-codex";
+			if (auth.source === "stored") return "auth ✓ Pi /login";
+			if (auth.source === "environment") return "auth ✓ Pi environment";
+			if (auth.source === "runtime") return "auth ✓ Pi runtime";
+			return "auth ✓ Pi credential";
+		} catch {
+			return "auth ? Pi status unavailable";
+		}
+	}
+
+	function backendStateSummary(
+		backend: string,
+		stateConfig: SearchConfig,
+		activeBackends: readonly string[],
+		codexAuth: string,
+	): { marker: "ON" | "OFF" | "AUTO"; details: string } {
+		const def = BACKEND_DEFS[backend];
+		const bc = (stateConfig.backends as Record<string, BackendConfig> | undefined)?.[backend];
+		const { configured, source } = getKeySource(backend, stateConfig);
+		const marker = bc?.enabled
+			? "ON"
+			: backend === "duckduckgo" && activeBackends.includes(backend)
+				? "AUTO"
+				: "OFF";
+		const details: string[] = [];
+
+		if (backend === "openai-codex") {
+			details.push(codexAuth);
+		} else if (def.needsKey) {
+			details.push(configured
+				? configuredAuthDetail(source)
+				: marker === "ON" ? "auth ✗ missing" : "auth — not configured");
+		} else if (def.optionalKey) {
+			details.push(configured ? configuredAuthDetail(source, true) : "auth — optional");
+		} else {
+			details.push("auth — not required");
+		}
+		if (def.needsInstanceUrl) {
+			details.push(bc?.instanceUrl?.trim() ? "URL ✓" : "URL ✗ missing");
+		}
+		return { marker, details: details.join(" · ") };
+	}
+
+	function searchMode(searchConfig: SearchConfig): "fallback" | "targeted" | "all" {
+		if (!searchConfig.combine) return "fallback";
+		return searchConfig.combineMode === "targeted" ? "targeted" : "all";
+	}
+
+	function searchModeLabel(mode: ReturnType<typeof searchMode>): string {
+		if (mode === "targeted") return "Targeted combine";
+		if (mode === "all") return "All-backend combine";
+		return "Fallback";
+	}
+
+	function averageLatency(backend: string): string | undefined {
+		const samples = latencyMap.get(backend) ?? [];
+		if (samples.length === 0) return undefined;
+		return `${Math.round(samples.reduce((sum, sample) => sum + sample.ms, 0) / samples.length)}ms avg`;
+	}
+
+	function valuesEqual(left: unknown, right: unknown): boolean {
+		return JSON.stringify(left) === JSON.stringify(right);
+	}
+
+	function draftIsDirty(state: SetupDraftState): boolean {
+		return !valuesEqual(state.original, state.draft);
+	}
+
+	function updateDraftBackend(state: SetupDraftState, backend: string, patch: BackendConfig): void {
+		const current = (state.draft.backends as Record<string, BackendConfig> | undefined)?.[backend] ?? {};
+		state.draft = {
+			...state.draft,
+			backends: {
+				...state.draft.backends,
+				[backend]: { ...current, ...patch },
+			},
+		};
+	}
+
+	function configuredCredentialCount(ctx: ExtensionContext, stateConfig: SearchConfig): number {
+		return Object.keys(BACKEND_DEFS).filter((backend) => {
+			if (backend === "openai-codex") return piAuthDetail(ctx).startsWith("auth ✓");
+			return getKeySource(backend, stateConfig).configured;
+		}).length;
+	}
+
+	function setupHomeTitle(ctx: ExtensionContext, state: SetupDraftState): string {
+		const effective = effectiveDraftConfig(state.draft, ctx.cwd);
+		const active = activeBackendsFor(effective);
+		const defaultBackend = effective.defaultBackend && active.includes(effective.defaultBackend)
+			? effective.defaultBackend
+			: active[0] ?? "none";
+		const readers = configuredReaderOrder(effective).map((reader) => READER_LABELS[reader]);
+		return [
+			"Search Hub setup",
+			draftIsDirty(state) ? "● Unsaved changes" : "No unsaved changes",
+			`Search: ${searchModeLabel(searchMode(effective))} · default ${defaultBackend}`,
+			`Reading: ${readers.join(" → ")}`,
+			`Backends: ${active.length} active · ${configuredCredentialCount(ctx, effective)} credentials configured`,
+			`Output: compact ${effective.compact ? "on" : "off"}`,
+		].join("\n");
+	}
+
+	function normalizeDraft(draft: SearchConfig): SearchConfig {
+		const normalized = cloneConfig(draft) as SearchConfig & Record<string, unknown>;
+		delete normalized.showStatus;
+		delete normalized.cacheTtl;
+		delete normalized.cacheMax;
+
+		if (normalized.reader && !READER_NAMES.includes(normalized.reader)) delete normalized.reader;
+		const defaultReader = normalized.reader ?? "jina";
+		normalized.readerFallback = Array.from(new Set(normalized.readerFallback ?? []))
+			.filter((reader): reader is ReaderName => READER_NAMES.includes(reader) && reader !== defaultReader);
+
+		const normalizedBackends: Record<string, BackendConfig> = {};
+		for (const [backend, backendConfig] of Object.entries(normalized.backends ?? {})) {
+			if (!backendConfig) continue;
+			const cleaned = { ...backendConfig };
+			if (typeof cleaned.apiKey === "string") {
+				cleaned.apiKey = cleaned.apiKey.trim();
+				if (!cleaned.apiKey) delete cleaned.apiKey;
+			}
+			if (typeof cleaned.instanceUrl === "string") {
+				cleaned.instanceUrl = cleaned.instanceUrl.trim();
+				if (!cleaned.instanceUrl) delete cleaned.instanceUrl;
+			}
+			normalizedBackends[backend] = cleaned;
+		}
+		normalized.backends = normalizedBackends;
+
+		const active = activeBackendsFor(normalized);
+		if (!normalized.defaultBackend || !active.includes(normalized.defaultBackend)) {
+			normalized.defaultBackend = active[0];
+		}
+		return normalized;
+	}
+
+	function saveDraft(ctx: ExtensionContext, state: SetupDraftState): boolean {
+		try {
+			const saved = normalizeDraft(state.draft);
+			writeGlobalConfig(saved);
+			state.original = cloneConfig(saved);
+			state.draft = cloneConfig(saved);
+			refreshRuntimeConfig(ctx);
+			const hasProjectOverrides = Object.keys(readProjectConfig(ctx.cwd)).length > 0;
+			ctx.ui.notify(
+				hasProjectOverrides
+					? "Search Hub configuration saved and applied. Current project overrides remain effective."
+					: "Search Hub configuration saved and applied.",
+				"info",
+			);
+			return true;
+		} catch (error) {
+			ctx.ui.notify(`Failed to save Search Hub configuration: ${(error as Error).message}`, "error");
+			return false;
+		}
+	}
+
+	async function confirmSetupClose(ctx: ExtensionContext, state: SetupDraftState): Promise<boolean> {
+		if (!draftIsDirty(state)) return true;
+		const choice = await ctx.ui.select("Unsaved Search Hub changes", [
+			"Save & apply",
+			"Discard changes",
+			"Continue editing",
+		]);
+		if (choice === "Save & apply") return saveDraft(ctx, state);
+		return choice === "Discard changes";
+	}
+
+	async function configureBackend(ctx: ExtensionContext, backend: string, state: SetupDraftState): Promise<void> {
+		const def = BACKEND_DEFS[backend];
+		const globalBackend = (state.draft.backends as Record<string, BackendConfig> | undefined)?.[backend];
+		const globalEnabled = globalBackend?.enabled === true;
+		const codexAuth = piAuthDetail(ctx);
+		const globalState = backendStateSummary(backend, state.draft, activeBackendsFor(state.draft), codexAuth);
+		const effective = effectiveDraftConfig(state.draft, ctx.cwd);
+		const effectiveState = backendStateSummary(backend, effective, activeBackendsFor(effective), codexAuth);
+		const title = [
+			def.label,
+			`Global draft:         [${globalState.marker}] ${globalState.details}`,
+			`Effective after save: [${effectiveState.marker}] ${effectiveState.details}`,
+		].join("\n");
+		const actions = [
+			globalEnabled ? "Disable globally (keep credentials)" : "Enable in global configuration",
+		];
+		if (def.needsInstanceUrl) actions.push("Update instance URL");
+		if (def.needsKey || def.optionalKey) {
+			actions.push(globalBackend?.apiKey ? "Update API key or reference" : "Set API key or reference");
+			if (globalBackend?.apiKey) actions.push("Remove saved API key or reference");
+		}
+		if (backend === "openai-codex") actions.push("Configure Pi auth with /login");
+		actions.push("↩ Back");
+
+		const action = await ctx.ui.select(title, actions);
+		if (!action || action === "↩ Back") return;
+		if (action === "Disable globally (keep credentials)") {
+			updateDraftBackend(state, backend, { enabled: false });
+			return;
+		}
+		if (action === "Configure Pi auth with /login") {
+			ctx.ui.notify("Run /login openai-codex to configure Pi authentication.", "info");
+			return;
+		}
+		if (action === "Remove saved API key or reference") {
+			updateDraftBackend(state, backend, { apiKey: undefined });
+			return;
+		}
+		if (action === "Update instance URL") {
+			const instanceUrl = await ctx.ui.input(
+				"Enter your instance URL (e.g. http://localhost:8888):",
+				globalBackend?.instanceUrl ?? "http://localhost:8888",
+			);
+			const trimmedUrl = instanceUrl?.trim() ?? "";
+			if (!trimmedUrl) {
+				ctx.ui.notify("An instance URL is required. Draft unchanged.", "warning");
+				return;
+			}
+			updateDraftBackend(state, backend, { instanceUrl: trimmedUrl });
+			return;
+		}
+		if (action === "Set API key or reference" || action === "Update API key or reference") {
+			const key = await ctx.ui.input(
+				`Enter your ${def.label} key, ENV_VAR reference, or !command:`,
+				"sk-...",
+			);
+			const trimmedKey = key?.trim() ?? "";
+			if (!trimmedKey) {
+				ctx.ui.notify("Draft unchanged.", "warning");
+				return;
+			}
+			updateDraftBackend(state, backend, { apiKey: trimmedKey });
+			return;
+		}
+
+		const patch: BackendConfig = { enabled: true };
+		if (def.needsInstanceUrl && !globalBackend?.instanceUrl?.trim()) {
+			const instanceUrl = await ctx.ui.input(
+				"Enter your instance URL (e.g. http://localhost:8888):",
+				"http://localhost:8888",
+			);
+			const trimmedUrl = instanceUrl?.trim() ?? "";
+			if (!trimmedUrl) {
+				ctx.ui.notify("An instance URL is required. Draft unchanged.", "warning");
+				return;
+			}
+			patch.instanceUrl = trimmedUrl;
+		}
+		if (def.needsKey && !getKeySource(backend, state.draft).configured) {
+			const key = await ctx.ui.input(
+				`Enter your ${def.label} key, ENV_VAR reference, or !command:`,
+				"sk-...",
+			);
+			const trimmedKey = key?.trim() ?? "";
+			if (!trimmedKey) {
+				ctx.ui.notify("An API key or credential reference is required. Draft unchanged.", "warning");
+				return;
+			}
+			patch.apiKey = trimmedKey;
+		}
+		updateDraftBackend(state, backend, patch);
+	}
+
+	function enableReadyKeylessBackends(state: SetupDraftState): void {
+		for (const backend of ["duckduckgo", "jina", "marginalia", "exa_mcp"]) {
+			updateDraftBackend(state, backend, { enabled: true });
+		}
+	}
+
+	async function configureReaderFallback(ctx: ExtensionContext, state: SetupDraftState): Promise<void> {
+		const current = configuredReaderOrder(state.draft).slice(1);
+		const action = await ctx.ui.select(
+			`Reader fallback order: ${current.length > 0 ? current.join(" → ") : "none"}`,
+			["Edit ordered fallback list", "Clear fallback list", "↩ Back"],
+		);
+		if (!action || action === "↩ Back") return;
+		if (action === "Clear fallback list") {
+			state.draft = { ...state.draft, readerFallback: [] };
+			return;
+		}
+
+		const input = await ctx.ui.input(
+			"Comma-separated readers (jina, sofya, firecrawl, exa, exa_mcp):",
+			current.join(", "),
+		);
+		if (!input?.trim()) {
+			ctx.ui.notify("Draft unchanged. Use Clear fallback list to remove all fallbacks.", "info");
+			return;
+		}
+		const requested = Array.from(new Set(input.split(",").map((reader) => reader.trim()).filter(Boolean)));
+		const invalid = requested.filter((reader) => !READER_NAMES.includes(reader as ReaderName));
+		if (invalid.length > 0) {
+			ctx.ui.notify(`Unknown readers: ${invalid.join(", ")}`, "error");
+			return;
+		}
+		const defaultReader = configuredReaderOrder(state.draft)[0];
+		const fallback = requested.filter((reader): reader is ReaderName => reader !== defaultReader) as ReaderName[];
+		state.draft = { ...state.draft, readerFallback: fallback };
+	}
+
+	async function configureSearchRouting(ctx: ExtensionContext, state: SetupDraftState): Promise<void> {
+		while (true) {
+			const active = activeBackendsFor(state.draft);
+			const settings = [
+				`Default search backend: ${state.draft.defaultBackend ?? active[0] ?? "none"}`,
+				`Search mode: ${searchModeLabel(searchMode(state.draft))}`,
+				`Selection strategy: ${state.draft.selectionStrategy ?? "sequential"}`,
+				"↩ Back",
+			];
+			const selected = await ctx.ui.select(
+				`Search routing${draftIsDirty(state) ? " · unsaved" : ""}`,
+				settings,
+			);
+			if (!selected || selected === "↩ Back") return;
+
+			if (selected.startsWith("Default search backend:")) {
+				const choice = await ctx.ui.select("Default search backend:", [...active, "↩ Back"]);
+				if (!choice || choice === "↩ Back") continue;
+				state.draft = { ...state.draft, defaultBackend: choice };
+				continue;
+			}
+			if (selected.startsWith("Search mode:")) {
+				const choice = await ctx.ui.select(
+					"Search mode:",
+					["Fallback", "Targeted combine", "All-backend combine", "↩ Back"],
+				);
+				if (!choice || choice === "↩ Back") continue;
+				const mode = choice === "Targeted combine" ? "targeted" : choice === "All-backend combine" ? "all" : "fallback";
+				if (mode === "fallback") {
+					const next = { ...state.draft, combine: false };
+					delete next.combineMode;
+					state.draft = next;
+				} else {
+					state.draft = { ...state.draft, combine: true, combineMode: mode };
+				}
+				continue;
+			}
+			if (selected.startsWith("Selection strategy:")) {
+				const choice = await ctx.ui.select(
+					"Selection strategy:",
+					["sequential", "random", "round-robin", "best-latency", "↩ Back"],
+				);
+				if (!choice || choice === "↩ Back") continue;
+				state.draft = { ...state.draft, selectionStrategy: choice as SearchConfig["selectionStrategy"] };
+			}
+		}
+	}
+
+	async function configureWebReading(ctx: ExtensionContext, state: SetupDraftState): Promise<void> {
+		while (true) {
+			const readerOrder = configuredReaderOrder(state.draft);
+			const fallback = readerOrder.slice(1);
+			const settings = [
+				`Default reader: ${READER_LABELS[readerOrder[0]]}`,
+				`Reader fallback order: ${fallback.length > 0 ? fallback.join(" → ") : "none"}`,
+				"↩ Back",
+			];
+			const selected = await ctx.ui.select(
+				`Web reading${draftIsDirty(state) ? " · unsaved" : ""}`,
+				settings,
+			);
+			if (!selected || selected === "↩ Back") return;
+
+			if (selected.startsWith("Default reader:")) {
+				const options = READER_NAMES.map((reader) => `${READER_LABELS[reader]} (${reader})`);
+				const choice = await ctx.ui.select("Default reader:", [...options, "↩ Back"]);
+				if (!choice || choice === "↩ Back") continue;
+				const reader = READER_NAMES.find((name) => choice.endsWith(`(${name})`));
+				if (!reader) continue;
+				const readerFallback = configuredReaderOrder(state.draft).filter((candidate) => candidate !== reader);
+				state.draft = { ...state.draft, reader, readerFallback };
+				continue;
+			}
+			if (selected.startsWith("Reader fallback order:")) {
+				await configureReaderFallback(ctx, state);
+			}
+		}
+	}
+
+	async function configureOutput(ctx: ExtensionContext, state: SetupDraftState): Promise<void> {
+		while (true) {
+			const selected = await ctx.ui.select(
+				`Output${draftIsDirty(state) ? " · unsaved" : ""}`,
+				[`Compact output: ${state.draft.compact ? "On" : "Off"}`, "↩ Back"],
+			);
+			if (!selected || selected === "↩ Back") return;
+			const choice = await ctx.ui.select("Compact output:", ["On", "Off", "↩ Back"]);
+			if (!choice || choice === "↩ Back") continue;
+			state.draft = { ...state.draft, compact: choice === "On" };
+		}
+	}
+
+	async function configureBackends(ctx: ExtensionContext, state: SetupDraftState): Promise<void> {
+		while (true) {
+			const effective = effectiveDraftConfig(state.draft, ctx.cwd);
+			const active = activeBackendsFor(effective);
+			const codexAuth = piAuthDetail(ctx);
+			const backendEntries = Object.keys(BACKEND_DEFS).map((backend) => {
+				const backendState = backendStateSummary(backend, effective, active, codexAuth);
+				const globalEnabled = (state.draft.backends as Record<string, BackendConfig> | undefined)?.[backend]?.enabled === true;
+				const effectiveEnabled = (effective.backends as Record<string, BackendConfig> | undefined)?.[backend]?.enabled === true;
+				const override = globalEnabled === effectiveEnabled
+					? ""
+					: ` · global ${globalEnabled ? "ON" : "OFF"} → effective ${effectiveEnabled ? "ON" : "OFF"}`;
+				const latency = averageLatency(backend);
+				const option = `[${backendState.marker}] ${BACKEND_DEFS[backend].label} · ${backendState.details}${override}${latency ? ` · ${latency}` : ""}`;
+				return { backend, option };
+			});
+			const backendByOption = Object.fromEntries(backendEntries.map(({ backend, option }) => [option, backend]));
+			const title = [
+				"Search backends",
+				draftIsDirty(state) ? "● Unsaved changes" : "No unsaved changes",
+				`${active.length} active · ${configuredCredentialCount(ctx, effective)} credentials configured`,
+			].join("\n");
+			const option = await ctx.ui.select(title, [
+				...backendEntries.map(({ option }) => option),
+				"⚡ Enable ready keyless backends",
+				"↩ Back",
+			]);
+			if (!option || option === "↩ Back") return;
+			if (option === "⚡ Enable ready keyless backends") {
+				enableReadyKeylessBackends(state);
+				continue;
+			}
+			const backend = backendByOption[option];
+			if (backend) await configureBackend(ctx, backend, state);
+		}
+	}
+
 	pi.registerCommand("search-setup", {
-		description: "Configure search backends interactively",
+		description: "View status and configure Search Hub",
 		handler: async (_args, ctx) => {
 			if (!ctx.hasUI) {
 				ctx.ui.notify("/search-setup requires interactive mode", "error");
 				return;
 			}
 
-			// Build backend list with rate limits for free backends
-			const backendList = Object.entries(BACKEND_DEFS)
-				.filter(([_, d]) => d.setupLabel !== null)
-				.map(([k, d]) => {
-					let label = d.setupLabel!;
-					// Add rate limit hints for free backends
-					if (k === "duckduckgo") label += " (rate-limited)";
-					if (k === "marginalia") label += " (rate-limited)";
-					if (k === "jina") label += " (1000/mo free)";
-					if (k === "exa_mcp") label += " (rate-limited)";
-					if (k === "searxng") label += " (self-hosted)";
-				return label;
-			});
-
-			const option = await ctx.ui.select("Which backend do you want to configure?", [
-				...backendList,
-				"⚡ Enable all free backends",
-				"⚙️ Global settings",
-				"✅ Done — save and exit",
-			]);
-
-			const backendKey: Record<string, string> = Object.fromEntries(
-				Object.entries(BACKEND_DEFS)
-					.filter(([_, d]) => d.setupLabel !== null)
-					.map(([k, d]) => {
-						let label = d.setupLabel!;
-						if (k === "duckduckgo") label += " (rate-limited)";
-						if (k === "marginalia") label += " (rate-limited)";
-						if (k === "jina") label += " (1000/mo free)";
-						if (k === "exa_mcp") label += " (rate-limited)";
-						if (k === "searxng") label += " (self-hosted)";
-					return [label, k];
-				})
-			);
-
-			if (!option || option.startsWith("✅ Done")) {
-				ctx.ui.notify("Search setup complete.", "info");
-				return;
-			}
-
-			if (option === "⚙️ Global settings") {
-				await configureGlobalSettings(ctx);
-				return;
-			}
-
-			if (option === "⚡ Enable all free backends") {
-				await enableAllFreeBackends(ctx);
-				return;
-			}
-
-			const backend = backendKey[option!];
-			const def = BACKEND_DEFS[backend];
-			const label = option;
-
-			// Free backends (needsKey: false) can be enabled without API key
-			if (!def.needsKey) {
-				// Auto-enable free backends directly
-				const configDir = join(getAgentDir(), "extensions");
-				const configPath = join(configDir, "search.json");
-				mkdirSync(configDir, { recursive: true });
-
-				let existing: SearchConfig = {};
-				if (existsSync(configPath)) {
-					try {
-						existing = JSON.parse(readFileSync(configPath, "utf-8"));
-					} catch {
-						// ignore
-					}
-				}
-
-				// Handle backends needing instance URL (e.g. SearXNG)
-				let backendConfig: BackendConfig = { enabled: true };
-				if (def.needsInstanceUrl) {
-					const instanceUrl = await ctx.ui.input(
-						"Enter your instance URL (e.g. http://localhost:8888):",
-						"http://localhost:8888",
-					);
-					if (!instanceUrl) {
-						ctx.ui.notify("Setup cancelled.", "info");
-						return;
-					}
-					backendConfig.instanceUrl = instanceUrl.trim();
-					// Optionally ask for API key (some instances require auth)
-					const optKey = await ctx.ui.input("Optional API key (press Enter to skip):", "sk-... (optional)");
-					if (optKey && optKey.trim()) {
-						backendConfig.apiKey = optKey.trim();
-					}
-				} else if (def.optionalKey) {
-					// Optionally ask for API key if optional
-					const optKey = await ctx.ui.input("Optional API key (press Enter to skip):", "sk-... (optional)");
-					if (optKey && optKey.trim()) {
-						backendConfig.apiKey = optKey.trim();
-					}
-				}
-
-				const updated: SearchConfig = {
-					...existing,
-					backends: {
-						...existing.backends,
-						[backend]: backendConfig,
-					},
-				};
-
-				writeFileSync(configPath, JSON.stringify(updated, null, 2) + "\n", { mode: 0o600 });
-				ctx.ui.notify(`${label} enabled. Run /reload to activate.`, "info");
-				return;
-			}
-
-			const key = await ctx.ui.input(`Enter your ${label} API key:`, "sk-...");
-
-			if (!key) {
-				ctx.ui.notify("Setup cancelled.", "info");
-				return;
-			}
-
-			const configDir = join(getAgentDir(), "extensions");
-			const configPath = join(configDir, "search.json");
-
-			mkdirSync(configDir, { recursive: true });
-
-			let existing: SearchConfig = {};
-			if (existsSync(configPath)) {
-				try {
-					existing = JSON.parse(readFileSync(configPath, "utf-8"));
-				} catch {
-					// ignore
-				}
-			}
-
-			// SearXNG setup needs both instance URL and optional API key
-			let backendConfig: BackendConfig = { enabled: true };
-			if (backend === "searxng") {
-				const url = await ctx.ui.input(
-					"Enter your SearXNG instance URL (e.g. http://localhost:8888):",
-					"http://localhost:8888",
-				);
-				if (!url) {
-					ctx.ui.notify("Setup cancelled.", "info");
-					return;
-				}
-				backendConfig.instanceUrl = url.trim();
-				// Optionally ask for API key (some instances require auth)
-				const optionalKey = await ctx.ui.input("Optional API key (leave empty if none):", "sk-... (optional)");
-				if (optionalKey && optionalKey.trim()) {
-					backendConfig.apiKey = optionalKey.trim();
-				}
-			} else {
-				backendConfig.apiKey = key?.trim() || "";
-			}
-
-			const updated: SearchConfig = {
-				...existing,
-				backends: {
-					...existing.backends,
-					[backend]: backendConfig,
-				},
+			refreshRuntimeConfig(ctx);
+			const original = readGlobalConfig();
+			const state: SetupDraftState = {
+				original: cloneConfig(original),
+				draft: cloneConfig(original),
 			};
+			while (true) {
+				const options = [
+					"🔀 Search routing",
+					"📖 Web reading",
+					"🔌 Backends",
+					"🖥 Output",
+					"💾 Save & apply",
+				];
+				if (draftIsDirty(state)) options.push("↩ Discard changes");
+				options.push("✅ Close");
+				const option = await ctx.ui.select(setupHomeTitle(ctx, state), options);
 
-			writeFileSync(configPath, JSON.stringify(updated, null, 2) + "\n", { mode: 0o600 });
-
-			ctx.ui.notify(
-				`${label} API key saved to ${configPath}. Run /reload to activate.`,
-				"info",
-			);
+				if (!option || option === "✅ Close") {
+					if (!(await confirmSetupClose(ctx, state))) continue;
+					ctx.ui.notify("Search setup complete.", "info");
+					return;
+				}
+				if (option === "🔀 Search routing") {
+					await configureSearchRouting(ctx, state);
+					continue;
+				}
+				if (option === "📖 Web reading") {
+					await configureWebReading(ctx, state);
+					continue;
+				}
+				if (option === "🔌 Backends") {
+					await configureBackends(ctx, state);
+					continue;
+				}
+				if (option === "🖥 Output") {
+					await configureOutput(ctx, state);
+					continue;
+				}
+				if (option === "💾 Save & apply") {
+					if (draftIsDirty(state)) saveDraft(ctx, state);
+					else ctx.ui.notify("No unsaved Search Hub changes.", "info");
+					continue;
+				}
+				if (option === "↩ Discard changes") {
+					state.draft = cloneConfig(state.original);
+					ctx.ui.notify("Unsaved Search Hub changes discarded.", "info");
+				}
+			}
 		},
 	});
-
-	// -------------------------------------------------------------------------
-	// Enable all free backends
-	// -------------------------------------------------------------------------
-
-	async function enableAllFreeBackends(ctx: ExtensionContext) {
-		const configDir = join(getAgentDir(), "extensions");
-		const configPath = join(configDir, "search.json");
-		mkdirSync(configDir, { recursive: true });
-
-		let existing: SearchConfig = {};
-		if (existsSync(configPath)) {
-			try {
-				existing = JSON.parse(readFileSync(configPath, "utf-8"));
-			} catch {
-				// ignore
-			}
-		}
-
-		// List of free backends to enable
-		const freeBackends = [
-			"duckduckgo",
-			"jina",
-			"marginalia",
-			"exa_mcp",
-			"searxng",
-		];
-
-		const updated: SearchConfig = {
-			...existing,
-			backends: {
-				...existing.backends,
-				...Object.fromEntries(
-					freeBackends.map(name => [name, { enabled: true }])
-				),
-			},
-		};
-
-		writeFileSync(configPath, JSON.stringify(updated, null, 2) + "\n", { mode: 0o600 });
-		ctx.ui.notify(
-			`Enabled: DuckDuckGo, Jina, Marginalia, Exa MCP, SearXNG. Run /reload to activate.`,
-			"info",
-		);
-	}
-
-	// -------------------------------------------------------------------------
-	// Global settings configuration
-	// -------------------------------------------------------------------------
-
-	async function configureGlobalSettings(ctx: ExtensionContext) {
-		const configDir = join(getAgentDir(), "extensions");
-		const configPath = join(configDir, "search.json");
-		mkdirSync(configDir, { recursive: true });
-
-		let existing: SearchConfig = {};
-		if (existsSync(configPath)) {
-			try {
-				existing = JSON.parse(readFileSync(configPath, "utf-8"));
-			} catch {
-				// ignore
-			}
-		}
-
-		const settings = [
-			["compact", "Compact output", existing.compact ? "On" : "Off"],
-			["showStatus", "Show status line", existing.showStatus !== false ? "On" : "Off"],
-			["combine", "Combine mode (parallel search)", existing.combine ? "On" : "Off"],
-			["combineMode", "Combine strategy", existing.combineMode ?? "all"],
-			["cacheTtl", "Cache TTL (ms)", String(existing.cacheTtl ?? 300000)],
-			["cacheMax", "Max cached queries", String(existing.cacheMax ?? 100)],
-			["reader", "Web reader", existing.reader ?? "jina"],
-			["selectionStrategy", "Selection strategy", existing.selectionStrategy ?? "sequential"],
-		];
-
-		const labels = settings.map(([key, label, current]) => `${label}: ${current}`);
-		labels.push("✅ Done — save and exit");
-
-		const selected = await ctx.ui.select("Configure global settings:", labels);
-		if (!selected || selected === "✅ Done — save and exit") {
-			ctx.ui.notify("Global settings saved.", "info");
-			return;
-		}
-
-		// Find which setting was selected
-		const idx = labels.indexOf(selected);
-		if (idx < 0 || idx >= settings.length) {
-			ctx.ui.notify("Setup cancelled.", "info");
-			return;
-		}
-
-		const [key, label] = settings[idx];
-		let value: unknown;
-
-		switch (key) {
-			case "compact":
-			case "showStatus":
-			case "combine": {
-				const toggle = await ctx.ui.select(`${label} — current: ${selected.split(": ")[1]}`, ["On", "Off", "Cancel"]);
-				if (toggle === "Cancel" || !toggle) {
-					ctx.ui.notify("Setup cancelled.", "info");
-					return;
-				}
-				value = toggle === "On";
-				break;
-			}
-			case "combineMode": {
-				const choice = await ctx.ui.select(`${label} — current: ${selected.split(": ")[1]}`, ["all", "targeted", "Cancel"]);
-				if (choice === "Cancel" || !choice) {
-					ctx.ui.notify("Setup cancelled.", "info");
-					return;
-				}
-				value = choice;
-				break;
-			}
-			case "cacheTtl":
-			case "cacheMax": {
-				const input = await ctx.ui.input(
-					`${label} — current: ${selected.split(": ")[1]}`,
-					selected.split(": ")[1],
-				);
-				if (!input) {
-					ctx.ui.notify("Setup cancelled.", "info");
-					return;
-				}
-				if (!/^\d+$/.test(input.trim())) {
-					ctx.ui.notify("Must be a number.", "error");
-					return;
-				}
-				value = parseInt(input, 10);
-				break;
-			}
-			case "reader": {
-				const choice = await ctx.ui.select(`${label} — current: ${selected.split(": ")[1]}`, [
-					"jina (free)", "sofya (needs key)", "firecrawl (keyless)", "exa (needs key)", "exa_mcp (free)", "Cancel"
-				]);
-				if (choice === "Cancel" || !choice) {
-					ctx.ui.notify("Setup cancelled.", "info");
-					return;
-				}
-				value = choice.startsWith("jina") ? "jina" : choice.startsWith("firecrawl") ? "firecrawl" : choice.startsWith("exa_mcp") ? "exa_mcp" : choice.startsWith("exa") ? "exa" : "sofya";
-				break;
-			}
-			case "selectionStrategy": {
-				const choice = await ctx.ui.select(`${label} — current: ${selected.split(": ")[1]}`, [
-					"sequential", "random", "round-robin", "best-latency", "Cancel",
-				]);
-				if (choice === "Cancel" || !choice) {
-					ctx.ui.notify("Setup cancelled.", "info");
-					return;
-				}
-				value = choice;
-				break;
-			}
-			default:
-				ctx.ui.notify("Unknown setting.", "error");
-				return;
-		}
-
-		const updated: SearchConfig = { ...existing, [key]: value };
-		writeFileSync(configPath, JSON.stringify(updated, null, 2) + "\n", { mode: 0o600 });
-		ctx.ui.notify(`${label} set. Run /reload to apply.`, "info");
-
-		// Allow configuring another setting
-		await configureGlobalSettings(ctx);
-	}
-
-	pi.registerCommand("search-status", {
-		description: "Show which search backends are configured and active",
-		handler: async (_args, ctx) => {
-			refreshConfig(ctx.cwd);
-
-			const backendLabels: Record<string, string> = Object.fromEntries(
-				Object.entries(BACKEND_DEFS).map(([k, v]) => [k, `${v.label}${k === "duckduckgo" ? " (free, no key)" : ""}`])
-			);
-
-			// Collect table rows first to compute aligned column widths
-			type Row = [string, string, string];
-			const rows: Row[] = [];
-
-			for (const [name, label] of Object.entries(backendLabels)) {
-				const { configured, source } = getKeySource(name, config);
-				const bc = config.backends?.[name as keyof typeof config.backends];
-				const samples = latencyMap.get(name) ?? [];
-				const avgLatency = samples.length > 0
-					? `${Math.round(samples.reduce((sum, s) => sum + s.ms, 0) / samples.length)}ms`
-					: "\u2014";
-
-				if (name === "duckduckgo") {
-					rows.push([label, "\u2713 enabled, key: \u2014 (free)", avgLatency]);
-				} else if (name === "marginalia" && bc?.enabled) {
-					rows.push([label, "\u2713 enabled, key: optional (public)", avgLatency]);
-				} else if (name === "searxng" && bc?.enabled) {
-					const urlInfo = bc.instanceUrl ? `url: ${bc.instanceUrl}` : "no URL set";
-					rows.push([label, `\u2713 enabled, ${urlInfo}${configured ? `, key: \u2713 (${source})` : ", key: \u2014"}`, avgLatency]);
-				} else if (bc?.enabled) {
-					const keyStatus = configured
-						? `\u2713${source ? ` (${source})` : ""}`
-						: "\u2014 (Pi auth)";
-					rows.push([label, `\u2713 enabled, key: ${keyStatus}`, avgLatency]);
-				} else {
-					rows.push([label, `\u2014 disabled${configured ? `, key: \u2713 (${source})` : ""}`, avgLatency]);
-				}
-			}
-
-			// Compute column widths from headers + data
-			const col1Header = "Backend";
-			const col2Header = "Status";
-			const col3Header = "Avg Latency";
-			const w1 = rows.reduce((max, [c]) => Math.max(max, c.length), col1Header.length);
-			const w2 = rows.reduce((max, [, s]) => Math.max(max, s.length), col2Header.length);
-			const w3 = rows.reduce((max, [, , s]) => Math.max(max, s.length), col3Header.length);
-
-			const pad = (s: string, w: number) => s + " ".repeat(w - s.length);
-
-			const tableLines = [
-				`| ${pad(col1Header, w1)} | ${pad(col2Header, w2)} | ${pad(col3Header, w3)} |`,
-				`| ${"-".repeat(w1)} | ${"-".repeat(w2)} | ${"-".repeat(w3)} |`,
-				...rows.map(([c1, c2, c3]) => `| ${pad(c1, w1)} | ${pad(c2, w2)} | ${pad(c3, w3)} |`),
-			];
-
-			const activeBackends = getActiveBackends();
-			const resolvedDefault = activeBackends[0] || "none";
-			const lines: string[] = [
-				"## Search Backend Status",
-				`Configured default: ${config.defaultBackend || "none"}`,
-				`Resolved default: ${resolvedDefault}`,
-				`Combine mode: ${config.combine ? (config.combineMode || "all") : "off"}`,
-				`Strategy: ${config.selectionStrategy || "sequential"}`,
-				`Active: ${activeBackends.join(", ") || "none"}`,
-				"",
-				...tableLines,
-			];
-
-			if (activeBackends.length === 1 && activeBackends[0] === "duckduckgo") {
-				lines.push("");
-				lines.push("Only DuckDuckGo is active (no API key needed).");
-				lines.push("Add a search backend with /search-setup to get more results.");
-			}
-
-			ctx.ui.notify(lines.join("\n"), "info");
-		},
-	});
-
 
 	// -----------------------------------------------------------------------
 	// Session start
@@ -965,10 +1178,6 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		clearCooldowns();
-		refreshConfig(ctx.cwd);
-		if (config.showStatus !== false) {
-			const status = getActiveBackends().join(", ");
-			ctx.ui.setStatus("search", `search: ${status}`);
-		}
+		refreshRuntimeConfig(ctx);
 	});
 }

--- a/packages/pi-search-hub/extensions/types.ts
+++ b/packages/pi-search-hub/extensions/types.ts
@@ -2,6 +2,8 @@
  * Shared types for pi-search-hub extension.
  */
 
+export type ReaderName = "jina" | "sofya" | "firecrawl" | "exa" | "exa_mcp";
+
 export interface BackendConfig {
 	enabled?: boolean;
 	apiKey?: string;
@@ -39,14 +41,10 @@ export interface SearchConfig {
 	/** Combine strategy when combine is enabled. "all" queries every active backend; "targeted" queries only enough ordered backends to collect up to 3 usable result sets. */
 	combineMode?: "all" | "targeted";
 	selectionStrategy?: "sequential" | "random" | "round-robin" | "best-latency";
-	/** Reader backend for web_read. "jina" (default, free), "sofya" (250+ site parsers, needs key), "firecrawl" (keyless, 1000 credits/mo), "exa" (needs key, 1000 req/mo), or "exa_mcp" (zero-config, rate-limited). */
-	reader?: "jina" | "sofya" | "firecrawl" | "exa" | "exa_mcp";
-	/** Show status line with enabled backends. Default: true. Set to false to hide. */
-	showStatus?: boolean;
-	/** Cache TTL in milliseconds. Default: 300000 (5 min). Set to 0 to disable. */
-	cacheTtl?: number;
-	/** Max cached queries. Default: 100. */
-	cacheMax?: number;
+	/** Default reader backend for web_read when the tool call does not choose one explicitly. */
+	reader?: ReaderName;
+	/** Ordered readers tried after the default reader when web_read does not choose one explicitly. */
+	readerFallback?: ReaderName[];
 	/** Default compact output. When true, returns single-line results (title + URL). Default: false. */
 	compact?: boolean;
 	backends?: {
@@ -86,6 +84,8 @@ export interface SearchResultWithBackend extends SearchResult {
 }
 
 export interface BackendRunner {
+	/** Existing Pi provider whose credential must be resolved from the current session registry. */
+	providerAuth?: string;
 	needsKey: boolean;
 	needsKeyFromConfig: boolean;
 	optionalKey: boolean;

--- a/packages/pi-search-hub/extensions/utils.ts
+++ b/packages/pi-search-hub/extensions/utils.ts
@@ -62,62 +62,6 @@ export function timeoutSignal(signal?: AbortSignal, timeoutMs?: number): AbortSi
 }
 
 // ---------------------------------------------------------------------------
-// Search result cache (LRU with TTL)
-// ---------------------------------------------------------------------------
-
-export interface CacheEntry<T> {
-	value: T;
-	timestamp: number;
-}
-
-const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-const DEFAULT_CACHE_MAX = 100;
-
-export class SearchCache<T> {
-	private cache = new Map<string, CacheEntry<T>>();
-	private readonly ttlMs: number;
-	private readonly maxSize: number;
-
-	constructor(ttlMs = DEFAULT_CACHE_TTL_MS, maxSize = DEFAULT_CACHE_MAX) {
-		this.ttlMs = ttlMs;
-		this.maxSize = maxSize;
-	}
-
-	get(key: string): T | undefined {
-		const entry = this.cache.get(key);
-		if (!entry) return undefined;
-		if (Date.now() - entry.timestamp > this.ttlMs) {
-			this.cache.delete(key);
-			return undefined;
-		}
-		// LRU: move to end (most recently used)
-		this.cache.delete(key);
-		this.cache.set(key, entry);
-		return entry.value;
-	}
-
-	set(key: string, value: T): void {
-		// Evict oldest if at capacity
-		if (this.cache.size >= this.maxSize) {
-			const oldest = this.cache.keys().next().value;
-			if (oldest !== undefined) this.cache.delete(oldest);
-		}
-		this.cache.set(key, { value, timestamp: Date.now() });
-	}
-
-	clear(): void {
-		this.cache.clear();
-	}
-
-	get size(): number {
-		return this.cache.size;
-	}
-}
-
-// Global search result cache instance
-export const searchCache = new SearchCache<Array<{ title: string; url: string; snippet?: string; content?: string }>>();
-
-// ---------------------------------------------------------------------------
 // Exa usage tracking (monthly quota)
 // ---------------------------------------------------------------------------
 
@@ -197,11 +141,6 @@ export function incrementExaUsage(): string | null {
 		}
 	}
 	return null;
-}
-
-/** Build a cache key from query + backend + numResults. */
-export function cacheKey(query: string, backend: string, numResults: number): string {
-	return `${backend}:${numResults}:${query}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pi-search-hub/search.json.example
+++ b/packages/pi-search-hub/search.json.example
@@ -1,7 +1,10 @@
 {
-  "defaultBackend": "auto",
+  "defaultBackend": "duckduckgo",
+  "combine": false,
+  "combineMode": "targeted",
+  "selectionStrategy": "sequential",
   "reader": "jina",
-  "showStatus": true,
+  "readerFallback": ["firecrawl", "exa_mcp"],
   "compact": false,
   "backends": {
     "duckduckgo": { "enabled": true },

--- a/packages/pi-search-hub/tests/integration.test.ts
+++ b/packages/pi-search-hub/tests/integration.test.ts
@@ -5,7 +5,6 @@
  * - Selection strategies
  * - RRF combiner
  * - Credential resolution
- * - SearchCache
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -15,7 +14,7 @@ import { reciprocalRankFusion, runTargetedCombine, selectBackendsForFallback } f
 import { recordBackendSuccess, recordBackendFailure } from "../extensions/scoring.js";
 import { resolveConfigValue, clearCredentialCache, FALLBACK_ENV_MAP } from "../extensions/credentials.js";
 import { loadConfig } from "../extensions/config.js";
-import { SearchCache } from "../extensions/utils.js";
+
 
 // ---------------------------------------------------------------------------
 // Tool display integration
@@ -473,18 +472,28 @@ describe("resolveConfigValue", () => {
 		expect(resolveConfigValue(undefined)).toBeUndefined();
 	});
 
-	it("returns undefined for empty string", () => {
+	it("returns undefined for empty or whitespace-only strings", () => {
 		expect(resolveConfigValue("")).toBeUndefined();
+		expect(resolveConfigValue("   ")).toBeUndefined();
 	});
 
 	it("returns literal key for non-ALL_CAPS strings", () => {
 		expect(resolveConfigValue("sk-abc123")).toBe("sk-abc123");
 	});
 
-	it("resolves ALL_CAPS from env var", () => {
-		process.env.TEST_SEARCH_KEY_123 = "secret-value";
+	it("resolves and trims ALL_CAPS values from env vars", () => {
+		process.env.TEST_SEARCH_KEY_123 = "  secret-value  ";
 		try {
 			expect(resolveConfigValue("TEST_SEARCH_KEY_123")).toBe("secret-value");
+		} finally {
+			delete process.env.TEST_SEARCH_KEY_123;
+		}
+	});
+
+	it("returns undefined for whitespace-only env var values", () => {
+		process.env.TEST_SEARCH_KEY_123 = "   ";
+		try {
+			expect(resolveConfigValue("TEST_SEARCH_KEY_123")).toBeUndefined();
 		} finally {
 			delete process.env.TEST_SEARCH_KEY_123;
 		}
@@ -612,67 +621,5 @@ describe("fetchSofya", () => {
 		await fetchSofya("https://example.com", "valid-key", undefined, { includeRawHtml: true });
 		const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string);
 		expect(body.include_raw_html).toBe(true);
-	});
-});
-
-// ---------------------------------------------------------------------------
-// SearchCache tests
-// ---------------------------------------------------------------------------
-
-describe("SearchCache", () => {
-	it("stores and retrieves values", () => {
-		const cache = new SearchCache<string>(60_000, 10);
-		cache.set("key1", "value1");
-		expect(cache.get("key1")).toBe("value1");
-	});
-
-	it("returns undefined for missing keys", () => {
-		const cache = new SearchCache<string>(60_000, 10);
-		expect(cache.get("missing")).toBeUndefined();
-	});
-
-	it("evicts entries after TTL", async () => {
-		const cache = new SearchCache<string>(20, 10); // 20ms TTL
-		cache.set("key1", "value1");
-		// Verify entry exists just before TTL expires
-		await new Promise((r) => setTimeout(r, 15));
-		expect(cache.get("key1")).toBe("value1"); // still valid at 15ms < 20ms TTL
-		// Verify entry is evicted after TTL
-		await new Promise((r) => setTimeout(r, 10)); // now at 25ms > 20ms TTL
-		expect(cache.get("key1")).toBeUndefined();
-	});
-
-	it("evicts oldest when at max capacity", () => {
-		const cache = new SearchCache<string>(60_000, 3);
-		cache.set("key1", "value1");
-		cache.set("key2", "value2");
-		cache.set("key3", "value3");
-		cache.set("key4", "value4"); // should evict key1
-
-		expect(cache.get("key1")).toBeUndefined();
-		expect(cache.get("key4")).toBe("value4");
-		expect(cache.size).toBe(3);
-	});
-
-	it("clear resets the cache", () => {
-		const cache = new SearchCache<string>(60_000, 10);
-		cache.set("key1", "value1");
-		cache.clear();
-		expect(cache.get("key1")).toBeUndefined();
-		expect(cache.size).toBe(0);
-	});
-
-	it("LRU: accessing an entry moves it to end", () => {
-		const cache = new SearchCache<string>(60_000, 2);
-		cache.set("key1", "value1");
-		cache.set("key2", "value2");
-
-		// Access key1 to move it to end (most recently used)
-		cache.get("key1");
-
-		// Adding key3 should evict key2 (oldest), not key1
-		cache.set("key3", "value3");
-		expect(cache.get("key1")).toBe("value1");
-		expect(cache.get("key2")).toBeUndefined();
 	});
 });

--- a/packages/pi-search-hub/tests/setup.test.ts
+++ b/packages/pi-search-hub/tests/setup.test.ts
@@ -1,0 +1,485 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import searchHubExtension from "../extensions/search-hub.js";
+import { FALLBACK_ENV_MAP } from "../extensions/credentials.js";
+import type { SearchConfig } from "../extensions/types.js";
+
+type Selection = string | undefined | ((options: string[]) => string | undefined);
+type CommandHandler = (args: string, ctx: any) => Promise<void> | void;
+type EventHandler = (event: any, ctx: any) => Promise<void> | void;
+
+type RegisteredTool = {
+	execute: (
+		toolCallId: string,
+		params: Record<string, any>,
+		signal: AbortSignal | undefined,
+		onUpdate: ((result: any) => void) | undefined,
+		ctx: any,
+	) => Promise<any>;
+};
+
+function createHarness(cwd: string, selections: Selection[] = [], inputs: Array<string | undefined> = []) {
+	const commands = new Map<string, CommandHandler>();
+	const events = new Map<string, EventHandler>();
+	const tools = new Map<string, RegisteredTool>();
+	const notifications: Array<{ message: string; level: string }> = [];
+	const setStatus = vi.fn();
+	const select = vi.fn(async (_title: string, options: string[]) => {
+		const next = selections.shift();
+		return typeof next === "function" ? next(options) : next;
+	});
+	const input = vi.fn(async () => inputs.shift());
+	const pi = {
+		registerTool(tool: RegisteredTool & { name: string }) {
+			tools.set(tool.name, tool);
+		},
+		registerCommand(name: string, definition: { handler: CommandHandler }) {
+			commands.set(name, definition.handler);
+		},
+		on(name: string, handler: EventHandler) {
+			events.set(name, handler);
+		},
+	} as unknown as ExtensionAPI;
+	searchHubExtension(pi);
+
+	const ctx = {
+		hasUI: true,
+		mode: "tui",
+		cwd,
+		modelRegistry: {
+			getProviderAuthStatus() {
+				return { configured: false };
+			},
+			getApiKeyForProvider: vi.fn(async () => undefined),
+		},
+		ui: {
+			select,
+			input,
+			setStatus,
+			notify(message: string, level: string) {
+				notifications.push({ message, level });
+			},
+		},
+	};
+
+	return { commands, events, tools, ctx, notifications, select, input, setStatus };
+}
+
+function pickOption(fragment: string): Selection {
+	return (options) => options.find((option) => option.includes(fragment));
+}
+
+function globalConfigPath(home: string): string {
+	return join(home, ".pi", "agent", "extensions", "search.json");
+}
+
+function writeJson(path: string, value: unknown): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, JSON.stringify(value, null, 2) + "\n");
+}
+
+function readGlobalConfig(home: string): SearchConfig {
+	return JSON.parse(readFileSync(globalConfigPath(home), "utf-8")) as SearchConfig;
+}
+
+describe("Search Hub setup and reader configuration", () => {
+	let home: string;
+	let cwd: string;
+	let previousHome: string | undefined;
+	const previousEnv = new Map<string, string | undefined>();
+
+	beforeEach(() => {
+		home = mkdtempSync(join(tmpdir(), "pi-search-hub-setup-"));
+		cwd = join(home, "project");
+		mkdirSync(cwd, { recursive: true });
+		previousHome = process.env.HOME;
+		process.env.HOME = home;
+		for (const name of new Set([...Object.values(FALLBACK_ENV_MAP), "JINA_API_KEY", "SERPER_API_KEY"])) {
+			previousEnv.set(name, process.env[name]);
+			delete process.env[name];
+		}
+	});
+
+	afterEach(() => {
+		if (previousHome === undefined) delete process.env.HOME;
+		else process.env.HOME = previousHome;
+		for (const [name, value] of previousEnv) {
+			if (value === undefined) delete process.env[name];
+			else process.env[name] = value;
+		}
+		previousEnv.clear();
+		rmSync(home, { recursive: true, force: true });
+	});
+
+	it("integrates readiness status into search-setup and removes search-status", async () => {
+		writeJson(globalConfigPath(home), {
+			backends: {
+				jina: { enabled: true, apiKey: "JINA_API_KEY" },
+				serper: { enabled: true, apiKey: "SERPER_API_KEY" },
+				tavily: { enabled: true, apiKey: "   " },
+				"openai-codex": { enabled: true },
+			},
+		});
+		const harness = createHarness(cwd, ["🔌 Backends", "↩ Back", "✅ Close"]);
+
+		await harness.commands.get("search-setup")!("", harness.ctx);
+
+		expect(harness.commands.has("search-status")).toBe(false);
+		expect(harness.select.mock.calls[0][0]).toContain("Search:");
+		const homeOptions = harness.select.mock.calls[0][1] as string[];
+		expect(homeOptions).toContain("🔌 Backends");
+		expect(homeOptions.some((option) => option.includes("Jina AI"))).toBe(false);
+		const backendOptions = harness.select.mock.calls[1][1] as string[];
+		expect(backendOptions.find((option) => option.includes("Jina AI"))).toContain("auth — optional");
+		expect(backendOptions.find((option) => option.includes("Jina AI"))).not.toContain("JINA_API_KEY");
+		expect(backendOptions.find((option) => option.includes("Serper"))).toContain("auth ✗ missing");
+		expect(backendOptions.find((option) => option.includes("Tavily"))).toContain("auth ✗ missing");
+		expect(backendOptions.find((option) => option.includes("OpenAI Codex"))).toContain("auth ✗ run /login openai-codex");
+	});
+
+	it("presents stored OpenAI Codex auth as a Pi login credential", async () => {
+		writeJson(globalConfigPath(home), {
+			backends: { "openai-codex": { enabled: true } },
+		});
+		const harness = createHarness(cwd, ["🔌 Backends", "↩ Back", "✅ Close"]);
+		harness.ctx.modelRegistry.getProviderAuthStatus = () => ({ configured: true, source: "stored" });
+
+		await harness.commands.get("search-setup")!("", harness.ctx);
+
+		const options = harness.select.mock.calls[1][1] as string[];
+		expect(options.find((option) => option.includes("OpenAI Codex"))).toContain("auth ✓ Pi /login");
+	});
+
+	it("shows global/effective state and re-enables a backend with retained credentials", async () => {
+		writeJson(globalConfigPath(home), {
+			backends: {
+				serper: { enabled: true, apiKey: "sk-retained", maxResults: 7 },
+			},
+		});
+		const disableHarness = createHarness(cwd, [
+			"🔌 Backends",
+			pickOption("Serper"),
+			"Disable globally (keep credentials)",
+			"↩ Back",
+			"💾 Save & apply",
+			"✅ Close",
+		]);
+
+		await disableHarness.commands.get("search-setup")!("", disableHarness.ctx);
+
+		expect(disableHarness.select.mock.calls[2][0]).toContain("Global draft:         [ON] auth ✓ saved key");
+		expect(disableHarness.select.mock.calls[2][0]).toContain("Effective after save: [ON] auth ✓ saved key");
+		expect(readGlobalConfig(home).backends?.serper).toEqual({
+			enabled: false,
+			apiKey: "sk-retained",
+			maxResults: 7,
+		});
+
+		const enableHarness = createHarness(cwd, [
+			"🔌 Backends",
+			pickOption("Serper"),
+			"Enable in global configuration",
+			"↩ Back",
+			"💾 Save & apply",
+			"✅ Close",
+		]);
+		await enableHarness.commands.get("search-setup")!("", enableHarness.ctx);
+		expect(enableHarness.input).not.toHaveBeenCalled();
+		expect(readGlobalConfig(home).backends?.serper).toEqual({
+			enabled: true,
+			apiKey: "sk-retained",
+			maxResults: 7,
+		});
+		expect(enableHarness.notifications.some(({ message }) => message.includes("saved and applied"))).toBe(true);
+		expect(enableHarness.setStatus).not.toHaveBeenCalled();
+	});
+
+	it("does not enable a required-key backend for whitespace input", async () => {
+		const harness = createHarness(
+			cwd,
+			["🔌 Backends", pickOption("Serper"), "Enable in global configuration", "↩ Back", "✅ Close"],
+			["   "],
+		);
+
+		await harness.commands.get("search-setup")!("", harness.ctx);
+
+		expect(existsSync(globalConfigPath(home))).toBe(false);
+		expect(harness.notifications).toContainEqual({
+			level: "warning",
+			message: expect.stringContaining("Draft unchanged"),
+		});
+	});
+
+	it("trims required keys and enables optional-key backends without empty fields", async () => {
+		const required = createHarness(
+			cwd,
+			[
+				"🔌 Backends",
+				pickOption("Serper"),
+				"Enable in global configuration",
+				"↩ Back",
+				"💾 Save & apply",
+				"✅ Close",
+			],
+			["  sk-test-value  "],
+		);
+		await required.commands.get("search-setup")!("", required.ctx);
+		expect(readGlobalConfig(home).backends?.serper).toEqual({ enabled: true, apiKey: "sk-test-value" });
+
+		rmSync(globalConfigPath(home));
+		const optional = createHarness(
+			cwd,
+			[
+				"🔌 Backends",
+				pickOption("Jina AI"),
+				"Enable in global configuration",
+				"↩ Back",
+				"💾 Save & apply",
+				"✅ Close",
+			],
+			[undefined],
+		);
+		await optional.commands.get("search-setup")!("", optional.ctx);
+		expect(readGlobalConfig(home).backends?.jina).toEqual({ enabled: true });
+		expect(readGlobalConfig(home).backends?.jina).not.toHaveProperty("apiKey");
+	});
+
+	it("updates and removes a saved key independently from the backend switch", async () => {
+		writeJson(globalConfigPath(home), {
+			backends: { serper: { enabled: false, apiKey: "sk-old" } },
+		});
+		const updateHarness = createHarness(
+			cwd,
+			[
+				"🔌 Backends",
+				pickOption("Serper"),
+				"Update API key or reference",
+				"↩ Back",
+				"💾 Save & apply",
+				"✅ Close",
+			],
+			["  sk-new  "],
+		);
+		await updateHarness.commands.get("search-setup")!("", updateHarness.ctx);
+		expect(readGlobalConfig(home).backends?.serper).toMatchObject({ enabled: false, apiKey: "sk-new" });
+
+		const removeHarness = createHarness(cwd, [
+			"🔌 Backends",
+			pickOption("Serper"),
+			"Remove saved API key or reference",
+			"↩ Back",
+			"💾 Save & apply",
+			"✅ Close",
+		]);
+		await removeHarness.commands.get("search-setup")!("", removeHarness.ctx);
+		expect(readGlobalConfig(home).backends?.serper).toEqual({ enabled: false });
+	});
+
+	it("bulk-enables only ready keyless backends", async () => {
+		const harness = createHarness(cwd, [
+			"🔌 Backends",
+			"⚡ Enable ready keyless backends",
+			"↩ Back",
+			"💾 Save & apply",
+			"✅ Close",
+		]);
+		await harness.commands.get("search-setup")!("", harness.ctx);
+
+		const backends = readGlobalConfig(home).backends;
+		for (const backend of ["duckduckgo", "jina", "marginalia", "exa_mcp"]) {
+			expect(backends?.[backend]?.enabled).toBe(true);
+		}
+		expect(backends?.searxng).toBeUndefined();
+	});
+
+	it("keeps edits in a shared draft and discards them without writing", async () => {
+		const harness = createHarness(cwd, [
+			"🖥 Output",
+			pickOption("Compact output:"),
+			"On",
+			"↩ Back",
+			"✅ Close",
+			"Discard changes",
+		]);
+
+		await harness.commands.get("search-setup")!("", harness.ctx);
+
+		expect(existsSync(globalConfigPath(home))).toBe(false);
+		expect(harness.select.mock.calls[4][0]).toContain("Unsaved changes");
+		expect(harness.notifications.some(({ message }) => message.includes("saved and applied"))).toBe(false);
+	});
+
+	it("can save the shared draft from the close confirmation", async () => {
+		const harness = createHarness(cwd, [
+			"🖥 Output",
+			pickOption("Compact output:"),
+			"On",
+			"↩ Back",
+			"✅ Close",
+			"Save & apply",
+		]);
+
+		await harness.commands.get("search-setup")!("", harness.ctx);
+
+		expect(readGlobalConfig(home).compact).toBe(true);
+		expect(harness.notifications.some(({ message }) => message.includes("saved and applied"))).toBe(true);
+	});
+
+	it("reports a project override when it keeps a globally disabled backend enabled", async () => {
+		writeJson(globalConfigPath(home), {
+			backends: { serper: { enabled: true, apiKey: "sk-global" } },
+		});
+		writeJson(join(cwd, ".pi", "search.json"), {
+			backends: { serper: { enabled: true } },
+		});
+		const harness = createHarness(cwd, [
+			"🔌 Backends",
+			pickOption("Serper"),
+			"Disable globally (keep credentials)",
+			"↩ Back",
+			"💾 Save & apply",
+			"✅ Close",
+		]);
+
+		await harness.commands.get("search-setup")!("", harness.ctx);
+
+		expect(readGlobalConfig(home).backends?.serper?.enabled).toBe(false);
+		expect(harness.notifications.some(({ message }) => message.includes("project overrides remain effective"))).toBe(true);
+	});
+
+	it("presents search mode as one setting and removes legacy status/cache fields on save", async () => {
+		writeJson(globalConfigPath(home), {
+			showStatus: true,
+			cacheTtl: 300000,
+			cacheMax: 100,
+			backends: { duckduckgo: { enabled: true } },
+		});
+		const harness = createHarness(cwd, [
+			"🔀 Search routing",
+			pickOption("Search mode:"),
+			"Targeted combine",
+			"↩ Back",
+			"💾 Save & apply",
+			"✅ Close",
+		]);
+
+		await harness.commands.get("search-setup")!("", harness.ctx);
+
+		const saved = JSON.parse(readFileSync(globalConfigPath(home), "utf-8")) as Record<string, unknown>;
+		expect(saved).toMatchObject({ combine: true, combineMode: "targeted" });
+		expect(saved).not.toHaveProperty("showStatus");
+		expect(saved).not.toHaveProperty("cacheTtl");
+		expect(saved).not.toHaveProperty("cacheMax");
+	});
+
+	it("configures ordered reader fallbacks and keeps the previous default when switching", async () => {
+		const fallbackHarness = createHarness(
+			cwd,
+			[
+				"📖 Web reading",
+				pickOption("Reader fallback order:"),
+				"Edit ordered fallback list",
+				"↩ Back",
+				"💾 Save & apply",
+				"✅ Close",
+			],
+			["firecrawl, exa_mcp, jina"],
+		);
+		await fallbackHarness.commands.get("search-setup")!("", fallbackHarness.ctx);
+		expect(readGlobalConfig(home).reader).toBeUndefined();
+		expect(readGlobalConfig(home).readerFallback).toEqual(["firecrawl", "exa_mcp"]);
+
+		const defaultHarness = createHarness(cwd, [
+			"📖 Web reading",
+			pickOption("Default reader:"),
+			"Firecrawl (firecrawl)",
+			"↩ Back",
+			"💾 Save & apply",
+			"✅ Close",
+		]);
+		await defaultHarness.commands.get("search-setup")!("", defaultHarness.ctx);
+		expect(readGlobalConfig(home).reader).toBe("firecrawl");
+		expect(readGlobalConfig(home).readerFallback).toEqual(["jina", "exa_mcp"]);
+	});
+
+	it("falls back across configured readers but honors an explicit reader", async () => {
+		writeJson(globalConfigPath(home), {
+			reader: "exa",
+			readerFallback: ["jina"],
+		});
+		const harness = createHarness(cwd);
+		const webRead = harness.tools.get("web_read")!;
+		await harness.events.get("session_start")!({ reason: "startup" }, harness.ctx);
+		const onUpdate = vi.fn();
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+			ok: true,
+			status: 200,
+			headers: new Headers(),
+			text: async () => "page content",
+		} as Response);
+
+		try {
+			const result = await webRead.execute(
+				"read-1",
+				{ url: "https://example.com", displaySummary: "Read example" },
+				undefined,
+				onUpdate,
+				harness.ctx,
+			);
+			expect(result.details.reader).toBe("jina");
+			expect(result.details.fallbackErrors[0]).toContain("exa:");
+			expect(onUpdate.mock.calls.map(([update]) => update.details.reader)).toEqual(["exa", "exa", "jina", "jina"]);
+			expect(harness.setStatus).not.toHaveBeenCalled();
+
+			fetchSpy.mockClear();
+			await expect(webRead.execute(
+				"read-2",
+				{ url: "https://example.com", reader: "exa", displaySummary: "Read with Exa" },
+				undefined,
+				onUpdate,
+				harness.ctx,
+			)).rejects.toThrow("Exa reader selected but no API key configured");
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it("resolves Codex auth through the current Pi model registry", async () => {
+		const harness = createHarness(cwd);
+		const onUpdate = vi.fn();
+
+		await expect(harness.tools.get("web_search")!.execute(
+			"search-codex",
+			{ query: "test", backend: "openai-codex", displaySummary: "Search with Codex" },
+			undefined,
+			onUpdate,
+			harness.ctx,
+		)).rejects.toThrow("OpenAI Codex authentication not found");
+
+		expect(harness.ctx.modelRegistry.getApiKeyForProvider).toHaveBeenCalledWith("openai-codex");
+	});
+
+	it("emits tool activity without creating footer status", async () => {
+		const harness = createHarness(cwd);
+		await harness.events.get("session_start")!({ reason: "startup" }, harness.ctx);
+		const onUpdate = vi.fn();
+
+		await expect(harness.tools.get("web_search")!.execute(
+			"search-1",
+			{ query: "test", backend: "serper", displaySummary: "Search test" },
+			undefined,
+			onUpdate,
+			harness.ctx,
+		)).rejects.toThrow("Serper backend not configured");
+
+		expect(onUpdate).toHaveBeenCalledTimes(2);
+		expect(onUpdate.mock.calls[0][0].details.activity).toContain("searching");
+		expect(onUpdate.mock.calls[1][0].details.activity).toContain("failed");
+		expect(harness.setStatus).not.toHaveBeenCalled();
+	});
+});

--- a/packages/pi-todo/CHANGELOG.md
+++ b/packages/pi-todo/CHANGELOG.md
@@ -14,6 +14,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Added the initial public fork of `@juicesharp/rpiv-todo` 1.20.0 with a persistent task overlay and branch-aware state snapshots.
-- Kept successful Todo tool nodes visually hidden while preserving model-facing content and structured session details; reducer and execution errors remain visible.
-- Kept test fixtures package-local so the published extension has no private workspace dependency.
+- Added atomic `batch` create/update/delete operations and expandable transcript audit summaries.
+
+### Changed
+
+- Restricted Todo guidance to meaningful multi-stage work instead of single-step actions.
+- Enforced one in-progress task, required `activeForm`, dependency readiness, and the documented pending → in-progress → completed lifecycle.
+- Reported reducer validation failures as real Pi tool errors.
+
+### Fixed
+
+- Isolated live Todo state per extension runtime so concurrent SDK AgentSessions in one process cannot overwrite each other.
+- Versioned and structurally validated replay snapshots while retaining compatibility with legacy snapshots.

--- a/packages/pi-todo/README.md
+++ b/packages/pi-todo/README.md
@@ -2,7 +2,7 @@
 
 面向 Pi 的 Todo 扩展，维护自 `@juicesharp/rpiv-todo`。它注册 `todo` 工具、`/todos` 命令以及持久化任务浮层，可独立安装，也包含在 `@zhcsyncer/pi-extensions` 聚合包中。
 
-该 fork 有意不接入工具 intent。成功的 Todo 调用在 TUI transcript 中渲染为零行，由持久化 widget 作为唯一的状态展示；执行错误仍会显示。工具的 `content` 与完整状态 `details` 保持不变，模型反馈、session 分支恢复和 reload 后重建不受影响。
+该 fork 有意不接入工具 intent。成功的 Todo 调用默认在 TUI transcript 中渲染为零行，由持久化 widget 展示当前状态；按 `Ctrl+O` 展开工具输出时可查看紧凑调用与结果摘要，执行错误始终显示。工具的 `content` 与版本化状态 `details` 保持在 session 中，模型反馈、分支恢复和 reload 后重建不受影响。
 
 ## 安装
 
@@ -18,6 +18,13 @@ pi install npm:@zhcsyncer/pi-todo
 pi install git:github.com/zhcsyncer/pi-extensions
 ```
 
+## 使用原则与状态契约
+
+- 单步骤、低风险工作直接执行，不创建 Todo；Todo 只表示有独立完成价值的多阶段里程碑。
+- 正常状态流转为 `pending → in_progress → completed`；遇到独立 blocker 时可把进行中任务重新排回 `pending`。
+- 同时只能有一个 `in_progress`，进入该状态必须提供 `activeForm`；依赖未全部完成的任务不能开始。
+- `batch` 可原子执行多条 create/update/delete，适合一次建立初始任务列表或完成任务交接；任一操作失败则整体回滚。
+
 ## 来源
 
 - 上游：[`juicesharp/rpiv-mono`](https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-todo)
@@ -29,11 +36,12 @@ pi install git:github.com/zhcsyncer/pi-extensions
 
 ## 展示与持久化
 
-- `renderShell: "self"` 配合空成功 renderer，移除重复的 tool call/result 节点。
-- reducer 错误及 Pi 执行错误仍以简短错误节点显示。
-- 每个 tool result 的 `details` 保存 `tasks` 与 `nextId` 快照。
-- `session_start`、`session_tree` 和 `session_compact` 从当前 branch 最后的 Todo 快照恢复状态。
-- 原始 tool call/result 仍保存在 session 中；这里只隐藏 TUI 成功节点。
+- `renderShell: "self"` 默认隐藏成功节点，展开模式提供可审计摘要，避免与 widget 重复展示。
+- reducer 校验失败会抛出真正的 Pi 工具错误；执行错误始终可见。
+- 每个 tool result 的 `details` 保存带 schema version 的 `tasks` 与 `nextId` 快照。
+- `session_start`、`session_tree` 和 `session_compact` 从当前 branch 最后的有效 Todo 快照恢复状态。
+- 每个扩展 runtime 持有独立 store，同一 Node.js 进程中的多个 SDK AgentSession 不会串状态。
+- 原始 tool call/result 仍保存在 session 中；默认隐藏只影响 TUI。
 
 ## 开发
 

--- a/packages/pi-todo/index.ts
+++ b/packages/pi-todo/index.ts
@@ -22,7 +22,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { I18N_NAMESPACE } from "./state/i18n-bridge.js";
 import { replayFromBranch } from "./state/replay.js";
-import { replaceState } from "./state/store.js";
+import { createTodoStore } from "./state/store.js";
 import { registerTodosCommand, registerTodoTool, TOOL_NAME } from "./todo.js";
 import { TodoOverlay } from "./todo-overlay.js";
 
@@ -52,16 +52,18 @@ function isStaleCtxError(e: unknown): boolean {
 }
 
 export default function (pi: ExtensionAPI) {
-	// Todo overlay widget — constructed lazily at the first session_start with UI.
+	// Every extension runtime owns an isolated store. This matters for SDK hosts
+	// that keep multiple AgentSession instances alive in one Node.js process.
+	const store = createTodoStore();
 	let todoOverlay: TodoOverlay | undefined;
 
-	registerTodoTool(pi);
-	registerTodosCommand(pi);
+	registerTodoTool(pi, store);
+	registerTodosCommand(pi, store);
 
 	pi.on("session_start", async (_event, ctx) => {
-		replaceState(replayFromBranch(ctx));
+		store.replaceState(replayFromBranch(ctx));
 		if (ctx.hasUI) {
-			todoOverlay ??= new TodoOverlay();
+			todoOverlay ??= new TodoOverlay(store);
 			todoOverlay.setUICtx(ctx.ui);
 			todoOverlay.resetCompletedDisplayState();
 			todoOverlay.update();
@@ -76,7 +78,7 @@ export default function (pi: ExtensionAPI) {
 		// state — so keep current state on a stale ctx. Other errors are real
 		// replay bugs and must propagate.
 		try {
-			replaceState(replayFromBranch(ctx));
+			store.replaceState(replayFromBranch(ctx));
 		} catch (e) {
 			if (!isStaleCtxError(e)) throw e;
 		}
@@ -86,7 +88,7 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_tree", async (_event, ctx) => {
 		try {
-			replaceState(replayFromBranch(ctx));
+			store.replaceState(replayFromBranch(ctx));
 		} catch (e) {
 			if (!isStaleCtxError(e)) throw e;
 		}
@@ -99,7 +101,7 @@ export default function (pi: ExtensionAPI) {
 		todoOverlay = undefined;
 	});
 
-	// Reads getTodos() at render time; do NOT call replayFromBranch here
+	// The overlay reads its runtime store at render time; do NOT replay here
 	// (branch is stale — message_end runs after tool_execution_end).
 	pi.on("tool_execution_end", async (event) => {
 		if (event.toolName !== TOOL_NAME || event.isError) return;

--- a/packages/pi-todo/state/invariants.ts
+++ b/packages/pi-todo/state/invariants.ts
@@ -1,14 +1,15 @@
 import type { TaskStatus } from "../tool/types.js";
 
 /**
- * Allowed forward transitions per source status. `completed` is one-way to
- * `deleted` (never back to `in_progress`); `deleted` is terminal.
+ * Normal lifecycle: pending → in_progress → completed. An in-progress task may
+ * return to pending when it is re-queued behind a newly discovered blocker.
+ * Any live task may be tombstoned; completed and deleted tasks cannot reopen.
  *
  * Idempotent same→same is checked separately in `isTransitionValid` so this
  * table only enumerates actual transitions.
  */
 export const VALID_TRANSITIONS: Record<TaskStatus, ReadonlySet<TaskStatus>> = {
-	pending: new Set(["in_progress", "completed", "deleted"]),
+	pending: new Set(["in_progress", "deleted"]),
 	in_progress: new Set(["pending", "completed", "deleted"]),
 	completed: new Set(["deleted"]),
 	deleted: new Set(),

--- a/packages/pi-todo/state/replay.test.ts
+++ b/packages/pi-todo/state/replay.test.ts
@@ -33,9 +33,19 @@ describe("isTaskDetails — defensive type guard", () => {
 		expect(isTaskDetails({ tasks: [], nextId: "1" })).toBe(false);
 	});
 
-	it("accepts well-formed snapshot envelopes", () => {
+	it("accepts legacy and versioned well-formed snapshot envelopes", () => {
 		expect(isTaskDetails({ tasks: [], nextId: 1 })).toBe(true);
-		expect(isTaskDetails({ action: "create", params: {}, tasks: [], nextId: 1 })).toBe(true);
+		expect(isTaskDetails({ schemaVersion: 1, action: "create", params: {}, tasks: [], nextId: 1 })).toBe(true);
+	});
+
+	it("rejects unknown snapshot versions and malformed task rows", () => {
+		expect(isTaskDetails({ schemaVersion: 2, tasks: [], nextId: 1 })).toBe(false);
+		expect(isTaskDetails({ schemaVersion: 1, tasks: [{ id: 1, subject: "x", status: "unknown" }], nextId: 2 })).toBe(
+			false,
+		);
+		expect(isTaskDetails({ schemaVersion: 1, tasks: [{ id: "1", subject: "x", status: "pending" }], nextId: 2 })).toBe(
+			false,
+		);
 	});
 });
 

--- a/packages/pi-todo/state/replay.ts
+++ b/packages/pi-todo/state/replay.ts
@@ -1,4 +1,4 @@
-import type { TaskDetails } from "../tool/types.js";
+import type { Task, TaskDetails, TaskStatus } from "../tool/types.js";
 import { EMPTY_STATE, type TaskState } from "./state.js";
 
 /**
@@ -6,10 +6,35 @@ import { EMPTY_STATE, type TaskState } from "./state.js";
  * shape. Defensive — branch entries from older or corrupt sessions are
  * skipped silently.
  */
+const TASK_STATUSES: ReadonlySet<TaskStatus> = new Set(["pending", "in_progress", "completed", "deleted"]);
+
+function isTask(value: unknown): value is Task {
+	if (!value || typeof value !== "object") return false;
+	const task = value as Record<string, unknown>;
+	if (!Number.isInteger(task.id) || (task.id as number) < 1) return false;
+	if (typeof task.subject !== "string" || !TASK_STATUSES.has(task.status as TaskStatus)) return false;
+	if (task.description !== undefined && typeof task.description !== "string") return false;
+	if (task.activeForm !== undefined && typeof task.activeForm !== "string") return false;
+	if (task.owner !== undefined && typeof task.owner !== "string") return false;
+	if (
+		task.blockedBy !== undefined &&
+		(!Array.isArray(task.blockedBy) || !task.blockedBy.every((id) => Number.isInteger(id) && id > 0))
+	) {
+		return false;
+	}
+	return task.metadata === undefined || (!!task.metadata && typeof task.metadata === "object" && !Array.isArray(task.metadata));
+}
+
 export function isTaskDetails(value: unknown): value is TaskDetails {
 	if (!value || typeof value !== "object") return false;
-	const v = value as Record<string, unknown>;
-	return Array.isArray(v.tasks) && typeof v.nextId === "number";
+	const snapshot = value as Record<string, unknown>;
+	if (snapshot.schemaVersion !== undefined && snapshot.schemaVersion !== 1) return false;
+	if (!Array.isArray(snapshot.tasks) || !snapshot.tasks.every(isTask)) return false;
+	if (!Number.isInteger(snapshot.nextId) || (snapshot.nextId as number) < 1) return false;
+	return (
+		snapshot.params === undefined ||
+		(!!snapshot.params && typeof snapshot.params === "object" && !Array.isArray(snapshot.params))
+	);
 }
 
 /**
@@ -17,9 +42,8 @@ export function isTaskDetails(value: unknown): value is TaskDetails {
  * `toolName === "todo"` and whose `details` shape matches `TaskDetails` wins
  * (last-write-wins). When no matching entry exists, returns `EMPTY_STATE`.
  *
- * Pure of module state — `index.ts` writes the returned snapshot into the
- * store after this returns. The function explicitly does NOT touch the store
- * cell.
+ * Pure of runtime state — `index.ts` writes the returned snapshot into its
+ * injected store after this returns. The function does not touch the store cell.
  */
 export function replayFromBranch(ctx: { sessionManager: { getBranch(): Iterable<unknown> } }): TaskState {
 	let result: TaskState = { tasks: [...EMPTY_STATE.tasks], nextId: EMPTY_STATE.nextId };

--- a/packages/pi-todo/state/state-reducer.test.ts
+++ b/packages/pi-todo/state/state-reducer.test.ts
@@ -24,6 +24,14 @@ describe("applyTaskMutation — create", () => {
 		expect(result.state.nextId).toBe(1);
 	});
 
+	it("rejects activeForm on a pending create", () => {
+		const result = applyTaskMutation(emptyState(), "create", { subject: "x", activeForm: "Working" });
+		expect(result.op).toEqual({
+			kind: "error",
+			message: "activeForm is only valid when status is in_progress",
+		});
+	});
+
 	it("rejects dangling blockedBy", () => {
 		const result = applyTaskMutation(emptyState(), "create", { subject: "x", blockedBy: [99] });
 		expect(result.op).toEqual({ kind: "error", message: "blockedBy: #99 not found" });
@@ -61,6 +69,55 @@ describe("applyTaskMutation — update", () => {
 			kind: "error",
 			message: "illegal transition completed → in_progress",
 		});
+	});
+
+	it("rejects pending → completed but allows re-queuing in_progress → pending", () => {
+		const pending = stateWith(task({ id: 1, subject: "x" }));
+		expect(applyTaskMutation(pending, "update", { id: 1, status: "completed" }).op).toEqual({
+			kind: "error",
+			message: "illegal transition pending → completed",
+		});
+		const active = stateWith(task({ id: 1, subject: "x", status: "in_progress", activeForm: "Working" }));
+		const requeued = applyTaskMutation(active, "update", { id: 1, status: "pending" });
+		expect(requeued.op).toEqual({ kind: "update", id: 1, fromStatus: "in_progress", toStatus: "pending" });
+		expect("activeForm" in requeued.state.tasks[0]).toBe(false);
+	});
+
+	it("requires activeForm and enforces a single in-progress task", () => {
+		const state = stateWith(task({ id: 1, subject: "a" }), task({ id: 2, subject: "b" }));
+		expect(applyTaskMutation(state, "update", { id: 1, status: "in_progress" }).op).toEqual({
+			kind: "error",
+			message: "activeForm required when status is in_progress",
+		});
+		const started = applyTaskMutation(state, "update", {
+			id: 1,
+			status: "in_progress",
+			activeForm: "Working on a",
+		}).state;
+		expect(
+			applyTaskMutation(started, "update", {
+				id: 2,
+				status: "in_progress",
+				activeForm: "Working on b",
+			}).op,
+		).toEqual({ kind: "error", message: "another task is already in_progress: #1" });
+	});
+
+	it("prevents blocked tasks from starting until dependencies complete", () => {
+		const state = stateWith(task({ id: 1, subject: "base" }), task({ id: 2, subject: "next", blockedBy: [1] }));
+		const result = applyTaskMutation(state, "update", {
+			id: 2,
+			status: "in_progress",
+			activeForm: "Working",
+		});
+		expect(result.op).toEqual({ kind: "error", message: "#2 is blocked by incomplete task #1" });
+	});
+
+	it("clears activeForm when an in-progress task completes", () => {
+		const state = stateWith(task({ id: 1, subject: "x", status: "in_progress", activeForm: "Working" }));
+		const result = applyTaskMutation(state, "update", { id: 1, status: "completed" });
+		expect(result.state.tasks[0].status).toBe("completed");
+		expect("activeForm" in result.state.tasks[0]).toBe(false);
 	});
 
 	it("allows completed → deleted transition", () => {
@@ -115,6 +172,48 @@ describe("applyTaskMutation — update", () => {
 	});
 });
 
+describe("applyTaskMutation — batch", () => {
+	it("commits ordered operations atomically", () => {
+		const state = stateWith(
+			task({ id: 1, subject: "first", status: "in_progress", activeForm: "Working" }),
+			task({ id: 2, subject: "second" }),
+		);
+		const result = applyTaskMutation(state, "batch", {
+			operations: [
+				{ action: "update", id: 1, status: "completed" },
+				{ action: "update", id: 2, status: "in_progress", activeForm: "Working on second" },
+				{ action: "create", subject: "third" },
+			],
+		});
+		expect(result.op.kind).toBe("batch");
+		expect(result.state.tasks.map(({ id, status }) => ({ id, status }))).toEqual([
+			{ id: 1, status: "completed" },
+			{ id: 2, status: "in_progress" },
+			{ id: 3, status: "pending" },
+		]);
+	});
+
+	it("rolls back every operation when one fails", () => {
+		const state = emptyState();
+		const result = applyTaskMutation(state, "batch", {
+			operations: [
+				{ action: "create", subject: "would be rolled back" },
+				{ action: "update", id: 99, status: "in_progress", activeForm: "Missing" },
+			],
+		});
+		expect(result.op).toEqual({ kind: "error", message: "batch operation 2: #99 not found" });
+		expect(result.state).toBe(state);
+		expect(result.state.tasks).toEqual([]);
+	});
+
+	it("rejects an empty batch", () => {
+		expect(applyTaskMutation(emptyState(), "batch", { operations: [] }).op).toEqual({
+			kind: "error",
+			message: "operations required for batch",
+		});
+	});
+});
+
 describe("applyTaskMutation — list/get/delete/clear", () => {
 	it("list emits Op with includeDeleted flag and optional statusFilter", () => {
 		const state = stateWith(
@@ -132,11 +231,12 @@ describe("applyTaskMutation — list/get/delete/clear", () => {
 		expect(result.op).toEqual({ kind: "error", message: "#1 is already deleted" });
 	});
 
-	it("delete emits Op with id + subject", () => {
-		const state = stateWith(task({ id: 1, subject: "x" }));
+	it("delete emits Op and clears an in-progress label", () => {
+		const state = stateWith(task({ id: 1, subject: "x", status: "in_progress", activeForm: "Working" }));
 		const result = applyTaskMutation(state, "delete", { id: 1 });
 		expect(result.op).toEqual({ kind: "delete", id: 1, subject: "x" });
 		expect(result.state.tasks[0].status).toBe("deleted");
+		expect("activeForm" in result.state.tasks[0]).toBe(false);
 	});
 
 	it("clear emits Op with prior count and resets nextId to 1", () => {
@@ -165,5 +265,10 @@ describe("isTransitionValid", () => {
 
 	it("allows completed → deleted", () => {
 		expect(isTransitionValid("completed", "deleted")).toBe(true);
+	});
+
+	it("rejects pending completion shortcuts but allows blocker-driven requeue", () => {
+		expect(isTransitionValid("pending", "completed")).toBe(false);
+		expect(isTransitionValid("in_progress", "pending")).toBe(true);
 	});
 });

--- a/packages/pi-todo/state/state-reducer.ts
+++ b/packages/pi-todo/state/state-reducer.ts
@@ -12,13 +12,17 @@ import { detectCycle } from "./task-graph.js";
  * `error` carries the message in-band so callers can pattern-match on
  * `op.kind === "error"` without a side-channel boolean.
  */
-export type Op =
+export type BatchItemOp =
 	| { kind: "create"; taskId: number }
 	| { kind: "update"; id: number; fromStatus: TaskStatus; toStatus: TaskStatus }
-	| { kind: "delete"; id: number; subject: string }
+	| { kind: "delete"; id: number; subject: string };
+
+export type Op =
+	| BatchItemOp
 	| { kind: "list"; statusFilter?: TaskStatus; includeDeleted: boolean }
 	| { kind: "get"; task: Task }
 	| { kind: "clear"; count: number }
+	| { kind: "batch"; operations: BatchItemOp[] }
 	| { kind: "error"; message: string };
 
 export interface ApplyResult {
@@ -28,6 +32,14 @@ export interface ApplyResult {
 
 function errorResult(state: TaskState, message: string): ApplyResult {
 	return { state, op: { kind: "error", message } };
+}
+
+function firstIncompleteDependencyId(tasks: readonly Task[], blockedBy: readonly number[]): number | undefined {
+	return blockedBy.find((id) => tasks.find((task) => task.id === id)?.status !== "completed");
+}
+
+function otherInProgressTask(tasks: readonly Task[], currentId: number): Task | undefined {
+	return tasks.find((task) => task.id !== currentId && task.status === "in_progress");
 }
 
 /**
@@ -47,6 +59,9 @@ export function applyTaskMutation(state: TaskState, action: TaskAction, params: 
 			if (!params.subject?.trim()) {
 				return errorResult(state, "subject required for create");
 			}
+			if (params.activeForm !== undefined) {
+				return errorResult(state, "activeForm is only valid when status is in_progress");
+			}
 			if (params.blockedBy?.length) {
 				for (const dep of params.blockedBy) {
 					const depTask = state.tasks.find((t) => t.id === dep);
@@ -60,8 +75,7 @@ export function applyTaskMutation(state: TaskState, action: TaskAction, params: 
 				status: "pending",
 			};
 			if (params.description) newTask.description = params.description;
-			if (params.activeForm) newTask.activeForm = params.activeForm;
-			if (params.blockedBy?.length) newTask.blockedBy = [...params.blockedBy];
+			if (params.blockedBy?.length) newTask.blockedBy = [...new Set(params.blockedBy)];
 			if (params.owner) newTask.owner = params.owner;
 			if (params.metadata) newTask.metadata = { ...params.metadata };
 
@@ -88,6 +102,9 @@ export function applyTaskMutation(state: TaskState, action: TaskAction, params: 
 				(params.addBlockedBy && params.addBlockedBy.length > 0) ||
 				(params.removeBlockedBy && params.removeBlockedBy.length > 0);
 			if (!hasMutation) return errorResult(state, "update requires at least one mutable field");
+			if (params.subject !== undefined && !params.subject.trim()) {
+				return errorResult(state, "subject must not be empty");
+			}
 
 			let newStatus = current.status;
 			if (params.status !== undefined) {
@@ -115,6 +132,24 @@ export function applyTaskMutation(state: TaskState, action: TaskAction, params: 
 				}
 			}
 
+			let newActiveForm = params.activeForm !== undefined ? params.activeForm.trim() || undefined : current.activeForm;
+			if (newStatus === "in_progress") {
+				if (!newActiveForm) return errorResult(state, "activeForm required when status is in_progress");
+				const active = otherInProgressTask(state.tasks, current.id);
+				if (active) return errorResult(state, `another task is already in_progress: #${active.id}`);
+				const blockerId = firstIncompleteDependencyId(state.tasks, newBlockedBy);
+				if (blockerId) return errorResult(state, `#${current.id} is blocked by incomplete task #${blockerId}`);
+			} else {
+				if (params.activeForm !== undefined && params.activeForm.trim()) {
+					return errorResult(state, "activeForm is only valid when status is in_progress");
+				}
+				newActiveForm = undefined;
+			}
+			if (newStatus === "completed") {
+				const blockerId = firstIncompleteDependencyId(state.tasks, newBlockedBy);
+				if (blockerId) return errorResult(state, `#${current.id} is blocked by incomplete task #${blockerId}`);
+			}
+
 			let newMetadata = current.metadata;
 			if (params.metadata !== undefined) {
 				const merged: Record<string, unknown> = { ...(current.metadata ?? {}) };
@@ -128,7 +163,8 @@ export function applyTaskMutation(state: TaskState, action: TaskAction, params: 
 			const updated: Task = { ...current, status: newStatus };
 			if (params.subject !== undefined) updated.subject = params.subject;
 			if (params.description !== undefined) updated.description = params.description;
-			if (params.activeForm !== undefined) updated.activeForm = params.activeForm;
+			if (newActiveForm === undefined) delete updated.activeForm;
+			else updated.activeForm = newActiveForm;
 			if (params.owner !== undefined) updated.owner = params.owner;
 			if (newBlockedBy.length) updated.blockedBy = newBlockedBy;
 			else delete updated.blockedBy;
@@ -141,6 +177,31 @@ export function applyTaskMutation(state: TaskState, action: TaskAction, params: 
 				state: { tasks: newTasks, nextId: state.nextId },
 				op: { kind: "update", id: updated.id, fromStatus: current.status, toStatus: newStatus },
 			};
+		}
+
+		case "batch": {
+			if (!params.operations?.length) return errorResult(state, "operations required for batch");
+			if (params.operations.length > 50) return errorResult(state, "batch supports at most 50 operations");
+
+			let nextState = state;
+			const operations: BatchItemOp[] = [];
+			for (const [index, operation] of params.operations.entries()) {
+				const result = applyTaskMutation(nextState, operation.action, operation);
+				if (result.op.kind === "error") {
+					return errorResult(state, `batch operation ${index + 1}: ${result.op.message}`);
+				}
+				switch (result.op.kind) {
+					case "create":
+					case "update":
+					case "delete":
+						operations.push(result.op);
+						break;
+					default:
+						return errorResult(state, `batch operation ${index + 1}: unsupported action ${operation.action}`);
+				}
+				nextState = result.state;
+			}
+			return { state: nextState, op: { kind: "batch", operations } };
 		}
 
 		case "list": {
@@ -168,6 +229,7 @@ export function applyTaskMutation(state: TaskState, action: TaskAction, params: 
 			const current = state.tasks[idx];
 			if (current.status === "deleted") return errorResult(state, `#${current.id} is already deleted`);
 			const updated: Task = { ...current, status: "deleted" };
+			delete updated.activeForm;
 			const newTasks = [...state.tasks];
 			newTasks[idx] = updated;
 			return {

--- a/packages/pi-todo/state/store.test.ts
+++ b/packages/pi-todo/state/store.test.ts
@@ -1,70 +1,67 @@
 import { describe, expect, it } from "vitest";
 import type { Task } from "../tool/types.js";
 import { EMPTY_STATE, type TaskState } from "./state.js";
-import { __resetState, commitState, getNextId, getState, getTodos, replaceState } from "./store.js";
+import { createTodoStore } from "./store.js";
 
 function makeTask(id: number, subject = `t${id}`): Task {
 	return { id, subject, status: "pending" };
 }
 
-describe("rpiv-todo/state/store — accessors and seams", () => {
-	it("__resetState() restores EMPTY_STATE shape (independent of EMPTY_STATE.tasks identity)", () => {
-		__resetState();
-		expect(getTodos()).toEqual(EMPTY_STATE.tasks);
-		expect(getNextId()).toBe(EMPTY_STATE.nextId);
-		// Reset clones — must NOT alias EMPTY_STATE.tasks (else mutations leak).
-		expect(getTodos()).not.toBe(EMPTY_STATE.tasks);
+describe("rpiv-todo/state/store — isolated accessors and seams", () => {
+	it("isolates state between extension runtimes", () => {
+		const first = createTodoStore();
+		const second = createTodoStore();
+		first.commitState({ tasks: [makeTask(1, "first")], nextId: 2 });
+		expect(first.getTodos()).toEqual([makeTask(1, "first")]);
+		expect(second.getTodos()).toEqual([]);
+		expect(second.getNextId()).toBe(1);
+	});
+
+	it("starts with a fresh EMPTY_STATE shape", () => {
+		const store = createTodoStore();
+		expect(store.getTodos()).toEqual(EMPTY_STATE.tasks);
+		expect(store.getNextId()).toBe(EMPTY_STATE.nextId);
+		expect(store.getTodos()).not.toBe(EMPTY_STATE.tasks);
 	});
 
 	it("getTodos() returns the live tasks reference (read-only typed)", () => {
-		__resetState();
+		const store = createTodoStore();
 		const next: TaskState = { tasks: [makeTask(1)], nextId: 2 };
-		commitState(next);
-		expect(getTodos()).toBe(next.tasks);
-		expect(getTodos()).toEqual([makeTask(1)]);
+		store.commitState(next);
+		expect(store.getTodos()).toBe(next.tasks);
+		expect(store.getTodos()).toEqual([makeTask(1)]);
 	});
 
-	it("getNextId() reflects the current cell value", () => {
-		__resetState();
-		commitState({ tasks: [], nextId: 42 });
-		expect(getNextId()).toBe(42);
-	});
-
-	it("getState() returns the same cell that getTodos/getNextId read from", () => {
-		__resetState();
+	it("getState() matches the task and next-id accessors", () => {
+		const store = createTodoStore();
 		const next: TaskState = { tasks: [makeTask(7, "lucky")], nextId: 8 };
-		commitState(next);
-		const snap = getState();
+		store.commitState(next);
+		const snap = store.getState();
 		expect(snap).toBe(next);
-		expect(snap.tasks).toBe(getTodos());
-		expect(snap.nextId).toBe(getNextId());
+		expect(snap.tasks).toBe(store.getTodos());
+		expect(snap.nextId).toBe(store.getNextId());
 	});
 
-	it("replaceState() publishes a new cell wholesale (replay seam)", () => {
-		__resetState();
+	it("replaceState() publishes a replayed cell wholesale", () => {
+		const store = createTodoStore();
 		const replayed: TaskState = {
 			tasks: [makeTask(10, "from-branch"), makeTask(11, "from-branch-2")],
 			nextId: 12,
 		};
-		replaceState(replayed);
-		expect(getState()).toBe(replayed);
-		expect(getTodos()).toEqual(replayed.tasks);
-		expect(getNextId()).toBe(12);
+		store.replaceState(replayed);
+		expect(store.getState()).toBe(replayed);
+		expect(store.getTodos()).toEqual(replayed.tasks);
+		expect(store.getNextId()).toBe(12);
 	});
 
-	it("commitState() and replaceState() are interchangeable seams over the same cell", () => {
-		__resetState();
-		commitState({ tasks: [makeTask(1)], nextId: 2 });
-		expect(getNextId()).toBe(2);
-		replaceState({ tasks: [], nextId: 99 });
-		expect(getTodos()).toEqual([]);
-		expect(getNextId()).toBe(99);
-	});
-
-	it("__resetState() after a commit clears the cell (test-isolation contract)", () => {
-		commitState({ tasks: [makeTask(1)], nextId: 2 });
-		__resetState();
-		expect(getTodos()).toEqual([]);
-		expect(getNextId()).toBe(1);
+	it("reset() clears only that store", () => {
+		const first = createTodoStore();
+		const second = createTodoStore();
+		first.commitState({ tasks: [makeTask(1)], nextId: 2 });
+		second.commitState({ tasks: [makeTask(2)], nextId: 3 });
+		first.reset();
+		expect(first.getTodos()).toEqual([]);
+		expect(first.getNextId()).toBe(1);
+		expect(second.getTodos()).toEqual([makeTask(2)]);
 	});
 });

--- a/packages/pi-todo/state/store.ts
+++ b/packages/pi-todo/state/store.ts
@@ -2,53 +2,42 @@ import type { Task } from "../tool/types.js";
 import { EMPTY_STATE, type TaskState } from "./state.js";
 
 /**
- * Module-level live state cell. Pre-refactor this lived as bare `tasks` /
- * `nextId` consts in `todo.ts`; centralizing here keeps the store as the
- * single mutation seam and lets the reducer remain pure.
+ * Session-local state boundary used by the tool, command, overlay, and replay
+ * handlers that belong to one extension runtime.
  */
-let state: TaskState = { tasks: [...EMPTY_STATE.tasks], nextId: EMPTY_STATE.nextId };
-
-/**
- * Live tasks accessor. Returned `readonly Task[]` so callers (overlay render
- * hook, `/todos` command, `renderCall` subject lookup) cannot mutate the live
- * cell. Consumers must not cast back.
- */
-export function getTodos(): readonly Task[] {
-	return state.tasks;
+export interface TodoStore {
+	getTodos(): readonly Task[];
+	getNextId(): number;
+	getState(): TaskState;
+	replaceState(next: TaskState): void;
+	commitState(next: TaskState): void;
+	reset(): void;
 }
 
-export function getNextId(): number {
-	return state.nextId;
-}
-
-/** Snapshot accessor used by reducer callers to pass canonical state in. */
-export function getState(): TaskState {
-	return state;
+function freshState(): TaskState {
+	return { tasks: [...EMPTY_STATE.tasks], nextId: EMPTY_STATE.nextId };
 }
 
 /**
- * Replay seam. Lifecycle handlers in `index.ts` call this on
- * `session_start` / `session_compact` / `session_tree` after
- * `replayFromBranch` decodes the latest snapshot.
+ * Create an isolated store for one extension runtime. Keeping the cell inside
+ * this factory prevents two AgentSession instances in the same Node.js process
+ * from overwriting each other's Todo state through the module cache.
  */
-export function replaceState(next: TaskState): void {
-	state = next;
-}
+export function createTodoStore(): TodoStore {
+	let state = freshState();
 
-/**
- * Post-reducer commit seam. Tool execute() calls this with the reducer's
- * `state` output to publish the new canonical state to live readers (overlay,
- * `/todos`, renderCall).
- */
-export function commitState(next: TaskState): void {
-	state = next;
-}
-
-/**
- * Test-setup reset. Wired into the global `test/setup.ts` `beforeEach` via
- * the existing `__resetState` import path. Name preserved verbatim — see
- * Plan §Decisions §Decision 7.
- */
-export function __resetState(): void {
-	state = { tasks: [...EMPTY_STATE.tasks], nextId: EMPTY_STATE.nextId };
+	return {
+		getTodos: () => state.tasks,
+		getNextId: () => state.nextId,
+		getState: () => state,
+		replaceState: (next) => {
+			state = next;
+		},
+		commitState: (next) => {
+			state = next;
+		},
+		reset: () => {
+			state = freshState();
+		},
+	};
 }

--- a/packages/pi-todo/todo-overlay.lifecycle.test.ts
+++ b/packages/pi-todo/todo-overlay.lifecycle.test.ts
@@ -1,7 +1,7 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { createMockPi, createMockUI } from "./test-fixtures.js";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { __resetState, registerTodoTool } from "./todo.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTodoStore, registerTodoTool } from "./todo.js";
 import { TodoOverlay } from "./todo-overlay.js";
 
 const WIDGET_KEY = "rpiv-todos";
@@ -13,8 +13,8 @@ const identityTheme = {
 	strikethrough: (s: string) => s,
 };
 
-// Register the todo tool and seed module state via its real execute() — this
-// exercises the same mutation path production uses.
+// Register the todo tool and seed its isolated store via real execute();
+// this exercises the same mutation path production uses.
 async function seed(captured: ReturnType<typeof createMockPi>["captured"], actions: unknown[]) {
 	const tool = captured.tools.get("todo");
 	if (!tool) throw new Error("todo tool not registered");
@@ -30,26 +30,25 @@ function makeCtx() {
 
 function registerTool() {
 	const { pi, captured } = createMockPi();
-	registerTodoTool(pi);
-	return { captured };
+	const store = createTodoStore();
+	registerTodoTool(pi, store);
+	return { captured, store };
 }
 
-beforeEach(() => {
-	__resetState();
-});
 afterEach(() => {
-	__resetState();
 	vi.restoreAllMocks();
 });
 
 describe("TodoOverlay — lifecycle", () => {
 	it("update() with no UI ctx bound is a no-op", () => {
-		const overlay = new TodoOverlay();
+		const store = createTodoStore();
+		const overlay = new TodoOverlay(store);
 		expect(() => overlay.update()).not.toThrow();
 	});
 
 	it("update() with empty todos does not register a widget", () => {
-		const overlay = new TodoOverlay();
+		const store = createTodoStore();
+		const overlay = new TodoOverlay(store);
 		const ui = makeCtx();
 		overlay.setUICtx(ui);
 		overlay.update();
@@ -57,9 +56,9 @@ describe("TodoOverlay — lifecycle", () => {
 	});
 
 	it("first update() with non-empty todos registers the widget exactly once", async () => {
-		const { captured } = registerTool();
+		const { captured, store } = registerTool();
 		await seed(captured, [{ action: "create", subject: "a" }]);
-		const overlay = new TodoOverlay();
+		const overlay = new TodoOverlay(store);
 		const ui = makeCtx();
 		overlay.setUICtx(ui);
 		overlay.update();
@@ -71,9 +70,9 @@ describe("TodoOverlay — lifecycle", () => {
 	});
 
 	it("second update() after registration calls tui.requestRender instead of re-registering", async () => {
-		const { captured } = registerTool();
+		const { captured, store } = registerTool();
 		await seed(captured, [{ action: "create", subject: "a" }]);
-		const overlay = new TodoOverlay();
+		const overlay = new TodoOverlay(store);
 		const ui = makeCtx();
 		overlay.setUICtx(ui);
 		overlay.update();
@@ -91,9 +90,9 @@ describe("TodoOverlay — lifecycle", () => {
 	});
 
 	it("transition non-empty → empty unregisters the widget", async () => {
-		const { captured } = registerTool();
+		const { captured, store } = registerTool();
 		const tool = await seed(captured, [{ action: "create", subject: "a" }]);
-		const overlay = new TodoOverlay();
+		const overlay = new TodoOverlay(store);
 		const ui = makeCtx();
 		overlay.setUICtx(ui);
 		overlay.update();
@@ -106,9 +105,9 @@ describe("TodoOverlay — lifecycle", () => {
 	});
 
 	it("empty → non-empty after empty transition re-registers", async () => {
-		const { captured } = registerTool();
+		const { captured, store } = registerTool();
 		const tool = await seed(captured, [{ action: "create", subject: "a" }]);
-		const overlay = new TodoOverlay();
+		const overlay = new TodoOverlay(store);
 		const ui = makeCtx();
 		overlay.setUICtx(ui);
 		overlay.update();
@@ -129,9 +128,9 @@ describe("TodoOverlay — lifecycle", () => {
 	});
 
 	it("setUICtx(same ctx) is idempotent", async () => {
-		const { captured } = registerTool();
+		const { captured, store } = registerTool();
 		await seed(captured, [{ action: "create", subject: "a" }]);
-		const overlay = new TodoOverlay();
+		const overlay = new TodoOverlay(store);
 		const ui = makeCtx();
 		overlay.setUICtx(ui);
 		overlay.update();
@@ -142,9 +141,9 @@ describe("TodoOverlay — lifecycle", () => {
 	});
 
 	it("setUICtx(different ctx) resets cached registration; next update re-registers under the new ctx", async () => {
-		const { captured } = registerTool();
+		const { captured, store } = registerTool();
 		await seed(captured, [{ action: "create", subject: "a" }]);
-		const overlay = new TodoOverlay();
+		const overlay = new TodoOverlay(store);
 		const ui1 = makeCtx();
 		overlay.setUICtx(ui1);
 		overlay.update();
@@ -156,9 +155,9 @@ describe("TodoOverlay — lifecycle", () => {
 	});
 
 	it("dispose() unregisters the widget and clears ctx; later update() without setUICtx is a no-op", async () => {
-		const { captured } = registerTool();
+		const { captured, store } = registerTool();
 		await seed(captured, [{ action: "create", subject: "a" }]);
-		const overlay = new TodoOverlay();
+		const overlay = new TodoOverlay(store);
 		const ui = makeCtx();
 		overlay.setUICtx(ui);
 		overlay.update();
@@ -172,9 +171,9 @@ describe("TodoOverlay — lifecycle", () => {
 	});
 
 	it("factory invalidate() forces re-registration on next update()", async () => {
-		const { captured } = registerTool();
+		const { captured, store } = registerTool();
 		await seed(captured, [{ action: "create", subject: "a" }]);
-		const overlay = new TodoOverlay();
+		const overlay = new TodoOverlay(store);
 		const ui = makeCtx();
 		overlay.setUICtx(ui);
 		overlay.update();
@@ -191,12 +190,13 @@ describe("TodoOverlay — lifecycle", () => {
 	});
 
 	it("resetCompletedDisplayState() lets replayed completed tasks be shown once again", async () => {
-		const { captured } = registerTool();
+		const { captured, store } = registerTool();
 		await seed(captured, [
 			{ action: "create", subject: "done" },
+			{ action: "update", id: 1, status: "in_progress", activeForm: "Finishing" },
 			{ action: "update", id: 1, status: "completed" },
 		]);
-		const overlay = new TodoOverlay();
+		const overlay = new TodoOverlay(store);
 		const ui = makeCtx();
 		overlay.setUICtx(ui);
 		overlay.update();
@@ -214,12 +214,13 @@ describe("TodoOverlay — lifecycle", () => {
 	});
 
 	it("hideCompletedTasksFromPreviousTurn() is a no-op when nothing is pending hide", () => {
-		const overlay = new TodoOverlay();
+		const store = createTodoStore();
+		const overlay = new TodoOverlay(store);
 		expect(() => overlay.hideCompletedTasksFromPreviousTurn()).not.toThrow();
 	});
 
 	it("all-deleted todos count as empty (no widget)", async () => {
-		const { captured } = registerTool();
+		const { captured, store } = registerTool();
 		const tool = await seed(captured, [{ action: "create", subject: "a" }]);
 		await tool.execute?.(
 			"tc",
@@ -228,7 +229,7 @@ describe("TodoOverlay — lifecycle", () => {
 			undefined as never,
 			{} as never,
 		);
-		const overlay = new TodoOverlay();
+		const overlay = new TodoOverlay(store);
 		const ui = makeCtx();
 		overlay.setUICtx(ui);
 		overlay.update();

--- a/packages/pi-todo/todo-overlay.render.test.ts
+++ b/packages/pi-todo/todo-overlay.render.test.ts
@@ -1,7 +1,7 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { createMockPi, createMockUI } from "./test-fixtures.js";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { __resetState, registerTodoTool, type TaskAction } from "./todo.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTodoStore, registerTodoTool, type TaskAction } from "./todo.js";
 import { TodoOverlay } from "./todo-overlay.js";
 
 const identityTheme = {
@@ -11,16 +11,23 @@ const identityTheme = {
 	strikethrough: (s: string) => s,
 };
 
+function completeActions(id: number): Array<{ action: TaskAction; [k: string]: unknown }> {
+	return [
+		{ action: "update", id, status: "in_progress", activeForm: `Completing #${id}` },
+		{ action: "update", id, status: "completed" },
+	];
+}
+
 async function setup(actions: Array<{ action: TaskAction; [k: string]: unknown }>) {
-	__resetState();
 	const { pi, captured } = createMockPi();
-	registerTodoTool(pi);
+	const store = createTodoStore();
+	registerTodoTool(pi, store);
 	const tool = captured.tools.get("todo")!;
 	for (const p of actions) {
 		await tool.execute?.("tc", p as never, undefined as never, undefined as never, {} as never);
 	}
 	const ui = createMockUI() as unknown as ExtensionUIContext;
-	const overlay = new TodoOverlay();
+	const overlay = new TodoOverlay(store);
 	overlay.setUICtx(ui);
 	overlay.update();
 	const setWidget = ui.setWidget as ReturnType<typeof vi.fn>;
@@ -32,11 +39,7 @@ async function setup(actions: Array<{ action: TaskAction; [k: string]: unknown }
 	return { widget, tool, ui, overlay };
 }
 
-beforeEach(() => {
-	__resetState();
-});
 afterEach(() => {
-	__resetState();
 	vi.restoreAllMocks();
 });
 
@@ -45,7 +48,7 @@ describe("TodoOverlay — heading", () => {
 		const { widget } = await setup([
 			{ action: "create", subject: "a" },
 			{ action: "create", subject: "b" },
-			{ action: "update", id: 1, status: "completed" },
+			...completeActions(1),
 		]);
 		const lines = widget.render(200);
 		expect(lines[0]).toContain("Todos (1/2)");
@@ -59,7 +62,7 @@ describe("TodoOverlay — heading", () => {
 	it("uses hollow icon '○' when all tasks are completed", async () => {
 		const { widget } = await setup([
 			{ action: "create", subject: "a" },
-			{ action: "update", id: 1, status: "completed" },
+			...completeActions(1),
 		]);
 		expect(widget.render(200)[0]).toContain("○");
 	});
@@ -101,8 +104,8 @@ describe("TodoOverlay — per-task formatting", () => {
 
 	it("in_progress task uses '◐' glyph and appends (activeForm)", async () => {
 		const { widget } = await setup([
-			{ action: "create", subject: "do it", activeForm: "Doing it" },
-			{ action: "update", id: 1, status: "in_progress" },
+			{ action: "create", subject: "do it" },
+			{ action: "update", id: 1, status: "in_progress", activeForm: "Doing it" },
 		]);
 		const line = widget.render(200)[1];
 		expect(line).toContain("◐");
@@ -113,7 +116,7 @@ describe("TodoOverlay — per-task formatting", () => {
 	it("completed task stays visible until the next agent turn starts", async () => {
 		const { widget, overlay } = await setup([
 			{ action: "create", subject: "done" },
-			{ action: "update", id: 1, status: "completed" },
+			...completeActions(1),
 		]);
 		const firstRender = widget.render(200);
 		expect(firstRender[1]).toContain("✓");
@@ -154,7 +157,7 @@ describe("TodoOverlay — overflow collapse", () => {
 		for (let i = 1; i <= 8; i++) actions.push({ action: "create", subject: `p${i}` });
 		for (let i = 9; i <= 12; i++) {
 			actions.push({ action: "create", subject: `c${i}` });
-			actions.push({ action: "update", id: i, status: "completed" });
+			actions.push(...completeActions(i));
 		}
 		const { widget } = await setup(actions);
 		const lines = widget.render(200);
@@ -190,7 +193,7 @@ describe("TodoOverlay — overflow collapse", () => {
 		for (let i = 1; i <= 12; i++) actions.push({ action: "create", subject: `p${i}` });
 		for (let i = 13; i <= 15; i++) {
 			actions.push({ action: "create", subject: `c${i}` });
-			actions.push({ action: "update", id: i, status: "completed" });
+			actions.push(...completeActions(i));
 		}
 		const { widget } = await setup(actions);
 		// Last line is the trailing spacer, so the summary is the second-to-last.
@@ -205,7 +208,7 @@ describe("TodoOverlay — overflow collapse", () => {
 		for (let i = 1; i <= 11; i++) actions.push({ action: "create", subject: `p${i}` });
 		for (let i = 12; i <= 16; i++) {
 			actions.push({ action: "create", subject: `c${i}` });
-			actions.push({ action: "update", id: i, status: "completed" });
+			actions.push(...completeActions(i));
 		}
 		const { widget, overlay } = await setup(actions);
 		const beforeNextTurn = widget.render(200).join("\n");
@@ -245,7 +248,7 @@ describe("TodoOverlay — width truncation", () => {
 	it("drops completed tasks from counts after the next agent turn starts", async () => {
 		const { widget, overlay } = await setup([
 			{ action: "create", subject: "done" },
-			{ action: "update", id: 1, status: "completed" },
+			...completeActions(1),
 			{ action: "create", subject: "next" },
 		]);
 		expect(widget.render(200).join("\n")).toContain("Todos (1/2)");

--- a/packages/pi-todo/todo-overlay.ts
+++ b/packages/pi-todo/todo-overlay.ts
@@ -6,15 +6,15 @@
  * refresh, 12-line collapse-not-scroll (plus a trailing spacer row, so the
  * widget renders up to 13 lines), auto-hide when empty.
  *
- * Reads live state via `getState()` at render time — NEVER `replayFromBranch`
- * from `tool_execution_end` (branch is stale; `message_end` runs after).
+ * Reads its injected store at render time — NEVER `replayFromBranch` from
+ * `tool_execution_end` (branch is stale; `message_end` runs after).
  */
 
 import type { ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
 import { type TUI, truncateToWidth } from "@earendil-works/pi-tui";
 import { formatStatusLabel, t } from "./state/i18n-bridge.js";
 import { selectHasActive, selectOverlayLayout, selectShowTaskIds, selectTodoCounts } from "./state/selectors.js";
-import { getState } from "./state/store.js";
+import type { TodoStore } from "./state/store.js";
 import { formatOverlayTaskLine } from "./view/format.js";
 
 const WIDGET_KEY = "rpiv-todos";
@@ -33,6 +33,8 @@ export class TodoOverlay {
 	private completedTaskIdsPendingHide = new Set<number>();
 	private hiddenCompletedTaskIds = new Set<number>();
 	private lastNextId: number | undefined;
+
+	constructor(private readonly store: TodoStore) {}
 
 	setUICtx(ctx: ExtensionUIContext): void {
 		// Identity-compare so repeat session_start handlers are idempotent;
@@ -95,7 +97,7 @@ export class TodoOverlay {
 	}
 
 	private getSnapshot() {
-		const state = getState();
+		const state = this.store.getState();
 		if (this.lastNextId !== undefined && state.nextId < this.lastNextId) {
 			this.resetCompletedDisplayState();
 		}

--- a/packages/pi-todo/todo.command.test.ts
+++ b/packages/pi-todo/todo.command.test.ts
@@ -1,13 +1,13 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { createMockCtx, createMockPi } from "./test-fixtures.js";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { __resetState, registerTodosCommand, registerTodoTool, TOOL_NAME } from "./todo.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTodoStore, registerTodosCommand, registerTodoTool, TOOL_NAME } from "./todo.js";
 
 function setup() {
-	__resetState();
 	const { pi, captured } = createMockPi();
-	registerTodoTool(pi);
-	registerTodosCommand(pi);
+	const store = createTodoStore();
+	registerTodoTool(pi, store);
+	registerTodosCommand(pi, store);
 	const tool = captured.tools.get(TOOL_NAME);
 	if (!tool) throw new Error("tool not registered");
 	const cmd = captured.commands.get("todos");
@@ -21,11 +21,7 @@ async function seed(tool: ReturnType<typeof setup>["tool"], actions: Array<Recor
 	}
 }
 
-beforeEach(() => {
-	__resetState();
-});
 afterEach(() => {
-	__resetState();
 	vi.restoreAllMocks();
 });
 
@@ -90,8 +86,8 @@ describe("/todos command — grouped output", () => {
 	it("renders 'In Progress' group with ◐ glyph and activeForm suffix", async () => {
 		const { tool, cmd } = setup();
 		await seed(tool, [
-			{ action: "create", subject: "build", activeForm: "Building" },
-			{ action: "update", id: 1, status: "in_progress" },
+			{ action: "create", subject: "build" },
+			{ action: "update", id: 1, status: "in_progress", activeForm: "Building" },
 		]);
 		const ctx = createMockCtx({ hasUI: true });
 		await cmd.handler("", ctx as never);
@@ -105,6 +101,7 @@ describe("/todos command — grouped output", () => {
 		const { tool, cmd } = setup();
 		await seed(tool, [
 			{ action: "create", subject: "ship" },
+			{ action: "update", id: 1, status: "in_progress", activeForm: "Shipping" },
 			{ action: "update", id: 1, status: "completed" },
 		]);
 		const ctx = createMockCtx({ hasUI: true });
@@ -119,10 +116,11 @@ describe("/todos command — grouped output", () => {
 		const { tool, cmd } = setup();
 		await seed(tool, [
 			{ action: "create", subject: "p" },
-			{ action: "create", subject: "ip" },
-			{ action: "update", id: 2, status: "in_progress" },
 			{ action: "create", subject: "done" },
-			{ action: "update", id: 3, status: "completed" },
+			{ action: "update", id: 2, status: "in_progress", activeForm: "Finishing" },
+			{ action: "update", id: 2, status: "completed" },
+			{ action: "create", subject: "ip" },
+			{ action: "update", id: 3, status: "in_progress", activeForm: "Working" },
 		]);
 		const ctx = createMockCtx({ hasUI: true });
 		await cmd.handler("", ctx as never);

--- a/packages/pi-todo/todo.guidance.test.ts
+++ b/packages/pi-todo/todo.guidance.test.ts
@@ -2,7 +2,13 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { createMockPi } from "./test-fixtures.js";
 import { beforeEach, describe, expect, it } from "vitest";
-import { DEFAULT_PROMPT_GUIDELINES, DEFAULT_PROMPT_SNIPPET, registerTodoTool, TOOL_NAME } from "./todo.js";
+import {
+	createTodoStore,
+	DEFAULT_PROMPT_GUIDELINES,
+	DEFAULT_PROMPT_SNIPPET,
+	registerTodoTool,
+	TOOL_NAME,
+} from "./todo.js";
 
 const CONFIG_PATH = join(process.env.HOME!, ".config", "rpiv-todo", "config.json");
 const DEFAULT_GUIDELINES_LENGTH = DEFAULT_PROMPT_GUIDELINES.length;
@@ -19,16 +25,20 @@ beforeEach(() => {
 describe("registerTodoTool — guidance overrides", () => {
 	it("uses built-in defaults when no config file exists", () => {
 		const { pi, captured } = createMockPi();
-		registerTodoTool(pi);
+		registerTodoTool(pi, createTodoStore());
 		const tool = captured.tools.get(TOOL_NAME)!;
 		expect(tool.promptSnippet).toBe(DEFAULT_PROMPT_SNIPPET);
-		expect((tool.promptGuidelines as string[]).length).toBe(DEFAULT_GUIDELINES_LENGTH);
+		const guidelines = tool.promptGuidelines as string[];
+		expect(guidelines).toHaveLength(DEFAULT_GUIDELINES_LENGTH);
+		expect(guidelines.join("\n")).toContain("single-step");
+		expect(guidelines.join("\n")).toContain("batch");
+		expect(guidelines.join("\n")).toContain("independently valuable milestones");
 	});
 
 	it("uses built-in defaults when config has no guidance field", () => {
 		writeConfig({ otherField: true });
 		const { pi, captured } = createMockPi();
-		registerTodoTool(pi);
+		registerTodoTool(pi, createTodoStore());
 		const tool = captured.tools.get(TOOL_NAME)!;
 		expect(tool.promptSnippet).toBe(DEFAULT_PROMPT_SNIPPET);
 	});
@@ -36,7 +46,7 @@ describe("registerTodoTool — guidance overrides", () => {
 	it("overrides promptSnippet with valid value", () => {
 		writeConfig({ guidance: { promptSnippet: "Custom todo snippet" } });
 		const { pi, captured } = createMockPi();
-		registerTodoTool(pi);
+		registerTodoTool(pi, createTodoStore());
 		const tool = captured.tools.get(TOOL_NAME)!;
 		expect(tool.promptSnippet).toBe("Custom todo snippet");
 		expect((tool.promptGuidelines as string[]).length).toBe(DEFAULT_GUIDELINES_LENGTH);
@@ -45,7 +55,7 @@ describe("registerTodoTool — guidance overrides", () => {
 	it("overrides promptGuidelines with valid value", () => {
 		writeConfig({ guidance: { promptGuidelines: ["Rule one", "Rule two"] } });
 		const { pi, captured } = createMockPi();
-		registerTodoTool(pi);
+		registerTodoTool(pi, createTodoStore());
 		const tool = captured.tools.get(TOOL_NAME)!;
 		expect(tool.promptSnippet).toBe(DEFAULT_PROMPT_SNIPPET);
 		expect(tool.promptGuidelines).toEqual(["Rule one", "Rule two"]);
@@ -54,7 +64,7 @@ describe("registerTodoTool — guidance overrides", () => {
 	it("overrides both promptSnippet and promptGuidelines", () => {
 		writeConfig({ guidance: { promptSnippet: "Custom", promptGuidelines: ["Rule"] } });
 		const { pi, captured } = createMockPi();
-		registerTodoTool(pi);
+		registerTodoTool(pi, createTodoStore());
 		const tool = captured.tools.get(TOOL_NAME)!;
 		expect(tool.promptSnippet).toBe("Custom");
 		expect(tool.promptGuidelines).toEqual(["Rule"]);
@@ -63,7 +73,7 @@ describe("registerTodoTool — guidance overrides", () => {
 	it("falls back to defaults on empty promptSnippet", () => {
 		writeConfig({ guidance: { promptSnippet: "" } });
 		const { pi, captured } = createMockPi();
-		registerTodoTool(pi);
+		registerTodoTool(pi, createTodoStore());
 		const tool = captured.tools.get(TOOL_NAME)!;
 		expect(tool.promptSnippet).toBe(DEFAULT_PROMPT_SNIPPET);
 	});
@@ -71,7 +81,7 @@ describe("registerTodoTool — guidance overrides", () => {
 	it("falls back to defaults on wrong types", () => {
 		writeConfig({ guidance: { promptSnippet: 123, promptGuidelines: "not-array" } });
 		const { pi, captured } = createMockPi();
-		registerTodoTool(pi);
+		registerTodoTool(pi, createTodoStore());
 		const tool = captured.tools.get(TOOL_NAME)!;
 		expect(tool.promptSnippet).toBe(DEFAULT_PROMPT_SNIPPET);
 		expect((tool.promptGuidelines as string[]).length).toBe(DEFAULT_GUIDELINES_LENGTH);
@@ -80,7 +90,7 @@ describe("registerTodoTool — guidance overrides", () => {
 	it("falls back to defaults on promptGuidelines with empty string item", () => {
 		writeConfig({ guidance: { promptGuidelines: ["valid", ""] } });
 		const { pi, captured } = createMockPi();
-		registerTodoTool(pi);
+		registerTodoTool(pi, createTodoStore());
 		const tool = captured.tools.get(TOOL_NAME)!;
 		expect((tool.promptGuidelines as string[]).length).toBe(DEFAULT_GUIDELINES_LENGTH);
 	});

--- a/packages/pi-todo/todo.invalidation.test.ts
+++ b/packages/pi-todo/todo.invalidation.test.ts
@@ -1,8 +1,6 @@
 import { createMockPi } from "./test-fixtures.js";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import registerTodo from "./index.js";
-import { getState, replaceState } from "./state/store.js";
-import { __resetState } from "./todo.js";
 
 // The exact phrase pi-core's ExtensionRunner throws from an invalidated proxy.
 const STALE_CTX_MESSAGE =
@@ -20,31 +18,44 @@ function throwingCtx(message: string) {
 	};
 }
 
-const SEEDED = { tasks: [{ id: 1, subject: "keep me", status: "pending" }], nextId: 2 };
-
 function setup() {
-	__resetState();
 	const { pi, captured } = createMockPi();
 	registerTodo(pi);
-	return { captured };
+	const tool = captured.tools.get("todo");
+	if (!tool) throw new Error("todo tool not registered");
+	return { captured, tool };
 }
 
-beforeEach(() => __resetState());
-afterEach(() => __resetState());
+async function call(tool: ReturnType<typeof setup>["tool"], params: Record<string, unknown>) {
+	return tool.execute?.("tc", params as never, undefined as never, undefined as never, {} as never);
+}
 
 describe.each(["session_compact", "session_tree"] as const)("%s — stale ctx handling", (event) => {
-	it("keeps current state on a stale ctx (replacement session replays)", async () => {
-		const { captured } = setup();
-		replaceState(SEEDED as never);
+	it("keeps the runtime-local state on a stale ctx", async () => {
+		const { captured, tool } = setup();
+		await call(tool, { action: "create", subject: "keep me" });
 		const handler = captured.events.get(event)?.[0];
 		await expect(handler?.({} as never, throwingCtx(STALE_CTX_MESSAGE) as never)).resolves.toBeUndefined();
-		// State untouched — no replay ran, the prior seed survives.
-		expect(getState()).toEqual(SEEDED);
+		const listed = await call(tool, { action: "list" });
+		expect(listed?.content[0]).toMatchObject({ text: expect.stringContaining("keep me") });
 	});
 
 	it("propagates a non-stale replay error", async () => {
 		const { captured } = setup();
 		const handler = captured.events.get(event)?.[0];
 		await expect(handler?.({} as never, throwingCtx("boom: real replay bug") as never)).rejects.toThrow("boom");
+	});
+});
+
+describe("extension runtime isolation", () => {
+	it("keeps Todo state separate across two extension instances in one process", async () => {
+		const first = setup();
+		const second = setup();
+		await call(first.tool, { action: "create", subject: "first runtime" });
+
+		const firstList = await call(first.tool, { action: "list" });
+		const secondList = await call(second.tool, { action: "list" });
+		expect(firstList?.content[0]).toMatchObject({ text: expect.stringContaining("first runtime") });
+		expect(secondList?.content[0]).toMatchObject({ text: "No tasks" });
 	});
 });

--- a/packages/pi-todo/todo.register.test.ts
+++ b/packages/pi-todo/todo.register.test.ts
@@ -1,15 +1,14 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { createMockPi, makeTheme } from "./test-fixtures.js";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { __resetState, registerTodoTool, type TaskDetails, TOOL_NAME } from "./todo.js";
+import { describe, expect, it } from "vitest";
+import { createTodoStore, registerTodoTool, type TaskDetails, TOOL_NAME } from "./todo.js";
 
 const theme = makeTheme() as unknown as Theme;
 
 function setup() {
-	__resetState();
 	const { pi, captured } = createMockPi();
-	registerTodoTool(pi);
+	registerTodoTool(pi, createTodoStore());
 	const tool = captured.tools.get(TOOL_NAME);
 	if (!tool) throw new Error("tool not registered");
 	return { tool, captured };
@@ -18,13 +17,6 @@ function setup() {
 async function call(tool: ReturnType<typeof setup>["tool"], params: Record<string, unknown>) {
 	return tool.execute?.("tc", params as never, undefined as never, undefined as never, {} as never);
 }
-
-beforeEach(() => {
-	__resetState();
-});
-afterEach(() => {
-	__resetState();
-});
 
 describe("registerTodoTool — registration shape", () => {
 	it("registers under the tool name 'todo' with the expected label and guidelines", () => {
@@ -38,16 +30,16 @@ describe("registerTodoTool — registration shape", () => {
 		expect((tool.promptGuidelines as string[]).length).toBeGreaterThan(0);
 	});
 
-	it("exposes a typebox parameters schema declaring the six actions", () => {
+	it("exposes a typebox parameters schema declaring all actions", () => {
 		const { tool } = setup();
 		const raw = JSON.stringify(tool.parameters);
-		for (const action of ["create", "update", "list", "get", "delete", "clear"]) {
+		for (const action of ["create", "update", "list", "get", "delete", "clear", "batch"]) {
 			expect(raw).toContain(action);
 		}
 	});
 });
 
-describe("registerTodoTool — execute mutates module state", () => {
+describe("registerTodoTool — execute mutates its injected store", () => {
 	it("create → list returns the seeded row", async () => {
 		const { tool } = setup();
 		const r1 = await call(tool, { action: "create", subject: "first" });
@@ -56,7 +48,7 @@ describe("registerTodoTool — execute mutates module state", () => {
 		expect(r2?.content[0]).toMatchObject({ text: expect.stringContaining("first") });
 	});
 
-	it("clear resets module state and nextId", async () => {
+	it("clear resets store state and nextId", async () => {
 		const { tool } = setup();
 		await call(tool, { action: "create", subject: "a" });
 		await call(tool, { action: "create", subject: "b" });
@@ -64,6 +56,20 @@ describe("registerTodoTool — execute mutates module state", () => {
 		const d = r?.details as TaskDetails;
 		expect(d.tasks).toEqual([]);
 		expect(d.nextId).toBe(1);
+	});
+
+	it("batch creates multiple tasks in one tool result", async () => {
+		const { tool } = setup();
+		const result = await call(tool, {
+			action: "batch",
+			operations: [
+				{ action: "create", subject: "first" },
+				{ action: "create", subject: "second", blockedBy: [1] },
+			],
+		});
+		const details = result?.details as TaskDetails;
+		expect(details.tasks.map((task) => task.subject)).toEqual(["first", "second"]);
+		expect(result?.content[0]).toMatchObject({ text: expect.stringContaining("Applied 2 todo operations") });
 	});
 });
 
@@ -77,6 +83,7 @@ describe("registerTodoTool — transcript rendering", () => {
 		{ action: "get", id: 1 },
 		{ action: "delete", id: 1 },
 		{ action: "clear" },
+		{ action: "batch", operations: [{ action: "create", subject: "a" }] },
 	])("renders no call lines for $action", (args) => {
 		const { tool } = setup();
 		const node = tool.renderCall?.(args as never, theme, undefined as never) as unknown as Text;
@@ -90,9 +97,10 @@ describe("registerTodoTool — transcript rendering", () => {
 			await call(tool, { action: "create", subject: "a" }),
 			await call(tool, { action: "list" }),
 			await call(tool, { action: "get", id: 1 }),
-			await call(tool, { action: "update", id: 1, status: "in_progress" }),
+			await call(tool, { action: "update", id: 1, status: "in_progress", activeForm: "Working" }),
 			await call(tool, { action: "delete", id: 1 }),
 			await call(tool, { action: "clear" }),
+			await call(tool, { action: "batch", operations: [{ action: "create", subject: "batched" }] }),
 		];
 
 		for (const result of results) {
@@ -101,11 +109,29 @@ describe("registerTodoTool — transcript rendering", () => {
 		}
 	});
 
-	it("keeps reducer-level errors visible", async () => {
+	it("reports reducer validation failures as real tool errors", async () => {
 		const { tool } = setup();
-		const result = await call(tool, { action: "create" });
-		const node = tool.renderResult?.(result as never, {} as never, theme, successContext) as unknown as Text;
-		expect(node.render(80).join("\n")).toContain("subject required for create");
+		await expect(call(tool, { action: "create" })).rejects.toThrow("subject required for create");
+	});
+
+	it("reveals successful call and result summaries in expanded mode", async () => {
+		const { tool } = setup();
+		const callNode = tool.renderCall?.(
+			{ action: "create", subject: "audit me" } as never,
+			theme,
+			{ expanded: true } as never,
+		) as unknown as Text;
+		expect(callNode.render(80).join("\n")).toContain("todo create");
+		expect(callNode.render(80).join("\n")).toContain("audit me");
+
+		const result = await call(tool, { action: "create", subject: "audit me" });
+		const resultNode = tool.renderResult?.(
+			result as never,
+			{ expanded: true } as never,
+			theme,
+			{ isError: false } as never,
+		) as unknown as Text;
+		expect(resultNode.render(80).join("\n")).toContain("Created #1");
 	});
 
 	it("keeps Pi execution errors visible when details are unavailable", () => {

--- a/packages/pi-todo/todo.ts
+++ b/packages/pi-todo/todo.ts
@@ -7,9 +7,8 @@
  * surface — it mirrors `packages/rpiv-ask-user-question/ask-user-question.ts`
  * which keeps the tool registration at the package root.
  *
- * Public re-exports below preserve the pre-refactor import surface so that
- * `index.ts`, `todo-overlay.ts`, and the global `test/setup.ts` `beforeEach`
- * continue to import from `./todo.js`.
+ * Public re-exports below keep the stable domain helpers while runtime state
+ * is explicitly injected through a per-extension `TodoStore`.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -18,7 +17,7 @@ import { formatStatusLabel, t } from "./state/i18n-bridge.js";
 import { replayFromBranch } from "./state/replay.js";
 import { selectTasksByStatus, selectTodoCounts, selectVisibleTasks } from "./state/selectors.js";
 import { applyTaskMutation } from "./state/state-reducer.js";
-import { commitState, getState, replaceState } from "./state/store.js";
+import type { TodoStore } from "./state/store.js";
 import { buildToolResult } from "./tool/response-envelope.js";
 import {
 	COMMAND_NAME,
@@ -29,7 +28,7 @@ import {
 	TOOL_NAME,
 	TodoParamsSchema,
 } from "./tool/types.js";
-import { formatCommandTaskLine, renderHiddenTodoNode, renderTodoResult } from "./view/format.js";
+import { formatCommandTaskLine, renderTodoCall, renderTodoResult } from "./view/format.js";
 
 // English fallbacks for localized /todos section headers — the box-drawing
 // decoration is part of the localized string so translators can adjust spacing.
@@ -44,18 +43,17 @@ const SECTION_COMPLETED = "── Completed ──";
 
 export { isTransitionValid } from "./state/invariants.js";
 export { applyTaskMutation } from "./state/state-reducer.js";
-export { __resetState, getNextId, getTodos } from "./state/store.js";
+export { createTodoStore, type TodoStore } from "./state/store.js";
 export { deriveBlocks, detectCycle } from "./state/task-graph.js";
 export type { Task, TaskAction, TaskDetails, TaskStatus } from "./tool/types.js";
 export { TOOL_NAME } from "./tool/types.js";
 
 /**
- * Backward-compat replay shim. Pre-refactor `reconstructTodoState(ctx)`
- * mutated module state directly; the new replay seam (`state/replay.ts`)
- * returns a `TaskState` and the caller commits via `replaceState`.
+ * Replay helper for callers that compose the tool manually. The target store
+ * is explicit so multiple extension runtimes cannot share session state.
  */
-export function reconstructTodoState(ctx: Parameters<typeof replayFromBranch>[0]): void {
-	replaceState(replayFromBranch(ctx));
+export function reconstructTodoState(ctx: Parameters<typeof replayFromBranch>[0], store: TodoStore): void {
+	store.replaceState(replayFromBranch(ctx));
 }
 
 // ---------------------------------------------------------------------------
@@ -64,39 +62,42 @@ export function reconstructTodoState(ctx: Parameters<typeof replayFromBranch>[0]
 
 export const DEFAULT_PROMPT_SNIPPET = "Manage a task list to track multi-step progress";
 export const DEFAULT_PROMPT_GUIDELINES: string[] = [
-	"Use `todo` for complex work with 3+ steps, when the user gives you a list of tasks, or immediately after receiving new instructions to capture requirements. Skip it for single trivial tasks and purely conversational requests.",
-	"When starting any task, mark it in_progress BEFORE beginning work. Mark it completed IMMEDIATELY when done — never batch completions. Exactly one task should be in_progress at a time.",
-	"Never mark a task completed if tests are failing, the implementation is partial, or you hit unresolved errors — keep it in_progress and create a new task for the blocker instead.",
-	"Task status is a 4-state machine: pending → in_progress → completed, plus deleted as a tombstone. Pass activeForm (present-continuous label, e.g. 'researching existing tool') when marking in_progress.",
-	"Use blockedBy to express dependencies (A is blocked by B). On create, pass blockedBy as the initial set. On update, use addBlockedBy / removeBlockedBy (additive merge — do not resend the full array). Cycles are rejected.",
-	"list hides tombstoned (deleted) tasks by default; pass includeDeleted:true to see them. Pass status to filter by a single status.",
-	"Subject must be short and imperative (e.g. 'Research existing tool'); description is for long-form detail. activeForm is a present-continuous label shown while in_progress.",
+	"Use `todo` only for work with multiple meaningful stages, an explicit user task list, dependencies, or material verification risk. Do not create a Todo for a single-step, low-risk action or a purely conversational request.",
+	"Todo items are independently valuable milestones, not a mirror of every command, file read, or tiny implementation action.",
+	"Use `todo` batch to create multiple initial tasks or apply several known create/update/delete operations atomically; if one operation fails, none are committed.",
+	"When starting a task, update it to in_progress with activeForm BEFORE beginning work. Mark it completed IMMEDIATELY when done. Exactly one task may be in_progress.",
+	"Never mark a task completed if tests are failing, the implementation is partial, or unresolved errors remain. Keep it in_progress while actively resolving; when separate blocker work is needed, re-queue it as pending with blockedBy and start the blocker task.",
+	"The normal lifecycle is pending → in_progress → completed, with deleted as a tombstone. An in-progress task may return to pending when re-queued behind a blocker; completed or deleted tasks cannot reopen.",
+	"Use blockedBy to express dependencies. A blocked task cannot start until every dependency is completed. On create use blockedBy; on update use addBlockedBy/removeBlockedBy. Cycles are rejected.",
+	"list hides tombstoned tasks by default; pass includeDeleted:true to include them or status to filter by one status.",
+	"Keep subject short and imperative; use description for durable context and activeForm for the present-continuous in-progress label.",
 ];
 
-export function registerTodoTool(pi: ExtensionAPI): void {
+export function registerTodoTool(pi: ExtensionAPI, store: TodoStore): void {
 	const guidance = validateGuidanceFields(loadConfig().guidance);
 	pi.registerTool({
 		name: TOOL_NAME,
 		label: TOOL_LABEL,
 		description:
-			"Manage a task list for tracking multi-step progress. Actions: create (new task), update (change status/fields/dependencies), list (all tasks, optionally filtered by status), get (single task details), delete (tombstone), clear (reset all). Status: pending → in_progress → completed, plus deleted tombstone. Use this to plan and track multi-step work like research, design, and implementation.",
+			"Manage a task list for tracking multi-step progress. Actions: create, update, list, get, delete, clear, and batch (atomic create/update/delete operations). Status: pending → in_progress → completed, plus deleted tombstone. Use this for meaningful multi-stage work, not single-step tasks.",
 		promptSnippet: guidance.promptSnippet ?? DEFAULT_PROMPT_SNIPPET,
 		promptGuidelines: guidance.promptGuidelines ?? DEFAULT_PROMPT_GUIDELINES,
 		parameters: TodoParamsSchema,
 		renderShell: "self",
 
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
-			const result = applyTaskMutation(getState(), params.action, params as TaskMutationParams);
-			commitState(result.state);
+			const result = applyTaskMutation(store.getState(), params.action, params as TaskMutationParams);
+			if (result.op.kind === "error") throw new Error(result.op.message);
+			store.commitState(result.state);
 			return buildToolResult(params.action, params as TaskMutationParams, result.state, result.op);
 		},
 
-		renderCall() {
-			return renderHiddenTodoNode();
+		renderCall(args, theme, context) {
+			return renderTodoCall(args as TaskMutationParams, theme, context?.expanded === true);
 		},
 
-		renderResult(result, _opts, theme, context) {
-			return renderTodoResult(result, theme, context.isError);
+		renderResult(result, options, theme, context) {
+			return renderTodoResult(result, theme, context.isError, options.expanded);
 		},
 	});
 }
@@ -105,7 +106,7 @@ export function registerTodoTool(pi: ExtensionAPI): void {
 // /todos slash command
 // ---------------------------------------------------------------------------
 
-export function registerTodosCommand(pi: ExtensionAPI): void {
+export function registerTodosCommand(pi: ExtensionAPI, store: TodoStore): void {
 	pi.registerCommand(COMMAND_NAME, {
 		description: "Show all todos on the current branch, grouped by status",
 		handler: async (_args, ctx) => {
@@ -113,7 +114,7 @@ export function registerTodosCommand(pi: ExtensionAPI): void {
 				ctx.ui.notify(t("command.requires_interactive", ERR_REQUIRES_INTERACTIVE), "error");
 				return;
 			}
-			const state = getState();
+			const state = store.getState();
 			const visible = selectVisibleTasks(state);
 			if (visible.length === 0) {
 				ctx.ui.notify(t("command.no_todos", MSG_NO_TODOS), "info");

--- a/packages/pi-todo/tool/response-envelope.test.ts
+++ b/packages/pi-todo/tool/response-envelope.test.ts
@@ -110,6 +110,22 @@ describe("formatContent", () => {
 		expect(formatContent({ kind: "create", taskId: 999 }, stateWith())).toBe("Created #999");
 	});
 
+	it("batch — summarizes each committed operation", () => {
+		const state = stateWith(t({ id: 1, subject: "alpha" }), t({ id: 2, subject: "beta", status: "deleted" }));
+		expect(
+			formatContent(
+				{
+					kind: "batch",
+					operations: [
+						{ kind: "create", taskId: 1 },
+						{ kind: "delete", id: 2, subject: "beta" },
+					],
+				},
+				state,
+			),
+		).toBe("Applied 2 todo operations\n- Created #1: alpha (pending)\n- Deleted #2: beta");
+	});
+
 	it("error — 'Error: <message>'", () => {
 		expect(formatContent({ kind: "error", message: "subject required for create" }, stateWith())).toBe(
 			"Error: subject required for create",
@@ -123,7 +139,13 @@ describe("buildToolResult", () => {
 		const env = buildToolResult("create", { subject: "alpha" }, state, { kind: "create", taskId: 1 });
 		expect(env).toEqual({
 			content: [{ type: "text", text: "Created #1: alpha (pending)" }],
-			details: { action: "create", params: { subject: "alpha" }, tasks: state.tasks, nextId: state.nextId },
+			details: {
+				schemaVersion: 1,
+				action: "create",
+				params: { subject: "alpha" },
+				tasks: state.tasks,
+				nextId: state.nextId,
+			},
 		});
 	});
 

--- a/packages/pi-todo/tool/response-envelope.ts
+++ b/packages/pi-todo/tool/response-envelope.ts
@@ -64,6 +64,11 @@ export function formatContent(op: Op, state: TaskState): string {
 		}
 		case "get":
 			return formatGetLines(op.task, state);
+		case "batch":
+			return [
+				`Applied ${op.operations.length} todo operations`,
+				...op.operations.map((operation) => `- ${formatContent(operation, state)}`),
+			].join("\n");
 		case "error":
 			return `Error: ${op.message}`;
 	}
@@ -84,6 +89,7 @@ export function buildToolResult(
 ): { content: Array<{ type: "text"; text: string }>; details: TaskDetails } {
 	const text = formatContent(op, state);
 	const details: TaskDetails = {
+		schemaVersion: 1,
 		action,
 		params: params as Record<string, unknown>,
 		tasks: state.tasks,

--- a/packages/pi-todo/tool/types.ts
+++ b/packages/pi-todo/tool/types.ts
@@ -25,7 +25,8 @@ export const MSG_NO_TODOS = "No todos yet. Ask the agent to add some!";
 
 export type TaskStatus = "pending" | "in_progress" | "completed" | "deleted";
 
-export type TaskAction = "create" | "update" | "list" | "get" | "delete" | "clear";
+export type TaskAction = "create" | "update" | "list" | "get" | "delete" | "clear" | "batch";
+export type TaskBatchOperationAction = "create" | "update" | "delete";
 
 export interface Task {
 	id: number;
@@ -41,10 +42,12 @@ export interface Task {
 /**
  * Persistence + replay snapshot. Every successful `todo` tool call returns this
  * shape under `details`; `state/replay.ts` reads the latest one from the branch
- * to reconstruct module state. Field order and field names are pinned by
+ * to reconstruct runtime state. Field order and field names are pinned by
  * cross-version replay compatibility.
  */
 export interface TaskDetails {
+	/** Missing only on snapshots written by versions before schema versioning. */
+	schemaVersion?: 1;
 	action: TaskAction;
 	params: Record<string, unknown>;
 	tasks: Task[];
@@ -57,6 +60,10 @@ export interface TaskDetails {
  * signature (`[key: string]: unknown`) lets the runtime pass through TypeBox
  * `Static<typeof TodoParamsSchema>` without `as` casts.
  */
+export interface TaskBatchOperation extends TaskMutationParams {
+	action: TaskBatchOperationAction;
+}
+
 export interface TaskMutationParams {
 	[key: string]: unknown;
 	subject?: string;
@@ -70,6 +77,7 @@ export interface TaskMutationParams {
 	metadata?: Record<string, unknown>;
 	id?: number;
 	includeDeleted?: boolean;
+	operations?: TaskBatchOperation[];
 }
 
 // ---------------------------------------------------------------------------
@@ -78,8 +86,22 @@ export interface TaskMutationParams {
 // pre-refactor schema at `packages/rpiv-todo/todo.ts:512-573`.
 // ---------------------------------------------------------------------------
 
+const TodoBatchOperationSchema = Type.Object({
+	action: StringEnum(["create", "update", "delete"] as const),
+	subject: Type.Optional(Type.String({ description: "Task subject line (required for create)" })),
+	description: Type.Optional(Type.String({ description: "Long-form task description" })),
+	activeForm: Type.Optional(Type.String({ description: "Required when transitioning to in_progress" })),
+	status: Type.Optional(StringEnum(["pending", "in_progress", "completed", "deleted"] as const)),
+	blockedBy: Type.Optional(Type.Array(Type.Number())),
+	addBlockedBy: Type.Optional(Type.Array(Type.Number())),
+	removeBlockedBy: Type.Optional(Type.Array(Type.Number())),
+	owner: Type.Optional(Type.String()),
+	metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+	id: Type.Optional(Type.Number()),
+});
+
 export const TodoParamsSchema = Type.Object({
-	action: StringEnum(["create", "update", "list", "get", "delete", "clear"] as const),
+	action: StringEnum(["create", "update", "list", "get", "delete", "clear", "batch"] as const),
 	subject: Type.Optional(Type.String({ description: "Task subject line (required for create)" })),
 	description: Type.Optional(Type.String({ description: "Long-form task description" })),
 	activeForm: Type.Optional(
@@ -121,6 +143,13 @@ export const TodoParamsSchema = Type.Object({
 	includeDeleted: Type.Optional(
 		Type.Boolean({
 			description: "If true, list action returns deleted (tombstoned) tasks as well. Default: false.",
+		}),
+	),
+	operations: Type.Optional(
+		Type.Array(TodoBatchOperationSchema, {
+			minItems: 1,
+			maxItems: 50,
+			description: "Atomic create/update/delete operations for batch; all roll back if one fails",
 		}),
 	),
 });

--- a/packages/pi-todo/view/format.ts
+++ b/packages/pi-todo/view/format.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
-import type { Task, TaskDetails, TaskStatus } from "../tool/types.js";
+import type { Task, TaskAction, TaskDetails, TaskMutationParams, TaskStatus } from "../tool/types.js";
 
 // Re-export so legacy import paths continue to resolve; the canonical
 // definition lives in the i18n bridge.
@@ -63,11 +63,44 @@ export function formatCommandTaskLine(t: Task, glyph: string): string {
 
 /**
  * Successful Todo calls are represented by the persistent widget, so their
- * transcript node intentionally renders no lines. `renderShell: "self"` on
- * the tool definition lets Pi collapse the surrounding tool shell as well.
+ * transcript node renders no lines by default. Expanded mode uses the audit
+ * renderers below. `renderShell: "self"` removes the surrounding tool shell.
  */
 export function renderHiddenTodoNode(): Text {
 	return new Text("", 0, 0);
+}
+
+type TodoCallArgs = TaskMutationParams & { action?: TaskAction };
+
+function formatTodoCallSummary(args: TodoCallArgs): string {
+	switch (args.action) {
+		case "create":
+			return `create${args.subject ? ` “${args.subject}”` : ""}`;
+		case "update":
+			return `update${args.id !== undefined ? ` #${args.id}` : ""}${args.status ? ` → ${args.status}` : ""}`;
+		case "delete":
+			return `delete${args.id !== undefined ? ` #${args.id}` : ""}`;
+		case "get":
+			return `get${args.id !== undefined ? ` #${args.id}` : ""}`;
+		case "list":
+			return `list${args.status ? ` ${args.status}` : ""}`;
+		case "clear":
+			return "clear";
+		case "batch":
+			return `batch (${args.operations?.length ?? 0} operations)`;
+		default:
+			return "todo";
+	}
+}
+
+/** Successful calls stay hidden by default but become auditable in expanded mode. */
+export function renderTodoCall(args: TodoCallArgs, theme: Theme, expanded = false): Text {
+	if (!expanded) return renderHiddenTodoNode();
+	return new Text(
+		theme.fg("toolTitle", theme.bold("todo ")) + theme.fg("muted", formatTodoCallSummary(args)),
+		0,
+		0,
+	);
 }
 
 type TodoRenderResult = {
@@ -76,18 +109,20 @@ type TodoRenderResult = {
 };
 
 /**
- * Keep successful results invisible while surfacing both reducer-level errors
- * (`details.error`) and failures reported by Pi (`isError`). The structured
- * result remains in the session even when this component renders zero lines.
+ * Keep successful results hidden by default, reveal them in expanded mode,
+ * and surface both legacy reducer errors (`details.error`) and Pi execution
+ * failures (`isError`). Structured results remain in the session either way.
  */
-export function renderTodoResult(result: TodoRenderResult, theme: Theme, isError = false): Text {
+export function renderTodoResult(
+	result: TodoRenderResult,
+	theme: Theme,
+	isError = false,
+	expanded = false,
+): Text {
 	const details = result.details as TaskDetails | undefined;
-	const failureText = details?.error ?? (
-		isError
-			? result.content?.find((item) => item.type === "text" && item.text)?.text ?? "Todo failed"
-			: undefined
-	);
-	return failureText
-		? new Text(theme.fg("error", `✗ ${failureText}`), 0, 0)
-		: renderHiddenTodoNode();
+	const resultText = result.content?.find((item) => item.type === "text" && item.text)?.text;
+	const failureText = details?.error ?? (isError ? resultText ?? "Todo failed" : undefined);
+	if (failureText) return new Text(theme.fg("error", `✗ ${failureText}`), 0, 0);
+	if (expanded && resultText) return new Text(theme.fg("muted", resultText), 0, 0);
+	return renderHiddenTodoNode();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,16 @@ importers:
       '@earendil-works/pi-tui':
         specifier: '*'
         version: 0.80.3
+    devDependencies:
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      tsx:
+        specifier: 4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/pi-search-hub:
     dependencies:

--- a/providers/pi-provider-volcengine-agent-plan/README.md
+++ b/providers/pi-provider-volcengine-agent-plan/README.md
@@ -78,6 +78,14 @@ Kimi K2.6 and Kimi K2.7 Code use Chat Completions because their Agent Plan Respo
 
 Kimi K2.7 Code does not support disabling thinking through the current gateway. Selecting Pi's `off` level therefore avoids sending an unsupported disable control but cannot guarantee that the model stops internal reasoning.
 
+Kimi K3 inherits only model-intrinsic capabilities from Pi's Moonshot catalog. Agent Plan continues to own its protocol, limits, compatibility settings, and plan rules. Its available Pi thinking levels are `low`, `high`, and `max`.
+
+## Cost reporting
+
+The catalog retains public pay-as-you-go API reference rates in USD per million tokens, allowing Pi to estimate session cost from actual token usage. Models with an existing Pi upstream card selectively inherit its rates; the Doubao models use API estimates normalized from [Volcengine's public price table](https://www.volcengine.com/docs/82379/1544106).
+
+This value compares session resource usage; it is not the Agent Plan bill. Volcengine still calculates the subscription price, AFP usage, and remaining quota separately.
+
 ## Security
 
 Pi's standard `auth.json` is protected by filesystem permissions but is not an operating-system keychain. Do not commit credentials, paste them into issue reports, or place them in project configuration.

--- a/providers/pi-provider-volcengine-agent-plan/README.zh-CN.md
+++ b/providers/pi-provider-volcengine-agent-plan/README.zh-CN.md
@@ -78,6 +78,14 @@ Kimi K2.6 和 Kimi K2.7 Code 使用 Chat Completions，因为兼容性测试中�
 
 当前网关不支持关闭 Kimi K2.7 Code 的 thinking。Pi 选择 `off` 时，本包不会发送不受支持的禁用参数，但无法保证模型停止内部推理。
 
+Kimi K3 只从 Pi 的 Moonshot 模型目录继承模型固有能力，并继续使用 Agent Plan 自己的协议、限额、兼容配置和套餐规则。Pi 中可选的 thinking 档位为 `low`、`high` 和 `max`。
+
+## 费用显示
+
+模型目录保留公共按量 API 的美元/百万 token 参考单价，因此 Pi 会根据实际 token usage 在 session 级估算费用。已有 Pi 上游模型卡的模型选择性继承其价格；Doubao 模型使用从[火山方舟公开价格表](https://www.volcengine.com/docs/82379/1544106)标准化得到的 API 估价。
+
+这个数值用于比较会话资源消耗，并不是 Agent Plan 的实际账单；套餐价格、AFP 消耗和剩余额度仍由火山方舟单独计算。
+
 ## 安全
 
 Pi 标准 `auth.json` 由文件系统权限保护，但不是操作系统 Keychain。请勿提交凭证、将凭证粘贴到 issue，或把凭证写入项目配置。

--- a/providers/pi-provider-volcengine-agent-plan/index.ts
+++ b/providers/pi-provider-volcengine-agent-plan/index.ts
@@ -8,6 +8,7 @@ import {
 	type Credential,
 	type Model,
 } from "@earendil-works/pi-ai";
+import { getBuiltinModel } from "@earendil-works/pi-ai/providers/all";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const PROVIDER_ID = "volcengine-agent-plan";
@@ -16,13 +17,6 @@ const TIER_ENV = "ARK_AGENT_PLAN_TIER";
 const KEY_ENV_NAMES = ["ARK_AGENT_PLAN_API_KEY", "VOLCENGINE_ARK_PLAN_API_KEY"] as const;
 const KEY_VALIDATION_URL = `${BASE_URL}/responses`;
 const KEY_VALIDATION_TIMEOUT_MS = 12_000;
-
-const ZERO_COST = {
-	input: 0,
-	output: 0,
-	cacheRead: 0,
-	cacheWrite: 0,
-};
 
 const RESPONSES_COMPAT = {
 	supportsDeveloperRole: true,
@@ -46,6 +40,57 @@ type CatalogEntry = Omit<Model<ArkApi>, "provider" | "baseUrl"> & {
 	minimumTier: PlanTier;
 };
 
+type EstimatedApiCost = Model<ArkApi>["cost"];
+
+type InheritedModelCapabilities = Pick<
+	Model<ArkApi>,
+	"name" | "reasoning" | "thinkingLevelMap" | "input" | "cost" | "contextWindow" | "maxTokens"
+>;
+
+type RouteCapabilityLimits = Pick<Model<ArkApi>, "input" | "contextWindow" | "maxTokens">;
+
+function copyEstimatedApiCost(cost: EstimatedApiCost): EstimatedApiCost {
+	return {
+		...cost,
+		...(cost.tiers ? { tiers: cost.tiers.map((tier) => ({ ...tier })) } : {}),
+	};
+}
+
+function inheritModelCapabilities(
+	upstream: InheritedModelCapabilities,
+	routeLimits: RouteCapabilityLimits,
+): InheritedModelCapabilities {
+	return {
+		name: upstream.name,
+		reasoning: upstream.reasoning,
+		...(upstream.thinkingLevelMap
+			? { thinkingLevelMap: { ...upstream.thinkingLevelMap } }
+			: {}),
+		input: upstream.input.filter((modality) => routeLimits.input.includes(modality)),
+		cost: copyEstimatedApiCost(upstream.cost),
+		contextWindow: Math.min(upstream.contextWindow, routeLimits.contextWindow),
+		maxTokens: Math.min(upstream.maxTokens, routeLimits.maxTokens),
+	};
+}
+
+// Pi has no native Doubao Seed 2.0 catalog yet. These USD-per-million-token
+// estimates follow public API listings normalized from Volcengine's price table.
+const DOUBAO_API_COSTS = {
+	"doubao-seed-2.0-mini": { input: 0.03, output: 0.28, cacheRead: 0.01, cacheWrite: 0.0024 },
+	"doubao-seed-2.0-lite": { input: 0.09, output: 0.51, cacheRead: 0.02, cacheWrite: 0.0024 },
+	"doubao-seed-evolving": { input: 0.9, output: 4.5, cacheRead: 0.18, cacheWrite: 0 },
+	"doubao-seed-2.0-code": { input: 0.9, output: 4.48, cacheRead: 0, cacheWrite: 0 },
+	"doubao-seed-2.0-pro": { input: 0.45, output: 2.24, cacheRead: 0.09, cacheWrite: 0.0024 },
+} satisfies Record<string, EstimatedApiCost>;
+
+// Only model capabilities and reference API pricing are inherited. Agent Plan
+// continues to own protocol, endpoint, compatibility, tier gating, and route limits.
+const KIMI_K3_CAPABILITIES = inheritModelCapabilities(getBuiltinModel("moonshotai", "kimi-k3"), {
+	input: ["text"],
+	contextWindow: 1_024_000,
+	maxTokens: 128_000,
+});
+
 const TIER_RANK: Record<PlanTier, number> = {
 	small: 0,
 	medium: 1,
@@ -63,7 +108,7 @@ const CATALOG: CatalogEntry[] = [
 		input: ["text"],
 		contextWindow: 256_000,
 		maxTokens: 128_000,
-		cost: ZERO_COST,
+		cost: copyEstimatedApiCost(DOUBAO_API_COSTS["doubao-seed-2.0-mini"]),
 		compat: RESPONSES_COMPAT,
 	},
 	{
@@ -75,7 +120,7 @@ const CATALOG: CatalogEntry[] = [
 		input: ["text"],
 		contextWindow: 256_000,
 		maxTokens: 128_000,
-		cost: ZERO_COST,
+		cost: copyEstimatedApiCost(DOUBAO_API_COSTS["doubao-seed-2.0-lite"]),
 		compat: RESPONSES_COMPAT,
 	},
 	{
@@ -87,7 +132,7 @@ const CATALOG: CatalogEntry[] = [
 		input: ["text"],
 		contextWindow: 1_024_000,
 		maxTokens: 384_000,
-		cost: ZERO_COST,
+		cost: copyEstimatedApiCost(getBuiltinModel("deepseek", "deepseek-v4-flash").cost),
 		compat: RESPONSES_COMPAT,
 	},
 	{
@@ -99,7 +144,7 @@ const CATALOG: CatalogEntry[] = [
 		input: ["text"],
 		contextWindow: 1_024_000,
 		maxTokens: 256_000,
-		cost: ZERO_COST,
+		cost: copyEstimatedApiCost(DOUBAO_API_COSTS["doubao-seed-evolving"]),
 		compat: RESPONSES_COMPAT,
 	},
 	{
@@ -111,7 +156,7 @@ const CATALOG: CatalogEntry[] = [
 		input: ["text"],
 		contextWindow: 256_000,
 		maxTokens: 128_000,
-		cost: ZERO_COST,
+		cost: copyEstimatedApiCost(DOUBAO_API_COSTS["doubao-seed-2.0-code"]),
 		compat: RESPONSES_COMPAT,
 	},
 	{
@@ -123,7 +168,7 @@ const CATALOG: CatalogEntry[] = [
 		input: ["text"],
 		contextWindow: 256_000,
 		maxTokens: 128_000,
-		cost: ZERO_COST,
+		cost: copyEstimatedApiCost(DOUBAO_API_COSTS["doubao-seed-2.0-pro"]),
 		compat: RESPONSES_COMPAT,
 	},
 	{
@@ -136,7 +181,7 @@ const CATALOG: CatalogEntry[] = [
 		input: ["text"],
 		contextWindow: 200_000,
 		maxTokens: 128_000,
-		cost: ZERO_COST,
+		cost: copyEstimatedApiCost(getBuiltinModel("minimax", "MiniMax-M2.7").cost),
 		compat: RESPONSES_COMPAT,
 	},
 	{
@@ -148,7 +193,7 @@ const CATALOG: CatalogEntry[] = [
 		input: ["text"],
 		contextWindow: 512_000,
 		maxTokens: 128_000,
-		cost: ZERO_COST,
+		cost: copyEstimatedApiCost(getBuiltinModel("minimax", "MiniMax-M3").cost),
 		compat: RESPONSES_COMPAT,
 	},
 	{
@@ -160,7 +205,7 @@ const CATALOG: CatalogEntry[] = [
 		input: ["text"],
 		contextWindow: 1_024_000,
 		maxTokens: 128_000,
-		cost: ZERO_COST,
+		cost: copyEstimatedApiCost(getBuiltinModel("opencode-go", "glm-5.2").cost),
 		compat: RESPONSES_COMPAT,
 	},
 	{
@@ -173,7 +218,7 @@ const CATALOG: CatalogEntry[] = [
 		input: ["text"],
 		contextWindow: 256_000,
 		maxTokens: 32_000,
-		cost: ZERO_COST,
+		cost: copyEstimatedApiCost(getBuiltinModel("moonshotai", "kimi-k2.6").cost),
 		compat: KIMI_CHAT_COMPAT,
 	},
 	{
@@ -186,7 +231,7 @@ const CATALOG: CatalogEntry[] = [
 		input: ["text"],
 		contextWindow: 256_000,
 		maxTokens: 32_000,
-		cost: ZERO_COST,
+		cost: copyEstimatedApiCost(getBuiltinModel("moonshotai", "kimi-k2.7-code").cost),
 		compat: KIMI_CHAT_COMPAT,
 	},
 	{
@@ -198,19 +243,14 @@ const CATALOG: CatalogEntry[] = [
 		input: ["text"],
 		contextWindow: 1_024_000,
 		maxTokens: 384_000,
-		cost: ZERO_COST,
+		cost: copyEstimatedApiCost(getBuiltinModel("deepseek", "deepseek-v4-pro").cost),
 		compat: RESPONSES_COMPAT,
 	},
 	{
 		id: "kimi-k3",
-		name: "Kimi K3",
+		...KIMI_K3_CAPABILITIES,
 		api: "openai-responses",
 		minimumTier: "medium",
-		reasoning: true,
-		input: ["text"],
-		contextWindow: 1_024_000,
-		maxTokens: 128_000,
-		cost: ZERO_COST,
 		compat: RESPONSES_COMPAT,
 	},
 ];

--- a/providers/pi-provider-volcengine-agent-plan/test/provider.test.ts
+++ b/providers/pi-provider-volcengine-agent-plan/test/provider.test.ts
@@ -7,6 +7,9 @@ import { createJiti } from "jiti";
 const jiti = createJiti(import.meta.url, {
 	moduleCache: false,
 	alias: {
+		"@earendil-works/pi-ai/providers/all": fileURLToPath(
+			new URL("../node_modules/@earendil-works/pi-ai/dist/providers/all.js", import.meta.url),
+		),
 		"@earendil-works/pi-ai": fileURLToPath(
 			new URL("../node_modules/@earendil-works/pi-ai/dist/compat.js", import.meta.url),
 		),
@@ -157,6 +160,29 @@ test("filters the static catalog by tier and resolves standard auth", async () =
 	assert.equal(auth?.env?.ARK_AGENT_PLAN_TIER, "medium");
 	assert.equal(auth?.source, "Pi auth.json");
 	assert.equal(await provider.auth.apiKey?.check?.({ ctx }), undefined);
+});
+
+test("provides public API cost estimates for every model", () => {
+	for (const model of createAgentPlanProvider().getModels()) {
+		assert.ok(model.cost.input > 0, `${model.id} must estimate input cost`);
+		assert.ok(model.cost.output > 0, `${model.id} must estimate output cost`);
+	}
+});
+
+test("exposes only Kimi K3's supported thinking levels", () => {
+	const kimiK3 = createAgentPlanProvider()
+		.getModels()
+		.find((model) => model.id === "kimi-k3");
+	assert.ok(kimiK3);
+	assert.deepEqual(kimiK3.thinkingLevelMap, {
+		off: null,
+		minimal: null,
+		low: "low",
+		medium: null,
+		high: "high",
+		xhigh: null,
+		max: "max",
+	});
 });
 
 test("applies MiniMax and Kimi request compatibility hooks", () => {

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -19,12 +19,20 @@ const requiredPackFiles = new Map([
 	[".", [
 		"README.md",
 		"README.zh-CN.md",
+		"packages/pi-recap/extensions/multiplexer.ts",
 		"packages/pi-glance/index.ts",
 		"packages/pi-glance/footer.ts",
 		"packages/pi-glance/README.md",
 		"packages/pi-glance/README.zh-CN.md",
 		"packages/pi-search-hub/README.md",
 		"packages/pi-search-hub/README.zh-CN.md",
+	]],
+	["./packages/pi-recap", [
+		"extensions/recap.ts",
+		"extensions/multiplexer.ts",
+		"examples/recap.json",
+		"README.md",
+		"README.zh-CN.md",
 	]],
 	["./packages/pi-glance", [
 		"index.ts",


### PR DESCRIPTION
## Summary

Batch four independently developed plugin updates for one atomic merge to `main` and one Changesets release:

- streamline Search Hub setup and routing in the root bundle
- add Herdr-aware multiplexer naming to Recap
- harden Todo state management and lifecycle contracts
- correct Volcengine Agent Plan model metadata and reference costs

## Planned releases

- `@zhcsyncer/pi-extensions`: `0.7.0` → `0.8.0` (minor)
- `@zhcsyncer/pi-recap`: `0.2.0` → `0.3.0` (minor)
- `@zhcsyncer/pi-todo`: `0.2.0` → `0.3.0` (minor)
- `pi-provider-volcengine-agent-plan`: `0.1.0` → `0.1.1` (patch)

Search Hub remains private and ships inside `@zhcsyncer/pi-extensions`.

## Validation

- `pnpm install --frozen-lockfile`
- affected-package typechecks and tests
- `pnpm check`
- `pnpm changeset status`
- root release backlog reviewed and complete
