### PR TITLE
feat(plan-mode): add audited lifecycle and compact tool display

### DIFF
--- a/.changeset/steady-plans-finish.md
+++ b/.changeset/steady-plans-finish.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": minor
+"@zhcsyncer/pi-plan-mode": minor
+---
+
+Add a branch-aware Plan implementation lifecycle with explicit `complete_plan`, `/plan complete|abandon|revise`, safe legacy-state migration, and new-Plan defaults after work closes. Render `submit_plan` and `complete_plan` as compact self-managed TUI nodes with expandable historical review and completion audit details. Emit balanced Herdr `blocked` events while revdiff, lifecycle selectors, and completion confirmations wait for user input.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A collection of Pi extensions by zhcsyncer.
 - [`@zhcsyncer/pi-tool-display-intent`](./packages/pi-tool-display-intent) — compact tool rendering with model-written intent phrases, RPC-visible summaries, adaptive diffs, and bounded Bash call previews.
 - [`@zhcsyncer/pi-todo`](./packages/pi-todo) — branch-aware task overlay with strict lifecycle rules, atomic batches, isolated SDK session state, and expandable audit summaries.
 - [`@zhcsyncer/pi-glance`](./packages/pi-glance) — maintained `pi-glance` fork with composable extension statuses, bottom-right context progress, and a highlighted auto-compaction marker.
-- [`@zhcsyncer/pi-plan-mode`](./packages/pi-plan-mode) — temporary read-only Plan Mode with word-aware revdiff review, immutable revisions, configurable English/Chinese Plan content, explicit approval, and collapsible TUI Steps.
+- [`@zhcsyncer/pi-plan-mode`](./packages/pi-plan-mode) — strict read-only planning with revdiff review, immutable revisions, compact audit rendering, and an explicit branch-aware implementation/completion lifecycle.
 - [`@zhcsyncer/pi-search-hub`](./packages/pi-search-hub) — bundle-private `web_search` and `web_read` tools integrated with intent-aware rendering.
 
 ## Bundle-private Search Hub

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@ zhcsyncer 维护的一组 Pi extensions。
 - [`@zhcsyncer/pi-tool-display-intent`](./packages/pi-tool-display-intent) — 紧凑工具展示，支持模型生成的 intent、RPC 可见摘要、自适应 diff 和受限的 Bash 调用预览。
 - [`@zhcsyncer/pi-todo`](./packages/pi-todo) — 分支感知的 Todo overlay，提供严格生命周期、原子批量操作、SDK Session 状态隔离和可展开审计摘要。
 - [`@zhcsyncer/pi-glance`](./packages/pi-glance) — `pi-glance` 的维护 fork，保留扩展状态，支持右下角 context 进度条和高亮自动压缩标记。
-- [`@zhcsyncer/pi-plan-mode`](./packages/pi-plan-mode) — 临时只读 Plan Mode，支持 word-aware revdiff 评审、不可变 revision、中英文 Plan 内容配置、显式批准和可折叠 TUI Steps。
+- [`@zhcsyncer/pi-plan-mode`](./packages/pi-plan-mode) — 严格只读规划，支持 revdiff 评审、不可变 revision、紧凑审计展示，以及显式且 branch-aware 的实现/完成生命周期。
 - [`@zhcsyncer/pi-search-hub`](./packages/pi-search-hub) — bundle 私有的 `web_search` 和 `web_read` 工具，集成 intent-aware 展示。
 
 ## Bundle 私有 Search Hub

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -2,9 +2,9 @@
 
 [简体中文](./README.zh-CN.md)
 
-A strict, TUI-only permission mode for planning in Pi. It combines fail-closed read-only tools, terminal review through [revdiff](https://github.com/umputun/revdiff), immutable Plan revisions, explicit approval, and compact Plan Mode widgets.
+A strict, TUI-only planning and approval workflow for Pi. It combines fail-closed read-only tools, terminal review through [revdiff](https://github.com/umputun/revdiff), immutable Plan revisions, explicit approval, a branch-aware implementation lifecycle, and compact Plan widgets.
 
-Plan Mode is temporary: approval immediately restores the tools that were active before planning and starts ordinary implementation in a fresh agent turn. The extension does not maintain an execution or completion workflow.
+Plan document review and implementation work are tracked independently. Approval restores the tools that were active before planning, starts ordinary implementation in a fresh agent turn, and activates `complete_plan`. Completion closes only the exact approved revision and makes the next `/plan on` start a new Plan by default.
 
 ## Requirements
 
@@ -30,8 +30,13 @@ brew install umputun/apps/revdiff
 - The original Pi system prompt, including `AGENTS.md` rules, is preserved and extended rather than replaced.
 - A clean revdiff exit is not approval. Pi asks for an explicit `Approve Plan`, `Keep planning`, or `Cancel review` decision.
 - Every complete submission creates an immutable `rN` Markdown file and SHA-256 hash. Approved revisions are never overwritten.
-- Approval restores normal tools, removes the read-only mode bar, retains the Plan summary, and starts implementation through a displayed custom context message rather than a user-role turn. The transcript renders only a compact approval event while the full approved revision remains in model context.
-- Steps are a display-only projection of `## Execution steps` or `## 执行步骤`. They have no completion state and do not integrate with or inspect Todo extensions.
+- Approval restores normal tools, removes the read-only mode bar, retains the Plan summary, enters `IMPLEMENTING`, and starts implementation through a displayed custom context message rather than a user-role turn. The transcript renders only a compact approval event while the full approved revision remains in model context.
+- `complete_plan` is active only for implementing or migrated legacy work. It requires the exact Plan ID/revision, an implementation summary, and successful verification checks; its result is terminating and must be the final tool call.
+- `/plan complete` is the user fallback when the agent did not close the work. `/plan abandon` closes it without claiming completion.
+- Re-entering Plan Mode while work is still implementing requires an explicit choice: revise it, mark it complete and start a new Plan, abandon it and start a new Plan, or cancel.
+- Steps remain a display-only projection of `## Execution steps` or `## 执行步骤`. Work completion does not mutate individual Steps and does not integrate with or inspect Todo extensions.
+- `submit_plan` and `complete_plan` use compact self-rendered transcript nodes. Approved/completed nodes stay hidden while collapsed because the persistent approval/lifecycle event is authoritative; `Ctrl+O` reveals Plan IDs, paths, hashes, completion evidence, and persisted review annotations.
+- Herdr integration is automatic and optional. Plan Mode emits Herdr's reserved `herdr:blocked` event around revdiff review, approval/lifecycle selectors, and completion/abandonment confirmations, then always clears it in `finally`. Non-Herdr environments simply have no listener.
 - Plan title, prose, lists, and required section headings can use English, Simplified Chinese, or automatically follow the conversation language through a read-only user config file.
 - TUI-only behavior is enforced with `ctx.mode === "tui"`. RPC, JSON, and print modes do not register Plan tools, change active tools, inject prompts, or write Plan state.
 
@@ -45,22 +50,26 @@ This is a capability boundary, not an OS sandbox. Read tools can still access fi
 4. Pi pauses its TUI and gives the terminal to revdiff.
 5. Annotations are returned as one feedback package. A complete resubmission creates `rN+1` and opens a revision diff with revdiff word-level highlighting.
 6. A clean review returns to Pi for an explicit approval decision.
-7. Approval records the exact revision and hash, turns Plan Mode off, restores normal tools, and starts ordinary implementation in a fresh turn.
+7. Approval records the exact revision and hash, turns Plan Mode off, restores normal tools, marks that exact revision `IMPLEMENTING`, and starts ordinary implementation in a fresh turn.
+8. After all approved scope is implemented and necessary verification passes, the agent calls `complete_plan`. The work becomes `COMPLETED`; the next `/plan on` starts unattached and creates a new Plan.
 
-Interrupting implementation has normal Pi semantics. The approved Plan remains available, but this extension does not track execution progress, restart work automatically, or require a completion tool. Re-entering Plan Mode injects the attached revision as planning context; the agent must still inspect the current workspace before revising it.
+Interrupting implementation still has normal Pi semantics. The approved Plan and its branch-aware work state survive resume and tree navigation, but the extension does not track per-step execution progress or restart work automatically. Use `/plan revise` to explicitly attach the approved revision again.
 
 ## Commands and shortcuts
 
 | Interaction | Behavior |
 |---|---|
-| `/plan on` | Enable strict read-only Plan Mode |
+| `/plan on` | Enable strict read-only Plan Mode; completed/abandoned work starts a new unattached Plan |
 | `/plan off` | Disable Plan Mode and restore normal tools |
-| `/plan` | Show current mode, content language/config path, Plan revision, path, and usage |
+| `/plan revise` | Explicitly attach the current approved work for a new immutable revision |
+| `/plan complete` | Confirm that all approved work and necessary verification are complete |
+| `/plan abandon` | Close the current approved work without claiming completion |
+| `/plan` | Show current mode, content language/config path, document focus, work state, revision, path, and usage |
 | `--plan` | Start the initial TUI Session with Plan Mode on |
 | `Ctrl+Alt+P` | Toggle Plan Mode |
 | `Ctrl+Alt+O` | Expand or collapse the current Plan Steps |
 
-`on` and `off` support command argument completion.
+All `/plan` actions support command argument completion.
 
 ## Plan content language
 
@@ -90,18 +99,22 @@ While Plan Mode is on, a below-editor widget is rendered with the standard Unico
 
 The extension uses Unicode `⏸` directly. It does not add a font setting, environment variable, Nerd Font branch, or ASCII fallback.
 
-After a Plan exists, an above-editor summary remains visible independently of whether Plan Mode is on:
+After a Plan exists, an above-editor summary remains visible independently of whether Plan Mode is on. During implementation it shows the work lifecycle rather than conflating it with document approval:
 
 ```text
-▌ PLAN  OAuth migration                              APPROVED · r2
+▌ PLAN  OAuth migration                           IMPLEMENTING · r2
 6 steps                                             Ctrl+Alt+O expand
 ```
+
+After explicit completion it becomes `COMPLETED · r2`; abandonment becomes `ABANDONED · r2`. A fresh `/plan on` hides the old summary so the new planning turn is unattached.
 
 The Plan path is intentionally hidden while collapsed. Expanding shows the path and the display-only Steps:
 
 ```text
-▌ PLAN  OAuth migration                              APPROVED · r2
+▌ PLAN  OAuth migration                           IMPLEMENTING · r2
 ~/.pi/agent/plans/…/revisions/r2.md
+Document: APPROVED
+Approved hash: sha256:…
   1. Update the policy
   2. Run integration tests
                                               Ctrl+Alt+O collapse
@@ -109,11 +122,15 @@ The Plan path is intentionally hidden while collapsed. Expanding shows the path 
 
 Steps are collapsed by default. `Ctrl+Alt+O` expands up to 30% of terminal height, bounded to 3–10 steps; overflow is shown as `… +N more`. Expansion is TUI-local and resets when the current Plan, revision, Session, or tree branch changes.
 
-Approval adds one compact custom event to the transcript:
+Approval and work closure add compact events to the transcript:
 
 ```text
 ✓ PLAN APPROVED · OAuth migration · r2 · 6 steps
+✓ PLAN COMPLETED · OAuth migration · r2
+! PLAN ABANDONED · OAuth migration · r2
 ```
+
+Successful `submit_plan` and `complete_plan` nodes are hidden while tool output is collapsed, avoiding duplicate events. Expand tool output with Pi's configured `app.tools.expand` binding (normally `Ctrl+O`) to inspect review annotations, paths, hashes, summaries, and verification evidence. Historical annotation rendering uses persisted tool-result content and never depends on the temporary `.review/annotations.md` file.
 
 Persistent widgets do not receive focus and Pi's public Widget API has no mouse click callback, so direct clicking is not supported.
 
@@ -137,7 +154,9 @@ The root is resolved with Pi's `getAgentDir()`, so `PI_CODING_AGENT_DIR` is resp
 
 Each submission writes a new revision with exclusive creation. The manifest records the stable Plan ID, current and approved revisions, document states (`draft`, `changes_requested`, or `approved`), SHA-256 hashes, extracted display Steps, Session ID, cwd, timestamps, and revision lineage.
 
-With `--no-session`, the extension uses `$TMPDIR/pi-plan-<random>/`, never appends Session state, and removes the directory on Session shutdown. Crash leftovers may remain until the operating system cleans its temporary directory.
+Implementation work state is deliberately not stored in the immutable artifact. Pi custom Session entries store separate `planning` and `work` references, including the exact approved revision/hash and `implementing`, `completed`, `abandoned`, or legacy `unknown` state. These entries follow the active Session tree branch. Legacy V2 approved pointers migrate to `unknown`; they are never guessed to be completed.
+
+With `--no-session`, the extension uses `$TMPDIR/pi-plan-<random>/`, keeps lifecycle state only in memory, never appends Session state or lifecycle events, and removes the directory on Session shutdown. Crash leftovers may remain until the operating system cleans its temporary directory.
 
 ## Plan artifact
 
@@ -160,7 +179,20 @@ submit_plan({
 })
 ```
 
-Omitting `planId` creates a different Plan. A supplied ID must match the current Session branch Plan; arbitrary or cross-Session adoption is rejected.
+Omitting `planId` creates a new Plan only when no revision is attached. Once a draft or explicit revision is attached, `submit_plan` requires that exact ID; use `/plan revise` to attach approved work. Arbitrary, stale, or cross-Session adoption is rejected.
+
+After approval, completion uses the exact work binding:
+
+```text
+complete_plan({
+  planId: "20260723T140506-add-cache-a1b2c3d4",
+  revision: 2,
+  summary: "Implemented cache invalidation and rollback handling",
+  verification: ["pnpm test", "pnpm typecheck"]
+})
+```
+
+`verification` must contain at least one successful check. The tool also re-verifies the approved artifact hash before recording completion. It cannot prove arbitrary project correctness, so the agent/user declaration remains explicit rather than inferred from final prose, file changes, or command history.
 
 Plans are limited to 256 KiB and should cover the nine required sections. English Plans use Goal, Non-goals, Current evidence, Decisions and rationale, Proposed changes, Execution steps, Verification, Risks, and Assumptions. Simplified Chinese Plans use 目标、非目标、当前证据、决策与理由、拟议改动、执行步骤、验证、风险和假设.
 
@@ -186,6 +218,9 @@ pi --no-extensions -e ./packages/pi-plan-mode
 - Interrupted review: remain in planning without approval.
 - Plan content or current revision changed while revdiff is open: reject approval and require another review.
 - Missing or cross-Session metadata during restore: keep normal mode and do not adopt that Plan pointer.
+- Legacy approved Session state: restore as `UNKNOWN` work and require an explicit revise/complete/abandon decision.
+- `complete_plan` ID/revision mismatch or approved-content/hash mismatch: reject completion without changing lifecycle state.
+- Re-entering with `IMPLEMENTING`/`UNKNOWN` work: require an explicit choice; never silently revise it or silently start parallel current work.
 - `/plan off`: restore normal tools without deleting or cancelling the current draft.
 
 ## Development

--- a/packages/pi-plan-mode/README.zh-CN.md
+++ b/packages/pi-plan-mode/README.zh-CN.md
@@ -2,9 +2,9 @@
 
 [English](./README.md)
 
-严格、仅 TUI 启用的 Pi 临时规划权限模式。它组合 fail-closed 只读工具、[revdiff](https://github.com/umputun/revdiff) 终端评审、不可变 Plan revision、显式批准和紧凑的 Plan Mode Widget。
+严格、仅 TUI 启用的 Pi 规划与审批工作流。它组合 fail-closed 只读工具、[revdiff](https://github.com/umputun/revdiff) 终端评审、不可变 Plan revision、显式批准、branch-aware 实现生命周期和紧凑 Plan Widget。
 
-Plan Mode 是临时模式：批准后立即恢复进入规划前的工具，并在新的 Agent turn 中开始普通实现。扩展不维护执行或完成工作流。
+Plan 文档评审与实现工作彼此独立。批准后立即恢复进入规划前的工具、在新的 Agent turn 中开始普通实现，并启用 `complete_plan`。完成操作只关闭精确获批 revision，之后再次 `/plan on` 会默认开始一份新 Plan。
 
 ## 环境要求
 
@@ -30,8 +30,13 @@ brew install umputun/apps/revdiff
 - 原始 Pi system prompt（包括 `AGENTS.md` 规则）会被保留并追加约束，而不是被替换。
 - revdiff 无批注退出不等于批准。Pi 会要求明确选择 `Approve Plan`、`Keep planning` 或 `Cancel review`。
 - 每次完整提交都会创建不可变的 `rN` Markdown 文件和 SHA-256 hash；获批 revision 永不覆盖。
-- 批准后恢复普通工具、移除只读模式条、保留 Plan 摘要，并通过 displayed custom context message 开始实现，而不是创建 user-role turn。Transcript 只渲染紧凑批准事件，完整获批 revision 仍保留在模型上下文中。
-- Steps 只是 `## Execution steps` 或 `## 执行步骤` 的展示投影，没有完成状态，也不会集成或探测 Todo 扩展。
+- 批准后恢复普通工具、移除只读模式条、保留 Plan 摘要、进入 `IMPLEMENTING`，并通过 displayed custom context message 开始实现，而不是创建 user-role turn。Transcript 只渲染紧凑批准事件，完整获批 revision 仍保留在模型上下文中。
+- `complete_plan` 仅在实现中或迁移后的 legacy work 上启用。它要求精确 Plan ID/revision、实现摘要和成功验证项；结果会 terminate，且必须作为最后一个工具调用。
+- Agent 未关闭工作时，用户可用 `/plan complete` 兜底；`/plan abandon` 可关闭工作但不声称实现完成。
+- 实现尚未关闭时重新进入 Plan Mode，必须明确选择修订、标记完成后新建、放弃后新建或取消。
+- Steps 仍只是 `## Execution steps` 或 `## 执行步骤` 的展示投影。工作完成不会改写单个 Step，也不会集成或探测 Todo 扩展。
+- `submit_plan` 和 `complete_plan` 使用紧凑自渲染 transcript 节点。批准/完成节点收起时隐藏，以持久批准/生命周期事件为准；通过 `Ctrl+O` 可展开 Plan ID、路径、hash、完成证据和已持久化评审批注。
+- Herdr 集成自动且可选。Plan Mode 会在 revdiff 评审、批准/生命周期选择器和完成/放弃确认框期间触发 Herdr 保留的 `herdr:blocked` 事件，并通过 `finally` 保证清除；非 Herdr 环境没有 listener，因此行为不变。
 - Plan 标题、正文、列表和必需章节标题可通过只读用户配置选择英文、简体中文或自动跟随会话语言。
 - 通过 `ctx.mode === "tui"` 强制仅 TUI 启用。RPC、JSON、print 模式不会注册 Plan 工具、切换活动工具、注入提示或写入 Plan 状态。
 
@@ -45,22 +50,26 @@ brew install umputun/apps/revdiff
 4. Pi 暂停自己的 TUI，把终端交给 revdiff。
 5. 批注整批返回 Agent；完整重提会创建 `rN+1`，并用 revdiff 词内高亮打开 revision Diff。
 6. 无批注 Review 返回 Pi，要求用户显式决定是否批准。
-7. 批准会记录精确 revision 和 hash、关闭 Plan Mode、恢复普通工具，并在新的 turn 中开始普通实现。
+7. 批准会记录精确 revision 和 hash、关闭 Plan Mode、恢复普通工具，把该 revision 标记为 `IMPLEMENTING`，并在新的 turn 中开始普通实现。
+8. 全部获批范围实现完毕且必要验证通过后，Agent 调用 `complete_plan`。工作进入 `COMPLETED`，下一次 `/plan on` 默认从未附着状态创建新 Plan。
 
-实现中断沿用普通 Pi 语义。获批 Plan 会继续保留，但扩展不跟踪执行进度、不自动重启工作，也不要求完成工具。重新进入 Plan Mode 时，扩展会把关联 revision 注入规划上下文；Agent 仍须先检查当前工作区再修订。
+实现中断仍沿用普通 Pi 语义。获批 Plan 和 branch-aware 工作状态可跨 resume 与 tree navigation 恢复，但扩展不跟踪逐 Step 执行进度，也不自动重启工作。需要继续修订时使用 `/plan revise` 显式挂载获批 revision。
 
 ## 命令与快捷键
 
 | 交互 | 行为 |
 |---|---|
-| `/plan on` | 开启严格只读 Plan Mode |
+| `/plan on` | 开启严格只读 Plan Mode；已完成/放弃的 work 默认开启新 Plan |
 | `/plan off` | 关闭 Plan Mode 并恢复普通工具 |
-| `/plan` | 显示当前模式、内容语言/配置路径、Plan revision、路径和用法 |
+| `/plan revise` | 显式挂载当前获批 work，创建新的不可变 revision |
+| `/plan complete` | 确认获批范围和必要验证均已完成 |
+| `/plan abandon` | 关闭当前获批 work，但不声称完成 |
+| `/plan` | 显示当前模式、内容语言/配置路径、文档焦点、工作状态、revision、路径和用法 |
 | `--plan` | 让初始 TUI Session 直接开启 Plan Mode |
 | `Ctrl+Alt+P` | 切换 Plan Mode |
 | `Ctrl+Alt+O` | 展开或收起当前 Plan Steps |
 
-`on` 和 `off` 支持命令参数补全。
+所有 `/plan` action 都支持命令参数补全。
 
 ## Plan 内容语言
 
@@ -90,18 +99,22 @@ Plan Mode 开启时，编辑器下方显示使用标准 Unicode 暂停符号的 
 
 扩展直接使用 Unicode `⏸`，不增加字体设置、环境变量、Nerd Font 分支或 ASCII fallback。
 
-存在 Plan 后，编辑器上方的摘要会独立于 Plan Mode 开关持续显示：
+存在 Plan 后，编辑器上方的摘要会独立于 Plan Mode 开关持续显示。实现期间显示工作生命周期，不再与文档批准状态混为一谈：
 
 ```text
-▌ PLAN  OAuth migration                              APPROVED · r2
+▌ PLAN  OAuth migration                           IMPLEMENTING · r2
 6 steps                                             Ctrl+Alt+O expand
 ```
+
+显式完成后变为 `COMPLETED · r2`，放弃后变为 `ABANDONED · r2`。进入全新 `/plan on` 时会隐藏旧摘要，确保新的规划 turn 没有挂载旧 revision。
 
 收起时刻意隐藏 Plan 路径。展开后显示路径和只用于展示的 Steps：
 
 ```text
-▌ PLAN  OAuth migration                              APPROVED · r2
+▌ PLAN  OAuth migration                           IMPLEMENTING · r2
 ~/.pi/agent/plans/…/revisions/r2.md
+Document: APPROVED
+Approved hash: sha256:…
   1. 更新策略
   2. 运行集成测试
                                               Ctrl+Alt+O collapse
@@ -109,11 +122,15 @@ Plan Mode 开启时，编辑器下方显示使用标准 Unicode 暂停符号的 
 
 Steps 默认收起。`Ctrl+Alt+O` 展开终端高度的最多 30%，并限制在 3–10 个 step；溢出显示 `… +N more`。展开状态只属于当前 TUI，切换当前 Plan、revision、Session 或 tree branch 时重置。
 
-批准后 transcript 增加一条紧凑 custom event：
+批准和关闭工作后，transcript 会增加紧凑事件：
 
 ```text
 ✓ PLAN APPROVED · OAuth migration · r2 · 6 steps
+✓ PLAN COMPLETED · OAuth migration · r2
+! PLAN ABANDONED · OAuth migration · r2
 ```
+
+工具输出收起时，成功的 `submit_plan` 和 `complete_plan` 节点会隐藏，避免和事件重复。使用 Pi 配置的 `app.tools.expand` 按键（默认 `Ctrl+O`）可查看评审批注、路径、hash、摘要和验证证据。历史批注直接来自持久化 tool result content，不依赖临时 `.review/annotations.md` 仍然存在。
 
 持久 Widget 不获取焦点，Pi 公开 Widget API 也没有鼠标点击回调，因此不支持直接点击。
 
@@ -137,7 +154,9 @@ Steps 默认收起。`Ctrl+Alt+O` 展开终端高度的最多 30%，并限制在
 
 每次提交都用 exclusive create 写入新 revision。manifest 记录稳定 Plan ID、当前与获批 revision、文档状态（`draft`、`changes_requested` 或 `approved`）、SHA-256 hash、提取出的展示 Steps、Session ID、cwd、时间戳和 revision lineage。
 
-使用 `--no-session` 时，扩展改用 `$TMPDIR/pi-plan-<random>/`，不会向 Session 追加状态，并在 Session shutdown 时删除目录。异常崩溃的残留文件可能要等操作系统清理临时目录。
+实现工作状态不会写进不可变 artifact。Pi custom Session entry 会分别保存 `planning` 和 `work` reference，包括精确获批 revision/hash，以及 `implementing`、`completed`、`abandoned` 或 legacy `unknown` 状态；这些 entry 跟随当前 Session tree branch。旧 V2 approved 指针迁移为 `unknown`，绝不会被猜测成已完成。
+
+使用 `--no-session` 时，扩展改用 `$TMPDIR/pi-plan-<random>/`，只在内存维护生命周期，不向 Session 追加状态或生命周期事件，并在 Session shutdown 时删除目录。异常崩溃的残留文件可能要等操作系统清理临时目录。
 
 ## Plan 产物
 
@@ -160,7 +179,20 @@ submit_plan({
 })
 ```
 
-省略 `planId` 会创建另一个 Plan。传入的 ID 必须匹配当前 Session branch 的 Plan；任意 ID 或跨 Session 接管会被拒绝。
+只有当前没有挂载 revision 时，省略 `planId` 才会创建新 Plan。一旦已有 draft 或显式挂载的 revision，`submit_plan` 必须使用该精确 ID；挂载获批 work 应先用 `/plan revise`。任意、过期或跨 Session ID 都会被拒绝。
+
+获批后，完成工具使用精确 work 绑定：
+
+```text
+complete_plan({
+  planId: "20260723T140506-add-cache-a1b2c3d4",
+  revision: 2,
+  summary: "实现缓存失效与回滚处理",
+  verification: ["pnpm test", "pnpm typecheck"]
+})
+```
+
+`verification` 至少包含一个成功检查。记录完成前，工具还会重新校验获批 artifact hash。工具无法通用证明任意项目正确性，因此完成仍是 Agent/用户的显式声明，不会根据最终回复、文件改动或命令历史自动推断。
 
 Plan 上限为 256 KiB，并应覆盖九个必需章节。英文 Plan 使用 Goal、Non-goals、Current evidence、Decisions and rationale、Proposed changes、Execution steps、Verification、Risks 和 Assumptions；简体中文 Plan 使用目标、非目标、当前证据、决策与理由、拟议改动、执行步骤、验证、风险和假设。
 
@@ -186,6 +218,9 @@ pi --no-extensions -e ./packages/pi-plan-mode
 - Review 被中断：保留 planning 模式，不产生批准。
 - revdiff 打开期间 Plan 内容或当前 revision 改变：拒绝批准并要求重新 Review。
 - 恢复时元数据缺失或属于另一 Session：保持 normal，不接管该 Plan 指针。
+- legacy approved Session state：恢复为 `UNKNOWN` work，并要求显式选择修订、完成或放弃。
+- `complete_plan` ID/revision 不匹配或获批内容/hash 不匹配：拒绝完成，生命周期状态不变。
+- 带有 `IMPLEMENTING`/`UNKNOWN` work 重入：必须显式选择，绝不静默续写旧 Plan，也不静默开启并行 current work。
 - `/plan off`：恢复普通工具，但不删除或取消当前草稿。
 
 ## 开发

--- a/packages/pi-plan-mode/docs/plan-lifecycle-plan.md
+++ b/packages/pi-plan-mode/docs/plan-lifecycle-plan.md
@@ -1,0 +1,440 @@
+# Plan 双层生命周期改造计划
+
+状态：已实现
+
+关联计划：[`submit-plan-tool-display-plan.md`](./submit-plan-tool-display-plan.md)
+
+## 问题
+
+当前 Plan Mode 只有 Plan 文档评审状态：
+
+```text
+draft → changes_requested → approved
+```
+
+`approved` 表示某个不可变 revision 已经过用户批准，但不表示对应代码已经实现完成。当前 Session state 仍持续保存 `planId` 和 `revision`；批准后的 Widget 也持续显示该 Plan。再次进入 Plan Mode 时，`before_agent_start` 会把这份已批准 revision 作为 `[CURRENT PLAN REFERENCE]` 注入 system prompt。
+
+因此即使用户提出一个明确的新问题，模型也容易把它理解为旧 Plan 的修订并继续传入旧 `planId`。工具允许省略 `planId` 创建新 Plan，但当前 prompt 与 Session 指针对旧 Plan 的突出展示形成了错误默认。
+
+## 判断
+
+对明确的新目标，默认续写旧 Plan 不合理。
+
+但不能简单把 `completed` 加入现有 `PlanStatus`：
+
+- `PlanStatus` 描述的是文档评审生命周期。
+- “实现中 / 已完成 / 已放弃”描述的是获批 revision 的工作生命周期。
+- 已批准 revision 必须继续保持 `approved` 和内容不可变，即使对应工作后来完成或放弃。
+
+采用两个正交状态机。
+
+## 已选择的方向
+
+### 文档评审状态
+
+保持现有语义：
+
+```text
+DRAFT → CHANGES_REQUESTED → APPROVED
+```
+
+### 实现生命周期
+
+新增 branch-aware 工作状态：
+
+```text
+NONE → IMPLEMENTING → COMPLETED
+                    ↘ ABANDONED
+```
+
+原则：
+
+- 批准精确 revision 后进入 `IMPLEMENTING`。
+- Agent 只有在实现、必要验证和收尾全部完成后，才调用 `complete_plan`。
+- 用户可用 `/plan complete` 手动兜底。
+- 未完成或存在失败验证时不得标记完成。
+- 不根据自然语言最终回复、文件改动或测试命令自动猜测完成状态。
+- `COMPLETED` 后再次 `/plan on` 默认开始全新的 Plan，不注入旧 Plan reference。
+- `IMPLEMENTING` 或 legacy 状态下再次进入 Plan Mode，必须显式决定是修订当前 Plan，还是关闭当前工作后开始新 Plan。
+
+## 推荐数据模型
+
+### Plan artifact / manifest
+
+保持 `PlanMetadata` 与 `PlanRevision` 的评审语义，不把工作状态写进不可变 revision。
+
+`PlanStatus` 继续是：
+
+```ts
+type PlanStatus = "draft" | "changes_requested" | "approved";
+```
+
+manifest 版本原则上无需因工作状态升级；Plan 文件和批准 hash 不受影响。
+
+### Branch-aware Session state
+
+升级 `SESSION_STATE_VERSION`，把当前单一 Plan 指针拆成规划焦点和获批工作：
+
+```ts
+type PlanWorkStatus = "implementing" | "completed" | "abandoned" | "unknown";
+
+interface PlanningPlanRef {
+  planId: string;
+  revision: number;
+}
+
+interface PlanWorkRef {
+  planId: string;
+  revision: number;
+  approvedHash: string;
+  status: PlanWorkStatus;
+  startedAt?: string;
+  completedAt?: string;
+  abandonedAt?: string;
+}
+
+interface PlanSessionStateV3 {
+  version: 3;
+  mode: "normal" | "planning";
+  normalTools: string[];
+  planning?: PlanningPlanRef;
+  work?: PlanWorkRef;
+}
+```
+
+约束：
+
+- `planning` 只表示当前 Plan Mode 正在新建或修订的文档焦点。
+- `work` 绑定精确的 `planId + revision + approvedHash`，避免 completion 错绑到另一 revision。
+- 状态通过 `pi.appendEntry()` 保存，因此跟随 Session tree branch。
+- `session_tree`、resume 和 reload 从当前 branch 的最新状态恢复；fork 创建新的 Session，继续沿用现有 cross-Session 拒绝策略，不接管原 Session artifact。
+- 不从全局 manifest 推断某一 Session branch 的工作完成状态。
+
+## 核心流程
+
+### 1. 新建 Plan
+
+```text
+/plan on
+  → planning = undefined
+  → 不注入旧 Plan reference
+  → submit_plan 不带 planId
+  → 创建新 Plan
+```
+
+提交 draft 后，`planning` 指向新 Plan 当前 revision。
+
+### 2. 批准 Plan
+
+批准时：
+
+```text
+planning = approved plan ref
+work = {
+  planId,
+  revision,
+  approvedHash,
+  status: "implementing"
+}
+planning = undefined
+mode = normal
+```
+
+随后恢复普通工具并发送现有 approved implementation handoff。
+
+handoff 需增加明确规则：
+
+- 按获批 revision 实现。
+- 完成全部范围并通过必要验证后，将 `complete_plan` 作为最终工具调用。
+- 存在失败测试、未实现范围或未解决错误时，不得调用 `complete_plan`。
+
+### 3. Agent 完成实现
+
+新增 `complete_plan` 工具，只在 `work.status === "implementing"` 的 normal mode 激活。
+
+建议参数绑定当前工作：
+
+```ts
+complete_plan({
+  planId,
+  revision,
+  summary?,
+  verification?
+})
+```
+
+执行要求：
+
+- `planId`、revision 必须匹配当前 branch 的 work ref。
+- 当前 work 必须是 `implementing`。
+- 校验 manifest 中对应 revision 仍是 approved，hash 与 `approvedHash` 一致。
+- 成功后写入 branch-aware Session state：`status = completed`、`completedAt`。
+- 移除 `complete_plan` 活动工具。
+- 不修改 approved revision 内容或 review status。
+- 返回紧凑 completion 结果，并建议使用 `terminate: true` 作为最终工具调用。
+
+建议 TUI 事件：
+
+```text
+✓ PLAN COMPLETED · Add cache invalidation · r2
+```
+
+完整实现总结仍由普通 assistant 文本或 tool result `content` 保留；事件只做紧凑投影。
+
+### 4. 用户手动完成
+
+新增命令：
+
+```text
+/plan complete
+```
+
+行为：
+
+- 仅对当前 `implementing` work 生效。
+- 显式确认后标记 completed。
+- 提供 Agent 忘记调用工具、用户手动实现或恢复旧 Session 时的兜底。
+- 不要求进入 Plan Mode。
+
+### 5. 放弃当前实现
+
+建议同时提供：
+
+```text
+/plan abandon
+```
+
+行为：
+
+- 仅对 `implementing` 或 `unknown` work 生效。
+- 显式确认后标记 abandoned。
+- 保留 approved artifact 和历史 transcript。
+- 不把 abandoned 误写为 completed。
+
+## 再次进入 Plan Mode 的决策
+
+### 当前 work 为 COMPLETED 或 ABANDONED
+
+`/plan on` 默认开启新 Plan：
+
+- `planning = undefined`
+- 不注入旧 `[CURRENT PLAN REFERENCE]`
+- 旧 Plan 仅作为历史 completed/abandoned work 和 transcript 事件保留
+- 新 `submit_plan` 省略 `planId`
+
+若用户确实要修订旧 Plan，应使用显式入口，例如：
+
+```text
+/plan revise
+```
+
+### 当前 work 为 IMPLEMENTING
+
+不得默认为旧 Plan，也不得静默开始另一份工作。进入 Plan Mode 时显示选择：
+
+```text
+Current Plan is still IMPLEMENTING: OAuth migration · r2
+
+- Revise the implementing Plan
+- Mark completed and start a new Plan
+- Abandon and start a new Plan
+- Cancel
+```
+
+选择语义：
+
+- `Revise`：设置 `planning` 为当前 work ref，并注入旧 Plan reference。
+- `Mark completed and start new`：先显式完成，再清空 planning 焦点。
+- `Abandon and start new`：先显式放弃，再清空 planning 焦点。
+- `Cancel`：不切换工具与模式。
+
+不允许“保留一个 implementing work，同时静默创建第二个当前 Plan”；首版保持每个 branch 至多一个当前 work，避免 Widget、completion 和工具激活歧义。
+
+### 当前文档为 DRAFT 或 CHANGES_REQUESTED
+
+自动恢复同一 planning Plan 是合理的，因为它尚未形成另一项获批实现工作：
+
+- 注入 current Plan reference。
+- `submit_plan` 继续要求传当前 `planId`。
+- revdiff 创建下一不可变 revision。
+
+## Prompt 改造
+
+当前 `[CURRENT PLAN REFERENCE]` 不应再由“Session 有任意 planId”触发。
+
+仅在以下情况注入：
+
+1. 存在 draft/changes-requested `planning`；或
+2. 用户通过 `Revise` / `/plan revise` 明确选择获批 work。
+
+新问题的默认 planning prompt 应明确：
+
+```text
+No Plan is currently attached for revision.
+Create a new Plan and omit planId when calling submit_plan.
+```
+
+对于显式 revision：
+
+```text
+The user explicitly chose to revise this approved Plan.
+Inspect the current workspace and the referenced revision before deciding changes.
+Pass this planId only for this revision lineage.
+```
+
+模型不得自行根据“最近有 approved Plan”选择旧 `planId`。
+
+## Tool 激活策略
+
+扩展管理的工具集合需包含：
+
+```text
+submit_plan
+complete_plan
+```
+
+规则：
+
+- planning mode：只启用 `submit_plan`，禁用 `complete_plan`。
+- normal + implementing：恢复 normal tools，并额外启用 `complete_plan`。
+- normal + completed/abandoned/none：移除两个 managed tools。
+- snapshot/restore normal tools 时，必须剥离两个 managed tool，防止泄漏。
+- resume、tree navigation、reload 后按 branch state 重新计算活动工具。
+
+## Herdr blocked 事件
+
+Plan Mode 对所有等待用户输入的流程触发 Herdr 保留事件：
+
+```ts
+pi.events.emit("herdr:blocked", { active: true, label: "plan review" });
+// user-facing review / selector / confirmation
+pi.events.emit("herdr:blocked", { active: false });
+```
+
+已覆盖：
+
+- revdiff 评审：`plan review`
+- 无批注后的显式批准选择：`plan approval`
+- implementing/legacy work 重入选择：`plan lifecycle decision`
+- `/plan complete` 确认：`plan completion confirmation`
+- `/plan abandon` 确认：`plan abandonment confirmation`
+
+所有 active 事件都通过 `finally` 平衡清除。事件 listener 异常不得破坏 Plan 流程；非 Herdr 环境没有 listener，因此不增加 CLI、socket 或运行时依赖。现有 Herdr tool/event adapter 与直接事件采用计数语义，可安全嵌套。
+
+## Widget 与 transcript
+
+### Widget
+
+Widget 需要区分文档状态与工作状态。建议主状态显示当前用户最关心的阶段：
+
+```text
+▌ PLAN  OAuth migration                         IMPLEMENTING · r2
+▌ PLAN  OAuth migration                           COMPLETED · r2
+▌ PLAN  OAuth migration                           ABANDONED · r2
+```
+
+展开后补充：
+
+```text
+Document: APPROVED
+Approved hash: sha256:...
+Plan: ~/.pi/agent/plans/.../revisions/r2.md
+```
+
+当新 Plan 产生 draft 时，Widget 切换到新的 planning Plan；旧 completed Plan 仍可从 transcript 和持久化 artifact 审计。
+
+### Transcript
+
+建议新增紧凑事件：
+
+```text
+✓ PLAN COMPLETED · OAuth migration · r2
+! PLAN ABANDONED · OAuth migration · r2
+```
+
+这些事件应有历史 renderer。是否进入模型上下文需在实施前确认：
+
+- TUI-only custom entry 更节省模型上下文；
+- custom message 可让后续模型明确知道旧工作已关闭。
+
+推荐：Session state 作为真相，completion/abandon event 用 TUI-only custom entry；下一次 planning prompt 根据 state 明确说明没有 attached revision。
+
+## Legacy Session 迁移
+
+不能把所有旧 `approved` 指针直接推断为 completed，也不能假设仍在 implementing。
+
+V2 Session 恢复建议：
+
+- draft / changes_requested → `planning`，不创建 work。
+- approved → `work.status = "unknown"`，绑定现有 revision/hash。
+- `unknown` Widget 保持接近当前 `APPROVED` 展示。
+- 进入 Plan Mode 时按 implementing 类似方式显式询问：修订、标记完成并新建、放弃并新建、取消。
+- `/plan complete` 与 `/plan abandon` 接受 unknown 作为迁移兜底。
+- 不重写旧 JSONL entry；仅在下一次状态变化时追加 V3 entry。
+
+## No-session 行为
+
+`--no-session` 下仍在内存中维护双层状态：
+
+- 工具激活和当前进程内 UX 一致。
+- 不追加 Session state。
+- shutdown 后临时 Plan 与生命周期状态一起消失。
+- 不承诺跨进程 completion 恢复。
+
+## 失败与边界
+
+- `complete_plan` 参数不匹配当前 work：拒绝，不改变状态。
+- approved hash 或 revision 完整性校验失败：拒绝完成并提示重新检查。
+- 测试失败但模型调用 complete：prompt 明确禁止；工具无法通用判断任意项目验证结果，因此最终仍是显式 Agent/User 声明，而不是证明系统。
+- completion 后 tree 跳回旧 branch：按该 branch 的最新 Session state 恢复，不能被另一 branch 的 completion 污染。
+- completed Plan 被显式 revise：新 revision 获批后创建新的 implementing work，绑定新 revision/hash。
+- changes requested 不创建 implementing work；只有批准才创建。
+- Keep planning / cancelled review 保持 planning 文档焦点，不改变现有 work。
+
+## 实际实现范围
+
+已修改：
+
+- `packages/pi-plan-mode/src/types.ts`
+- `packages/pi-plan-mode/src/policy.ts`
+- `packages/pi-plan-mode/src/prompts.ts`
+- `packages/pi-plan-mode/src/widgets.ts`
+- `packages/pi-plan-mode/extensions/plan-mode.ts`
+- `packages/pi-plan-mode/README.md`
+- `packages/pi-plan-mode/README.zh-CN.md`
+
+已新增：
+
+- `packages/pi-plan-mode/src/lifecycle.ts`
+- `packages/pi-plan-mode/src/tool-display.ts`
+- `packages/pi-plan-mode/src/herdr.ts`
+- `packages/pi-plan-mode/tests/lifecycle.test.ts`
+- `packages/pi-plan-mode/tests/tool-display.test.ts`
+- `packages/pi-plan-mode/tests/herdr.test.ts`
+
+并扩展 extension、policy、prompt 与 widget 测试。approved artifact 完整性继续复用 `storage.ts` 的 `verifyApprovedPlan()`，manifest 不新增 work status。
+
+## 验收标准
+
+1. Plan 文档 review status 与实现 work status 明确分离。
+2. 批准后当前 branch 进入 implementing，并只绑定精确 approved revision/hash。
+3. Agent 和用户都能显式完成当前 Plan。
+4. completed 后再次进入 Plan Mode 默认新建，不注入旧 Plan reference。
+5. implementing/legacy 状态重入时不静默续旧或静默新建，必须显式选择。
+6. draft/changes requested 可自动继续同一 revision lineage。
+7. completed/abandoned 不修改 approved revision 或 hash。
+8. Session resume、reload 和 tree navigation 保持 branch-aware 行为；fork 不越过既有 Session ownership 边界。
+9. V2 approved Session 不被误判为 completed。
+10. managed tools 不泄漏到错误模式。
+11. Widget 和 transcript 能表达 implementing/completed/abandoned。
+12. 原有 revdiff、审批、不可变 revision、工具恢复和 handoff 行为继续通过。
+
+## 实施决议
+
+- `complete_plan` 强制要求精确 `planId`、revision、非空 `summary` 和至少一个成功 `verification` 项。
+- completion/abandon event 使用 TUI-only custom entry；branch-aware Session state 是生命周期真相。
+- `/plan revise` 只挂载当前 branch 的最近 work，不提供全局 Plan selector。
+- implementing/legacy 重入选择器依次提供：修订、完成后新建、放弃后新建、取消；没有静默默认。
+- completed/abandoned Widget 在 normal mode 保留；进入未挂载的新 Plan Mode 时隐藏，首次提交后切换到新 draft。
+- `complete_plan` 返回 `terminate: true`，并由 prompt 要求作为唯一且最终的工具调用。
+- 首版每个 branch 至多保留一个当前 work；不允许在旧 work 仍 implementing 时静默开启第二个 current work。

--- a/packages/pi-plan-mode/docs/submit-plan-tool-display-plan.md
+++ b/packages/pi-plan-mode/docs/submit-plan-tool-display-plan.md
@@ -1,0 +1,192 @@
+# `submit_plan` Tool Call TUI 展示计划
+
+状态：已实现
+
+## 背景
+
+改造前，`submit_plan` 注册了工具定义与执行流程，但没有提供 `renderCall`、`renderResult` 或 `renderShell`。Pi 因而回退到默认工具展示：调用阶段只显示工具名 `submit_plan`，不会显示标题、revision 或评审状态；完成后直接渲染模型可见的原始结果文本。
+
+这与当前 bundle 中已采用的 Claude 风格内置工具行、Plan Widget 和 `PLAN APPROVED` custom event 不一致，也会在要求修改时把完整 annotations 直接铺进 transcript。
+
+## 已确认的展示方向
+
+采用“极简无痕”方案：
+
+- 评审期间只显示一条紧凑、语义化的状态行。
+- 要求修改、取消或失败时保留一条历史摘要。
+- 批准成功后，收起状态隐藏 `submit_plan` 工具节点，只保留已有的紧凑批准事件。
+- 历史 transcript 在展开状态下重新显示关键审计信息。
+- annotations 必须能够从历史 Session 展开查看，不依赖当前磁盘上的 review workspace。
+
+## TUI 与模型上下文边界
+
+本展示改动严格限定为 TUI 投影；同批实现的双层生命周期属于关联计划 [`plan-lifecycle-plan.md`](./plan-lifecycle-plan.md)，不属于 renderer 自身职责：
+
+- 不修改工具名称、Schema、参数或 prompt guidance。
+- 不增加 `displaySummary`，避免改变模型 tool call arguments 和 token 使用。
+- 不修改 Plan 保存、revdiff、审批、工具恢复或 implementation handoff 流程。
+- 不修改工具结果的模型可见 `content`。
+- Session 继续保存原始 assistant tool call 与 tool result；TUI 在当前渲染器下重新投影这些数据。
+
+现有数据已经足够支持历史渲染：
+
+- Tool call arguments：`title`、`planId`、完整 `markdown`。
+- Tool result details：`kind`、`planId`、`revision`、`planPath`、`approvedHash`。
+- Tool result content：review feedback、annotations、取消或失败原因。
+- Approved custom message：标题、revision、step count、path、hash 和完整获批 Plan。
+
+## 状态展示规格
+
+### 1. 提交与评审中
+
+收起和展开状态均显示紧凑状态行，不展示完整 Markdown：
+
+```text
+● Reviewing Plan: Add cache invalidation…
+```
+
+可选的窄屏降级：
+
+```text
+● Reviewing Plan…
+```
+
+### 2. 要求修改
+
+收起状态：
+
+```text
+● Plan changes requested · Add cache invalidation · r2
+  ⎿ 3 annotations · Ctrl+O to inspect
+```
+
+展开状态：
+
+```text
+● Plan changes requested · Add cache invalidation · r2
+
+  Annotations
+  1. Step 2: add rollback handling
+  2. Verification: include an integration test
+  3. Risks: document cache stampede behavior
+
+  Plan ID: 20260723T...
+  Plan: ~/.pi/agent/plans/.../revisions/r2.md
+```
+
+要求：
+
+- annotations 从已持久化的 tool result `content` 提取，历史恢复后仍可查看。
+- 不依赖 `.review/annotations.md` 存在；临时 Session 清理后仍须可审计。
+- 展开内容设置视觉行预算，超出时显示 `… +N more`。
+- annotation 数量只有在格式可可靠解析时才显示精确值；否则使用 `Review annotations available`，不得猜测数量。
+
+### 3. 批准成功
+
+收起状态隐藏 `submit_plan` 工具节点，只保留：
+
+```text
+✓ PLAN APPROVED · Add cache invalidation · r2 · 6 steps
+```
+
+当全局工具输出处于展开状态时，允许 `submit_plan` 节点重新出现，提供审计元数据：
+
+```text
+Submit Plan · Add cache invalidation · r2
+  Plan ID: 20260723T...
+  Plan: ~/.pi/agent/plans/.../revisions/r2.md
+  Approved hash: sha256:...
+```
+
+不在此节点重复完整获批 Plan；完整内容已存在于 approved custom message 的模型上下文和 Session 中。
+
+### 4. Keep planning / Cancelled
+
+收起状态保留一行，避免看起来像批准成功：
+
+```text
+● Plan review kept as draft · Add cache invalidation · r2
+```
+
+或：
+
+```text
+● Plan review cancelled · Add cache invalidation · r2
+```
+
+展开后显示 `planId`、path 和原始原因。
+
+### 5. 无效输入、存储错误、revdiff 错误、完整性错误
+
+收起状态必须使用 warning/error 语义，不依赖 Pi 默认 success 背景：
+
+```text
+● Plan submission failed · storage error
+```
+
+展开后显示原始错误、`planId`、revision 和 path（若存在）。
+
+## 历史 transcript 实现原则
+
+Pi 在恢复 Session 时，会按 `toolCallId` 配对持久化的 assistant tool call 与 tool result，并重新调用当前工具的 `renderCall`/`renderResult`。实现应利用：
+
+- `context.args`：读取标题和提交参数。
+- `context.state`：在 call/result 两个 slot 间共享最终状态，使批准节点在收起时整体隐藏、展开时重新出现。
+- `context.lastComponent`：需要时复用组件，避免闪烁。
+- `options.expanded` / `context.expanded`：决定是否显示审计详情。
+- `context.isError` 与 `details.kind`：共同决定视觉状态。
+
+渲染不得读取当前 Plan 文件或 review workspace 来补齐历史信息；文件可能已移动、删除，或来自已清理的临时 Session。
+
+## 预期实现范围
+
+已新增：
+
+- `packages/pi-plan-mode/src/tool-display.ts`
+  - 解析 call/result 展示数据。
+  - 提供 `renderSubmitPlanCall` 和 `renderSubmitPlanResult`。
+  - 处理宽度、ANSI、换行和展开预算。
+
+已修改：
+
+- `packages/pi-plan-mode/extensions/plan-mode.ts`
+  - 为 `submit_plan` 接入 `renderCall`、`renderResult`。
+  - 根据最终视觉方案决定 `renderShell: "self"`。
+  - 保持 `execute`、结果 `content` 和审批控制流不变。
+
+已新增测试：
+
+- `packages/pi-plan-mode/tests/tool-display.test.ts`
+  - pending、changes requested、approved、keep planning、cancelled、error。
+  - collapsed/expanded 两种状态。
+  - 历史 Session 数据、不依赖文件系统。
+  - annotations 长度预算与窄终端。
+  - approved 节点收起隐藏、展开可审计。
+  - 主题颜色与 ANSI 宽度安全。
+
+必要时扩展：
+
+- `packages/pi-plan-mode/tests/extension.test.ts`
+  - 断言工具注册包含 renderer。
+  - 断言现有执行和审批结果未改变。
+
+文档更新在实现完成后再决定，避免当前讨论草案被误写成已发布行为。
+
+## 验收标准
+
+1. `submit_plan` 评审中不再只显示裸工具名。
+2. 收起 transcript 保持极简，不重复完整 Plan 或完整 annotations。
+3. Changes requested 的历史节点可通过 `Ctrl+O` 查看 annotations 关键内容。
+4. Approved 的 `submit_plan` 节点收起时隐藏，展开时可查看 planId、revision、path 和 hash。
+5. 取消和错误不会使用误导性的成功视觉。
+6. Session 恢复后展示一致，且不访问 Plan/review 文件。
+7. Renderer 不修改模型收到的 tool call arguments 或 tool result content；approved handoff 的生命周期扩展由关联计划单独负责。
+8. Plan Mode、revdiff、revision、审批、工具恢复及 handoff 测试继续通过。
+
+## 实施决议
+
+- annotations 使用 12 个视觉行预算，超出后显示剩余视觉行数。
+- 仅当所有非空 annotations 行都具有 Markdown 列表标记时才报告精确数量；其他格式显示 `Review annotations available`。
+- Approved 展开节点显示 Plan ID、path 和 approved hash，不重复 Markdown 大小、Steps 或完整 Plan。
+- 使用 `renderShell: "self"` 和 Pi Theme 语义色；渲染异常仍由 Pi 默认 fallback 兜底。
+- `ask_user_question` 与 Context7 renderer 不在本次范围内。

--- a/packages/pi-plan-mode/extensions/plan-mode.ts
+++ b/packages/pi-plan-mode/extensions/plan-mode.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
 import { Buffer } from "node:buffer";
+import path from "node:path";
 import { Type } from "typebox";
 import {
 	getAgentDir,
@@ -13,8 +13,19 @@ import {
 	loadPlanModeConfig,
 	type PlanContentLanguage,
 } from "../src/config.ts";
+import { withHerdrBlocked } from "../src/herdr.ts";
 import {
+	closePlanWork,
+	createImplementingWork,
+	isCompletableWork,
+	migrateStoredPlanSessionState,
+	parseStoredPlanSessionState,
+	type StoredPlanSessionState,
+} from "../src/lifecycle.ts";
+import {
+	COMPLETE_PLAN_TOOL,
 	SUBMIT_PLAN_TOOL,
+	getNormalTools,
 	getPlanningTools,
 	isPlanningToolAllowed,
 	withoutManagedTools,
@@ -37,24 +48,37 @@ import {
 	removeTemporaryPlanRoot,
 	saveSubmittedPlan,
 	updatePlanStatus,
+	verifyApprovedPlan,
 	writeReviewAnnotations,
 } from "../src/storage.ts";
+import {
+	renderCompletePlanCall,
+	renderCompletePlanResult,
+	renderSubmitPlanCall,
+	renderSubmitPlanResult,
+	type PlanToolDetails,
+} from "../src/tool-display.ts";
 import {
 	SESSION_STATE_VERSION,
 	type PlanMetadata,
 	type PlanMode,
+	type PlanReference,
 	type PlanSessionState,
 	type PlanStorageMode,
+	type PlanWorkReference,
 } from "../src/types.ts";
 import {
 	renderModeWidget,
 	renderPlanApprovedEvent,
+	renderPlanLifecycleEvent,
 	renderPlanWidget,
 	type PlanApprovedEventData,
+	type PlanLifecycleEventData,
 } from "../src/widgets.ts";
 
 const STATE_ENTRY_TYPE = "zhcsyncer-plan-mode-state";
 export const APPROVED_PLAN_MESSAGE_TYPE = "zhcsyncer-plan-approved";
+export const PLAN_LIFECYCLE_ENTRY_TYPE = "zhcsyncer-plan-lifecycle";
 const PLAN_WIDGET_KEY = "zhcsyncer-plan-mode-document";
 const MODE_WIDGET_KEY = "zhcsyncer-plan-mode-indicator";
 const MAX_PLAN_BYTES = 256 * 1024;
@@ -62,16 +86,13 @@ const APPROVE_CHOICE = "Approve Plan";
 const KEEP_PLANNING_CHOICE = "Keep planning";
 const CANCEL_REVIEW_CHOICE = "Cancel review";
 
+export const REVISE_WORK_CHOICE = "Revise the current Plan";
+export const COMPLETE_AND_NEW_CHOICE = "Mark completed and start a new Plan";
+export const ABANDON_AND_NEW_CHOICE = "Abandon and start a new Plan";
+export const CANCEL_PLAN_ENTRY_CHOICE = "Cancel";
+
 export const PLAN_MODE_SHORTCUT = "ctrl+alt+p";
 export const PLAN_STEPS_SHORTCUT = "ctrl+alt+o";
-
-interface ToolDetails {
-	kind: string;
-	planId?: string;
-	revision?: number;
-	planPath?: string;
-	approvedHash?: string;
-}
 
 interface ApprovedPlanMessageDetails extends PlanApprovedEventData {
 	title: string;
@@ -82,33 +103,26 @@ interface ApprovedPlanMessageDetails extends PlanApprovedEventData {
 	planPath: string;
 }
 
+interface WorkRecord {
+	metadata: PlanMetadata;
+	planPath: string;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseSessionState(value: unknown): PlanSessionState | undefined {
-	if (!isRecord(value) || value.version !== SESSION_STATE_VERSION) return undefined;
-	if (value.mode !== "normal" && value.mode !== "planning") return undefined;
-	if (!Array.isArray(value.normalTools) || !value.normalTools.every((tool) => typeof tool === "string")) return undefined;
-	if (value.planId !== undefined && (typeof value.planId !== "string" || !isValidPlanId(value.planId))) return undefined;
-	if (value.revision !== undefined && (typeof value.revision !== "number" || !Number.isInteger(value.revision) || value.revision < 1)) {
-		return undefined;
-	}
-	if ((value.planId === undefined) !== (value.revision === undefined)) return undefined;
-	return value as unknown as PlanSessionState;
-}
-
-function findLatestSessionState(ctx: ExtensionContext): PlanSessionState | undefined {
-	let latest: PlanSessionState | undefined;
+function findLatestStoredSessionState(ctx: ExtensionContext): StoredPlanSessionState | undefined {
+	let latest: StoredPlanSessionState | undefined;
 	for (const entry of ctx.sessionManager.getBranch()) {
 		if (entry.type !== "custom" || entry.customType !== STATE_ENTRY_TYPE) continue;
-		const parsed = parseSessionState(entry.data);
+		const parsed = parseStoredPlanSessionState(entry.data);
 		if (parsed) latest = parsed;
 	}
 	return latest;
 }
 
-function textResult(text: string, details: ToolDetails, terminate = false) {
+function textResult(text: string, details: PlanToolDetails, terminate = false) {
 	return {
 		content: [{ type: "text" as const, text }],
 		details,
@@ -144,12 +158,19 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		};
 	});
 
+	pi.registerEntryRenderer<PlanLifecycleEventData>(PLAN_LIFECYCLE_ENTRY_TYPE, (entry, options, theme) => {
+		const data = isRecord(entry.data) ? entry.data as PlanLifecycleEventData : {};
+		return {
+			render: (width) => renderPlanLifecycleEvent(data, width, theme, options.expanded),
+			invalidate() {},
+		};
+	});
+
 	let tuiEnabled = false;
 	let toolsRegistered = false;
 	let mode: PlanMode = "normal";
-	let planId: string | undefined;
-	let currentRevision: number | undefined;
-	let currentMetadata: PlanMetadata | undefined;
+	let planning: PlanReference | undefined;
+	let work: PlanWorkReference | undefined;
 	let planRoot: string | undefined;
 	let normalTools: string[] = [];
 	let temporaryRoot: string | undefined;
@@ -157,15 +178,16 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 	let stepsExpanded = false;
 	let contentLanguage: PlanContentLanguage = DEFAULT_PLAN_MODE_CONFIG.contentLanguage;
 	let planConfigPath = getPlanModeConfigPath();
+	const metadataByPlanId = new Map<string, PlanMetadata>();
 
 	function persistState(ctx: ExtensionContext): void {
 		if (!isPersistentSession(ctx)) return;
 		const data: PlanSessionState = {
 			version: SESSION_STATE_VERSION,
 			mode,
-			planId,
-			revision: currentRevision,
 			normalTools,
+			...(planning ? { planning } : {}),
+			...(work ? { work } : {}),
 		};
 		pi.appendEntry(STATE_ENTRY_TYPE, data);
 	}
@@ -173,24 +195,52 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 	function applyNormalTools(fallback?: string[]): void {
 		const restore = normalTools.length > 0 ? normalTools : fallback ?? withoutManagedTools(pi.getActiveTools());
 		normalTools = withoutManagedTools(restore);
-		pi.setActiveTools(normalTools);
+		pi.setActiveTools(getNormalTools(normalTools, isCompletableWork(work)));
 	}
 
 	function applyPlanningTools(): void {
 		pi.setActiveTools(getPlanningTools(normalTools));
 	}
 
+	function metadataFor(reference: PlanReference | undefined): PlanMetadata | undefined {
+		return reference ? metadataByPlanId.get(reference.planId) : undefined;
+	}
+
+	function revisionFor(reference: PlanReference | undefined) {
+		const metadata = metadataFor(reference);
+		return reference && metadata ? metadata.revisions[reference.revision - 1] : undefined;
+	}
+
+	function displayReference(): { reference: PlanReference; workRef?: PlanWorkReference } | undefined {
+		if (planning) return { reference: planning };
+		if (mode === "planning" || !work) return undefined;
+		return { reference: work, workRef: work };
+	}
+
+	function planPathFor(reference: PlanReference): string | undefined {
+		if (!planRoot) return undefined;
+		const revision = revisionFor(reference);
+		if (!revision) return undefined;
+		return getPlanPaths(planRoot, reference.planId, reference.revision, revision.basedOn).plan;
+	}
+
 	function refreshWidgets(ctx: ExtensionContext): void {
 		if (ctx.mode !== "tui") return;
-		const revision = currentRevisionMetadata();
-		if (planId && currentMetadata && revision && planRoot) {
-			const planPath = getPlanPaths(planRoot, planId, revision.revision, revision.basedOn).plan;
+		const displayed = displayReference();
+		const metadata = metadataFor(displayed?.reference);
+		const revision = revisionFor(displayed?.reference);
+		const planPath = displayed ? planPathFor(displayed.reference) : undefined;
+		if (displayed && metadata && revision && planPath) {
 			ctx.ui.setWidget(
 				PLAN_WIDGET_KEY,
 				(tui, theme) => ({
 					render: (width) => renderPlanWidget({
-						title: currentMetadata?.title ?? "Plan",
+						title: metadata.title,
 						status: revision.status,
+						...(displayed.workRef ? {
+							workStatus: displayed.workRef.status,
+							approvedHash: displayed.workRef.approvedHash,
+						} : {}),
 						revision: revision.revision,
 						planPath,
 						steps: revision.steps,
@@ -236,45 +286,188 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		return { root: temporaryRoot, storage: "temporary" };
 	}
 
-	function setMode(ctx: ExtensionContext, nextMode: PlanMode, notify = true): void {
-		if (nextMode === mode) {
-			if (notify) ctx.ui.notify(`Plan Mode is already ${mode === "planning" ? "on" : "off"}.`, "info");
+	function setNormalMode(ctx: ExtensionContext, notify = true): void {
+		if (mode === "normal") {
+			if (notify) ctx.ui.notify("Plan Mode is already off.", "info");
 			return;
 		}
-		if (nextMode === "planning") {
-			normalTools = withoutManagedTools(pi.getActiveTools());
-			mode = "planning";
-			applyPlanningTools();
-			persistState(ctx);
-			refreshWidgets(ctx);
-			if (notify) ctx.ui.notify("Plan Mode enabled. Tools are restricted to read-only exploration and submit_plan.", "info");
-			return;
-		}
-		applyNormalTools();
 		mode = "normal";
+		applyNormalTools();
 		persistState(ctx);
 		refreshWidgets(ctx);
 		if (notify) ctx.ui.notify("Plan Mode disabled. Normal tools restored.", "info");
 	}
 
-	function currentRevisionMetadata() {
-		if (!currentMetadata || currentRevision === undefined) return undefined;
-		return currentMetadata.revisions[currentRevision - 1];
+	function appendLifecycleEvent(ctx: ExtensionContext, data: PlanLifecycleEventData): void {
+		if (isPersistentSession(ctx)) pi.appendEntry(PLAN_LIFECYCLE_ENTRY_TYPE, data);
+	}
+
+	async function resolveWorkRecord(ctx: ExtensionContext, target: PlanWorkReference): Promise<WorkRecord> {
+		const storage = await ensurePlanRoot(ctx);
+		const metadata = await readPlanMetadata(storage.root, target.planId);
+		const revision = metadata?.revisions[target.revision - 1];
+		if (!metadata || metadata.sessionId !== ctx.sessionManager.getSessionId()) {
+			throw new Error("Current Plan metadata is missing or belongs to another Session");
+		}
+		if (!revision || revision.status !== "approved" || revision.hash !== target.approvedHash) {
+			throw new Error("Current Plan work does not match an approved revision");
+		}
+		metadataByPlanId.set(target.planId, metadata);
+		return {
+			metadata,
+			planPath: getPlanPaths(storage.root, target.planId, target.revision, revision.basedOn).plan,
+		};
+	}
+
+	async function closeCurrentWork(
+		ctx: ExtensionContext,
+		status: "completed" | "abandoned",
+		source: "agent" | "user" | "migration",
+		audit: { summary?: string; verification?: string[] } = {},
+		notify = true,
+	): Promise<PlanLifecycleEventData> {
+		if (!work || !isCompletableWork(work)) throw new Error("There is no implementing Plan to close");
+		const target = work;
+		const record = await resolveWorkRecord(ctx, target);
+		if (status === "completed") {
+			const integrity = await verifyApprovedPlan(planRoot!, target.planId, target.revision, target.approvedHash);
+			if (!integrity.ok) throw new Error(integrity.reason ?? "Approved Plan integrity check failed");
+		}
+		work = closePlanWork(target, status);
+		if (mode === "normal") applyNormalTools();
+		persistState(ctx);
+		refreshWidgets(ctx);
+		const data: PlanLifecycleEventData = {
+			kind: status,
+			title: record.metadata.title,
+			planId: target.planId,
+			revision: target.revision,
+			planPath: record.planPath,
+			approvedHash: target.approvedHash,
+			source,
+			...(audit.summary?.trim() ? { summary: audit.summary.trim() } : {}),
+			...(audit.verification?.length ? { verification: [...audit.verification] } : {}),
+		};
+		appendLifecycleEvent(ctx, data);
+		if (notify) {
+			ctx.ui.notify(
+				status === "completed"
+					? `Plan completed: ${record.metadata.title} · r${target.revision}`
+					: `Plan abandoned: ${record.metadata.title} · r${target.revision}`,
+				status === "completed" ? "info" : "warning",
+			);
+		}
+		return data;
+	}
+
+	async function enterPlanningMode(ctx: ExtensionContext, notify = true): Promise<boolean> {
+		if (mode === "planning") {
+			if (notify) ctx.ui.notify("Plan Mode is already on.", "info");
+			return true;
+		}
+
+		if (!planning && isCompletableWork(work)) {
+			const metadata = metadataFor(work) ?? (work ? (await resolveWorkRecord(ctx, work)).metadata : undefined);
+			const status = work?.status === "unknown" ? "LEGACY APPROVED" : "IMPLEMENTING";
+			const choice = await withHerdrBlocked(pi, "plan lifecycle decision", () =>
+				ctx.ui.select(
+					`Current Plan is ${status}: ${metadata?.title ?? "Plan"} · r${work?.revision}`,
+					[REVISE_WORK_CHOICE, COMPLETE_AND_NEW_CHOICE, ABANDON_AND_NEW_CHOICE, CANCEL_PLAN_ENTRY_CHOICE],
+				),
+			);
+			if (choice === REVISE_WORK_CHOICE && work) {
+				planning = { planId: work.planId, revision: work.revision };
+			} else if (choice === COMPLETE_AND_NEW_CHOICE || choice === ABANDON_AND_NEW_CHOICE) {
+				const closingAs = choice === COMPLETE_AND_NEW_CHOICE ? "completed" : "abandoned";
+				try {
+					await closeCurrentWork(
+						ctx,
+						closingAs,
+						"user",
+						{ summary: closingAs === "completed" ? "Marked complete while starting a new Plan." : "Abandoned while starting a new Plan." },
+						false,
+					);
+				} catch (error) {
+					ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+					return false;
+				}
+				planning = undefined;
+			} else {
+				if (notify) ctx.ui.notify("Plan Mode entry cancelled.", "info");
+				return false;
+			}
+		}
+
+		normalTools = withoutManagedTools(pi.getActiveTools());
+		mode = "planning";
+		stepsExpanded = false;
+		applyPlanningTools();
+		persistState(ctx);
+		refreshWidgets(ctx);
+		if (notify) {
+			ctx.ui.notify(
+				planning
+					? "Plan Mode enabled for an explicit Plan revision. Tools are restricted to read-only exploration and submit_plan."
+					: "Plan Mode enabled for a new Plan. Tools are restricted to read-only exploration and submit_plan.",
+				"info",
+			);
+		}
+		return true;
+	}
+
+	async function reviseCurrentWork(ctx: ExtensionContext): Promise<void> {
+		if (!work) {
+			ctx.ui.notify("No approved Plan is available to revise.", "info");
+			return;
+		}
+		if (planning && (planning.planId !== work.planId || planning.revision !== work.revision)) {
+			ctx.ui.notify("A different draft Plan is already attached. Finish or leave that revision before revising the approved Plan.", "warning");
+			return;
+		}
+		try {
+			await resolveWorkRecord(ctx, work);
+		} catch (error) {
+			ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+			return;
+		}
+		planning = { planId: work.planId, revision: work.revision };
+		if (mode !== "planning") {
+			normalTools = withoutManagedTools(pi.getActiveTools());
+			mode = "planning";
+		}
+		stepsExpanded = false;
+		applyPlanningTools();
+		persistState(ctx);
+		refreshWidgets(ctx);
+		ctx.ui.notify(`Plan Mode enabled to revise r${work.revision}.`, "info");
 	}
 
 	function showPlanStatus(ctx: ExtensionContext): void {
 		const lines = [
 			`Plan Mode: ${mode === "planning" ? "on" : "off"}`,
-			"Usage: /plan on|off",
+			"Usage: /plan on|off|revise|complete|abandon",
 			`Plan content language: ${contentLanguage}`,
 			`Config: ${planConfigPath}`,
 		];
-		const revision = currentRevisionMetadata();
-		if (planId && currentMetadata && revision && planRoot) {
+		if (planning) {
+			const metadata = metadataFor(planning);
+			const revision = revisionFor(planning);
+			const planPath = planPathFor(planning);
+			if (metadata && revision && planPath) {
+				lines.push(
+					`Planning Plan: ${metadata.title}`,
+					`Document: ${revision.status.toUpperCase()} · r${revision.revision}`,
+					`Path: ${planPath}`,
+				);
+			}
+		}
+		if (work) {
+			const metadata = metadataFor(work);
+			const planPath = planPathFor(work);
 			lines.push(
-				`Current Plan: ${currentMetadata.title}`,
-				`Document: ${revision.status.toUpperCase()} · r${revision.revision}`,
-				`Path: ${getPlanPaths(planRoot, planId, revision.revision, revision.basedOn).plan}`,
+				`Plan work: ${work.status.toUpperCase()}${metadata ? ` · ${metadata.title}` : ""} · r${work.revision}`,
+				`Approved hash: ${work.approvedHash}`,
+				...(planPath ? [`Path: ${planPath}`] : []),
 			);
 		}
 		ctx.ui.notify(lines.join("\n"), "info");
@@ -299,14 +492,17 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 			promptGuidelines: [
 				"Use submit_plan only in Plan Mode after repository exploration is complete.",
 				"Call submit_plan with the entire Plan, never a delta, and as the only tool in its tool-call batch.",
-				"Pass the current planId when revising the same Plan; omit planId only when starting a different Plan.",
+				"Pass the attached planId only when explicitly revising that Plan; omit planId for a new unattached Plan.",
 			],
 			parameters: Type.Object({
-				planId: Type.Optional(Type.String({ description: "Current Plan ID when submitting another revision of the same Plan." })),
+				planId: Type.Optional(Type.String({ description: "Attached Plan ID when submitting another revision of the same Plan." })),
 				title: Type.String({ minLength: 1, maxLength: 160, description: "Concise Plan title." }),
 				markdown: Type.String({ minLength: 1, description: "Complete decision-ready Markdown Plan." }),
 			}),
 			executionMode: "sequential",
+			renderShell: "self",
+			renderCall: renderSubmitPlanCall,
+			renderResult: renderSubmitPlanResult,
 			async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 				if (!tuiEnabled || ctx.mode !== "tui" || mode !== "planning") {
 					return textResult("submit_plan is available only while TUI Plan Mode is on.", { kind: "unavailable" }, true);
@@ -321,9 +517,19 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 				if (Buffer.byteLength(markdown, "utf8") > MAX_PLAN_BYTES) {
 					return textResult(`Plan exceeds the ${MAX_PLAN_BYTES} byte limit.`, { kind: "invalid" }, true);
 				}
-				if (requestedPlanId && (!isValidPlanId(requestedPlanId) || requestedPlanId !== planId)) {
+				if (requestedPlanId && !isValidPlanId(requestedPlanId)) {
+					return textResult("planId is not valid.", { kind: "invalid_plan_id" }, true);
+				}
+				if (planning && requestedPlanId !== planning.planId) {
 					return textResult(
-						"planId must match the current Session branch Plan. Omit it to create a new Plan.",
+						"The attached Plan requires its exact planId. Use /plan on for a new Plan only after closing the current workflow.",
+						{ kind: "invalid_plan_id", planId: planning.planId, revision: planning.revision },
+						true,
+					);
+				}
+				if (!planning && requestedPlanId) {
+					return textResult(
+						"No Plan is attached for revision. Omit planId to create a new Plan or use /plan revise first.",
 						{ kind: "invalid_plan_id" },
 						true,
 					);
@@ -343,7 +549,7 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 							storage: storage.storage,
 							sessionId: ctx.sessionManager.getSessionId(),
 							cwd: ctx.cwd,
-							...(requestedPlanId && currentRevision ? { basedOn: currentRevision } : {}),
+							...(planning ? { basedOn: planning.revision } : {}),
 						}),
 					);
 				} catch (error) {
@@ -354,22 +560,24 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 					);
 				}
 
-				planId = activePlanId;
-				currentRevision = submitted.revision.revision;
-				currentMetadata = submitted.metadata;
+				planning = { planId: activePlanId, revision: submitted.revision.revision };
+				metadataByPlanId.set(activePlanId, submitted.metadata);
 				stepsExpanded = false;
 				persistState(ctx);
 				refreshWidgets(ctx);
 
-				const review = await reviewPlanWithRevdiff(ctx, {
-					paths: submitted.paths,
-					hasPrevious: submitted.hasPrevious,
-					cwd: ctx.cwd,
-				});
+				const review = await withHerdrBlocked(pi, "plan review", () =>
+					reviewPlanWithRevdiff(ctx, {
+						paths: submitted.paths,
+						hasPrevious: submitted.hasPrevious,
+						cwd: ctx.cwd,
+					}),
+				);
 
 				if (review.kind === "changes_requested") {
 					await writeReviewAnnotations(submitted.paths, review.annotations);
-					currentMetadata = await updatePlanStatus(storage.root, activePlanId, "changes_requested");
+					const metadata = await updatePlanStatus(storage.root, activePlanId, "changes_requested");
+					metadataByPlanId.set(activePlanId, metadata);
 					persistState(ctx);
 					refreshWidgets(ctx);
 					return textResult(buildReviewFeedback(activePlanId, submitted.revision.revision, review.annotations), {
@@ -381,7 +589,8 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 				}
 
 				if (review.kind === "cancelled" || review.kind === "error") {
-					currentMetadata = await updatePlanStatus(storage.root, activePlanId, "draft");
+					const metadata = await updatePlanStatus(storage.root, activePlanId, "draft");
+					metadataByPlanId.set(activePlanId, metadata);
 					persistState(ctx);
 					refreshWidgets(ctx);
 					return textResult(
@@ -396,13 +605,16 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 					);
 				}
 
-				const decision = await ctx.ui.select("Plan review finished. Choose an explicit decision:", [
-					APPROVE_CHOICE,
-					KEEP_PLANNING_CHOICE,
-					CANCEL_REVIEW_CHOICE,
-				]);
+				const decision = await withHerdrBlocked(pi, "plan approval", () =>
+					ctx.ui.select("Plan review finished. Choose an explicit decision:", [
+						APPROVE_CHOICE,
+						KEEP_PLANNING_CHOICE,
+						CANCEL_REVIEW_CHOICE,
+					]),
+				);
 				if (decision !== APPROVE_CHOICE) {
-					currentMetadata = await updatePlanStatus(storage.root, activePlanId, "draft");
+					const metadata = await updatePlanStatus(storage.root, activePlanId, "draft");
+					metadataByPlanId.set(activePlanId, metadata);
 					persistState(ctx);
 					refreshWidgets(ctx);
 					const keepPlanning = decision === KEEP_PLANNING_CHOICE;
@@ -426,7 +638,8 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 						approvePlan(storage.root, activePlanId, submitted.revision.revision, submitted.submittedHash),
 					);
 				} catch (error) {
-					currentMetadata = await readPlanMetadata(storage.root, activePlanId);
+					const metadata = await readPlanMetadata(storage.root, activePlanId);
+					if (metadata) metadataByPlanId.set(activePlanId, metadata);
 					refreshWidgets(ctx);
 					return textResult(
 						`Approval was not recorded: ${error instanceof Error ? error.message : String(error)}. Submit the current Plan for review again.`,
@@ -440,12 +653,13 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 					);
 				}
 
-				currentMetadata = approved;
-				currentRevision = submitted.revision.revision;
-				await cleanupReviewWorkspace(storage.root, activePlanId);
-				setMode(ctx, "normal", false);
+				metadataByPlanId.set(activePlanId, approved);
 				const approvedHash = approved.approvedHash;
 				if (!approvedHash) throw new Error("Approval did not produce an approved hash");
+				work = createImplementingWork({ planId: activePlanId, revision: submitted.revision.revision }, approvedHash);
+				planning = undefined;
+				await cleanupReviewWorkspace(storage.root, activePlanId);
+				setNormalMode(ctx, false);
 				pi.sendMessage<ApprovedPlanMessageDetails>(
 					{
 						customType: APPROVED_PLAN_MESSAGE_TYPE,
@@ -483,43 +697,118 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 				);
 			},
 		});
+
+		pi.registerTool({
+			name: COMPLETE_PLAN_TOOL,
+			label: "Complete Plan",
+			description: "Close the exact approved Plan work only after all approved scope is implemented and necessary verification passes. Never use while work is partial, checks fail, or unresolved errors remain.",
+			promptSnippet: "Mark the current approved Plan implementation complete after successful verification",
+			promptGuidelines: [
+				"Call complete_plan only after every item in the exact approved Plan is implemented and all necessary verification passes.",
+				"Never call complete_plan while implementation is partial, tests or checks fail, or unresolved errors remain.",
+				"Call complete_plan with the current exact planId and revision as the only and final tool in its batch.",
+			],
+			parameters: Type.Object({
+				planId: Type.String({ description: "Exact current approved Plan ID." }),
+				revision: Type.Integer({ minimum: 1, description: "Exact current approved revision." }),
+				summary: Type.String({ minLength: 1, maxLength: 2000, description: "Concise summary of the completed implementation." }),
+				verification: Type.Array(Type.String({ minLength: 1, maxLength: 500 }), {
+					minItems: 1,
+					maxItems: 20,
+					description: "Checks that completed successfully. Do not include failing or pending checks.",
+				}),
+			}),
+			executionMode: "sequential",
+			renderShell: "self",
+			renderCall: renderCompletePlanCall,
+			renderResult: renderCompletePlanResult,
+			async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+				if (!tuiEnabled || ctx.mode !== "tui" || mode !== "normal" || !work || !isCompletableWork(work)) {
+					throw new Error("complete_plan is available only for the current implementing Plan in TUI normal mode");
+				}
+				if (params.planId !== work.planId || params.revision !== work.revision) {
+					throw new Error(`complete_plan must target ${work.planId} r${work.revision}`);
+				}
+				const summary = params.summary.trim();
+				const verification = params.verification.map((item) => item.trim()).filter(Boolean);
+				if (!summary || verification.length === 0) throw new Error("Completion summary and successful verification checks are required");
+				const event = await closeCurrentWork(ctx, "completed", "agent", { summary, verification }, false);
+				const completedAt = work.completedAt;
+				return textResult(
+					`Plan ${params.planId} r${params.revision} is complete.\n\nSummary: ${summary}\n\nVerification:\n${verification.map((item) => `- ${item}`).join("\n")}`,
+					{
+						kind: "completed",
+						planId: params.planId,
+						revision: params.revision,
+						planPath: event.planPath,
+						approvedHash: event.approvedHash,
+						title: event.title,
+						completedAt,
+						summary,
+						verification,
+					},
+					true,
+				);
+			},
+		});
+	}
+
+	async function loadMetadataForReference(ctx: ExtensionContext, reference: PlanReference): Promise<PlanMetadata | undefined> {
+		const root = await ensurePersistentPlanRoot(path.join(getAgentDir(), "plans"));
+		planRoot = root;
+		const metadata = await readPlanMetadata(root, reference.planId);
+		if (!metadata || metadata.sessionId !== ctx.sessionManager.getSessionId() || !metadata.revisions[reference.revision - 1]) {
+			return undefined;
+		}
+		metadataByPlanId.set(reference.planId, metadata);
+		return metadata;
 	}
 
 	async function restoreState(ctx: ExtensionContext): Promise<void> {
 		const fallbackTools = normalTools.length > 0 ? normalTools : withoutManagedTools(pi.getActiveTools());
-		const restored = findLatestSessionState(ctx);
-		if (!restored) {
+		const stored = findLatestStoredSessionState(ctx);
+		metadataByPlanId.clear();
+		planRoot = undefined;
+		planning = undefined;
+		work = undefined;
+		if (!stored) {
 			mode = "normal";
-			planId = undefined;
-			currentRevision = undefined;
-			currentMetadata = undefined;
-			planRoot = undefined;
 			normalTools = fallbackTools;
 			applyNormalTools(fallbackTools);
 			refreshWidgets(ctx);
 			return;
 		}
 
-		normalTools = withoutManagedTools(restored.normalTools.length > 0 ? restored.normalTools : fallbackTools);
-		mode = restored.mode;
-		planId = restored.planId;
-		currentRevision = restored.revision;
-		currentMetadata = undefined;
-		planRoot = undefined;
-
-		if (planId && currentRevision) {
-			const root = await ensurePersistentPlanRoot(path.join(getAgentDir(), "plans"));
-			const metadata = await readPlanMetadata(root, planId);
-			const revision = metadata?.revisions[currentRevision - 1];
-			if (metadata && revision && metadata.sessionId === ctx.sessionManager.getSessionId()) {
-				planRoot = root;
-				currentMetadata = metadata;
-			} else {
-				planId = undefined;
-				currentRevision = undefined;
+		let restored: PlanSessionState;
+		if (stored.version === SESSION_STATE_VERSION) {
+			restored = stored;
+		} else {
+			let metadata: PlanMetadata | undefined;
+			if (stored.planId && stored.revision) {
+				metadata = await loadMetadataForReference(ctx, { planId: stored.planId, revision: stored.revision });
 			}
+			restored = migrateStoredPlanSessionState(stored, metadata);
 		}
 
+		normalTools = withoutManagedTools(restored.normalTools.length > 0 ? restored.normalTools : fallbackTools);
+		mode = restored.mode;
+		planning = restored.planning;
+		work = restored.work;
+
+		if (planning && !(await loadMetadataForReference(ctx, planning))) planning = undefined;
+		if (work) {
+			const metadata = metadataFor(work) ?? await loadMetadataForReference(ctx, work);
+			const revision = metadata?.revisions[work.revision - 1];
+			if (!metadata || !revision || revision.status !== "approved" || revision.hash !== work.approvedHash) work = undefined;
+		}
+
+		if (mode === "planning" && !planning && isCompletableWork(work)) {
+			mode = "normal";
+			applyNormalTools(fallbackTools);
+			refreshWidgets(ctx);
+			await enterPlanningMode(ctx, false);
+			return;
+		}
 		if (mode === "planning") applyPlanningTools();
 		else applyNormalTools(fallbackTools);
 		refreshWidgets(ctx);
@@ -545,7 +834,7 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		registerTools();
 		await restoreState(ctx);
 		if (event.reason === "startup" && pi.getFlag("plan") === true && mode === "normal") {
-			setMode(ctx, "planning", false);
+			await enterPlanningMode(ctx, false);
 		}
 	});
 
@@ -562,9 +851,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		temporaryRoot = undefined;
 		if (!isPersistentSession(ctx)) {
 			mode = "normal";
-			planId = undefined;
-			currentRevision = undefined;
-			currentMetadata = undefined;
+			planning = undefined;
+			work = undefined;
+			metadataByPlanId.clear();
 			planRoot = undefined;
 			normalTools = [];
 		}
@@ -580,28 +869,33 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 
 	pi.on("before_agent_start", async (event, ctx) => {
 		if (!tuiEnabled || ctx.mode !== "tui" || mode !== "planning") return;
-		const revision = currentRevisionMetadata();
-		if (!planRoot || !planId || !currentMetadata || !revision) {
+		const metadata = metadataFor(planning);
+		const revision = revisionFor(planning);
+		const planPath = planning ? planPathFor(planning) : undefined;
+		if (!planning || !metadata || !revision || !planPath) {
 			return { systemPrompt: appendPlanningPrompt(event.systemPrompt, undefined, contentLanguage) };
 		}
 		return {
 			systemPrompt: appendPlanningPrompt(event.systemPrompt, {
-				planId,
-				title: currentMetadata.title,
+				planId: planning.planId,
+				title: metadata.title,
 				revision: revision.revision,
 				status: revision.status,
-				planPath: getPlanPaths(planRoot, planId, revision.revision, revision.basedOn).plan,
+				planPath,
 			}, contentLanguage),
 		};
 	});
 
 	pi.registerCommand("plan", {
-		description: "Turn strict read-only Plan Mode on or off",
+		description: "Manage strict read-only Plan Mode and the approved Plan lifecycle",
 		getArgumentCompletions: (argumentPrefix) => {
 			const prefix = argumentPrefix.trim().toLowerCase();
 			const options = [
 				{ value: "on", label: "on", description: "Enable read-only Plan Mode" },
 				{ value: "off", label: "off", description: "Disable Plan Mode and restore normal tools" },
+				{ value: "revise", label: "revise", description: "Explicitly revise the current approved Plan" },
+				{ value: "complete", label: "complete", description: "Mark the current approved Plan work complete" },
+				{ value: "abandon", label: "abandon", description: "Abandon the current approved Plan work" },
 			];
 			return options.filter((option) => option.value.startsWith(prefix));
 		},
@@ -612,19 +906,61 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 				showPlanStatus(ctx);
 				return;
 			}
-			if (action !== "on" && action !== "off") {
-				ctx.ui.notify("Usage: /plan on|off", "warning");
+			if (action === "on") {
+				await enterPlanningMode(ctx);
 				return;
 			}
-			setMode(ctx, action === "on" ? "planning" : "normal");
+			if (action === "off") {
+				setNormalMode(ctx);
+				return;
+			}
+			if (action === "revise") {
+				await reviseCurrentWork(ctx);
+				return;
+			}
+			if (action === "complete" || action === "abandon") {
+				if (!work || !isCompletableWork(work)) {
+					ctx.ui.notify("There is no implementing or legacy approved Plan to close.", "info");
+					return;
+				}
+				if (mode !== "normal") {
+					ctx.ui.notify("Turn Plan Mode off before closing implementation work.", "warning");
+					return;
+				}
+				const verb = action === "complete" ? "complete" : "abandon";
+				const confirmed = await withHerdrBlocked(
+					pi,
+					verb === "complete" ? "plan completion confirmation" : "plan abandonment confirmation",
+					() => ctx.ui.confirm(
+						`${verb === "complete" ? "Complete" : "Abandon"} current Plan?`,
+						verb === "complete"
+							? "Confirm only if all approved scope is implemented and necessary verification passes."
+							: "The approved artifact remains available, but this work will no longer be active.",
+					),
+				);
+				if (!confirmed) return;
+				try {
+					await closeCurrentWork(
+						ctx,
+						verb === "complete" ? "completed" : "abandoned",
+						"user",
+						{ summary: verb === "complete" ? "Marked complete by the user." : "Abandoned by the user." },
+					);
+				} catch (error) {
+					ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+				}
+				return;
+			}
+			ctx.ui.notify("Usage: /plan on|off|revise|complete|abandon", "warning");
 		},
 	});
 
 	pi.registerShortcut(PLAN_MODE_SHORTCUT, {
 		description: "Toggle Plan Mode",
-		handler: (ctx) => {
+		handler: async (ctx) => {
 			if (!ensureCommandAvailable(ctx)) return;
-			setMode(ctx, mode === "planning" ? "normal" : "planning");
+			if (mode === "planning") setNormalMode(ctx);
+			else await enterPlanningMode(ctx);
 		},
 	});
 
@@ -632,7 +968,7 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		description: "Expand or collapse current Plan steps",
 		handler: (ctx) => {
 			if (!ensureCommandAvailable(ctx)) return;
-			if (!currentRevisionMetadata()) {
+			if (!displayReference()) {
 				ctx.ui.notify("No current Plan.", "info");
 				return;
 			}

--- a/packages/pi-plan-mode/package.json
+++ b/packages/pi-plan-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zhcsyncer/pi-plan-mode",
   "version": "0.1.0",
-  "description": "Temporary read-only Plan Mode for Pi with revdiff review and immutable revisions.",
+  "description": "Strict Plan Mode for Pi with revdiff review, immutable revisions, and explicit lifecycle completion.",
   "keywords": [
     "pi-package",
     "pi-extension",

--- a/packages/pi-plan-mode/src/herdr.ts
+++ b/packages/pi-plan-mode/src/herdr.ts
@@ -1,0 +1,39 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export const HERDR_BLOCKED_EVENT = "herdr:blocked";
+
+export interface HerdrBlockedEventData {
+	active: boolean;
+	label?: string;
+}
+
+type EventAPI = Pick<ExtensionAPI, "events">;
+
+/**
+ * Emit Herdr's reserved blocked-state event without creating a hard runtime
+ * dependency on Herdr. Pi's shared event bus is process-local, so non-Herdr
+ * environments simply have no listener. Listener failures must never break
+ * the Plan workflow.
+ */
+export function emitHerdrBlocked(pi: EventAPI, active: boolean, label?: string): void {
+	const data: HerdrBlockedEventData = active && label ? { active, label } : { active };
+	try {
+		pi.events.emit(HERDR_BLOCKED_EVENT, data);
+	} catch {
+		// Optional integration: Plan behavior must remain unchanged if a listener fails.
+	}
+}
+
+/** Mark a user-facing approval/question UI as blocked and always balance it. */
+export async function withHerdrBlocked<T>(
+	pi: EventAPI,
+	label: string,
+	operation: () => T | Promise<T>,
+): Promise<T> {
+	emitHerdrBlocked(pi, true, label);
+	try {
+		return await operation();
+	} finally {
+		emitHerdrBlocked(pi, false);
+	}
+}

--- a/packages/pi-plan-mode/src/lifecycle.ts
+++ b/packages/pi-plan-mode/src/lifecycle.ts
@@ -1,0 +1,146 @@
+import {
+	LEGACY_SESSION_STATE_VERSION,
+	SESSION_STATE_VERSION,
+	type LegacyPlanSessionState,
+	type PlanMetadata,
+	type PlanReference,
+	type PlanSessionState,
+	type PlanWorkReference,
+	type PlanWorkStatus,
+} from "./types.ts";
+import { isValidPlanId } from "./storage.ts";
+
+const APPROVED_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const WORK_STATUSES = new Set<PlanWorkStatus>(["implementing", "completed", "abandoned", "unknown"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRevision(value: unknown): value is number {
+	return typeof value === "number" && Number.isInteger(value) && value >= 1;
+}
+
+function isTimestamp(value: unknown): value is string | undefined {
+	return value === undefined || typeof value === "string";
+}
+
+function parseReference(value: unknown): PlanReference | undefined {
+	if (!isRecord(value)) return undefined;
+	if (typeof value.planId !== "string" || !isValidPlanId(value.planId)) return undefined;
+	if (!isRevision(value.revision)) return undefined;
+	return { planId: value.planId, revision: value.revision };
+}
+
+function parseWorkReference(value: unknown): PlanWorkReference | undefined {
+	const reference = parseReference(value);
+	if (!reference || !isRecord(value)) return undefined;
+	if (typeof value.approvedHash !== "string" || !APPROVED_HASH_PATTERN.test(value.approvedHash)) return undefined;
+	if (typeof value.status !== "string" || !WORK_STATUSES.has(value.status as PlanWorkStatus)) return undefined;
+	if (!isTimestamp(value.startedAt) || !isTimestamp(value.completedAt) || !isTimestamp(value.abandonedAt)) return undefined;
+	return {
+		...reference,
+		approvedHash: value.approvedHash,
+		status: value.status as PlanWorkStatus,
+		...(value.startedAt ? { startedAt: value.startedAt } : {}),
+		...(value.completedAt ? { completedAt: value.completedAt } : {}),
+		...(value.abandonedAt ? { abandonedAt: value.abandonedAt } : {}),
+	};
+}
+
+function parseNormalTools(value: unknown): string[] | undefined {
+	if (!Array.isArray(value) || !value.every((tool) => typeof tool === "string")) return undefined;
+	return [...new Set(value)];
+}
+
+export type StoredPlanSessionState = PlanSessionState | LegacyPlanSessionState;
+
+export function parseStoredPlanSessionState(value: unknown): StoredPlanSessionState | undefined {
+	if (!isRecord(value)) return undefined;
+	if (value.mode !== "normal" && value.mode !== "planning") return undefined;
+	const normalTools = parseNormalTools(value.normalTools);
+	if (!normalTools) return undefined;
+
+	if (value.version === SESSION_STATE_VERSION) {
+		const planning = value.planning === undefined ? undefined : parseReference(value.planning);
+		const work = value.work === undefined ? undefined : parseWorkReference(value.work);
+		if (value.planning !== undefined && !planning) return undefined;
+		if (value.work !== undefined && !work) return undefined;
+		return {
+			version: SESSION_STATE_VERSION,
+			mode: value.mode,
+			normalTools,
+			...(planning ? { planning } : {}),
+			...(work ? { work } : {}),
+		};
+	}
+
+	if (value.version !== LEGACY_SESSION_STATE_VERSION) return undefined;
+	if (value.planId !== undefined && (typeof value.planId !== "string" || !isValidPlanId(value.planId))) return undefined;
+	if (value.revision !== undefined && !isRevision(value.revision)) return undefined;
+	if ((value.planId === undefined) !== (value.revision === undefined)) return undefined;
+	return {
+		version: LEGACY_SESSION_STATE_VERSION,
+		mode: value.mode,
+		normalTools,
+		...(value.planId ? { planId: value.planId, revision: value.revision as number } : {}),
+	};
+}
+
+export function migrateStoredPlanSessionState(
+	state: StoredPlanSessionState,
+	metadata?: PlanMetadata,
+): PlanSessionState {
+	if (state.version === SESSION_STATE_VERSION) return state;
+	const migrated: PlanSessionState = {
+		version: SESSION_STATE_VERSION,
+		mode: state.mode,
+		normalTools: [...state.normalTools],
+	};
+	if (!state.planId || !state.revision || !metadata || metadata.planId !== state.planId) return migrated;
+	const revision = metadata.revisions[state.revision - 1];
+	if (!revision) return migrated;
+	if (revision.status === "approved" && APPROVED_HASH_PATTERN.test(revision.hash)) {
+		migrated.work = {
+			planId: state.planId,
+			revision: state.revision,
+			approvedHash: revision.hash,
+			status: "unknown",
+		};
+	} else {
+		migrated.planning = { planId: state.planId, revision: state.revision };
+	}
+	return migrated;
+}
+
+export function createImplementingWork(
+	reference: PlanReference,
+	approvedHash: string,
+	now = new Date(),
+): PlanWorkReference {
+	if (!APPROVED_HASH_PATTERN.test(approvedHash)) throw new Error("Invalid approved Plan hash");
+	return {
+		...reference,
+		approvedHash,
+		status: "implementing",
+		startedAt: now.toISOString(),
+	};
+}
+
+export function isCompletableWork(work: PlanWorkReference | undefined): boolean {
+	return work?.status === "implementing" || work?.status === "unknown";
+}
+
+export function closePlanWork(
+	work: PlanWorkReference,
+	status: "completed" | "abandoned",
+	now = new Date(),
+): PlanWorkReference {
+	if (!isCompletableWork(work)) throw new Error(`Plan work is already ${work.status}`);
+	const timestamp = now.toISOString();
+	return {
+		...work,
+		status,
+		...(status === "completed" ? { completedAt: timestamp } : { abandonedAt: timestamp }),
+	};
+}

--- a/packages/pi-plan-mode/src/policy.ts
+++ b/packages/pi-plan-mode/src/policy.ts
@@ -1,4 +1,5 @@
 export const SUBMIT_PLAN_TOOL = "submit_plan";
+export const COMPLETE_PLAN_TOOL = "complete_plan";
 
 const READ_ONLY_PLANNING_TOOLS = new Set([
 	"read",
@@ -13,7 +14,7 @@ const READ_ONLY_PLANNING_TOOLS = new Set([
 	"questionnaire",
 ]);
 
-const MANAGED_TOOLS = new Set([SUBMIT_PLAN_TOOL]);
+const MANAGED_TOOLS = new Set([SUBMIT_PLAN_TOOL, COMPLETE_PLAN_TOOL]);
 
 export function withoutManagedTools(toolNames: string[]): string[] {
 	return [...new Set(toolNames.filter((name) => !MANAGED_TOOLS.has(name)))];
@@ -24,6 +25,15 @@ export function getPlanningTools(previouslyActive: string[]): string[] {
 		...new Set([
 			...previouslyActive.filter((name) => READ_ONLY_PLANNING_TOOLS.has(name)),
 			SUBMIT_PLAN_TOOL,
+		]),
+	];
+}
+
+export function getNormalTools(previouslyActive: string[], canCompletePlan: boolean): string[] {
+	return [
+		...new Set([
+			...withoutManagedTools(previouslyActive),
+			...(canCompletePlan ? [COMPLETE_PLAN_TOOL] : []),
 		]),
 	];
 }

--- a/packages/pi-plan-mode/src/prompts.ts
+++ b/packages/pi-plan-mode/src/prompts.ts
@@ -74,9 +74,12 @@ export function appendPlanningPrompt(
 	contentLanguage: PlanContentLanguage = "auto",
 ): string {
 	const base = `${systemPrompt}\n\n${buildPlanningPrompt(contentLanguage)}`;
-	if (!currentPlan) return base;
+	if (!currentPlan) {
+		return `${base}\n\n[NEW PLAN]
+No Plan revision is attached for revision. Create a new Plan for the current goal and omit planId when calling submit_plan. Do not reuse a recently approved Plan ID unless the user explicitly enters its revision workflow.`;
+	}
 	return `${base}\n\n[CURRENT PLAN REFERENCE]
-A Plan is attached to the current Session branch. Use it as context and inspect the current workspace before deciding whether it still applies. Pass this planId to submit_plan only when revising the same goal; omit planId to create a different Plan.
+The user explicitly attached this Plan revision for continued planning. Use it as context and inspect the current workspace before deciding changes. Pass this exact planId to submit_plan for this revision lineage.
 
 Plan: ${currentPlan.title}
 Plan ID: ${currentPlan.planId}
@@ -107,6 +110,8 @@ Approved hash: ${input.approvedHash}
 Plan path: ${input.planPath}
 
 Implement the approved Plan using the current workspace as the source of truth. If repository facts invalidate a decision, stop and ask the user rather than silently changing scope.
+
+After every approved item is implemented and all necessary verification passes, call complete_plan with this exact Plan ID and revision, a concise implementation summary, and the completed verification checks. Call complete_plan as the only and final tool in its batch. Do not call it while scope is incomplete, verification is failing, or unresolved errors remain.
 
 --- BEGIN APPROVED PLAN ---
 ${input.markdown}

--- a/packages/pi-plan-mode/src/tool-display.ts
+++ b/packages/pi-plan-mode/src/tool-display.ts
@@ -1,0 +1,327 @@
+import { keyHint, type Theme } from "@earendil-works/pi-coding-agent";
+import { Container, Text, truncateToWidth, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
+import { compactPlanPath } from "./widgets.ts";
+
+const ANNOTATION_VISUAL_LINE_BUDGET = 12;
+
+export interface SubmitPlanCallArgs {
+	planId?: string;
+	title?: string;
+	markdown?: string;
+}
+
+export interface CompletePlanCallArgs {
+	planId?: string;
+	revision?: number;
+	summary?: string;
+	verification?: string[];
+}
+
+export interface PlanToolDetails {
+	kind?: string;
+	planId?: string;
+	revision?: number;
+	planPath?: string;
+	approvedHash?: string;
+	title?: string;
+	completedAt?: string;
+	summary?: string;
+	verification?: string[];
+}
+
+interface RenderResultLike {
+	content?: Array<{ type: string; text?: string }>;
+	details?: unknown;
+}
+
+interface ToolOutcome {
+	details: PlanToolDetails;
+	resultText: string;
+	isError: boolean;
+}
+
+interface ToolDisplayState {
+	outcome?: ToolOutcome;
+	callComponent?: MutableCallComponent;
+}
+
+class MutableCallComponent implements Component {
+	private renderLine: (width: number) => string | undefined = () => undefined;
+
+	setRenderer(renderer: (width: number) => string | undefined): void {
+		this.renderLine = renderer;
+	}
+
+	render(width: number): string[] {
+		if (width <= 0) return [];
+		const line = this.renderLine(width);
+		return line ? [truncateToWidth(line, width)] : [];
+	}
+
+	invalidate(): void {}
+}
+
+class DynamicLinesComponent implements Component {
+	constructor(private readonly buildLines: (width: number) => string[]) {}
+
+	render(width: number): string[] {
+		if (width <= 0) return [];
+		return this.buildLines(width).map((line) => truncateToWidth(line, width));
+	}
+
+	invalidate(): void {}
+}
+
+function emptyComponent(): Component {
+	return new Container();
+}
+
+function textContent(result: RenderResultLike): string {
+	return result.content
+		?.filter((item) => item.type === "text" && typeof item.text === "string")
+		.map((item) => item.text)
+		.join("\n") ?? "";
+}
+
+function toolDetails(value: unknown): PlanToolDetails {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+	return value as PlanToolDetails;
+}
+
+function titleOf(args: SubmitPlanCallArgs | undefined): string {
+	return args?.title?.trim() || "Plan";
+}
+
+function metadataSuffix(title: string, revision?: number): string {
+	return `${title}${Number.isInteger(revision) && revision! > 0 ? ` · r${revision}` : ""}`;
+}
+
+function failureSummary(text: string, fallback: string): string {
+	const firstLine = text.trim().split(/\r?\n/, 1)[0]?.trim();
+	if (!firstLine) return fallback;
+	const colon = firstLine.indexOf(":");
+	return (colon >= 0 ? firstLine.slice(colon + 1) : firstLine).trim() || fallback;
+}
+
+function isSubmitFailure(kind: string | undefined, isError: boolean): boolean {
+	return isError || ["unavailable", "invalid", "invalid_plan_id", "storage_error", "integrity_error", "error"].includes(kind ?? "");
+}
+
+function expandAuditHint(): string {
+	try {
+		return keyHint("app.tools.expand", "to inspect");
+	} catch {
+		return "Ctrl+O to inspect";
+	}
+}
+
+function formatSubmitCall(
+	args: SubmitPlanCallArgs | undefined,
+	outcome: ToolOutcome | undefined,
+	expanded: boolean,
+	theme: Theme,
+	width: number,
+): string | undefined {
+	const title = titleOf(args);
+	if (!outcome) {
+		const prefix = theme.fg("accent", "● Reviewing Plan");
+		const suffix = theme.fg("muted", `: ${title}…`);
+		return `${prefix}${truncateToWidth(suffix, Math.max(0, width - 18))}`;
+	}
+
+	const { details, resultText, isError } = outcome;
+	const suffix = metadataSuffix(title, details.revision);
+	if (details.kind === "approved") {
+		if (!expanded) return undefined;
+		return `${theme.fg("toolTitle", theme.bold("Submit Plan"))}${theme.fg("muted", ` · ${suffix}`)}`;
+	}
+	if (details.kind === "changes_requested") {
+		return `${theme.fg("warning", "● Plan changes requested")}${theme.fg("muted", ` · ${suffix}`)}`;
+	}
+	if (details.kind === "keep_planning") {
+		return `${theme.fg("accent", "● Plan review kept as draft")}${theme.fg("muted", ` · ${suffix}`)}`;
+	}
+	if (details.kind === "cancelled") {
+		return `${theme.fg("warning", "● Plan review cancelled")}${theme.fg("muted", ` · ${suffix}`)}`;
+	}
+	if (isSubmitFailure(details.kind, isError)) {
+		return `${theme.fg("error", "✗ Plan submission failed")}${theme.fg("muted", ` · ${failureSummary(resultText, details.kind ?? "error")}`)}`;
+	}
+	return `${theme.fg("accent", "● Plan submitted")}${theme.fg("muted", ` · ${suffix}`)}`;
+}
+
+interface ParsedAnnotations {
+	raw: string;
+	items?: string[];
+}
+
+export function parseReviewAnnotations(resultText: string): ParsedAnnotations | undefined {
+	const separator = resultText.indexOf("\n\n");
+	if (separator < 0) return undefined;
+	const raw = resultText.slice(separator + 2).trim();
+	if (!raw) return undefined;
+	const lines = raw.split(/\r?\n/).filter((line) => line.trim().length > 0);
+	const listItems = lines.map((line) => /^\s*(?:[-*+]\s+|\d+[.)]\s+)(.+?)\s*$/.exec(line));
+	if (listItems.length > 0 && listItems.every((item) => item !== null)) {
+		return { raw, items: listItems.map((item) => item![1]!.trim()) };
+	}
+	return { raw };
+}
+
+function wrapLine(line: string, width: number): string[] {
+	return wrapTextWithAnsi(line, Math.max(1, width));
+}
+
+function renderAnnotationLines(parsed: ParsedAnnotations, width: number, theme: Theme): string[] {
+	const sourceLines: string[] = [];
+	if (parsed.items) {
+		for (const [index, item] of parsed.items.entries()) {
+			sourceLines.push(...wrapLine(`${theme.fg("accent", `  ${index + 1}. `)}${theme.fg("muted", item)}`, width));
+		}
+	} else {
+		for (const line of parsed.raw.split(/\r?\n/)) {
+			if (!line.trim()) continue;
+			sourceLines.push(...wrapLine(theme.fg("muted", `  ${line.trim()}`), width));
+		}
+	}
+	if (sourceLines.length <= ANNOTATION_VISUAL_LINE_BUDGET) return sourceLines;
+	const visible = sourceLines.slice(0, ANNOTATION_VISUAL_LINE_BUDGET);
+	visible.push(theme.fg("dim", `  … +${sourceLines.length - ANNOTATION_VISUAL_LINE_BUDGET} more lines`));
+	return visible;
+}
+
+function auditMetadata(details: PlanToolDetails, theme: Theme): string[] {
+	const lines: string[] = [];
+	if (details.planId) lines.push(theme.fg("dim", `  Plan ID: ${details.planId}`));
+	if (details.planPath) lines.push(theme.fg("dim", `  Plan: ${compactPlanPath(details.planPath)}`));
+	if (details.approvedHash) lines.push(theme.fg("dim", `  Approved hash: ${details.approvedHash}`));
+	return lines;
+}
+
+function renderSubmitResultLines(
+	outcome: ToolOutcome,
+	expanded: boolean,
+	theme: Theme,
+	width: number,
+): string[] {
+	const { details, resultText, isError } = outcome;
+	if (details.kind === "approved") return expanded ? auditMetadata(details, theme) : [];
+
+	if (details.kind === "changes_requested") {
+		const parsed = parseReviewAnnotations(resultText);
+		if (!expanded) {
+			const summary = parsed?.items
+				? `${parsed.items.length} ${parsed.items.length === 1 ? "annotation" : "annotations"}`
+				: "Review annotations available";
+			return [theme.fg("dim", `  ⎿ ${summary} · ${expandAuditHint()}`)];
+		}
+		const lines = [theme.fg("muted", "  Annotations")];
+		if (parsed) lines.push(...renderAnnotationLines(parsed, width, theme));
+		else lines.push(theme.fg("dim", "  Review feedback is stored in the tool result."));
+		lines.push(...auditMetadata(details, theme));
+		return lines;
+	}
+
+	if (expanded) {
+		const lines: string[] = [];
+		if (resultText.trim()) lines.push(...wrapLine(theme.fg(isSubmitFailure(details.kind, isError) ? "error" : "muted", `  ${resultText.trim()}`), width));
+		lines.push(...auditMetadata(details, theme));
+		return lines;
+	}
+	return [];
+}
+
+export function renderSubmitPlanCall(
+	args: SubmitPlanCallArgs,
+	theme: Theme,
+	context: { state: ToolDisplayState; lastComponent?: Component; expanded?: boolean },
+): Component {
+	const component = context.lastComponent instanceof MutableCallComponent
+		? context.lastComponent
+		: new MutableCallComponent();
+	context.state.callComponent = component;
+	component.setRenderer((width) => formatSubmitCall(args, context.state.outcome, context.expanded === true, theme, width));
+	return component;
+}
+
+export function renderSubmitPlanResult(
+	result: RenderResultLike,
+	options: { expanded: boolean; isPartial: boolean },
+	theme: Theme,
+	context: { state: ToolDisplayState; args: SubmitPlanCallArgs; isError: boolean; expanded?: boolean },
+): Component {
+	if (options.isPartial) return emptyComponent();
+	const outcome: ToolOutcome = {
+		details: toolDetails(result.details),
+		resultText: textContent(result),
+		isError: context.isError,
+	};
+	context.state.outcome = outcome;
+	context.state.callComponent?.setRenderer((width) =>
+		formatSubmitCall(context.args, outcome, options.expanded, theme, width));
+	return new DynamicLinesComponent((width) => renderSubmitResultLines(outcome, options.expanded, theme, width));
+}
+
+function formatCompleteCall(
+	args: CompletePlanCallArgs | undefined,
+	outcome: ToolOutcome | undefined,
+	expanded: boolean,
+	theme: Theme,
+): string | undefined {
+	const revision = Number.isInteger(args?.revision) && args!.revision! > 0 ? ` · r${args!.revision}` : "";
+	if (!outcome) return `${theme.fg("accent", "● Completing Plan")}${theme.fg("muted", revision)}`;
+	if (outcome.details.kind === "completed") {
+		if (!expanded) return undefined;
+		return `${theme.fg("toolTitle", theme.bold("Complete Plan"))}${theme.fg("muted", revision)}`;
+	}
+	return `${theme.fg("error", "✗ Plan completion failed")}${theme.fg("muted", ` · ${failureSummary(outcome.resultText, "error")}`)}`;
+}
+
+function renderCompleteResultLines(outcome: ToolOutcome, expanded: boolean, theme: Theme, width: number): string[] {
+	if (outcome.details.kind === "completed") {
+		if (!expanded) return [];
+		const lines: string[] = [];
+		if (outcome.details.summary) lines.push(...wrapLine(theme.fg("muted", `  Summary: ${outcome.details.summary}`), width));
+		for (const item of outcome.details.verification ?? []) {
+			lines.push(...wrapLine(theme.fg("dim", `  Verified: ${item}`), width));
+		}
+		lines.push(...auditMetadata(outcome.details, theme));
+		if (outcome.details.completedAt) lines.push(theme.fg("dim", `  Completed: ${outcome.details.completedAt}`));
+		return lines;
+	}
+	return expanded && outcome.resultText ? wrapLine(theme.fg("error", `  ${outcome.resultText}`), width) : [];
+}
+
+export function renderCompletePlanCall(
+	args: CompletePlanCallArgs,
+	theme: Theme,
+	context: { state: ToolDisplayState; lastComponent?: Component; expanded?: boolean },
+): Component {
+	const component = context.lastComponent instanceof MutableCallComponent
+		? context.lastComponent
+		: new MutableCallComponent();
+	context.state.callComponent = component;
+	component.setRenderer(() => formatCompleteCall(args, context.state.outcome, context.expanded === true, theme));
+	return component;
+}
+
+export function renderCompletePlanResult(
+	result: RenderResultLike,
+	options: { expanded: boolean; isPartial: boolean },
+	theme: Theme,
+	context: { state: ToolDisplayState; args: CompletePlanCallArgs; isError: boolean },
+): Component {
+	if (options.isPartial) return emptyComponent();
+	const outcome: ToolOutcome = {
+		details: toolDetails(result.details),
+		resultText: textContent(result),
+		isError: context.isError,
+	};
+	context.state.outcome = outcome;
+	context.state.callComponent?.setRenderer(() => formatCompleteCall(context.args, outcome, options.expanded, theme));
+	return new DynamicLinesComponent((width) => renderCompleteResultLines(outcome, options.expanded, theme, width));
+}
+
+export function renderHiddenPlanToolNode(): Text {
+	return new Text("", 0, 0);
+}

--- a/packages/pi-plan-mode/src/types.ts
+++ b/packages/pi-plan-mode/src/types.ts
@@ -1,8 +1,10 @@
 export const PLAN_METADATA_VERSION = 2 as const;
-export const SESSION_STATE_VERSION = 2 as const;
+export const SESSION_STATE_VERSION = 3 as const;
+export const LEGACY_SESSION_STATE_VERSION = 2 as const;
 
 export type PlanMode = "normal" | "planning";
 export type PlanStatus = "draft" | "changes_requested" | "approved";
+export type PlanWorkStatus = "implementing" | "completed" | "abandoned" | "unknown";
 export type PlanStorageMode = "persistent" | "temporary";
 
 export interface PlanRevision {
@@ -43,8 +45,29 @@ export interface PlanPaths {
 	annotations: string;
 }
 
+export interface PlanReference {
+	planId: string;
+	revision: number;
+}
+
+export interface PlanWorkReference extends PlanReference {
+	approvedHash: string;
+	status: PlanWorkStatus;
+	startedAt?: string;
+	completedAt?: string;
+	abandonedAt?: string;
+}
+
 export interface PlanSessionState {
 	version: typeof SESSION_STATE_VERSION;
+	mode: PlanMode;
+	planning?: PlanReference;
+	work?: PlanWorkReference;
+	normalTools: string[];
+}
+
+export interface LegacyPlanSessionState {
+	version: typeof LEGACY_SESSION_STATE_VERSION;
 	mode: PlanMode;
 	planId?: string;
 	revision?: number;

--- a/packages/pi-plan-mode/src/widgets.ts
+++ b/packages/pi-plan-mode/src/widgets.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { type Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import type { PlanStatus } from "./types.ts";
+import type { PlanStatus, PlanWorkStatus } from "./types.ts";
 
 const PLAN_PREFIX = "▌ PLAN  ";
 const MODE_LABEL = "⏸ PLAN MODE · READ-ONLY";
@@ -12,6 +12,8 @@ const STEPS_HINT = "Ctrl+Alt+O";
 export interface PlanWidgetData {
 	title: string;
 	status: PlanStatus;
+	workStatus?: PlanWorkStatus;
+	approvedHash?: string;
 	revision: number;
 	planPath: string;
 	steps: string[];
@@ -25,17 +27,31 @@ export interface PlanApprovedEventData {
 	stepCount?: number;
 }
 
+export interface PlanLifecycleEventData {
+	kind?: "completed" | "abandoned";
+	title?: string;
+	planId?: string;
+	revision?: number;
+	planPath?: string;
+	approvedHash?: string;
+	source?: "agent" | "user" | "migration";
+	summary?: string;
+	verification?: string[];
+}
+
 function clamp(value: number, minimum: number, maximum: number): number {
 	return Math.min(maximum, Math.max(minimum, value));
 }
 
-function statusLabel(status: PlanStatus): string {
-	return status === "changes_requested" ? "CHANGES REQUESTED" : status.toUpperCase();
+function statusLabel(status: PlanStatus | PlanWorkStatus): string {
+	if (status === "changes_requested") return "CHANGES REQUESTED";
+	if (status === "unknown") return "APPROVED";
+	return status.toUpperCase();
 }
 
-function statusColor(status: PlanStatus): "success" | "warning" | "accent" {
-	if (status === "approved") return "success";
-	if (status === "changes_requested") return "warning";
+function statusColor(status: PlanStatus | PlanWorkStatus): "success" | "warning" | "accent" | "error" {
+	if (status === "approved" || status === "completed") return "success";
+	if (status === "changes_requested" || status === "abandoned" || status === "unknown") return "warning";
 	return "accent";
 }
 
@@ -72,7 +88,8 @@ export function compactPlanPath(planPath: string, home = homedir()): string {
 export function renderPlanWidget(data: PlanWidgetData, width: number, theme: Theme): string[] {
 	if (width <= 0) return [];
 	const title = `${theme.fg("accent", PLAN_PREFIX)}${theme.bold(data.title)}`;
-	const state = theme.fg(statusColor(data.status), `${statusLabel(data.status)} · r${data.revision}`);
+	const displayedStatus = data.workStatus ?? data.status;
+	const state = theme.fg(statusColor(displayedStatus), `${statusLabel(displayedStatus)} · r${data.revision}`);
 	const lines = [alignRight(title, state, width)];
 
 	if (!data.expanded) {
@@ -84,6 +101,10 @@ export function renderPlanWidget(data: PlanWidgetData, width: number, theme: The
 
 	const planPath = theme.fg("dim", compactPlanPath(data.planPath));
 	lines.push(truncateToWidth(planPath, width));
+	if (data.workStatus && data.workStatus !== "unknown") {
+		lines.push(truncateToWidth(theme.fg("muted", `Document: ${statusLabel(data.status)}`), width));
+		if (data.approvedHash) lines.push(truncateToWidth(theme.fg("dim", `Approved hash: ${data.approvedHash}`), width));
+	}
 	if (data.steps.length === 0) {
 		lines.push(truncateToWidth(theme.fg("muted", "  No execution steps"), width));
 	} else {
@@ -114,6 +135,38 @@ export function renderPlanApprovedEvent(data: PlanApprovedEventData, width: numb
 	if (width - statusWidth < 3) return [truncateToWidth(status, width)];
 	const suffix = theme.fg("dim", ` · ${metadata.join(" · ")}`);
 	return [`${status}${truncateToWidth(suffix, width - statusWidth)}`];
+}
+
+export function renderPlanLifecycleEvent(
+	data: PlanLifecycleEventData,
+	width: number,
+	theme: Theme,
+	expanded = false,
+): string[] {
+	if (width <= 0) return [];
+	const completed = data.kind === "completed";
+	const abandoned = data.kind === "abandoned";
+	const label = completed ? "✓ PLAN COMPLETED" : abandoned ? "! PLAN ABANDONED" : "! PLAN LIFECYCLE";
+	const status = theme.fg(completed ? "success" : "warning", label);
+	const metadata: string[] = [];
+	if (data.title?.trim()) metadata.push(data.title.trim());
+	if (Number.isInteger(data.revision) && data.revision! > 0) metadata.push(`r${data.revision}`);
+	const statusWidth = visibleWidth(status);
+	const first = metadata.length > 0 && width - statusWidth >= 3
+		? `${status}${truncateToWidth(theme.fg("dim", ` · ${metadata.join(" · ")}`), width - statusWidth)}`
+		: truncateToWidth(status, width);
+	if (!expanded) return [first];
+
+	const lines = [first];
+	if (data.summary?.trim()) lines.push(truncateToWidth(theme.fg("muted", `  Summary: ${data.summary.trim()}`), width));
+	for (const item of data.verification ?? []) {
+		lines.push(truncateToWidth(theme.fg("dim", `  Verified: ${item}`), width));
+	}
+	if (data.planId) lines.push(truncateToWidth(theme.fg("dim", `  Plan ID: ${data.planId}`), width));
+	if (data.planPath) lines.push(truncateToWidth(theme.fg("dim", `  Plan: ${compactPlanPath(data.planPath)}`), width));
+	if (data.approvedHash) lines.push(truncateToWidth(theme.fg("dim", `  Approved hash: ${data.approvedHash}`), width));
+	if (data.source) lines.push(truncateToWidth(theme.fg("dim", `  Source: ${data.source}`), width));
+	return lines;
 }
 
 export function renderModeWidget(width: number, theme: Theme): string[] {

--- a/packages/pi-plan-mode/tests/extension.test.ts
+++ b/packages/pi-plan-mode/tests/extension.test.ts
@@ -5,11 +5,13 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { afterEach, describe, expect, it, vi } from "vitest";
 import planModeExtension, {
 	APPROVED_PLAN_MESSAGE_TYPE,
+	PLAN_LIFECYCLE_ENTRY_TYPE,
 	PLAN_MODE_SHORTCUT,
 	PLAN_STEPS_SHORTCUT,
+	REVISE_WORK_CHOICE,
 	isPersistentSession,
 } from "../extensions/plan-mode.ts";
-import { SUBMIT_PLAN_TOOL } from "../src/policy.ts";
+import { COMPLETE_PLAN_TOOL, SUBMIT_PLAN_TOOL } from "../src/policy.ts";
 
 interface CustomEntry {
 	type: "custom";
@@ -30,7 +32,12 @@ class FakePi {
 	readonly sentUserMessages: Array<{ content: string; options?: unknown }> = [];
 	readonly sentMessages: Array<{ message: any; options?: unknown; activeTools: string[] }> = [];
 	readonly messageRenderers = new Map<string, any>();
+	readonly entryRenderers = new Map<string, any>();
 	readonly flags = new Map<string, unknown>();
+	readonly emittedEvents: Array<{ event: string; data: unknown }> = [];
+	readonly events = {
+		emit: (event: string, data: unknown) => this.emittedEvents.push({ event, data }),
+	};
 	onSendMessage?: () => void;
 
 	constructor(entries: CustomEntry[] = []) {
@@ -66,6 +73,10 @@ class FakePi {
 
 	registerMessageRenderer(customType: string, renderer: unknown): void {
 		this.messageRenderers.set(customType, renderer);
+	}
+
+	registerEntryRenderer(customType: string, renderer: unknown): void {
+		this.entryRenderers.set(customType, renderer);
 	}
 
 	registerShortcut(shortcut: string, definition: unknown): void {
@@ -151,6 +162,7 @@ function fakeContext(options: FakeContextOptions = {}): FakeContextHarness {
 				else widgets.set(key, { content, placement: widgetOptions?.placement });
 			},
 			select: async () => choices.shift(),
+			confirm: async () => choices.shift() === "confirm",
 			custom: async (factory: any) => {
 				let completed = false;
 				let value: unknown;
@@ -293,6 +305,12 @@ describe("Plan Mode extension lifecycle", () => {
 		await pi.emit("session_start", { reason: "startup" }, harness.ctx);
 
 		expect(pi.activeTools).toEqual(["read", "grep", "find", "ls", SUBMIT_PLAN_TOOL]);
+		for (const toolName of [SUBMIT_PLAN_TOOL, COMPLETE_PLAN_TOOL]) {
+			const tool = pi.tools.get(toolName);
+			expect(tool).toMatchObject({ renderShell: "self" });
+			expect(tool.renderCall).toBeTypeOf("function");
+			expect(tool.renderResult).toBeTypeOf("function");
+		}
 		const belowEntry = [...harness.widgets.entries()].find(([, widget]) => widget.placement === "belowEditor");
 		expect(belowEntry).toBeDefined();
 		expect(harness.renderWidget(belowEntry![0])?.join("\n")).toContain("⏸ PLAN MODE · READ-ONLY");
@@ -339,7 +357,13 @@ describe("Plan Mode extension lifecycle", () => {
 		await pi.emit("session_start", { reason: "startup" }, ctx);
 		const command = pi.commands.get("plan") as any;
 
-		expect(command.getArgumentCompletions("").map((item: any) => item.value)).toEqual(["on", "off"]);
+		expect(command.getArgumentCompletions("").map((item: any) => item.value)).toEqual([
+			"on",
+			"off",
+			"revise",
+			"complete",
+			"abandon",
+		]);
 		expect(command.getArgumentCompletions("o").map((item: any) => item.value)).toEqual(["on", "off"]);
 		await command.handler("", ctx);
 		expect(notifications.at(-1)?.message).toContain("Plan Mode: off");
@@ -363,37 +387,43 @@ describe("Plan Mode extension lifecycle", () => {
 		expect(pi.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls"]);
 		expect([...harness.widgets.values()].some((widget) => widget.placement === "belowEditor")).toBe(false);
 		await command.handler("bad", ctx);
-		expect(notifications.at(-1)?.message).toBe("Usage: /plan on|off");
+		expect(notifications.at(-1)?.message).toBe("Usage: /plan on|off|revise|complete|abandon");
 	});
 
-	it("uses temporary revision storage, exits Plan Mode on approval, and cleans up", async () => {
+	it("uses temporary revision storage, enters implementation, and explicitly reattaches for revision", async () => {
 		await fakeRevdiff();
 		const pi = new FakePi();
 		planModeExtension(pi.api());
-		const harness = fakeContext({ entries: pi.entries, choices: ["Approve Plan"] });
+		const harness = fakeContext({ entries: pi.entries, choices: ["Approve Plan", REVISE_WORK_CHOICE] });
 		await pi.emit("session_start", { reason: "startup" }, harness.ctx);
 		await turnPlanOn(pi, harness.ctx);
 		expect(isPersistentSession(harness.ctx)).toBe(false);
 		expect(pi.entries).toHaveLength(0);
 		pi.onSendMessage = () => {
-			expect(pi.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls"]);
+			expect(pi.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls", COMPLETE_PLAN_TOOL]);
 			expect([...harness.widgets.values()].some((widget) => widget.placement === "belowEditor")).toBe(false);
 		};
 
 		const result = await submitPlan(pi, harness.ctx) as { details: { planId: string; planPath: string; approvedHash: string; revision: number } };
+		expect(pi.emittedEvents).toEqual([
+			{ event: "herdr:blocked", data: { active: true, label: "plan review" } },
+			{ event: "herdr:blocked", data: { active: false } },
+			{ event: "herdr:blocked", data: { active: true, label: "plan approval" } },
+			{ event: "herdr:blocked", data: { active: false } },
+		]);
 		const planRoot = path.dirname(path.dirname(path.dirname(result.details.planPath)));
 		expect(planRoot).toMatch(new RegExp(`${path.sep.replace("\\", "\\\\")}pi-plan-`));
 		expect(result.details.revision).toBe(1);
 		expect(result.details.planPath).toMatch(/revisions[/\\]r1\.md$/);
 		expect(await readFile(result.details.planPath, "utf8")).toContain("Implement it");
 		expect(pi.entries).toHaveLength(0);
-		expect(pi.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls"]);
+		expect(pi.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls", COMPLETE_PLAN_TOOL]);
 		expect(harness.terminal).toMatchObject({ stops: 1, starts: 1 });
 		expect(pi.sentUserMessages).toHaveLength(0);
 		expect(pi.sentMessages).toHaveLength(1);
 		const sent = pi.sentMessages[0];
 		expect(sent.options).toEqual({ triggerTurn: true, deliverAs: "followUp" });
-		expect(sent.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls"]);
+		expect(sent.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls", COMPLETE_PLAN_TOOL]);
 		expect(sent.message).toMatchObject({
 			customType: APPROVED_PLAN_MESSAGE_TYPE,
 			display: true,
@@ -426,7 +456,7 @@ describe("Plan Mode extension lifecycle", () => {
 		expect(plain(fallbackMessage[0])).toBe("✓ PLAN APPROVED");
 		const aboveEntry = [...harness.widgets.entries()].find(([, widget]) => widget.placement === "aboveEditor");
 		expect(aboveEntry).toBeDefined();
-		expect(plain(harness.renderWidget(aboveEntry![0])?.join("\n"))).toContain("APPROVED · r1");
+		expect(plain(harness.renderWidget(aboveEntry![0])?.join("\n"))).toContain("IMPLEMENTING · r1");
 		expect(plain(harness.renderWidget(aboveEntry![0])?.join("\n"))).toContain("2 steps");
 		expect([...harness.widgets.values()].some((widget) => widget.placement === "belowEditor")).toBe(false);
 		const stepsShortcut = pi.shortcuts.get(PLAN_STEPS_SHORTCUT) as { handler: (ctx: ExtensionContext) => void };
@@ -435,6 +465,10 @@ describe("Plan Mode extension lifecycle", () => {
 		expect(plain(harness.renderWidget(aboveEntry![0])?.join("\n"))).toContain("Ctrl+Alt+O collapse");
 
 		await turnPlanOn(pi, harness.ctx);
+		expect(pi.emittedEvents.slice(-2)).toEqual([
+			{ event: "herdr:blocked", data: { active: true, label: "plan lifecycle decision" } },
+			{ event: "herdr:blocked", data: { active: false } },
+		]);
 		const replanningPrompt = await pi.emit("before_agent_start", { systemPrompt: "BASE" }, harness.ctx) as { systemPrompt: string };
 		expect(replanningPrompt.systemPrompt).toContain("[CURRENT PLAN REFERENCE]");
 		expect(replanningPrompt.systemPrompt).toContain(`Plan ID: ${result.details.planId}`);
@@ -475,6 +509,149 @@ describe("Plan Mode extension lifecycle", () => {
 		expect(pi.activeTools).toContain("edit");
 	});
 
+	it("reports manual lifecycle confirmations as balanced Herdr blocked events", async () => {
+		await fakeRevdiff();
+		const pi = new FakePi();
+		planModeExtension(pi.api());
+		const harness = fakeContext({ entries: pi.entries, choices: ["Approve Plan", "confirm"] });
+		await pi.emit("session_start", { reason: "startup" }, harness.ctx);
+		await turnPlanOn(pi, harness.ctx);
+		await submitPlan(pi, harness.ctx);
+		const command = pi.commands.get("plan") as { handler: (args: string, ctx: ExtensionContext) => Promise<void> };
+		await command.handler("abandon", harness.ctx);
+		expect(pi.emittedEvents.slice(-2)).toEqual([
+			{ event: "herdr:blocked", data: { active: true, label: "plan abandonment confirmation" } },
+			{ event: "herdr:blocked", data: { active: false } },
+		]);
+		expect(pi.activeTools).not.toContain(COMPLETE_PLAN_TOOL);
+		const aboveKey = [...harness.widgets.entries()].find(([, widget]) => widget.placement === "aboveEditor")?.[0];
+		expect(plain(harness.renderWidget(aboveKey!)?.join("\n"))).toContain("ABANDONED · r1");
+	});
+
+	it("completes exact approved work and starts the next Plan unattached by default", async () => {
+		await fakeRevdiff();
+		const agentDir = await mkdtemp(path.join(tmpdir(), "pi-plan-complete-test-"));
+		cleanup.add(agentDir);
+		vi.stubEnv("PI_CODING_AGENT_DIR", agentDir);
+		const sessionFile = path.join(agentDir, "sessions", "session.jsonl");
+		const entries: CustomEntry[] = [];
+		const pi = new FakePi(entries);
+		planModeExtension(pi.api());
+		const harness = fakeContext({
+			sessionFile,
+			sessionId: "complete-session",
+			entries,
+			choices: ["Approve Plan"],
+		});
+		await pi.emit("session_start", { reason: "startup" }, harness.ctx);
+		await turnPlanOn(pi, harness.ctx);
+		const approved = await submitPlan(pi, harness.ctx) as {
+			details: { planId: string; revision: number; approvedHash: string; planPath: string };
+		};
+		const implementingBranch = [...entries];
+		const completeTool = pi.tools.get(COMPLETE_PLAN_TOOL);
+		expect(completeTool).toBeDefined();
+		await expect(completeTool.execute(
+			"complete-wrong",
+			{
+				planId: approved.details.planId,
+				revision: 2,
+				summary: "Wrong revision",
+				verification: ["pnpm test"],
+			},
+			undefined,
+			undefined,
+			harness.ctx,
+		)).rejects.toThrow(`must target ${approved.details.planId} r1`);
+		expect(pi.activeTools).toContain(COMPLETE_PLAN_TOOL);
+		const completed = await completeTool.execute(
+			"complete-1",
+			{
+				planId: approved.details.planId,
+				revision: approved.details.revision,
+				summary: "Implemented the approved scope",
+				verification: ["pnpm test", "pnpm typecheck"],
+			},
+			undefined,
+			undefined,
+			harness.ctx,
+		);
+		expect(completed).toMatchObject({
+			terminate: true,
+			details: {
+				kind: "completed",
+				planId: approved.details.planId,
+				revision: 1,
+				summary: "Implemented the approved scope",
+			},
+		});
+		expect(pi.activeTools).not.toContain(COMPLETE_PLAN_TOOL);
+		const lifecycleEntry = entries.find((entry) => entry.customType === PLAN_LIFECYCLE_ENTRY_TYPE && (entry.data as any).kind === "completed");
+		expect(lifecycleEntry).toBeDefined();
+		const lifecycleRenderer = pi.entryRenderers.get(PLAN_LIFECYCLE_ENTRY_TYPE);
+		expect(lifecycleRenderer).toBeDefined();
+		expect(plain(lifecycleRenderer(lifecycleEntry, { expanded: false }, (harness.ctx.ui as any).theme).render(100).join("\n")))
+			.toBe("✓ PLAN COMPLETED · Implement simple Plan Mode · r1");
+		const aboveKey = [...harness.widgets.entries()].find(([, widget]) => widget.placement === "aboveEditor")?.[0];
+		expect(aboveKey).toBeDefined();
+		expect(plain(harness.renderWidget(aboveKey!)?.join("\n"))).toContain("COMPLETED · r1");
+
+		const completedBranch = [...entries];
+		const older = fakeContext({ sessionFile, sessionId: "complete-session", entries: implementingBranch });
+		await pi.emit("session_tree", { newLeafId: "older" }, older.ctx);
+		expect(pi.activeTools).toContain(COMPLETE_PLAN_TOOL);
+		const olderWidget = [...older.widgets.entries()].find(([, widget]) => widget.placement === "aboveEditor")?.[0];
+		expect(plain(older.renderWidget(olderWidget!)?.join("\n"))).toContain("IMPLEMENTING · r1");
+		const latest = fakeContext({ sessionFile, sessionId: "complete-session", entries: completedBranch });
+		await pi.emit("session_tree", { newLeafId: "latest" }, latest.ctx);
+		expect(pi.activeTools).not.toContain(COMPLETE_PLAN_TOOL);
+		const latestWidget = [...latest.widgets.entries()].find(([, widget]) => widget.placement === "aboveEditor")?.[0];
+		expect(plain(latest.renderWidget(latestWidget!)?.join("\n"))).toContain("COMPLETED · r1");
+
+		await turnPlanOn(pi, harness.ctx);
+		expect(pi.activeTools).toEqual(["read", "grep", "find", "ls", SUBMIT_PLAN_TOOL]);
+		expect([...harness.widgets.values()].some((widget) => widget.placement === "aboveEditor")).toBe(false);
+		const prompt = await pi.emit("before_agent_start", { systemPrompt: "BASE" }, harness.ctx) as { systemPrompt: string };
+		expect(prompt.systemPrompt).toContain("[NEW PLAN]");
+		expect(prompt.systemPrompt).not.toContain("[CURRENT PLAN REFERENCE]");
+		expect(prompt.systemPrompt).not.toContain(approved.details.planId);
+	});
+
+	it("migrates legacy approved pointers to unknown work instead of assuming completion", async () => {
+		await fakeRevdiff();
+		const agentDir = await mkdtemp(path.join(tmpdir(), "pi-plan-legacy-test-"));
+		cleanup.add(agentDir);
+		vi.stubEnv("PI_CODING_AGENT_DIR", agentDir);
+		const sessionFile = path.join(agentDir, "sessions", "session.jsonl");
+		const entries: CustomEntry[] = [];
+		const firstPi = new FakePi(entries);
+		planModeExtension(firstPi.api());
+		const first = fakeContext({ sessionFile, sessionId: "legacy-session", entries, choices: ["Approve Plan"] });
+		await firstPi.emit("session_start", { reason: "startup" }, first.ctx);
+		await turnPlanOn(firstPi, first.ctx);
+		const approved = await submitPlan(firstPi, first.ctx) as { details: { planId: string } };
+		entries.push({
+			type: "custom",
+			customType: "zhcsyncer-plan-mode-state",
+			data: {
+				version: 2,
+				mode: "normal",
+				planId: approved.details.planId,
+				revision: 1,
+				normalTools: ["read", "bash", "edit", "write", "grep", "find", "ls"],
+			},
+		});
+
+		const resumedPi = new FakePi(entries);
+		planModeExtension(resumedPi.api());
+		const resumed = fakeContext({ sessionFile, sessionId: "legacy-session", entries });
+		await resumedPi.emit("session_start", { reason: "resume" }, resumed.ctx);
+		expect(resumedPi.activeTools).toContain(COMPLETE_PLAN_TOOL);
+		const command = resumedPi.commands.get("plan") as { handler: (args: string, ctx: ExtensionContext) => Promise<void> };
+		await command.handler("", resumed.ctx);
+		expect(resumed.notifications.at(-1)?.message).toContain("Plan work: UNKNOWN");
+	});
+
 	it("restores normal mode and the current Plan pointer from persistent Session state", async () => {
 		await fakeRevdiff();
 		const agentDir = await mkdtemp(path.join(tmpdir(), "pi-plan-agent-test-"));
@@ -489,16 +666,16 @@ describe("Plan Mode extension lifecycle", () => {
 		await firstPi.emit("session_start", { reason: "startup" }, first.ctx);
 		await turnPlanOn(firstPi, first.ctx);
 		const approved = await submitPlan(firstPi, first.ctx) as { details: { planPath: string } };
-		expect(entries.some((entry) => (entry.data as any).mode === "normal" && (entry.data as any).revision === 1)).toBe(true);
+		expect(entries.some((entry) => (entry.data as any).mode === "normal" && (entry.data as any).work?.revision === 1)).toBe(true);
 
 		const resumedPi = new FakePi(entries);
 		planModeExtension(resumedPi.api());
 		const resumed = fakeContext({ sessionFile, sessionId: "persistent-session", entries });
 		await resumedPi.emit("session_start", { reason: "resume" }, resumed.ctx);
-		expect(resumedPi.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls"]);
+		expect(resumedPi.activeTools).toEqual(["read", "bash", "edit", "write", "grep", "find", "ls", COMPLETE_PLAN_TOOL]);
 		const command = resumedPi.commands.get("plan") as { handler: (args: string, ctx: ExtensionContext) => Promise<void> };
 		await command.handler("", resumed.ctx);
-		expect(resumed.notifications.at(-1)?.message).toContain("APPROVED · r1");
+		expect(resumed.notifications.at(-1)?.message).toContain("IMPLEMENTING · Implement simple Plan Mode · r1");
 		expect(resumed.notifications.at(-1)?.message).toContain(approved.details.planPath);
 	});
 });

--- a/packages/pi-plan-mode/tests/herdr.test.ts
+++ b/packages/pi-plan-mode/tests/herdr.test.ts
@@ -1,0 +1,45 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { HERDR_BLOCKED_EVENT, emitHerdrBlocked, withHerdrBlocked } from "../src/herdr.ts";
+
+function eventApi(onEmit: (event: string, data: unknown) => void): Pick<ExtensionAPI, "events"> {
+	return {
+		events: { emit: onEmit } as unknown as ExtensionAPI["events"],
+	};
+}
+
+describe("Herdr blocked event adapter", () => {
+	it("balances active state around a successful user interaction", async () => {
+		const events: Array<{ event: string; data: unknown }> = [];
+		const result = await withHerdrBlocked(
+			eventApi((event, data) => events.push({ event, data })),
+			"plan review",
+			async () => "approved",
+		);
+		expect(result).toBe("approved");
+		expect(events).toEqual([
+			{ event: HERDR_BLOCKED_EVENT, data: { active: true, label: "plan review" } },
+			{ event: HERDR_BLOCKED_EVENT, data: { active: false } },
+		]);
+	});
+
+	it("always clears blocked state when the interaction fails", async () => {
+		const events: Array<{ event: string; data: unknown }> = [];
+		await expect(withHerdrBlocked(
+			eventApi((event, data) => events.push({ event, data })),
+			"plan approval",
+			async () => {
+				throw new Error("dialog failed");
+			},
+		)).rejects.toThrow("dialog failed");
+		expect(events.at(-1)).toEqual({ event: HERDR_BLOCKED_EVENT, data: { active: false } });
+	});
+
+	it("does not let an optional Herdr listener break Plan behavior", async () => {
+		const api = eventApi(() => {
+			throw new Error("listener failed");
+		});
+		expect(() => emitHerdrBlocked(api, true, "plan review")).not.toThrow();
+		await expect(withHerdrBlocked(api, "plan approval", async () => 42)).resolves.toBe(42);
+	});
+});

--- a/packages/pi-plan-mode/tests/lifecycle.test.ts
+++ b/packages/pi-plan-mode/tests/lifecycle.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+	closePlanWork,
+	createImplementingWork,
+	isCompletableWork,
+	migrateStoredPlanSessionState,
+	parseStoredPlanSessionState,
+} from "../src/lifecycle.ts";
+import type { LegacyPlanSessionState, PlanMetadata } from "../src/types.ts";
+
+const planId = "20260723T140506-lifecycle-a1b2c3d4";
+const approvedHash = `sha256:${"a".repeat(64)}`;
+
+function metadata(status: "draft" | "approved"): PlanMetadata {
+	return {
+		version: 2,
+		planId,
+		title: "Lifecycle",
+		status,
+		storage: "persistent",
+		sessionId: "session-1",
+		cwd: "/repo",
+		createdAt: "2026-07-23T14:05:06.000Z",
+		updatedAt: "2026-07-23T14:05:06.000Z",
+		currentRevision: 1,
+		...(status === "approved" ? { approvedRevision: 1, approvedHash } : {}),
+		revisions: [{
+			revision: 1,
+			status,
+			path: "revisions/r1.md",
+			hash: approvedHash,
+			createdAt: "2026-07-23T14:05:06.000Z",
+			steps: ["Implement it"],
+			...(status === "approved" ? { approvedAt: "2026-07-23T14:05:06.000Z" } : {}),
+		}],
+	};
+}
+
+const legacy: LegacyPlanSessionState = {
+	version: 2,
+	mode: "normal",
+	planId,
+	revision: 1,
+	normalTools: ["read", "edit"],
+};
+
+describe("Plan work lifecycle", () => {
+	it("parses V3 branch state and rejects malformed references", () => {
+		const parsed = parseStoredPlanSessionState({
+			version: 3,
+			mode: "normal",
+			normalTools: ["read", "read", "edit"],
+			work: {
+				planId,
+				revision: 1,
+				approvedHash,
+				status: "implementing",
+				startedAt: "2026-07-23T14:05:06.000Z",
+			},
+		});
+		expect(parsed).toMatchObject({
+			version: 3,
+			normalTools: ["read", "edit"],
+			work: { planId, revision: 1, status: "implementing" },
+		});
+		expect(parseStoredPlanSessionState({
+			version: 3,
+			mode: "normal",
+			normalTools: [],
+			work: { planId: "../escape", revision: 1, approvedHash, status: "implementing" },
+		})).toBeUndefined();
+	});
+
+	it("migrates legacy draft pointers to planning and approved pointers to unknown work", () => {
+		const draft = migrateStoredPlanSessionState(legacy, metadata("draft"));
+		expect(draft).toMatchObject({ version: 3, planning: { planId, revision: 1 } });
+		expect(draft.work).toBeUndefined();
+		const approved = migrateStoredPlanSessionState(legacy, metadata("approved"));
+		expect(approved).toMatchObject({
+			version: 3,
+			work: { planId, revision: 1, approvedHash, status: "unknown" },
+		});
+		expect(approved.planning).toBeUndefined();
+	});
+
+	it("binds implementing and closed states to an exact approved revision", () => {
+		const implementing = createImplementingWork(
+			{ planId, revision: 2 },
+			approvedHash,
+			new Date("2026-07-23T15:00:00.000Z"),
+		);
+		expect(implementing).toMatchObject({
+			planId,
+			revision: 2,
+			approvedHash,
+			status: "implementing",
+			startedAt: "2026-07-23T15:00:00.000Z",
+		});
+		expect(isCompletableWork(implementing)).toBe(true);
+		const completed = closePlanWork(implementing, "completed", new Date("2026-07-23T16:00:00.000Z"));
+		expect(completed).toMatchObject({ status: "completed", completedAt: "2026-07-23T16:00:00.000Z" });
+		expect(isCompletableWork(completed)).toBe(false);
+		expect(() => closePlanWork(completed, "abandoned")).toThrow("already completed");
+	});
+});

--- a/packages/pi-plan-mode/tests/policy.test.ts
+++ b/packages/pi-plan-mode/tests/policy.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+	COMPLETE_PLAN_TOOL,
 	SUBMIT_PLAN_TOOL,
+	getNormalTools,
 	getPlanningTools,
 	isPlanningToolAllowed,
 	withoutManagedTools,
@@ -18,8 +20,10 @@ describe("strict planning tool policy", () => {
 		}
 	});
 
-	it("restores the previous normal tools without leaking submit_plan", () => {
-		const saved = ["read", "bash", "edit", SUBMIT_PLAN_TOOL, "read"];
+	it("restores normal tools and activates complete_plan only for closable work", () => {
+		const saved = ["read", "bash", "edit", SUBMIT_PLAN_TOOL, COMPLETE_PLAN_TOOL, "read"];
 		expect(withoutManagedTools(saved)).toEqual(["read", "bash", "edit"]);
+		expect(getNormalTools(saved, false)).toEqual(["read", "bash", "edit"]);
+		expect(getNormalTools(saved, true)).toEqual(["read", "bash", "edit", COMPLETE_PLAN_TOOL]);
 	});
 });

--- a/packages/pi-plan-mode/tests/prompts.test.ts
+++ b/packages/pi-plan-mode/tests/prompts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { appendPlanningPrompt, buildPlanningPrompt } from "../src/prompts.ts";
+import { appendPlanningPrompt, buildImplementationHandoff, buildPlanningPrompt } from "../src/prompts.ts";
 
 describe("Plan Mode prompts", () => {
 	it("requires English content and section headings for en", () => {
@@ -28,7 +28,14 @@ describe("Plan Mode prompts", () => {
 		expect(prompt).toContain("## 执行步骤");
 	});
 
-	it("keeps the current Plan reference when applying a configured language", () => {
+	it("makes an unattached planning turn create a new Plan by default", () => {
+		const prompt = appendPlanningPrompt("BASE", undefined, "en");
+		expect(prompt).toContain("[NEW PLAN]");
+		expect(prompt).toContain("omit planId");
+		expect(prompt).not.toContain("[CURRENT PLAN REFERENCE]");
+	});
+
+	it("keeps the explicitly attached Plan reference when applying a configured language", () => {
 		const prompt = appendPlanningPrompt("BASE", {
 			planId: "plan-1",
 			title: "现有计划",
@@ -40,5 +47,20 @@ describe("Plan Mode prompts", () => {
 		expect(prompt).toContain("Configured content language: zh-CN");
 		expect(prompt).toContain("Plan ID: plan-1");
 		expect(prompt).toContain("Revision: r2");
+		expect(prompt).toContain("explicitly attached");
+	});
+
+	it("requires complete_plan only after implementation and verification succeed", () => {
+		const handoff = buildImplementationHandoff({
+			planId: "plan-1",
+			title: "Implement lifecycle",
+			revision: 3,
+			approvedHash: `sha256:${"a".repeat(64)}`,
+			planPath: "/plans/plan-1/revisions/r3.md",
+			markdown: "# Goal\n",
+		});
+		expect(handoff).toContain("call complete_plan");
+		expect(handoff).toContain("only and final tool");
+		expect(handoff).toContain("Do not call it while scope is incomplete");
 	});
 });

--- a/packages/pi-plan-mode/tests/tool-display.test.ts
+++ b/packages/pi-plan-mode/tests/tool-display.test.ts
@@ -1,0 +1,187 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import {
+	parseReviewAnnotations,
+	renderCompletePlanCall,
+	renderCompletePlanResult,
+	renderSubmitPlanCall,
+	renderSubmitPlanResult,
+} from "../src/tool-display.ts";
+
+const theme = {
+	fg: (_color: string, text: string) => `\x1b[36m${text}\x1b[39m`,
+	bold: (text: string) => `\x1b[1m${text}\x1b[22m`,
+} as unknown as Theme;
+
+function plain(lines: string[]): string {
+	return lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+const args = {
+	title: "Add cache invalidation",
+	markdown: "# Goal\n\nA very long Plan body that must never be rendered.\n",
+};
+
+function submitHarness(expanded = false) {
+	const state = {} as any;
+	const callContext = { state, expanded } as any;
+	const call = renderSubmitPlanCall(args, theme, callContext);
+	return {
+		state,
+		call,
+		result(result: any, isError = false) {
+			return renderSubmitPlanResult(result, { expanded, isPartial: false }, theme, {
+				state,
+				args,
+				isError,
+				expanded,
+			} as any);
+		},
+	};
+}
+
+describe("Plan tool display", () => {
+	it("renders a compact width-safe reviewing line without Plan Markdown", () => {
+		const harness = submitHarness();
+		const rendered = plain(harness.call.render(40));
+		expect(rendered).toContain("Reviewing Plan");
+		expect(rendered).not.toContain("very long Plan body");
+		for (const width of [8, 16, 24, 40]) {
+			for (const line of harness.call.render(width)) expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+		}
+	});
+
+	it("summarizes requested changes and reveals persisted annotations when expanded", () => {
+		const content = "The user reviewed plan p r2 and requested changes.\n\n1. Step 2: add rollback handling\n2. Verification: add an integration test";
+		const collapsed = submitHarness(false);
+		const collapsedResult = collapsed.result({
+			content: [{ type: "text", text: content }],
+			details: { kind: "changes_requested", planId: "p", revision: 2, planPath: "/plans/p/r2.md" },
+		});
+		expect(plain(collapsed.call.render(100))).toBe("● Plan changes requested · Add cache invalidation · r2");
+		expect(plain(collapsedResult.render(100))).toContain("2 annotations");
+		expect(plain(collapsedResult.render(100))).not.toContain("rollback handling");
+
+		const expanded = submitHarness(true);
+		const expandedResult = expanded.result({
+			content: [{ type: "text", text: content }],
+			details: { kind: "changes_requested", planId: "p", revision: 2, planPath: "/plans/p/r2.md" },
+		});
+		const audit = plain(expandedResult.render(100));
+		expect(audit).toContain("Annotations");
+		expect(audit).toContain("1. Step 2: add rollback handling");
+		expect(audit).toContain("2. Verification: add an integration test");
+		expect(audit).toContain("Plan ID: p");
+		expect(audit).toContain("Plan: /plans/p/r2.md");
+	});
+
+	it("does not guess annotation counts for unstructured feedback", () => {
+		const parsed = parseReviewAnnotations("Feedback header\n\nPlease handle rollback.\nAlso inspect retries.");
+		expect(parsed).toEqual({ raw: "Please handle rollback.\nAlso inspect retries." });
+		const harness = submitHarness(false);
+		const result = harness.result({
+			content: [{ type: "text", text: "Feedback header\n\nPlease handle rollback.\nAlso inspect retries." }],
+			details: { kind: "changes_requested", revision: 1 },
+		});
+		expect(plain(result.render(100))).toContain("Review annotations available");
+	});
+
+	it("caps expanded annotation output by visual lines", () => {
+		const annotations = Array.from({ length: 20 }, (_, index) => `${index + 1}. Annotation ${index + 1}`).join("\n");
+		const harness = submitHarness(true);
+		const result = harness.result({
+			content: [{ type: "text", text: `Header\n\n${annotations}` }],
+			details: { kind: "changes_requested", revision: 3 },
+		});
+		const rendered = plain(result.render(60));
+		expect(rendered).toContain("… +8 more lines");
+		expect(rendered).not.toContain("20. Annotation 20");
+	});
+
+	it("hides an approved submit node when collapsed and reveals audit metadata when expanded", () => {
+		const collapsed = submitHarness(false);
+		const collapsedResult = collapsed.result({
+			content: [{ type: "text", text: "approved" }],
+			details: {
+				kind: "approved",
+				planId: "p",
+				revision: 2,
+				planPath: "/plans/p/r2.md",
+				approvedHash: `sha256:${"a".repeat(64)}`,
+			},
+		});
+		expect(collapsed.call.render(100)).toEqual([]);
+		expect(collapsedResult.render(100)).toEqual([]);
+
+		const expanded = submitHarness(true);
+		const expandedResult = expanded.result({
+			content: [{ type: "text", text: "approved" }],
+			details: {
+				kind: "approved",
+				planId: "p",
+				revision: 2,
+				planPath: "/plans/p/r2.md",
+				approvedHash: `sha256:${"a".repeat(64)}`,
+			},
+		});
+		expect(plain(expanded.call.render(100))).toContain("Submit Plan · Add cache invalidation · r2");
+		expect(plain(expandedResult.render(100))).toContain("Approved hash: sha256:");
+	});
+
+	it("keeps cancelled and failed submissions visible", () => {
+		const cancelled = submitHarness(false);
+		cancelled.result({
+			content: [{ type: "text", text: "Plan review was cancelled: interrupted" }],
+			details: { kind: "cancelled", revision: 1 },
+		});
+		expect(plain(cancelled.call.render(100))).toContain("Plan review cancelled");
+
+		const failed = submitHarness(false);
+		failed.result({
+			content: [{ type: "text", text: "Plan revision was not saved: disk full" }],
+			details: { kind: "storage_error" },
+		});
+		expect(plain(failed.call.render(100))).toContain("Plan submission failed · disk full");
+	});
+
+	it("hides successful complete_plan nodes but keeps expanded completion audit", () => {
+		const completeArgs = {
+			planId: "p",
+			revision: 2,
+			summary: "Implemented cache invalidation",
+			verification: ["pnpm test"],
+		};
+		const state = {} as any;
+		const call = renderCompletePlanCall(completeArgs, theme, { state, expanded: false } as any);
+		const result = renderCompletePlanResult({
+			content: [{ type: "text", text: "complete" }],
+			details: {
+				kind: "completed",
+				planId: "p",
+				revision: 2,
+				summary: completeArgs.summary,
+				verification: completeArgs.verification,
+				planPath: "/plans/p/r2.md",
+			},
+		}, { expanded: false, isPartial: false }, theme, { state, args: completeArgs, isError: false } as any);
+		expect(call.render(100)).toEqual([]);
+		expect(result.render(100)).toEqual([]);
+
+		const expandedState = {} as any;
+		const expandedCall = renderCompletePlanCall(completeArgs, theme, { state: expandedState, expanded: true } as any);
+		const expandedResult = renderCompletePlanResult({
+			content: [{ type: "text", text: "complete" }],
+			details: {
+				kind: "completed",
+				planId: "p",
+				revision: 2,
+				summary: completeArgs.summary,
+				verification: completeArgs.verification,
+				planPath: "/plans/p/r2.md",
+			},
+		}, { expanded: true, isPartial: false }, theme, { state: expandedState, args: completeArgs, isError: false } as any);
+		expect(plain(expandedCall.render(100))).toContain("Complete Plan · r2");
+		expect(plain(expandedResult.render(100))).toContain("Verified: pnpm test");
+	});
+});

--- a/packages/pi-plan-mode/tests/widgets.test.ts
+++ b/packages/pi-plan-mode/tests/widgets.test.ts
@@ -5,6 +5,7 @@ import {
 	compactPlanPath,
 	renderModeWidget,
 	renderPlanApprovedEvent,
+	renderPlanLifecycleEvent,
 	renderPlanWidget,
 } from "../src/widgets.ts";
 
@@ -62,6 +63,45 @@ describe("Plan Mode widgets", () => {
 		expect(rendered).toContain("Ctrl+Alt+O collapse");
 	});
 
+	it("renders implementing and completed work independently from document approval", () => {
+		const implementing = plain(renderPlanWidget({
+			...plan,
+			workStatus: "implementing",
+			approvedHash: `sha256:${"a".repeat(64)}`,
+			expanded: false,
+		}, 100, theme).join("\n"));
+		expect(implementing).toContain("IMPLEMENTING · r2");
+		const completed = plain(renderPlanWidget({
+			...plan,
+			workStatus: "completed",
+			approvedHash: `sha256:${"a".repeat(64)}`,
+			expanded: true,
+		}, 100, theme).join("\n"));
+		expect(completed).toContain("COMPLETED · r2");
+		expect(completed).toContain("Document: APPROVED");
+		expect(completed).toContain("Approved hash: sha256:");
+	});
+
+	it("renders compact and expandable lifecycle events", () => {
+		const data = {
+			kind: "completed" as const,
+			title: plan.title,
+			planId: "plan-1",
+			revision: 2,
+			planPath: plan.planPath,
+			approvedHash: `sha256:${"a".repeat(64)}`,
+			source: "agent" as const,
+			summary: "Implemented OAuth",
+			verification: ["pnpm test"],
+		};
+		expect(plain(renderPlanLifecycleEvent(data, 100, theme, false).join("\n")))
+			.toBe("✓ PLAN COMPLETED · OAuth migration · r2");
+		const expanded = plain(renderPlanLifecycleEvent(data, 100, theme, true).join("\n"));
+		expect(expanded).toContain("Summary: Implemented OAuth");
+		expect(expanded).toContain("Verified: pnpm test");
+		expect(expanded).toContain("Plan ID: plan-1");
+	});
+
 	it("renders a compact width-safe approval event", () => {
 		const wide = plain(renderPlanApprovedEvent({ title: plan.title, revision: 2, stepCount: 5 }, 100, theme).join("\n"));
 		expect(wide).toBe("✓ PLAN APPROVED · OAuth migration · r2 · 5 steps");
@@ -77,6 +117,9 @@ describe("Plan Mode widgets", () => {
 				expect(visibleWidth(line)).toBeLessThanOrEqual(width);
 			}
 			for (const line of renderPlanApprovedEvent({ title: plan.title, revision: 2, stepCount: 5 }, width, theme)) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+			}
+			for (const line of renderPlanLifecycleEvent({ kind: "abandoned", title: plan.title, revision: 2 }, width, theme, true)) {
 				expect(visibleWidth(line)).toBeLessThanOrEqual(width);
 			}
 		}


### PR DESCRIPTION
## Summary

- split Plan document approval from branch-local implementation lifecycle state
- add explicit `complete_plan` and `/plan revise|complete|abandon` transitions with safe legacy migration
- render `submit_plan` and `complete_plan` as compact expandable audit nodes
- emit balanced Herdr `herdr:blocked` events around Plan review and lifecycle prompts
- document the lifecycle/display designs and update bilingual package docs

## Release plan

- `@zhcsyncer/pi-extensions`: `0.9.0` → `0.10.0` (minor)
- `@zhcsyncer/pi-plan-mode`: `0.1.0` → `0.2.0` (minor)
- release via the Changesets-generated `chore: version packages` PR only

## Verification

- `pnpm --filter @zhcsyncer/pi-plan-mode check` (10 files, 58 tests)
- `pnpm check`
- `git diff --check`
