### PR TITLE
feat: unify extension data storage

### DIFF
--- a/.changeset/unified-extension-data.md
+++ b/.changeset/unified-extension-data.md
@@ -1,0 +1,9 @@
+---
+"@zhcsyncer/pi-extensions": minor
+"@zhcsyncer/pi-recap": minor
+"@zhcsyncer/pi-glance": minor
+"@zhcsyncer/pi-tool-display-intent": minor
+"@zhcsyncer/pi-plan-mode": minor
+---
+
+Unify bundle extension configuration and state under `$PI_CODING_AGENT_DIR/extension-data/<extension-id>/`. Existing global and trusted-project files are migrated and upgraded automatically, unmappable fields are discarded with user-visible warnings, malformed files are preserved, and Plan artifacts remain at `$PI_CODING_AGENT_DIR/plans/`.

--- a/.changeset/unified-extension-data.md
+++ b/.changeset/unified-extension-data.md
@@ -6,4 +6,4 @@
 "@zhcsyncer/pi-plan-mode": minor
 ---
 
-Unify bundle extension configuration and state under `$PI_CODING_AGENT_DIR/extension-data/<extension-id>/`. Existing global and trusted-project files are migrated and upgraded automatically, unmappable fields are discarded with user-visible warnings, malformed files are preserved, and Plan artifacts remain at `$PI_CODING_AGENT_DIR/plans/`.
+Unify bundle extension configuration and state under `$PI_CODING_AGENT_DIR/extension-data/<extension-id>/`. Existing global and trusted-project files are migrated and upgraded automatically, unmappable fields are discarded with user-visible warnings, malformed files are preserved, and Plan artifacts remain at `$PI_CODING_AGENT_DIR/plans/`. Search Hub now reads refreshed configuration through Jiti-safe accessors so reader selection, credentials, and round-robin state take effect immediately.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The aggregate `@zhcsyncer/pi-extensions` package includes the private Search Hub
 
 This fork keeps upstream multi-backend search and page extraction while integrating model-written `displaySummary` intents, semantic query/URL call lines, backend and reader status, and the shared tool-display result modes. See the [Search Hub documentation](./packages/pi-search-hub/README.md) or its [Simplified Chinese version](./packages/pi-search-hub/README.zh-CN.md) for configuration and local behavior.
 
+## Persistent extension data
+
+Bundle extension configuration and state live under `$PI_CODING_AGENT_DIR/extension-data/<extension-id>/`. Existing files are migrated and upgraded automatically; unmappable fields are dropped with a warning, while malformed source files are preserved. Trusted project overrides for Recap and Search Hub use `.pi/extension-data/<extension-id>/config.json`. Plan artifacts intentionally remain in `$PI_CODING_AGENT_DIR/plans/`.
+
 ## Install from Git
 
 Install the whole extension bundle from this repository:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,6 +19,10 @@ zhcsyncer 维护的一组 Pi extensions。
 
 该 fork 保留上游多后端搜索和页面提取能力，同时集成模型生成的 `displaySummary` intent、语义化 query/URL 调用行、backend 和 reader 状态，以及共享的工具结果展示模式。配置与本地行为详见 [Search Hub 中文文档](./packages/pi-search-hub/README.zh-CN.md) 或其 [英文版本](./packages/pi-search-hub/README.md)。
 
+## 扩展持久化数据
+
+Bundle 内扩展的配置和状态统一保存在 `$PI_CODING_AGENT_DIR/extension-data/<extension-id>/`。旧文件会自动迁移升级；无法映射的字段会被丢弃并提示 warning，格式损坏的源文件会原样保留。Recap 与 Search Hub 在受信任项目中的覆盖配置使用 `.pi/extension-data/<extension-id>/config.json`。Plan artifact 刻意继续保存在 `$PI_CODING_AGENT_DIR/plans/`。
+
 ## 从 Git 安装
 
 从本仓库安装完整 extension bundle：

--- a/extension-data-layout-design.md
+++ b/extension-data-layout-design.md
@@ -1,0 +1,289 @@
+# Pi 扩展持久化目录统一方案
+
+## 实现状态
+
+已实现：各扩展统一路径、自动迁移升级、trust 边界、迁移通知和回归测试已落地。
+
+本文只约束 `pi-agent-cases` 仓库内扩展的配置与状态路径，不改 Pi core，也不处理仓库外第三方扩展。
+
+## 背景
+
+当前各扩展自行选择持久化位置，配置、状态与扩展源码目录混杂：
+
+```text
+~/.pi/agent/recap.json
+~/.pi/agent/extensions/search.json
+~/.pi/agent/exa-usage.json
+~/.pi/agent/pi-glance/config.json
+~/.pi/agent/extensions/pi-tool-display-intent/config.json
+~/.pi/agent/plan-mode.json
+~/.pi/agent/plans/
+```
+
+问题不在于文件数量，而在于缺少统一的信息架构：
+
+- 无法从一个固定根目录盘点本仓库扩展的持久化数据；
+- 配置、运行状态和扩展源码混在不同层级；
+- 部分实现直接拼接 `~/.pi/agent`，没有遵循 `PI_CODING_AGENT_DIR`；
+- Search Hub 的配置与 Exa 用量状态分散，且路径帮助文本散落在多处。
+
+## 已确认决策
+
+1. **统一目录，不合并配置文件**：每个扩展继续拥有独立 schema、默认值和迁移逻辑，不引入单体 `extensions.json`。
+2. **统一根目录**：仓库内扩展的持久化数据统一进入 `$PI_CODING_AGENT_DIR/extension-data/<extension-id>/`。
+3. **暂不建设共享存储层**：本期不新增 `extension-storage` 公共 package；各扩展直接完成自己的路径迁移。
+4. **暂不改造密钥机制**：继续保留各扩展现有 credential 字段、环境变量、shell command 和明文值行为；不新增 `secrets.json`、OS keychain 适配或通用 Secret Store。
+5. **Provider 凭证不在本方案范围**：Provider 继续使用 Pi 的 `auth.json` 与 `/login` 机制，不迁移、不复制，也不注册伪 Provider 来承载非 Provider 密钥。
+6. **Plan Mode 状态是唯一例外**：Plan revision 与 manifest 继续保存在现有全局目录 `$PI_CODING_AGENT_DIR/plans/`，不迁入 `extension-data`；只有 `plan-mode.json` 配置迁入统一目录。
+7. **Search Hub 必须修复目录实现**：配置与 Exa 用量状态迁入统一目录，并消除自行硬编码 `~/.pi/agent` 的实现。
+
+## 目标目录
+
+默认 `PI_CODING_AGENT_DIR=~/.pi/agent` 时：
+
+```text
+~/.pi/agent/
+├── extension-data/
+│   ├── pi-recap/
+│   │   └── config.json
+│   ├── pi-search-hub/
+│   │   ├── config.json
+│   │   └── state/
+│   │       └── exa-usage.json
+│   ├── pi-glance/
+│   │   └── config.json
+│   ├── pi-tool-display-intent/
+│   │   ├── config.json
+│   │   ├── config.legacy.json        # 已存在或 schema 迁移时生成的一次性备份
+│   │   └── state/
+│   │       └── debug.log
+│   └── pi-plan-mode/
+│       └── config.json
+└── plans/                       # Plan Mode 状态例外，保持现状
+    └── <plan-id>/
+        ├── manifest.json
+        ├── revisions/
+        └── .review/
+```
+
+`extension-id` 使用稳定 package slug，而不是展示名：
+
+```text
+pi-recap
+pi-search-hub
+pi-glance
+pi-tool-display-intent
+pi-plan-mode
+```
+
+## 项目级配置
+
+只有当前已经支持项目覆盖的扩展继续保留该能力，本期不为其他扩展新增项目级配置。
+
+```text
+<project>/.pi/extension-data/pi-recap/config.json
+<project>/.pi/extension-data/pi-search-hub/config.json
+```
+
+约束：
+
+- 项目配置覆盖全局配置，合并语义保持各扩展当前行为；
+- 项目配置只在项目受信任时读取；未受信任时不得探测、读取或提示新旧项目配置；
+- 项目路径实现必须使用 Pi 导出的 `CONFIG_DIR_NAME`，不能硬编码 `.pi`；本文继续用 `.pi` 表示默认目录；
+- 配置 UI 的用户编辑仍只写全局文件；但受信任项目中的旧项目配置会自动迁移到新路径。配置预览、覆盖检测、迁移通知和保存后的生效提示必须遵循同一 trust 判断；
+- `pi-glance`、`pi-tool-display-intent` 和 `pi-plan-mode` 本期仍为全局配置；
+- 运行状态不写入项目 `.pi/extension-data/`。
+
+### 项目旧路径兼容与优先级
+
+只在 `ctx.isProjectTrusted()` 为 `true` 时执行以下判断：
+
+| 新项目路径 | 旧项目路径 | 行为 |
+|---|---|---|
+| 不存在 | 不存在 | 不加载项目配置 |
+| 不存在 | 存在 | 自动解析、升级并原子写入新文件；验证成功后删除旧文件并通知迁移结果 |
+| 存在 | 不存在 | 只读取新文件 |
+| 存在 | 存在 | 只读取新文件；保留旧文件并提示其已被忽略，不做合并或自动删除 |
+
+项目迁移只在受信任项目中执行。无法映射的旧字段允许丢弃，但通知必须列出被丢弃的字段路径；JSON 无法解析或根结构无法识别时不得删除旧文件。
+
+## 路径迁移表
+
+| 扩展 | 当前路径 | 目标路径 | 备注 |
+|---|---|---|---|
+| Pi Recap | `$PI_CODING_AGENT_DIR/recap.json` | `$PI_CODING_AGENT_DIR/extension-data/pi-recap/config.json` | 全局配置 |
+| Pi Recap | `<project>/.pi/recap.json` | `<project>/.pi/extension-data/pi-recap/config.json` | 受信任项目覆盖 |
+| Search Hub | `$PI_CODING_AGENT_DIR/extensions/search.json` | `$PI_CODING_AGENT_DIR/extension-data/pi-search-hub/config.json` | 全局配置 |
+| Search Hub | `<project>/.pi/search.json` | `<project>/.pi/extension-data/pi-search-hub/config.json` | 受信任项目覆盖 |
+| Search Hub | `$PI_CODING_AGENT_DIR/exa-usage.json` | `$PI_CODING_AGENT_DIR/extension-data/pi-search-hub/state/exa-usage.json` | 运行状态，不是配置 |
+| Pi Glance | `$PI_CODING_AGENT_DIR/pi-glance/config.json` | `$PI_CODING_AGENT_DIR/extension-data/pi-glance/config.json` | 全局配置 |
+| Tool Display Intent | `$PI_CODING_AGENT_DIR/extensions/pi-tool-display-intent/config.json` | `$PI_CODING_AGENT_DIR/extension-data/pi-tool-display-intent/config.json` | 全局配置 |
+| Tool Display Intent | `$PI_CODING_AGENT_DIR/extensions/pi-tool-display-intent/config.legacy.json` | `$PI_CODING_AGENT_DIR/extension-data/pi-tool-display-intent/config.legacy.json` | 已存在或 schema 迁移生成的一次性配置备份 |
+| Tool Display Intent | `$PI_CODING_AGENT_DIR/extensions/pi-tool-display-intent/debug/debug.log` | `$PI_CODING_AGENT_DIR/extension-data/pi-tool-display-intent/state/debug.log` | 调试运行状态；不存在时不创建 |
+| Plan Mode | `$PI_CODING_AGENT_DIR/plan-mode.json` | `$PI_CODING_AGENT_DIR/extension-data/pi-plan-mode/config.json` | 全局配置 |
+| Plan Mode | `$PI_CODING_AGENT_DIR/plans/` | **保持不变** | 全局 Plan 状态例外 |
+| Pi Todo | Session JSONL custom entries | **保持不变** | 无独立配置文件 |
+
+## Search Hub 专项修复
+
+Search Hub 是本次路径治理中需要额外修正的实现：
+
+1. 删除 `packages/pi-search-hub/extensions/utils.ts` 中自行拼接 `$HOME/.pi/agent` 的 `getAgentDir()`；统一使用 Pi 导出的 `getAgentDir()`，正确遵循 `PI_CODING_AGENT_DIR`。
+2. 全局配置读取、`/search-setup` 保存和帮助文本统一指向：
+
+   ```text
+   $PI_CODING_AGENT_DIR/extension-data/pi-search-hub/config.json
+   ```
+
+3. 项目配置统一指向：
+
+   ```text
+   <project>/.pi/extension-data/pi-search-hub/config.json
+   ```
+
+4. Exa 用量文件迁入：
+
+   ```text
+   $PI_CODING_AGENT_DIR/extension-data/pi-search-hub/state/exa-usage.json
+   ```
+
+5. `loadConfig`、`refreshConfig`、设置 UI 的 effective config 预览和项目覆盖提示都必须显式接收当前 `cwd` 与 `projectTrusted`；不得在缺少 trust 上下文时读取项目配置。
+6. 配置缓存键至少包含 canonical config path、`cwd` 和 `projectTrusted`，Session 切换、cwd 变化或 trust 变化后不得复用旧项目的 effective config。
+7. 项目路径使用 `CONFIG_DIR_NAME`，不再硬编码 `.pi`。
+8. 更新 README、示例、错误消息、credential 帮助文本和测试中的旧路径，避免实现与文档再次漂移。
+9. 保留当前配置内容和 credential 解析语义，不在本次工作中拆分密钥文件。
+
+## 配置、状态与 Session 的边界
+
+### 配置
+
+用户可编辑、需要 schema 和默认值的设置：
+
+```text
+extension-data/<extension-id>/config.json
+```
+
+### 状态
+
+扩展运行产生、通常不应手工编辑的数据：
+
+```text
+extension-data/<extension-id>/state/
+```
+
+当前明确迁入该层的状态包括：
+
+- Search Hub 的 Exa 用量：`pi-search-hub/state/exa-usage.json`；
+- Tool Display Intent 的调试日志：`pi-tool-display-intent/state/debug.log`。
+
+Tool Display Intent 的 `config.legacy.json` 是一次性配置备份，不属于运行状态，保留在该扩展目录根部。
+
+### Session 状态
+
+与 Pi Session branch 语义绑定的数据继续使用 `pi.appendEntry()` 或 tool result details，不搬入 `extension-data`。Pi Todo 和 Recap 历史属于此类。
+
+### Plan Mode 例外
+
+Plan revision 是用户可直接定位、review 和引用的持久产物，不按普通扩展内部状态处理。因此：
+
+```text
+$PI_CODING_AGENT_DIR/plans/
+```
+
+保持为稳定全局路径；不能因配置目录统一而迁移。
+
+## 密钥边界
+
+本期只整理路径，不改变安全模型：
+
+- Search Hub 的 `apiKey` 仍可保存环境变量名、shell command 或明文值；
+- OpenAI Codex backend 继续读取 Pi Provider credential；
+- 不新增通用扩展 Secret Store；
+- 不把非 Provider credential 写入 `auth.json`；
+- 不拆出 `secrets.json`；
+- 含 credential 的 Search Hub 全局配置继续以 `0600` 权限原子写入。
+
+通用 Secret Store、OS keychain 和 typed credential reference 作为未来独立议题，不阻塞本次目录迁移。
+
+## 迁移原则
+
+1. 新路径是唯一写入目标，禁止新旧路径双写。
+2. 实现必须识别旧全局文件并执行一次性迁移，避免升级后静默丢配置或用量状态。
+3. 迁移必须在该文件第一次正常读取或写入之前完成；不能先按默认值运行、随后再迁移。
+4. 迁移流程必须先在新路径完成原子写入并验证成功，再删除旧文件；失败时保留旧文件并明确告警。
+5. 受信任项目中的旧项目配置按“项目旧路径兼容与优先级”自动迁移；未受信任时不得探测或修改。
+6. 自动迁移成功后不再兼容读取旧路径；迁移失败时保留旧文件供下次重试，不形成永久双路径读取层。
+7. 配置文件权限沿用各扩展现有要求；Search Hub 因可能含 credential，目录使用私有权限，配置文件和迁移临时文件必须保持 `0600`。
+8. 每个 package 应提供唯一的 package-local 路径模块，供加载、保存、状态、帮助文本和迁移共同使用；“不建设共享存储层”不等于在同一 package 内重复拼接路径。
+9. 迁移和状态更新必须考虑多个 Pi 进程并发，不能依赖单进程内布尔标记来证明“一次性”。
+
+### 全局文件迁移状态机
+
+新路径一旦存在，即为 canonical path。迁移不得静默覆盖任一已有文件：
+
+| 新文件 | 旧文件 | 行为 |
+|---|---|---|
+| 不存在 | 不存在 | 使用默认值；第一次保存只写新路径 |
+| 不存在 | 存在且可解析 | 在锁内按当前 schema normalize/升级，写入新文件、验证、再删除旧文件；通知迁移及被丢弃字段 |
+| 不存在 | 存在但 JSON 无法解析、根结构无法识别或不可读 | 不创建新文件，不删除旧文件，按扩展现有无效配置行为回退并明确告警 |
+| 存在且有效 | 不存在 | 只使用新文件 |
+| 存在且有效 | 存在且语义等价 | 使用新文件；在锁内验证等价后可删除旧文件 |
+| 存在且有效 | 存在但冲突或不可读 | 使用新文件，保留旧文件并明确告警；禁止自动合并或覆盖 |
+| 存在但无效或不可读 | 任意 | 不用旧文件覆盖新文件，不删除任一文件，按扩展现有无效配置行为回退并明确告警 |
+
+“语义等价”由各扩展在 parse、normalize 后比较，而不是比较原始 JSON 文本。迁移统一以当前 schema/normalize 为准：可识别字段升级到当前格式，无法映射、未知或已废弃字段直接丢弃。通知必须包含旧路径、新路径和被丢弃字段路径；字段过多时可显示计数与前若干项。
+
+### 原子性、验证与并发
+
+- 在目标目录创建同文件系统临时文件，完整写入并设置所需权限后，以 rename 原子替换目标；失败时清理临时文件但保留旧文件。
+- 写入后必须重新读取验证。JSON 配置/状态还需执行 JSON 解析、schema/normalize 和语义 round trip；`debug.log` 等非结构化文件按字节内容或校验和验证。Search Hub 的配置与 Exa 状态还必须检查 `0600` 权限。
+- 迁移、旧文件删除和状态 read-modify-write 必须使用跨进程互斥。实现可采用目标目录内通过 exclusive create 获取的 lock file；未获得锁时不得迁移、删除或基于陈旧值写回，应等待有限时间或留待下次访问，并明确告警。
+- lock 必须包含可诊断的 pid/时间信息并定义过期锁恢复；恢复过期锁后仍须重新读取新旧文件并从状态机起点重新判断。
+- 告警在有 UI 时使用 `ctx.ui.notify`，无 UI 模式写入 stderr；同一问题每个进程或 Session 最多报告一次，避免每次工具调用重复刷屏。
+
+### Exa 用量专项一致性
+
+Exa 用量是会持续变化的运行状态，迁移不能与增量更新分开处理：
+
+1. `checkExaUsage()` 和 `incrementExaUsage()` 访问状态前都先解析 canonical agent dir，并进入同一个跨进程互斥区；必要时将现有同步接口改为异步并更新全部调用点，不能为保留同步签名而绕过互斥。
+2. 锁内按上述状态机完成旧用量文件迁移，再重新读取 canonical 文件。
+3. increment 的 read-modify-write 在同一锁内完成，并通过临时文件、`0600` 写入和原子 rename 提交。
+4. 禁止继续吞掉读取、迁移或写入错误；检查调用可带告警继续，增量写入失败必须返回可观察告警，但不得删除旧文件或把损坏内容重置为零。
+5. 测试至少覆盖两个并发进程首次迁移、迁移与 increment 交错、进程在写临时文件后退出、过期锁恢复，以及月份切换。
+
+## 非目标
+
+本期明确不做：
+
+- 共享配置/状态存储 package；
+- 一个 bundle 级巨型配置文件；
+- 统一所有扩展的 schema 或深度合并算法；
+- 通用 Secret Store；
+- credential 加密、OS keychain 或 password manager 集成；
+- 把非 Provider credential 塞入 Pi `auth.json`；
+- 移动 `$PI_CODING_AGENT_DIR/plans/`；
+- 为当前不支持项目配置的扩展新增项目覆盖；
+- 修改 Pi core。
+
+## 后续实施拆分
+
+后续独立推进时建议按 package 分批完成，每批包含源码、测试、双语 README 和 changeset：
+
+1. Search Hub：先修正 `getAgentDir()`、配置路径、Exa 状态路径及旧文件迁移。
+2. Recap：迁移全局与项目配置路径。
+3. Pi Glance：迁移全局配置路径。
+4. Tool Display Intent：自动迁移并升级全局配置，同时迁移 `config.legacy.json` 与调试日志，并把后续调试日志写入 `state/debug.log`。
+5. Plan Mode：只迁移 `plan-mode.json`，明确回归验证 `plans/` 路径完全不变。
+6. 全仓扫描旧路径字面量，补齐根 README、示例和发布说明。
+
+## 验收标准
+
+1. 本仓库所有独立配置均可从 `$PI_CODING_AGENT_DIR/extension-data/<extension-id>/config.json` 定位。
+2. Recap 与 Search Hub 的项目覆盖位于 `.pi/extension-data/<extension-id>/config.json`，且只在项目受信任时生效。
+3. Search Hub 在设置 `PI_CODING_AGENT_DIR` 后，配置与 Exa 状态都写入覆盖目录，不再访问硬编码的 `~/.pi/agent`。
+4. Search Hub 的旧配置、credential 与 Exa 用量可安全迁移，不静默丢失；并发迁移与 increment 的测试通过。
+5. Search Hub 在不受信任项目中不探测或读取新旧项目配置；切换 cwd 或 trust 后缓存不会泄漏上一项目的 effective config。
+6. Tool Display Intent 的 `config.legacy.json` 与 `debug/debug.log` 按迁移表处理，不在旧目录继续写入调试日志。
+7. `$PI_CODING_AGENT_DIR/plans/` 在 Plan Mode 迁移前后保持完全相同。
+8. 不产生 `secrets.json`，不改变现有 credential 解析和 Provider `auth.json` 行为。
+9. 新旧路径不双写，文档、帮助文本与实现使用同一组 canonical path。

--- a/packages/pi-glance/README.md
+++ b/packages/pi-glance/README.md
@@ -188,7 +188,7 @@ pnpm debug:git
 - No Pi core patches — public extension APIs only
 - No render-time IO — Git is collected asynchronously and cached; Pi settings are sampled during lifecycle refreshes
 - pi-glance never replaces Pi's native Header or resource area. Context/Skills/Prompts/Extensions keep Pi's native compact/expanded hierarchy; expanded Extensions stay grouped by project/user/path, with `npm:`/`git:` package sources and local file paths shown by Pi
-- Global config at `~/.pi/agent/pi-glance/config.json` (schema version 11; older configs preserve Glance palette behavior unless `colorSource` was explicitly set)
+- Global config at `$PI_CODING_AGENT_DIR/extension-data/pi-glance/config.json` (schema version 11). The previous path is migrated and upgraded automatically; unmappable fields are dropped with a warning, while malformed files are preserved
 
 ## License and attribution
 

--- a/packages/pi-glance/README.zh-CN.md
+++ b/packages/pi-glance/README.zh-CN.md
@@ -122,7 +122,7 @@ Pi 原有的两行 workspace/usage/context/model 信息不再重建，也没有�
 }
 ```
 
-配置保存在 `~/.pi/agent/pi-glance/config.json`。当前 schema 为版本 11；旧配置会自动迁移并保留原 Glance palette，Pi Header 始终由 Pi 原生负责，同时继续丢弃已废弃的 Footer 和详情开关。
+配置保存在 `$PI_CODING_AGENT_DIR/extension-data/pi-glance/config.json`。当前 schema 为版本 11；旧路径与旧 schema 会自动迁移升级，无法映射的字段会被丢弃并提示 warning，格式损坏的文件会原样保留。Pi Header 始终由 Pi 原生负责，同时继续丢弃已废弃的 Footer 和详情开关。
 
 ## 工作区标题
 

--- a/packages/pi-glance/config.ts
+++ b/packages/pi-glance/config.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { chmodSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import {
@@ -38,9 +39,29 @@ import type {
 	WorkspaceLabelMode,
 } from "./types.js";
 
-const CONFIG_PATH = join(getAgentDir(), "pi-glance", "config.json");
 // CONFIG_VERSION is the on-disk config schema version, not the npm package version.
 const CONFIG_VERSION = 11 as const;
+const emittedMigrationNotices = new Set<string>();
+const pendingMigrationNotices: string[] = [];
+const waitBuffer = new Int32Array(new SharedArrayBuffer(4));
+
+export function getGlanceConfigPath(agentDir = getAgentDir()): string {
+	return join(agentDir, "extension-data", "pi-glance", "config.json");
+}
+
+export function getLegacyGlanceConfigPath(agentDir = getAgentDir()): string {
+	return join(agentDir, "pi-glance", "config.json");
+}
+
+export function consumeGlanceConfigNotices(): string[] {
+	return pendingMigrationNotices.splice(0);
+}
+
+function queueMigrationNotice(message: string): void {
+	if (emittedMigrationNotices.has(message)) return;
+	emittedMigrationNotices.add(message);
+	pendingMigrationNotices.push(message);
+}
 
 const COLOR_SOURCES = new Set<ColorSource>(COLOR_SOURCE_VALUES);
 const ICON_MODES = new Set<IconMode>(ICON_MODE_VALUES);
@@ -282,27 +303,160 @@ export function configToText(config: GlanceConfig): string {
 	return `${JSON.stringify(normalizeConfig(config), null, "\t")}\n`;
 }
 
-export function loadConfigSync(): GlanceConfig {
+const CONFIG_SHAPE: Record<string, ReadonlySet<string> | undefined> = {
+	"": new Set(["version", "enabled", "colorSource", "theme", "icons", "editor", "display", "segments", "model", "git", "context", "cost", "tokens", "throughput", "bottomDetails"]),
+	theme: new Set(["light", "dark"]),
+	editor: new Set(["minContentRows", "topMarginRows"]),
+	display: new Set(["showProvider", "workspaceLabel"]),
+	model: new Set(["customNames", "showThinking"]),
+	git: new Set(["showDirty", "showAheadBehind", "shaMode", "timeoutMs", "refreshDebounceMs", "pollIntervalMs"]),
+	context: new Set(["display", "unknown", "progressStyle", "progressWidth"]),
+	cost: new Set(["hideZero"]),
+	tokens: new Set(["display", "cache"]),
+	throughput: new Set(["precision"]),
+	bottomDetails: new Set(["showAutoCompact"]),
+};
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function collectDroppedConfigFields(value: unknown): string[] {
+	if (!isRecordValue(value)) return ["<root>"];
+	const dropped: string[] = [];
+	for (const [key, child] of Object.entries(value)) {
+		if (!CONFIG_SHAPE[""]!.has(key)) {
+			dropped.push(key);
+			continue;
+		}
+		const fields = CONFIG_SHAPE[key];
+		if (fields && isRecordValue(child)) {
+			for (const childKey of Object.keys(child)) if (!fields.has(childKey)) dropped.push(`${key}.${childKey}`);
+		}
+		if (key === "segments" && Array.isArray(child)) {
+			for (const [index, segment] of child.entries()) {
+				if (!isRecordValue(segment)) continue;
+				for (const segmentKey of Object.keys(segment)) if (segmentKey !== "id" && segmentKey !== "enabled") dropped.push(`segments[${index}].${segmentKey}`);
+			}
+		}
+	}
+	return [...new Set(dropped)];
+}
+
+function droppedSummary(dropped: readonly string[]): string {
+	return dropped.length > 0 ? ` Dropped unmappable fields: ${dropped.join(", ")}.` : "";
+}
+
+function sleepSync(milliseconds: number): void {
+	Atomics.wait(waitBuffer, 0, 0, milliseconds);
+}
+
+function withConfigLock<T>(directory: string, fn: () => T): T {
+	mkdirSync(directory, { recursive: true, mode: 0o700 });
+	const lockPath = join(directory, ".config-migration.lock");
+	const deadline = Date.now() + 1_000;
+	let descriptor: number | undefined;
+	while (descriptor === undefined) {
+		try {
+			descriptor = openSync(lockPath, "wx", 0o600);
+			writeFileSync(descriptor, `${JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() })}\n`);
+		} catch (error) {
+			if (!isRecordValue(error) || error.code !== "EEXIST") throw error;
+			try {
+				if (Date.now() - statSync(lockPath).mtimeMs > 30_000) {
+					unlinkSync(lockPath);
+					continue;
+				}
+			} catch (statError) {
+				if (isRecordValue(statError) && statError.code === "ENOENT") continue;
+				throw statError;
+			}
+			if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${lockPath}`);
+			sleepSync(20);
+		}
+	}
 	try {
-		const text = readFileSync(CONFIG_PATH, "utf8");
-		return configFromText(text);
-	} catch {
+		return fn();
+	} finally {
+		closeSync(descriptor);
+		rmSync(lockPath, { force: true });
+	}
+}
+
+function writeConfigSync(file: string, config: GlanceConfig): void {
+	const directory = dirname(file);
+	mkdirSync(directory, { recursive: true, mode: 0o700 });
+	const temporary = join(directory, `.${randomUUID()}.tmp`);
+	try {
+		writeFileSync(temporary, configToText(config), { encoding: "utf8", mode: 0o600, flag: "wx" });
+		renameSync(temporary, file);
+		chmodSync(file, 0o600);
+	} finally {
+		rmSync(temporary, { force: true });
+	}
+}
+
+function parseStoredConfig(file: string): { config: GlanceConfig; raw: unknown; dropped: string[] } {
+	const raw = JSON.parse(readFileSync(file, "utf8")) as unknown;
+	if (!isRecordValue(raw)) throw new Error("the root value must be a JSON object");
+	return { config: normalizeConfig(raw), raw, dropped: collectDroppedConfigFields(raw) };
+}
+
+export function loadConfigSync(): GlanceConfig {
+	const target = getGlanceConfigPath();
+	const legacy = getLegacyGlanceConfigPath();
+	if (existsSync(target)) {
+		try {
+			let loaded = parseStoredConfig(target);
+			const rawVersion = isRecordValue(loaded.raw) ? loaded.raw.version : undefined;
+			if (rawVersion !== CONFIG_VERSION || loaded.dropped.length > 0) {
+				loaded = withConfigLock(dirname(target), () => {
+					const current = parseStoredConfig(target);
+					const currentVersion = isRecordValue(current.raw) ? current.raw.version : undefined;
+					if (currentVersion !== CONFIG_VERSION || current.dropped.length > 0) writeConfigSync(target, current.config);
+					return current;
+				});
+				queueMigrationNotice(`Upgraded pi-glance config at ${target}.${droppedSummary(loaded.dropped)}`);
+			}
+			if (existsSync(legacy)) queueMigrationNotice(`Ignored conflicting legacy pi-glance config at ${legacy}; canonical config is ${target}.`);
+			return loaded.config;
+		} catch (error) {
+			queueMigrationNotice(`Failed to read pi-glance config at ${target}: ${error instanceof Error ? error.message : String(error)}. The file was preserved.`);
+			return defaultConfig();
+		}
+	}
+	if (!existsSync(legacy)) return defaultConfig();
+	try {
+		return withConfigLock(dirname(target), () => {
+			if (existsSync(target)) return parseStoredConfig(target).config;
+			const loaded = parseStoredConfig(legacy);
+			writeConfigSync(target, loaded.config);
+			const verified = parseStoredConfig(target).config;
+			unlinkSync(legacy);
+			queueMigrationNotice(`Migrated pi-glance config from ${legacy} to ${target}.${droppedSummary(loaded.dropped)}`);
+			return verified;
+		});
+	} catch (error) {
+		queueMigrationNotice(`Failed to migrate pi-glance config from ${legacy} to ${target}: ${error instanceof Error ? error.message : String(error)}. The legacy file was preserved.`);
 		return defaultConfig();
 	}
 }
 
 export async function loadConfig(): Promise<GlanceConfig> {
-	try {
-		const text = await readFile(CONFIG_PATH, "utf8");
-		return configFromText(text);
-	} catch {
-		return defaultConfig();
-	}
+	return loadConfigSync();
 }
 
 export async function saveConfig(config: GlanceConfig): Promise<void> {
-	await mkdir(dirname(CONFIG_PATH), { recursive: true });
-	await writeFile(CONFIG_PATH, configToText(config), "utf8");
+	const target = getGlanceConfigPath();
+	const directory = dirname(target);
+	await mkdir(directory, { recursive: true, mode: 0o700 });
+	const temporary = join(directory, `.${randomUUID()}.tmp`);
+	try {
+		await writeFile(temporary, configToText(config), { encoding: "utf8", mode: 0o600, flag: "wx" });
+		await rename(temporary, target);
+	} finally {
+		await rm(temporary, { force: true });
+	}
 }
 
 export function moveSegment(config: GlanceConfig, id: SegmentId, direction: -1 | 1): GlanceConfig {

--- a/packages/pi-glance/index.ts
+++ b/packages/pi-glance/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { loadConfig, loadConfigSync, saveConfig } from "./config.js";
+import { consumeGlanceConfigNotices, loadConfig, loadConfigSync, saveConfig } from "./config.js";
 import { showGlancePane } from "./pane.js";
 import { createGlanceRuntime } from "./runtime.js";
 
@@ -9,6 +9,7 @@ export default function piGlance(pi: ExtensionAPI): void {
 		loadConfigSync,
 		loadConfig,
 		saveConfig,
+		consumeConfigNotices: consumeGlanceConfigNotices,
 		showPane: showGlancePane,
 	});
 

--- a/packages/pi-glance/runtime.ts
+++ b/packages/pi-glance/runtime.ts
@@ -31,6 +31,7 @@ export interface GlanceRuntimeAdapters {
 	loadConfigSync(): GlanceConfig;
 	loadConfig(): Promise<GlanceConfig>;
 	saveConfig(config: GlanceConfig): Promise<void>;
+	consumeConfigNotices?(): string[];
 	showPane(initial: GlanceConfig, ctx: ExtensionCommandContext, previewState?: GlanceState, options?: RuntimeShowPaneOptions): Promise<GlancePaneResult>;
 	createGitRefresher?: (options: CreateGitRefresherOptions) => RuntimeGitRefresher;
 	nowMs?: () => number;
@@ -245,6 +246,7 @@ export function createGlanceRuntime(adapters: GlanceRuntimeAdapters): GlanceRunt
 		events: {
 			sessionStart: (_event, ctx) => {
 				config = adapters.loadConfigSync();
+				for (const notice of adapters.consumeConfigNotices?.() ?? []) ctx.ui.notify?.(notice, "warning");
 				refreshSession.sessionStart(ctx);
 				installInputSurface(ctx);
 			},

--- a/packages/pi-glance/scripts/test-config-io.ts
+++ b/packages/pi-glance/scripts/test-config-io.ts
@@ -12,6 +12,7 @@ interface ConfigModule {
 	loadConfigSync(): GlanceConfig;
 	loadConfig(): Promise<GlanceConfig>;
 	saveConfig(config: GlanceConfig): Promise<void>;
+	consumeGlanceConfigNotices(): string[];
 }
 
 async function writeConfigText(configPath: string, text: string): Promise<void> {
@@ -25,14 +26,20 @@ async function main(): Promise<void> {
 	process.env.PI_CODING_AGENT_DIR = agentDir;
 
 	try {
-		// CONFIG_PATH is computed when config.js is imported, so set the isolated
-		// agent dir before this dynamic import to avoid touching real user config.
 		const configModule = (await import(`../config.js?config-io=${process.pid}-${Date.now()}`)) as ConfigModule;
-		const { configFromText, configToText, defaultConfig, loadConfig, loadConfigSync, normalizeConfig, saveConfig } = configModule;
-		const configPath = join(agentDir, "pi-glance", "config.json");
+		const { configFromText, configToText, consumeGlanceConfigNotices, defaultConfig, loadConfig, loadConfigSync, normalizeConfig, saveConfig } = configModule;
+		const configPath = join(agentDir, "extension-data", "pi-glance", "config.json");
+		const legacyConfigPath = join(agentDir, "pi-glance", "config.json");
 
 		assert.deepEqual(loadConfigSync(), defaultConfig(), "missing config file should make loadConfigSync fall back to defaults");
 		assert.deepEqual(await loadConfig(), defaultConfig(), "missing config file should make async loadConfig fall back to defaults");
+
+		await writeConfigText(legacyConfigPath, JSON.stringify({ version: 10, enabled: false, obsolete: true }));
+		assert.equal(loadConfigSync().enabled, false, "legacy config should migrate and retain mapped fields");
+		assert.match(consumeGlanceConfigNotices().join("\n"), /obsolete/, "migration should report discarded fields");
+		await assert.rejects(readFile(legacyConfigPath, "utf8"), /ENOENT/, "verified migration should delete the legacy file");
+		assert.equal(JSON.parse(await readFile(configPath, "utf8")).version, 11, "migration should write the current schema version");
+		await rm(configPath, { force: true });
 
 		await writeConfigText(configPath, "{");
 		assert.deepEqual(loadConfigSync(), defaultConfig(), "invalid JSON should make loadConfigSync fall back to defaults");

--- a/packages/pi-glance/scripts/test-glance-command-save.ts
+++ b/packages/pi-glance/scripts/test-glance-command-save.ts
@@ -119,7 +119,7 @@ async function main(): Promise<void> {
 	process.env.PI_CODING_AGENT_DIR = agentDir;
 
 	try {
-		const configDir = join(agentDir, "pi-glance");
+		const configDir = join(agentDir, "extension-data", "pi-glance");
 		const configPath = join(configDir, "config.json");
 		const { configToText, defaultConfig } = await import("../config.js");
 		const initialConfig = defaultConfig();

--- a/packages/pi-glance/scripts/test-session-start-order.ts
+++ b/packages/pi-glance/scripts/test-session-start-order.ts
@@ -89,8 +89,8 @@ async function main(): Promise<void> {
 			assert.deepEqual(nonTuiCalls, [], `${mode} session_start should not install or clear TUI footer/editor`);
 		}
 
-		await mkdir(join(agentDir, "pi-glance"), { recursive: true });
-		await writeFile(join(agentDir, "pi-glance", "config.json"), `${JSON.stringify({ enabled: false })}\n`, "utf8");
+		await mkdir(join(agentDir, "extension-data", "pi-glance"), { recursive: true });
+		await writeFile(join(agentDir, "extension-data", "pi-glance", "config.json"), `${JSON.stringify({ enabled: false })}\n`, "utf8");
 
 		const disabledPi = createPi();
 		piGlance(disabledPi.api);

--- a/packages/pi-plan-mode/README.md
+++ b/packages/pi-plan-mode/README.md
@@ -73,7 +73,7 @@ All `/plan` actions support command argument completion.
 
 ## Plan content language
 
-Plan Mode reads one optional user-level file from `<agent-dir>/plan-mode.json` (normally `~/.pi/agent/plan-mode.json`):
+Plan Mode reads one optional user-level file from `<agent-dir>/extension-data/pi-plan-mode/config.json` (normally `~/.pi/agent/extension-data/pi-plan-mode/config.json`):
 
 ```json
 {
@@ -87,7 +87,7 @@ Supported values:
 - `en`: require English title, content, and section headings.
 - `zh-CN`: require Simplified Chinese title, content, and section headings.
 
-The extension only reads this file and never creates or rewrites it. Reload or restart Pi after editing it. Invalid JSON or an unsupported value produces a warning and falls back to `auto`. This setting controls generated Plan content and headings only; Plan Mode UI, revdiff UI, control prompts, and approval events remain English.
+Reload or restart Pi after editing it. On first load, the previous `plan-mode.json` path is automatically migrated and upgraded; unmappable fields are dropped with a warning. Invalid JSON or an unsupported value is preserved, produces a warning, and falls back to `auto`. This setting controls generated Plan content and headings only; Plan Mode UI, revdiff UI, control prompts, and approval events remain English.
 
 ## Widgets
 
@@ -136,10 +136,10 @@ Persistent widgets do not receive focus and Pi's public Widget API has no mouse 
 
 ## Storage
 
-Persistent Sessions store application data separately from Pi JSONL transcripts. The optional language config is a sibling of the `plans/` directory:
+Persistent Sessions store application data separately from Pi JSONL transcripts. Only the optional language config moves under `extension-data`; Plan artifacts remain at their stable path:
 
 ```text
-~/.pi/agent/plan-mode.json
+~/.pi/agent/extension-data/pi-plan-mode/config.json
 ~/.pi/agent/plans/
 └── <plan-id>/
     ├── manifest.json

--- a/packages/pi-plan-mode/README.zh-CN.md
+++ b/packages/pi-plan-mode/README.zh-CN.md
@@ -73,7 +73,7 @@ brew install umputun/apps/revdiff
 
 ## Plan 内容语言
 
-Plan Mode 从 `<agent-dir>/plan-mode.json`（通常是 `~/.pi/agent/plan-mode.json`）读取一个可选用户级配置：
+Plan Mode 从 `<agent-dir>/extension-data/pi-plan-mode/config.json`（通常是 `~/.pi/agent/extension-data/pi-plan-mode/config.json`）读取一个可选用户级配置：
 
 ```json
 {
@@ -87,7 +87,7 @@ Plan Mode 从 `<agent-dir>/plan-mode.json`（通常是 `~/.pi/agent/plan-mode.js
 - `en`：要求英文标题、内容和章节标题。
 - `zh-CN`：要求简体中文标题、内容和章节标题。
 
-扩展只读取该文件，不会自动创建或改写。编辑后需 reload 或重启 Pi。JSON 无效或值不受支持时会提示 warning 并回退到 `auto`。该设置只控制生成的 Plan 内容和标题；Plan Mode UI、revdiff UI、控制 prompt 和批准事件仍使用英文。
+编辑后需 reload 或重启 Pi。首次加载时会自动迁移并升级旧的 `plan-mode.json` 路径；无法映射的字段会被丢弃并提示 warning。JSON 无效或值不受支持时会保留原文件、提示 warning 并回退到 `auto`。该设置只控制生成的 Plan 内容和标题；Plan Mode UI、revdiff UI、控制 prompt 和批准事件仍使用英文。
 
 ## Widgets
 
@@ -136,10 +136,10 @@ Steps 默认收起。`Ctrl+Alt+O` 展开终端高度的最多 30%，并限制在
 
 ## 存储方式
 
-持久 Session 把应用数据与 Pi JSONL transcript 分开保存。可选语言配置与 `plans/` 目录同级：
+持久 Session 把应用数据与 Pi JSONL transcript 分开保存。只有可选语言配置迁入 `extension-data`；Plan artifact 继续使用稳定路径：
 
 ```text
-~/.pi/agent/plan-mode.json
+~/.pi/agent/extension-data/pi-plan-mode/config.json
 ~/.pi/agent/plans/
 └── <plan-id>/
     ├── manifest.json

--- a/packages/pi-plan-mode/src/config.ts
+++ b/packages/pi-plan-mode/src/config.ts
@@ -1,4 +1,5 @@
-import { readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, open, readFile, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
@@ -29,6 +30,10 @@ function isMissingFile(error: unknown): boolean {
 }
 
 export function getPlanModeConfigPath(agentDir = getAgentDir()): string {
+	return path.join(agentDir, "extension-data", "pi-plan-mode", "config.json");
+}
+
+export function getLegacyPlanModeConfigPath(agentDir = getAgentDir()): string {
 	return path.join(agentDir, "plan-mode.json");
 }
 
@@ -41,27 +46,119 @@ export function parsePlanModeConfig(value: unknown): PlanModeConfig {
 	return { contentLanguage: value.contentLanguage as PlanContentLanguage };
 }
 
+async function exists(file: string): Promise<boolean> {
+	try {
+		await stat(file);
+		return true;
+	} catch (error) {
+		if (isMissingFile(error)) return false;
+		throw error;
+	}
+}
+
+async function writeConfigAtomically(file: string, config: PlanModeConfig): Promise<void> {
+	const directory = path.dirname(file);
+	await mkdir(directory, { recursive: true, mode: 0o700 });
+	const temporary = path.join(directory, `.${randomUUID()}.tmp`);
+	try {
+		await writeFile(temporary, `${JSON.stringify(config, null, 2)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+		await rename(temporary, file);
+		await chmod(file, 0o600);
+	} finally {
+		await rm(temporary, { force: true });
+	}
+}
+
+async function withMigrationLock<T>(directory: string, fn: () => Promise<T>): Promise<T> {
+	await mkdir(directory, { recursive: true, mode: 0o700 });
+	const lockPath = path.join(directory, ".config-migration.lock");
+	const deadline = Date.now() + 2_000;
+	let handle: Awaited<ReturnType<typeof open>> | undefined;
+	while (!handle) {
+		try {
+			handle = await open(lockPath, "wx", 0o600);
+			await handle.writeFile(`${JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() })}\n`);
+		} catch (error) {
+			if (!isRecord(error) || error.code !== "EEXIST") throw error;
+			try {
+				if (Date.now() - (await stat(lockPath)).mtimeMs > 30_000) {
+					await unlink(lockPath);
+					continue;
+				}
+			} catch (statError) {
+				if (isMissingFile(statError)) continue;
+				throw statError;
+			}
+			if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${lockPath}`);
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+	}
+	try {
+		return await fn();
+	} finally {
+		await handle.close();
+		await rm(lockPath, { force: true });
+	}
+}
+
+function parseStoredConfig(raw: string): { config: PlanModeConfig; dropped: string[] } {
+	const value = JSON.parse(raw) as unknown;
+	const config = parsePlanModeConfig(value);
+	const dropped = isRecord(value) ? Object.keys(value).filter((key) => key !== "contentLanguage") : [];
+	return { config, dropped };
+}
+
+function droppedSummary(dropped: readonly string[]): string {
+	return dropped.length > 0 ? ` Dropped unmappable fields: ${dropped.join(", ")}.` : "";
+}
+
 export async function loadPlanModeConfig(agentDir = getAgentDir()): Promise<LoadedPlanModeConfig> {
 	const configPath = getPlanModeConfigPath(agentDir);
-	let raw: string;
-	try {
-		raw = await readFile(configPath, "utf8");
-	} catch (error) {
-		if (isMissingFile(error)) return { config: { ...DEFAULT_PLAN_MODE_CONFIG }, path: configPath };
-		return {
-			config: { ...DEFAULT_PLAN_MODE_CONFIG },
-			path: configPath,
-			warning: `Failed to read Plan Mode config at ${configPath}: ${error instanceof Error ? error.message : String(error)}. Using contentLanguage "auto".`,
-		};
+	const legacyPath = getLegacyPlanModeConfigPath(agentDir);
+	if (await exists(configPath)) {
+		try {
+			let loaded = parseStoredConfig(await readFile(configPath, "utf8"));
+			let warning: string | undefined;
+			if (loaded.dropped.length > 0) {
+				loaded = await withMigrationLock(path.dirname(configPath), async () => {
+					const current = parseStoredConfig(await readFile(configPath, "utf8"));
+					if (current.dropped.length > 0) await writeConfigAtomically(configPath, current.config);
+					return current;
+				});
+				warning = `Upgraded Plan Mode config at ${configPath}.${droppedSummary(loaded.dropped)}`;
+			}
+			if (await exists(legacyPath)) warning = `${warning ? `${warning} ` : ""}Ignored conflicting legacy Plan Mode config at ${legacyPath}.`;
+			return { config: loaded.config, path: configPath, ...(warning ? { warning } : {}) };
+		} catch (error) {
+			return {
+				config: { ...DEFAULT_PLAN_MODE_CONFIG },
+				path: configPath,
+				warning: `Invalid Plan Mode config at ${configPath}: ${error instanceof Error ? error.message : String(error)}. The file was preserved; Using contentLanguage "auto".`,
+			};
+		}
 	}
-
+	if (!(await exists(legacyPath))) return { config: { ...DEFAULT_PLAN_MODE_CONFIG }, path: configPath };
 	try {
-		return { config: parsePlanModeConfig(JSON.parse(raw) as unknown), path: configPath };
+		return await withMigrationLock(path.dirname(configPath), async () => {
+			if (await exists(configPath)) {
+				const raced = parseStoredConfig(await readFile(configPath, "utf8"));
+				return { config: raced.config, path: configPath };
+			}
+			const loaded = parseStoredConfig(await readFile(legacyPath, "utf8"));
+			await writeConfigAtomically(configPath, loaded.config);
+			const verified = parseStoredConfig(await readFile(configPath, "utf8")).config;
+			await unlink(legacyPath);
+			return {
+				config: verified,
+				path: configPath,
+				warning: `Migrated Plan Mode config from ${legacyPath} to ${configPath}.${droppedSummary(loaded.dropped)}`,
+			};
+		});
 	} catch (error) {
 		return {
 			config: { ...DEFAULT_PLAN_MODE_CONFIG },
 			path: configPath,
-			warning: `Invalid Plan Mode config at ${configPath}: ${error instanceof Error ? error.message : String(error)}. Using contentLanguage "auto".`,
+			warning: `Invalid Plan Mode config at ${legacyPath}: ${error instanceof Error ? error.message : String(error)}. The legacy file was preserved; Using contentLanguage "auto".`,
 		};
 	}
 }

--- a/packages/pi-plan-mode/tests/config.test.ts
+++ b/packages/pi-plan-mode/tests/config.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -34,6 +34,7 @@ describe("Plan Mode config", () => {
 
 	it.each(["auto", "en", "zh-CN"] as const)("loads supported content language %s", async (contentLanguage) => {
 		const directory = await agentDir();
+		await mkdir(path.dirname(getPlanModeConfigPath(directory)), { recursive: true });
 		await writeFile(getPlanModeConfigPath(directory), `${JSON.stringify({ contentLanguage })}\n`, "utf8");
 		expect(await loadPlanModeConfig(directory)).toEqual({
 			config: { contentLanguage },
@@ -47,10 +48,24 @@ describe("Plan Mode config", () => {
 		["unsupported language", '{"contentLanguage":"fr"}'],
 	])("warns and falls back for %s", async (_label, content) => {
 		const directory = await agentDir();
+		await mkdir(path.dirname(getPlanModeConfigPath(directory)), { recursive: true });
 		await writeFile(getPlanModeConfigPath(directory), content, "utf8");
 		const loaded = await loadPlanModeConfig(directory);
 		expect(loaded.config).toEqual({ contentLanguage: "auto" });
 		expect(loaded.warning).toContain("Invalid Plan Mode config");
 		expect(loaded.warning).toContain('Using contentLanguage "auto"');
+	});
+
+	it("migrates the legacy config and drops unmappable fields", async () => {
+		const directory = await agentDir();
+		const legacyPath = path.join(directory, "plan-mode.json");
+		await writeFile(legacyPath, '{"contentLanguage":"zh-CN","obsolete":true}\n', "utf8");
+
+		const loaded = await loadPlanModeConfig(directory);
+
+		expect(loaded.config).toEqual({ contentLanguage: "zh-CN" });
+		expect(loaded.warning).toContain("obsolete");
+		expect(JSON.parse(await readFile(getPlanModeConfigPath(directory), "utf8"))).toEqual({ contentLanguage: "zh-CN" });
+		await expect(stat(legacyPath)).rejects.toMatchObject({ code: "ENOENT" });
 	});
 });

--- a/packages/pi-plan-mode/tests/extension.test.ts
+++ b/packages/pi-plan-mode/tests/extension.test.ts
@@ -11,6 +11,7 @@ import planModeExtension, {
 	REVISE_WORK_CHOICE,
 	isPersistentSession,
 } from "../extensions/plan-mode.ts";
+import { getPlanModeConfigPath } from "../src/config.ts";
 import { COMPLETE_PLAN_TOOL, SUBMIT_PLAN_TOOL } from "../src/policy.ts";
 
 interface CustomEntry {
@@ -318,8 +319,9 @@ describe("Plan Mode extension lifecycle", () => {
 
 	it("loads zh-CN Plan content language into status and the planning prompt", async () => {
 		const revdiff = await fakeRevdiff();
-		const configPath = path.join(path.dirname(revdiff), "plan-mode.json");
-		await writeFile(configPath, '{"contentLanguage":"zh-CN"}\n', "utf8");
+		const legacyConfigPath = path.join(path.dirname(revdiff), "plan-mode.json");
+		const configPath = getPlanModeConfigPath(path.dirname(revdiff));
+		await writeFile(legacyConfigPath, '{"contentLanguage":"zh-CN"}\n', "utf8");
 		const pi = new FakePi();
 		planModeExtension(pi.api());
 		const harness = fakeContext({ entries: pi.entries });

--- a/packages/pi-recap/README.md
+++ b/packages/pi-recap/README.md
@@ -65,7 +65,7 @@ Generate a recent activity recap. It will:
 Open the TUI config screen and save common settings to:
 
 ```text
-~/.pi/agent/recap.json
+$PI_CODING_AGENT_DIR/extension-data/pi-recap/config.json
 ```
 
 ```text
@@ -83,11 +83,11 @@ recap only runs in Pi TUI mode. Headless modes such as `print`, `json`, and `rpc
 The extension reads:
 
 ```text
-~/.pi/agent/recap.json
-.pi/recap.json
+$PI_CODING_AGENT_DIR/extension-data/pi-recap/config.json
+.pi/extension-data/pi-recap/config.json
 ```
 
-Project-local `.pi/recap.json` is read only when the project is trusted, and it overrides global config.
+Project-local `.pi/extension-data/pi-recap/config.json` is read only when the project is trusted, and it overrides global config. On first load, the previous global and trusted-project paths are automatically migrated and upgraded; unmappable fields are dropped with a warning, and malformed files are preserved.
 
 See example config:
 

--- a/packages/pi-recap/README.zh-CN.md
+++ b/packages/pi-recap/README.zh-CN.md
@@ -65,7 +65,7 @@ pi -e ./packages/pi-recap
 打开 TUI 配置界面，修改常用配置并保存到：
 
 ```text
-~/.pi/agent/recap.json
+$PI_CODING_AGENT_DIR/extension-data/pi-recap/config.json
 ```
 
 ```text
@@ -83,11 +83,11 @@ recap 只在 Pi TUI 模式工作。`print`、`json`、`rpc` 等 headless 模式�
 插件读取：
 
 ```text
-~/.pi/agent/recap.json
-.pi/recap.json
+$PI_CODING_AGENT_DIR/extension-data/pi-recap/config.json
+.pi/extension-data/pi-recap/config.json
 ```
 
-项目级 `.pi/recap.json` 仅在项目被 Pi trust 后读取，并覆盖全局配置。
+项目级 `.pi/extension-data/pi-recap/config.json` 仅在项目被 Pi trust 后读取，并覆盖全局配置。首次加载时会自动迁移并升级旧的全局路径和受信任项目路径；无法映射的字段会被丢弃并提示 warning，格式损坏的文件会原样保留。
 
 示例配置见：
 

--- a/packages/pi-recap/extensions/recap.ts
+++ b/packages/pi-recap/extensions/recap.ts
@@ -6,11 +6,12 @@
  * - Optionally sync Pi session name to the nearest terminal multiplexer.
  *
  * Config:
- *   ~/.pi/agent/recap.json
- *   .pi/recap.json          (only read when the project is trusted)
+ *   $PI_CODING_AGENT_DIR/extension-data/pi-recap/config.json
+ *   .pi/extension-data/pi-recap/config.json (trusted projects only)
  */
 
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, open, readFile, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { complete } from "@earendil-works/pi-ai/compat";
 import {
@@ -132,27 +133,48 @@ function deepMerge<T extends Record<string, unknown>>(base: T, override: unknown
 type ConfigMigration = {
 	value: unknown;
 	changed: boolean;
+	dropped: string[];
 };
+
+const CONFIG_FIELDS: Record<string, ReadonlySet<string>> = {
+	recap: new Set(["enabled", "auto", "manualCommand", "idleAfterTurnMs", "minSessionTurns", "neverTwiceInARow", "model", "fallbackToCurrentModel", "maxRecentChars", "maxTokens", "language"]),
+	display: new Set(["widgetPlacement"]),
+	title: new Set(["generate", "applyToSessionName", "applyPolicy", "maxLength"]),
+	multiplexer: new Set(["enabled", "template", "maxLength", "restoreOnShutdown"]),
+};
+const emittedMigrationNotices = new Set<string>();
+
+function stripUnknownConfig(value: unknown): { value: unknown; dropped: string[] } {
+	if (!isRecord(value)) throw new Error("the root value must be a JSON object");
+	const result: Record<string, unknown> = {};
+	const dropped: string[] = [];
+	for (const [section, sectionValue] of Object.entries(value)) {
+		const fields = CONFIG_FIELDS[section];
+		if (!fields) {
+			dropped.push(section);
+			continue;
+		}
+		if (!isRecord(sectionValue)) {
+			dropped.push(section);
+			continue;
+		}
+		const nextSection: Record<string, unknown> = {};
+		for (const [key, fieldValue] of Object.entries(sectionValue)) {
+			if (fields.has(key)) nextSection[key] = fieldValue;
+			else dropped.push(`${section}.${key}`);
+		}
+		result[section] = nextSection;
+	}
+	return { value: result, dropped };
+}
 
 function migrateLegacyConfig(value: unknown): ConfigMigration {
 	const multiplexerMigration = migrateMultiplexerConfig(value);
-	const migrated = multiplexerMigration.value;
-	if (!isRecord(migrated) || !isRecord(migrated.display)) {
-		return multiplexerMigration;
-	}
-
-	const display = { ...migrated.display };
-	let changed = multiplexerMigration.changed;
-	for (const key of ["notify", "mode", "widget", "clearWidgetOnNextAgentStart"]) {
-		if (key in display) {
-			delete display[key];
-			changed = true;
-		}
-	}
-
+	const stripped = stripUnknownConfig(multiplexerMigration.value);
 	return {
-		value: changed ? { ...migrated, display } : migrated,
-		changed,
+		value: stripped.value,
+		changed: multiplexerMigration.changed || stripped.dropped.length > 0,
+		dropped: stripped.dropped,
 	};
 }
 
@@ -165,42 +187,159 @@ async function readJsonIfExists(file: string): Promise<unknown | undefined> {
 	}
 }
 
-function getGlobalConfigPath(): string {
-	return path.join(getAgentDir(), "recap.json");
+async function pathExists(file: string): Promise<boolean> {
+	try {
+		await stat(file);
+		return true;
+	} catch (error) {
+		if (isRecord(error) && error.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+export function getGlobalConfigPath(agentDir = getAgentDir()): string {
+	return path.join(agentDir, "extension-data", "pi-recap", "config.json");
+}
+
+export function getLegacyGlobalConfigPath(agentDir = getAgentDir()): string {
+	return path.join(agentDir, "recap.json");
+}
+
+export function getProjectConfigPath(cwd: string): string {
+	return path.join(cwd, CONFIG_DIR_NAME, "extension-data", "pi-recap", "config.json");
+}
+
+export function getLegacyProjectConfigPath(cwd: string): string {
+	return path.join(cwd, CONFIG_DIR_NAME, "recap.json");
 }
 
 async function writeJsonConfig(file: string, value: unknown): Promise<void> {
-	await mkdir(path.dirname(file), { recursive: true });
-	await writeFile(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+	const directory = path.dirname(file);
+	await mkdir(directory, { recursive: true, mode: 0o700 });
+	const temporary = path.join(directory, `.${randomUUID()}.tmp`);
+	try {
+		await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+		await rename(temporary, file);
+		await chmod(file, 0o600);
+	} finally {
+		await rm(temporary, { force: true });
+	}
+}
+
+async function withMigrationLock<T>(directory: string, fn: () => Promise<T>): Promise<T> {
+	await mkdir(directory, { recursive: true, mode: 0o700 });
+	const lockPath = path.join(directory, ".config-migration.lock");
+	const deadline = Date.now() + 2_000;
+	let handle: Awaited<ReturnType<typeof open>> | undefined;
+	while (!handle) {
+		try {
+			handle = await open(lockPath, "wx", 0o600);
+			await handle.writeFile(`${JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() })}\n`);
+		} catch (error) {
+			if (!isRecord(error) || error.code !== "EEXIST") throw error;
+			try {
+				if (Date.now() - (await stat(lockPath)).mtimeMs > 30_000) {
+					await unlink(lockPath);
+					continue;
+				}
+			} catch (statError) {
+				if (isRecord(statError) && statError.code === "ENOENT") continue;
+				throw statError;
+			}
+			if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${lockPath}`);
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+	}
+	try {
+		return await fn();
+	} finally {
+		await handle.close();
+		await rm(lockPath, { force: true });
+	}
+}
+
+function notifyMigration(ctx: ExtensionContext, message: string): void {
+	if (emittedMigrationNotices.has(message)) return;
+	emittedMigrationNotices.add(message);
+	if (ctx.hasUI === false) console.warn(message);
+	else ctx.ui.notify(message, "warning");
+}
+
+function droppedSummary(dropped: readonly string[]): string {
+	return dropped.length > 0 ? ` Dropped unmappable fields: ${dropped.join(", ")}.` : "";
 }
 
 async function saveGlobalConfig(config: RecapConfig): Promise<void> {
 	await writeJsonConfig(getGlobalConfigPath(), config);
 }
 
-async function loadConfigSource(file: string, ctx: ExtensionContext): Promise<unknown | undefined> {
-	const migration = migrateLegacyConfig(await readJsonIfExists(file));
-	if (migration.changed) {
+async function loadConfigSource(target: string, legacy: string, scope: "global" | "project", ctx: ExtensionContext): Promise<unknown | undefined> {
+	let targetValue: unknown | undefined;
+	try {
+		targetValue = await readJsonIfExists(target);
+	} catch (error) {
+		notifyMigration(ctx, `Invalid ${scope} Recap config at ${target}: ${error instanceof Error ? error.message : String(error)}. The file was preserved.`);
+		return undefined;
+	}
+	if (targetValue !== undefined) {
 		try {
-			await writeJsonConfig(file, migration.value);
+			let migration = migrateLegacyConfig(targetValue);
+			if (migration.changed) {
+				migration = await withMigrationLock(path.dirname(target), async () => {
+					const current = migrateLegacyConfig(await readJsonIfExists(target));
+					if (current.changed) await writeJsonConfig(target, current.value);
+					return current;
+				});
+				notifyMigration(ctx, `Upgraded ${scope} Recap config at ${target}.${droppedSummary(migration.dropped)}`);
+			}
+			try {
+				if (await pathExists(legacy)) notifyMigration(ctx, `Ignored conflicting legacy ${scope} Recap config at ${legacy}; canonical config is ${target}.`);
+			} catch (error) {
+				notifyMigration(ctx, `Could not inspect legacy ${scope} Recap config at ${legacy}: ${error instanceof Error ? error.message : String(error)}.`);
+			}
+			return migration.value;
 		} catch (error) {
-			ctx.ui.notify(
-				`Using migrated recap config in memory, but failed to update ${file}: ${error instanceof Error ? error.message : String(error)}`,
-				"warning",
-			);
+			notifyMigration(ctx, `Failed to upgrade ${scope} Recap config at ${target}: ${error instanceof Error ? error.message : String(error)}.`);
+			return undefined;
 		}
 	}
-	return migration.value;
+	let legacyValue: unknown | undefined;
+	try {
+		legacyValue = await readJsonIfExists(legacy);
+	} catch (error) {
+		notifyMigration(ctx, `Invalid legacy ${scope} Recap config at ${legacy}: ${error instanceof Error ? error.message : String(error)}. The file was preserved.`);
+		return undefined;
+	}
+	if (legacyValue === undefined) return undefined;
+	try {
+		return await withMigrationLock(path.dirname(target), async () => {
+			const racedTarget = await readJsonIfExists(target);
+			if (racedTarget !== undefined) return migrateLegacyConfig(racedTarget).value;
+			const migration = migrateLegacyConfig(legacyValue);
+			await writeJsonConfig(target, migration.value);
+			const verified = migrateLegacyConfig(await readJsonIfExists(target)).value;
+			await unlink(legacy);
+			notifyMigration(ctx, `Migrated ${scope} Recap config from ${legacy} to ${target}.${droppedSummary(migration.dropped)}`);
+			return verified;
+		});
+	} catch (error) {
+		notifyMigration(ctx, `Failed to migrate ${scope} Recap config from ${legacy} to ${target}: ${error instanceof Error ? error.message : String(error)}. The legacy file was preserved.`);
+		try {
+			return migrateLegacyConfig(await readJsonIfExists(legacy)).value;
+		} catch {
+			return undefined;
+		}
+	}
 }
 
-async function loadConfig(ctx: ExtensionContext): Promise<RecapConfig> {
+export async function loadRecapConfig(ctx: ExtensionContext): Promise<RecapConfig> {
 	let config = deepMerge(DEFAULT_CONFIG as unknown as Record<string, unknown>, {}) as RecapConfig;
 
-	const globalConfig = await loadConfigSource(getGlobalConfigPath(), ctx);
+	const globalConfig = await loadConfigSource(getGlobalConfigPath(), getLegacyGlobalConfigPath(), "global", ctx);
 	config = deepMerge(config as unknown as Record<string, unknown>, globalConfig) as RecapConfig;
 
 	if (ctx.isProjectTrusted()) {
-		const projectConfig = await loadConfigSource(path.join(ctx.cwd, CONFIG_DIR_NAME, "recap.json"), ctx);
+		const projectConfig = await loadConfigSource(getProjectConfigPath(ctx.cwd), getLegacyProjectConfigPath(ctx.cwd), "project", ctx);
 		config = deepMerge(config as unknown as Record<string, unknown>, projectConfig) as RecapConfig;
 	}
 
@@ -948,7 +1087,7 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		try {
-			state.config = await loadConfig(ctx);
+			state.config = await loadRecapConfig(ctx);
 		} catch (error) {
 			ctx.ui.notify(`Failed to load recap config: ${error instanceof Error ? error.message : String(error)}`, "warning");
 			state.config = DEFAULT_CONFIG;

--- a/packages/pi-recap/tests/config-migration.test.ts
+++ b/packages/pi-recap/tests/config-migration.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	getGlobalConfigPath,
+	getLegacyGlobalConfigPath,
+	getLegacyProjectConfigPath,
+	getProjectConfigPath,
+	loadRecapConfig,
+} from "../extensions/recap.ts";
+
+async function writeJson(file: string, value: unknown): Promise<void> {
+	await mkdir(path.dirname(file), { recursive: true });
+	await writeFile(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function context(cwd: string, trusted: boolean, notifications: string[]): ExtensionContext {
+	return {
+		cwd,
+		isProjectTrusted: () => trusted,
+		ui: {
+			notify(message: string) {
+				notifications.push(message);
+			},
+		},
+	} as unknown as ExtensionContext;
+}
+
+test("Recap migrates global and trusted project configs while dropping unmappable fields", async () => {
+	const root = await mkdtemp(path.join(tmpdir(), "pi-recap-config-"));
+	const agentDir = path.join(root, "agent");
+	const cwd = path.join(root, "project");
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	const notifications: string[] = [];
+	try {
+		await writeJson(getLegacyGlobalConfigPath(), {
+			recap: { enabled: false, removed: true },
+			display: { widgetPlacement: "belowEditor", notify: true },
+		});
+		await writeJson(getLegacyProjectConfigPath(cwd), {
+			title: { maxLength: 72, obsolete: true },
+		});
+
+		const untrusted = await loadRecapConfig(context(cwd, false, notifications));
+		assert.equal(untrusted.recap.enabled, false);
+		assert.equal(untrusted.title.maxLength, 50);
+		assert.equal(existsSync(getLegacyProjectConfigPath(cwd)), true);
+		assert.equal(existsSync(getProjectConfigPath(cwd)), false);
+
+		const trusted = await loadRecapConfig(context(cwd, true, notifications));
+		assert.equal(trusted.title.maxLength, 72);
+		assert.equal(existsSync(getLegacyGlobalConfigPath()), false);
+		assert.equal(existsSync(getLegacyProjectConfigPath(cwd)), false);
+		assert.equal(existsSync(getGlobalConfigPath()), true);
+		assert.equal(existsSync(getProjectConfigPath(cwd)), true);
+		assert.doesNotMatch(await readFile(getGlobalConfigPath(), "utf8"), /removed|notify/);
+		assert.match(notifications.join("\n"), /recap\.removed/);
+		assert.match(notifications.join("\n"), /display\.notify/);
+		assert.match(notifications.join("\n"), /title\.obsolete/);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(root, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-search-hub/README.md
+++ b/packages/pi-search-hub/README.md
@@ -68,10 +68,12 @@ Global `results.mode` controls whether Search Hub results are hidden, summarized
 
 Search Hub reads configuration from:
 
-1. `$PI_CODING_AGENT_DIR/extensions/search.json` for global settings;
-2. `.pi/search.json` in the current project.
+1. `$PI_CODING_AGENT_DIR/extension-data/pi-search-hub/config.json` for global settings;
+2. `.pi/extension-data/pi-search-hub/config.json` in a trusted current project.
 
-Project settings win. Backend maps are merged per backend, so a project can override one backend without repeating every global entry. Configuration is refreshed during use; interactive edits are staged until `Save & apply`.
+Trusted project settings win. Backend maps are merged per backend, so a project can override one backend without repeating every global entry. Untrusted projects are never probed for Search Hub configuration. Configuration is refreshed during use; interactive edits are staged until `Save & apply`.
+
+On first use, Search Hub automatically migrates the previous global and trusted-project paths, upgrades recognized settings, drops unmappable fields with a warning, and removes the old file only after the new file passes a semantic round trip. Exa usage state similarly moves to `$PI_CODING_AGENT_DIR/extension-data/pi-search-hub/state/exa-usage.json` with serialized atomic updates.
 
 ### Interactive setup
 
@@ -81,7 +83,7 @@ Each concise backend row starts with `[ON]`, `[OFF]`, or `[AUTO]` and uses one `
 
 All pages edit one in-memory global draft. `Back` never writes, and the home page marks unsaved changes. `Save & apply` normalizes the draft, removes obsolete fields, writes the global file atomically with mode `0600`, refreshes runtime configuration once, and emits one result notification. Closing with pending edits offers `Save & apply`, `Discard changes`, or `Continue editing`. After a successful save, `/reload` or a new session is not required.
 
-`/search-setup` changes only the global file. A project `.pi/search.json` can override that change for the current project; Search Hub reports this after saving. Disabling a backend does not delete a stored credential; use `Remove saved API key or reference` in that backend's detail menu when it must also be removed from disk. Search Hub does not cache search results locally; `web_read.fresh` only asks supported remote readers to bypass their own caches.
+`/search-setup` changes only the global file. A trusted project `.pi/extension-data/pi-search-hub/config.json` can override that change for the current project; Search Hub reports this after saving. Disabling a backend does not delete a stored credential; use `Remove saved API key or reference` in that backend's detail menu when it must also be removed from disk. Search Hub does not cache search results locally; `web_read.fresh` only asks supported remote readers to bypass their own caches.
 
 Minimal example:
 

--- a/packages/pi-search-hub/README.zh-CN.md
+++ b/packages/pi-search-hub/README.zh-CN.md
@@ -68,10 +68,12 @@
 
 Search Hub 从以下位置读取配置：
 
-1. `$PI_CODING_AGENT_DIR/extensions/search.json`：全局设置；
-2. 当前项目的 `.pi/search.json`。
+1. `$PI_CODING_AGENT_DIR/extension-data/pi-search-hub/config.json`：全局设置；
+2. 受信任当前项目的 `.pi/extension-data/pi-search-hub/config.json`。
 
-项目设置优先。backend map 会按单个 backend 合并，因此项目可以只覆盖一个 backend，无需重复全部全局条目。配置会在使用过程中刷新；交互式修改会暂存在草稿中，直到选择 `Save & apply`。
+受信任项目的设置优先。backend map 会按单个 backend 合并，因此项目可以只覆盖一个 backend，无需重复全部全局条目。未受信任项目中的 Search Hub 配置不会被探测或读取。配置会在使用过程中刷新；交互式修改会暂存在草稿中，直到选择 `Save & apply`。
+
+首次使用时，Search Hub 会自动迁移旧的全局路径和受信任项目路径，升级可识别设置，丢弃无法映射的字段并发出 warning；只有新文件通过语义 round trip 后才删除旧文件。Exa 用量状态也会迁入 `$PI_CODING_AGENT_DIR/extension-data/pi-search-hub/state/exa-usage.json`，并使用串行化原子更新。
 
 ### 交互式配置
 
@@ -81,7 +83,7 @@ Search Hub 从以下位置读取配置：
 
 所有页面共同编辑一份内存中的全局草稿。`Back` 不会写盘，一级页面会标记未保存修改。`Save & apply` 会归一化草稿、清理废弃字段、以 `0600` 权限原子写入全局文件，只刷新一次运行时配置，并只发一条结果通知。带未保存修改关闭时，可选择 `Save & apply`、`Discard changes` 或 `Continue editing`。保存成功后无需 `/reload` 或新建会话。
 
-`/search-setup` 只修改全局文件。项目 `.pi/search.json` 可以在当前项目中覆盖这次修改，Search Hub 会在保存后提示。禁用 backend 不会删除已保存的 credential；如果还需要从磁盘移除，请在该 backend 的详情菜单选择 `Remove saved API key or reference`。Search Hub 不在本地缓存搜索结果；`web_read.fresh` 只要求支持它的远端 reader 绕过自身缓存。
+`/search-setup` 只修改全局文件。受信任项目的 `.pi/extension-data/pi-search-hub/config.json` 可以覆盖这次修改，Search Hub 会在保存后提示。禁用 backend 不会删除已保存的 credential；如果还需要从磁盘移除，请在该 backend 的详情菜单选择 `Remove saved API key or reference`。Search Hub 不在本地缓存搜索结果；`web_read.fresh` 只要求支持它的远端 reader 绕过自身缓存。
 
 最小示例：
 

--- a/packages/pi-search-hub/extensions/backends/exa.ts
+++ b/packages/pi-search-hub/extensions/backends/exa.ts
@@ -18,7 +18,7 @@ export async function fetchExaContents(
 	signal?: AbortSignal,
 ): Promise<{ title: string; url: string; content: string; warning?: string }> {
 	// Check quota before making request
-	const preWarning = checkExaUsage();
+	const preWarning = await checkExaUsage();
 
 	const response = await fetch("https://api.exa.ai/contents", {
 		method: "POST",
@@ -42,7 +42,7 @@ export async function fetchExaContents(
 	}
 
 	// Increment usage after successful request
-	const warning = incrementExaUsage();
+	const warning = await incrementExaUsage();
 
 	const data = (await response.json()) as Record<string, unknown>;
 	const results = Array.isArray(data.results)
@@ -102,7 +102,7 @@ export async function searchExa(
 	}
 
 	// Increment usage after successful request
-	const warning = incrementExaUsage();
+	const warning = await incrementExaUsage();
 
 	const data = (await response.json()) as Record<string, unknown>;
 	return {

--- a/packages/pi-search-hub/extensions/backends/registry.ts
+++ b/packages/pi-search-hub/extensions/backends/registry.ts
@@ -5,7 +5,7 @@
 import type { BackendRunner, BackendConfig, SearchResult } from "../types.js";
 import { MISSING_KEY_HELP, waitForCooldown, markCooldown } from "../utils.js";
 import { resolveBackendKey } from "../credentials.js";
-import { config } from "../config.js";
+import { getConfig } from "../config.js";
 import { recordBackendSuccess, recordBackendFailure } from "../scoring.js";
 
 import { searchDuckDuckGo } from "./duckduckgo.js";
@@ -40,12 +40,11 @@ export const BACKEND_DEFS: Record<string, BackendRunner> = {
 		needsInstanceUrl: false,
 		label: "DuckDuckGo",
 		setupLabel: null,
-		search: async (query, numResults, { signal }) => {
-			const bc = (config.backends as Record<string, BackendConfig> | undefined)?.duckduckgo;
+		search: async (query, numResults, { signal, backendConfig }) => {
 			const ddg = await searchDuckDuckGo(query, numResults, signal, {
-				backend: bc?.ddgsBackend,
-				region: bc?.ddgsRegion,
-				timelimit: bc?.ddgsTimelimit,
+				backend: backendConfig?.ddgsBackend,
+				region: backendConfig?.ddgsRegion,
+				timelimit: backendConfig?.ddgsTimelimit,
 			});
 			return { results: ddg.results };
 		},
@@ -190,9 +189,8 @@ export const BACKEND_DEFS: Record<string, BackendRunner> = {
 		needsInstanceUrl: false,
 		label: "Perplexity",
 		setupLabel: "Perplexity Sonar (unlimited free)",
-		search: async (query, numResults, { key, signal }) => {
-			const model = (config.backends?.perplexity as BackendConfig | undefined)?.model;
-			const result = await searchPerplexity(query, numResults, key!, signal, model);
+		search: async (query, numResults, { key, signal, backendConfig }) => {
+			const result = await searchPerplexity(query, numResults, key!, signal, backendConfig?.model);
 			return { results: result.results };
 		},
 	},
@@ -215,9 +213,8 @@ export const BACKEND_DEFS: Record<string, BackendRunner> = {
 		needsInstanceUrl: false,
 		label: "Brave LLM",
 		setupLabel: "Brave LLM Context (same key as Brave, pre-extracted AI chunks)",
-		search: async (query, numResults, { key, signal }) => {
-			const bc = (config.backends as Record<string, BackendConfig> | undefined)?.["brave-llm"];
-			const result = await searchBraveLLM(query, numResults, key!, signal, bc?.tokenBudget);
+		search: async (query, numResults, { key, signal, backendConfig }) => {
+			const result = await searchBraveLLM(query, numResults, key!, signal, backendConfig?.tokenBudget);
 			return { results: result.results };
 		},
 	},
@@ -228,9 +225,8 @@ export const BACKEND_DEFS: Record<string, BackendRunner> = {
 		needsInstanceUrl: false,
 		label: "Linkup",
 		setupLabel: "Linkup (EU/GDPR, AI-native, $20 free credit)",
-		search: async (query, numResults, { key, signal }) => {
-			const bc = (config.backends as Record<string, BackendConfig> | undefined)?.linkup;
-			const result = await searchLinkup(query, numResults, key!, signal, bc?.depth);
+		search: async (query, numResults, { key, signal, backendConfig }) => {
+			const result = await searchLinkup(query, numResults, key!, signal, backendConfig?.depth);
 			return { results: result.results };
 		},
 	},
@@ -253,9 +249,8 @@ export const BACKEND_DEFS: Record<string, BackendRunner> = {
 		needsInstanceUrl: false,
 		label: "fastCRW",
 		setupLabel: "fastCRW (500 free/mo, self-hostable)",
-		search: async (query, numResults, { key, signal }) => {
-			const bc = (config.backends as Record<string, BackendConfig> | undefined)?.fastcrw;
-			const result = await searchFastcrw(query, numResults, key!, signal, bc?.baseUrl);
+		search: async (query, numResults, { key, signal, backendConfig }) => {
+			const result = await searchFastcrw(query, numResults, key!, signal, backendConfig?.baseUrl);
 			return { results: result.results };
 		},
 	},
@@ -294,6 +289,7 @@ export async function runBackend(
 	await waitForCooldown(backend);
 	const def = BACKEND_DEFS[backend];
 	if (!def) throw new Error(`Unknown backend: ${backend}`);
+	const config = getConfig();
 
 	let key: string | undefined;
 	if (def.providerAuth) {

--- a/packages/pi-search-hub/extensions/config-storage.ts
+++ b/packages/pi-search-hub/extensions/config-storage.ts
@@ -1,0 +1,288 @@
+import {
+	closeSync,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";
+import type { BackendConfig, ReaderName, SearchConfig } from "./types.js";
+
+export type MigrationNoticeSink = (message: string) => void;
+
+const ROOT_FIELDS = new Set([
+	"defaultBackend",
+	"combine",
+	"combineMode",
+	"selectionStrategy",
+	"reader",
+	"readerFallback",
+	"compact",
+	"backends",
+]);
+const BACKEND_FIELDS = new Set([
+	"enabled",
+	"apiKey",
+	"timeout",
+	"maxResults",
+	"headers",
+	"instanceUrl",
+	"model",
+	"ddgsBackend",
+	"ddgsRegion",
+	"ddgsTimelimit",
+	"tokenBudget",
+	"depth",
+	"baseUrl",
+	"searchDepth",
+	"topic",
+]);
+const READERS = new Set<ReaderName>(["jina", "sofya", "firecrawl", "exa", "exa_mcp"]);
+const SELECTION_STRATEGIES = new Set(["sequential", "random", "round-robin", "best-latency"]);
+const emittedNotices = new Set<string>();
+const LOCK_STALE_MS = 30_000;
+const LOCK_WAIT_MS = 1_000;
+const LOCK_RETRY_MS = 20;
+const waitBuffer = new Int32Array(new SharedArrayBuffer(4));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function emitNotice(sink: MigrationNoticeSink | undefined, message: string): void {
+	if (emittedNotices.has(message)) return;
+	emittedNotices.add(message);
+	(sink ?? ((text) => console.warn(text)))(message);
+}
+
+function droppedSummary(paths: readonly string[]): string {
+	if (paths.length === 0) return "";
+	const shown = paths.slice(0, 8).join(", ");
+	return ` Dropped ${paths.length} unmappable field${paths.length === 1 ? "" : "s"}: ${shown}${paths.length > 8 ? ", …" : ""}.`;
+}
+
+function keepString(source: Record<string, unknown>, target: Record<string, unknown>, key: string, dropped: string[], prefix = ""): void {
+	if (!(key in source)) return;
+	if (typeof source[key] === "string") target[key] = source[key];
+	else dropped.push(`${prefix}${key}`);
+}
+
+function keepBoolean(source: Record<string, unknown>, target: Record<string, unknown>, key: string, dropped: string[], prefix = ""): void {
+	if (!(key in source)) return;
+	if (typeof source[key] === "boolean") target[key] = source[key];
+	else dropped.push(`${prefix}${key}`);
+}
+
+function keepPositiveNumber(source: Record<string, unknown>, target: Record<string, unknown>, key: string, dropped: string[], prefix = ""): void {
+	if (!(key in source)) return;
+	const value = source[key];
+	if (typeof value === "number" && Number.isFinite(value) && value > 0) target[key] = value;
+	else dropped.push(`${prefix}${key}`);
+}
+
+function normalizeBackend(value: unknown, prefix: string, dropped: string[]): BackendConfig | undefined {
+	if (!isRecord(value)) {
+		dropped.push(prefix.slice(0, -1));
+		return undefined;
+	}
+	const normalized: Record<string, unknown> = {};
+	for (const key of Object.keys(value)) {
+		if (!BACKEND_FIELDS.has(key)) dropped.push(`${prefix}${key}`);
+	}
+	keepBoolean(value, normalized, "enabled", dropped, prefix);
+	for (const key of ["apiKey", "instanceUrl", "model", "ddgsBackend", "ddgsRegion", "ddgsTimelimit", "baseUrl"] as const) {
+		keepString(value, normalized, key, dropped, prefix);
+	}
+	for (const key of ["timeout", "maxResults", "tokenBudget"] as const) {
+		keepPositiveNumber(value, normalized, key, dropped, prefix);
+	}
+	if ("headers" in value) {
+		if (isRecord(value.headers)) {
+			const headers: Record<string, string> = {};
+			for (const [name, headerValue] of Object.entries(value.headers)) {
+				if (typeof headerValue === "string") headers[name] = headerValue;
+				else dropped.push(`${prefix}headers.${name}`);
+			}
+			normalized.headers = headers;
+		} else {
+			dropped.push(`${prefix}headers`);
+		}
+	}
+	if ("depth" in value) {
+		if (value.depth === "standard" || value.depth === "deep") normalized.depth = value.depth;
+		else dropped.push(`${prefix}depth`);
+	}
+	if ("searchDepth" in value) {
+		if (value.searchDepth === "snippets" || value.searchDepth === "basic") normalized.searchDepth = value.searchDepth;
+		else dropped.push(`${prefix}searchDepth`);
+	}
+	if ("topic" in value) {
+		if (value.topic === "general" || value.topic === "news") normalized.topic = value.topic;
+		else dropped.push(`${prefix}topic`);
+	}
+	return normalized as BackendConfig;
+}
+
+export function normalizeSearchConfigForStorage(value: unknown): { config: SearchConfig; dropped: string[] } {
+	if (!isRecord(value)) throw new Error("the root value must be a JSON object");
+	const dropped: string[] = [];
+	const normalized: Record<string, unknown> = {};
+	for (const key of Object.keys(value)) {
+		if (!ROOT_FIELDS.has(key)) dropped.push(key);
+	}
+	keepString(value, normalized, "defaultBackend", dropped);
+	keepBoolean(value, normalized, "combine", dropped);
+	keepBoolean(value, normalized, "compact", dropped);
+	if ("combineMode" in value) {
+		if (value.combineMode === "all" || value.combineMode === "targeted") normalized.combineMode = value.combineMode;
+		else dropped.push("combineMode");
+	}
+	if ("selectionStrategy" in value) {
+		if (typeof value.selectionStrategy === "string" && SELECTION_STRATEGIES.has(value.selectionStrategy)) {
+			normalized.selectionStrategy = value.selectionStrategy;
+		} else dropped.push("selectionStrategy");
+	}
+	if ("reader" in value) {
+		if (typeof value.reader === "string" && READERS.has(value.reader as ReaderName)) normalized.reader = value.reader;
+		else dropped.push("reader");
+	}
+	if ("readerFallback" in value) {
+		if (Array.isArray(value.readerFallback)) {
+			const readers: ReaderName[] = [];
+			for (const [index, reader] of value.readerFallback.entries()) {
+				if (typeof reader === "string" && READERS.has(reader as ReaderName)) {
+					if (!readers.includes(reader as ReaderName)) readers.push(reader as ReaderName);
+				} else dropped.push(`readerFallback[${index}]`);
+			}
+			normalized.readerFallback = readers;
+		} else dropped.push("readerFallback");
+	}
+	if ("backends" in value) {
+		if (isRecord(value.backends)) {
+			const backends: Record<string, BackendConfig | undefined> = {};
+			for (const [backend, backendValue] of Object.entries(value.backends)) {
+				const normalizedBackend = normalizeBackend(backendValue, `backends.${backend}.`, dropped);
+				if (normalizedBackend) backends[backend] = normalizedBackend;
+			}
+			normalized.backends = backends;
+		} else dropped.push("backends");
+	}
+	return { config: normalized as SearchConfig, dropped: [...new Set(dropped)] };
+}
+
+function sleepSync(milliseconds: number): void {
+	Atomics.wait(waitBuffer, 0, 0, milliseconds);
+}
+
+function withLock<T>(directory: string, name: string, fn: () => T): T {
+	mkdirSync(directory, { recursive: true, mode: 0o700 });
+	const lockPath = join(directory, name);
+	const deadline = Date.now() + LOCK_WAIT_MS;
+	let descriptor: number | undefined;
+	while (descriptor === undefined) {
+		try {
+			descriptor = openSync(lockPath, "wx", 0o600);
+			writeFileSync(descriptor, `${JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() })}\n`);
+		} catch (error) {
+			if (!isRecord(error) || error.code !== "EEXIST") throw error;
+			try {
+				if (Date.now() - statSync(lockPath).mtimeMs > LOCK_STALE_MS) {
+					unlinkSync(lockPath);
+					continue;
+				}
+			} catch (statError) {
+				if (isRecord(statError) && statError.code === "ENOENT") continue;
+				throw statError;
+			}
+			if (Date.now() >= deadline) throw new Error(`Timed out waiting for migration lock ${lockPath}`);
+			sleepSync(LOCK_RETRY_MS);
+		}
+	}
+	try {
+		return fn();
+	} finally {
+		closeSync(descriptor);
+		rmSync(lockPath, { force: true });
+	}
+}
+
+export function writeSearchConfigAtomically(file: string, config: SearchConfig): void {
+	const directory = dirname(file);
+	mkdirSync(directory, { recursive: true, mode: 0o700 });
+	const temporary = join(directory, `.${randomUUID()}.tmp`);
+	try {
+		writeFileSync(temporary, `${JSON.stringify(config, null, 2)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+		renameSync(temporary, file);
+	} finally {
+		rmSync(temporary, { force: true });
+	}
+}
+
+export function saveSearchConfig(file: string, config: SearchConfig): void {
+	withLock(dirname(file), ".config-migration.lock", () => writeSearchConfigAtomically(file, config));
+}
+
+function readAndNormalize(file: string): { config: SearchConfig; dropped: string[]; raw: unknown } {
+	const raw = JSON.parse(readFileSync(file, "utf8")) as unknown;
+	const normalized = normalizeSearchConfigForStorage(raw);
+	return { ...normalized, raw };
+}
+
+export function loadMigratedSearchConfig(options: {
+	targetPath: string;
+	legacyPath: string;
+	scope: "global" | "project";
+	onNotice?: MigrationNoticeSink;
+}): SearchConfig {
+	const { targetPath, legacyPath, scope, onNotice } = options;
+	if (existsSync(targetPath)) {
+		try {
+			let loaded = readAndNormalize(targetPath);
+			if (JSON.stringify(loaded.raw) !== JSON.stringify(loaded.config)) {
+				loaded = withLock(dirname(targetPath), ".config-migration.lock", () => {
+					const current = readAndNormalize(targetPath);
+					if (JSON.stringify(current.raw) !== JSON.stringify(current.config)) writeSearchConfigAtomically(targetPath, current.config);
+					return current;
+				});
+				emitNotice(onNotice, `Search Hub upgraded ${scope} config at ${targetPath}.${droppedSummary(loaded.dropped)}`);
+			}
+			if (existsSync(legacyPath)) {
+				emitNotice(onNotice, `Search Hub ignored conflicting legacy ${scope} config at ${legacyPath}; canonical config is ${targetPath}.`);
+			}
+			return loaded.config;
+		} catch (error) {
+			emitNotice(onNotice, `Search Hub could not read canonical ${scope} config at ${targetPath}: ${error instanceof Error ? error.message : String(error)}. The legacy file was not used or removed.`);
+			return {};
+		}
+	}
+	if (!existsSync(legacyPath)) return {};
+	try {
+		return withLock(dirname(targetPath), ".config-migration.lock", () => {
+			if (existsSync(targetPath)) return readAndNormalize(targetPath).config;
+			const loaded = readAndNormalize(legacyPath);
+			writeSearchConfigAtomically(targetPath, loaded.config);
+			const verified = readAndNormalize(targetPath).config;
+			if (JSON.stringify(verified) !== JSON.stringify(loaded.config)) throw new Error("semantic round trip verification failed");
+			unlinkSync(legacyPath);
+			emitNotice(onNotice, `Search Hub migrated ${scope} config from ${legacyPath} to ${targetPath}.${droppedSummary(loaded.dropped)}`);
+			return verified;
+		});
+	} catch (error) {
+		emitNotice(onNotice, `Search Hub failed to migrate ${scope} config from ${legacyPath} to ${targetPath}: ${error instanceof Error ? error.message : String(error)}. The legacy file was preserved.`);
+		try {
+			return readAndNormalize(legacyPath).config;
+		} catch {
+			return {};
+		}
+	}
+}
+
+export function resetSearchConfigMigrationNoticesForTests(): void {
+	emittedNotices.clear();
+}

--- a/packages/pi-search-hub/extensions/config.ts
+++ b/packages/pi-search-hub/extensions/config.ts
@@ -2,11 +2,15 @@
  * Config loading and module-level mutable state for pi-search-hub extension.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
 import type { BackendConfig, SearchConfig } from "./types.js";
-import { getAgentDir } from "./utils.js";
 import { clearCredentialCache, FALLBACK_ENV_MAP } from "./credentials.js";
+import { loadMigratedSearchConfig, type MigrationNoticeSink } from "./config-storage.js";
+import {
+	getGlobalConfigPath,
+	getLegacyGlobalConfigPath,
+	getLegacyProjectConfigPath,
+	getProjectConfigPath,
+} from "./paths.js";
 
 // ---------------------------------------------------------------------------
 // Module-level mutable state
@@ -43,46 +47,38 @@ export function recordLatency(backend: string, ms: number): void {
 // Config loading
 // ---------------------------------------------------------------------------
 
-export function loadConfig(cwd: string): SearchConfig {
-	const globalPath = join(getAgentDir(), "extensions", "search.json");
-	const projectPath = join(cwd, ".pi", "search.json");
+export function loadConfig(cwd: string, projectTrusted = false, onNotice?: MigrationNoticeSink): SearchConfig {
+	let config: SearchConfig = {
+		defaultBackend: "duckduckgo",
+		backends: {},
+		...loadMigratedSearchConfig({
+			targetPath: getGlobalConfigPath(),
+			legacyPath: getLegacyGlobalConfigPath(),
+			scope: "global",
+			onNotice,
+		}),
+	};
 
-	let config: SearchConfig = { defaultBackend: "duckduckgo", backends: {} };
-
-	if (existsSync(globalPath)) {
-		try {
-			config = { ...config, ...JSON.parse(readFileSync(globalPath, "utf-8")) };
-		} catch {
-			// ignore
-		}
-	}
-
-	// Save global backends before project config overwrites them
+	// Save global backends before project config overwrites them.
 	const preProjectBackends = { ...(config.backends ?? {}) };
 
-	if (existsSync(projectPath)) {
-		try {
-			const project = JSON.parse(readFileSync(projectPath, "utf-8"));
-			config = { ...config, ...project };
-			// Guard: if project config set backends to null/undefined, restore global backends
-			if (config.backends == null) {
-				config.backends = preProjectBackends;
+	if (projectTrusted) {
+		const project = loadMigratedSearchConfig({
+			targetPath: getProjectConfigPath(cwd),
+			legacyPath: getLegacyProjectConfigPath(cwd),
+			scope: "project",
+			onNotice,
+		});
+		config = { ...config, ...project };
+		if (config.backends == null) config.backends = preProjectBackends;
+		if (project.backends && typeof project.backends === "object") {
+			const merged = { ...preProjectBackends, ...config.backends };
+			for (const [key, val] of Object.entries(project.backends)) {
+				const bc = val as BackendConfig | undefined;
+				if (bc && merged[key]) merged[key] = { ...merged[key], ...bc };
+				else merged[key] = bc;
 			}
-			if (project.backends && typeof project.backends === "object") {
-				// Deep merge: merge per-backend so global backends not re-listed in project config are preserved
-				const merged = { ...preProjectBackends, ...config.backends };
-				for (const [key, val] of Object.entries(project.backends)) {
-					const bc = val as BackendConfig | undefined;
-					if (bc && merged[key]) {
-						merged[key] = { ...merged[key], ...bc };
-					} else {
-						merged[key] = bc;
-					}
-				}
-				config.backends = merged;
-			}
-		} catch {
-			// ignore
+			config.backends = merged;
 		}
 	}
 
@@ -112,14 +108,22 @@ export function loadConfig(cwd: string): SearchConfig {
 
 let activeBackendsList: string[] = [];
 let configCacheTime = 0;
+let configCacheKey = "";
 const CONFIG_TTL_MS = 10_000; // re-read config at most every 10s
 
-export function refreshConfig(cwd: string, force = false): string[] {
+export function refreshConfig(
+	cwd: string,
+	projectTrusted = false,
+	force = false,
+	onNotice?: MigrationNoticeSink,
+): string[] {
 	const now = Date.now();
-	if (!force && now - configCacheTime < CONFIG_TTL_MS) return activeBackendsList;
+	const nextCacheKey = `${getGlobalConfigPath()}\0${cwd}\0${projectTrusted ? "trusted" : "untrusted"}`;
+	if (!force && nextCacheKey === configCacheKey && now - configCacheTime < CONFIG_TTL_MS) return activeBackendsList;
 
-	config = loadConfig(cwd);
+	config = loadConfig(cwd, projectTrusted, onNotice);
 	configCacheTime = now;
+	configCacheKey = nextCacheKey;
 
 	activeBackendsList = Object.entries(config.backends || {})
 		.filter(([_, bc]) => bc?.enabled)

--- a/packages/pi-search-hub/extensions/config.ts
+++ b/packages/pi-search-hub/extensions/config.ts
@@ -16,11 +16,15 @@ import {
 // Module-level mutable state
 // ---------------------------------------------------------------------------
 
-/** Module-level config accessible from helper functions. */
-export let config: SearchConfig = { defaultBackend: "duckduckgo", backends: {} };
+/** Current runtime config. Keep private so consumers cannot retain a stale Jiti import snapshot. */
+let config: SearchConfig = { defaultBackend: "duckduckgo", backends: {} };
+
+export function getConfig(): SearchConfig {
+	return config;
+}
 
 /** Round-robin counter — increments on each call, never resets until pi restarts. */
-export let roundRobinIndex = 0;
+let roundRobinIndex = 0;
 
 export function incrementRoundRobin(): number {
 	return roundRobinIndex++;

--- a/packages/pi-search-hub/extensions/dispatch.ts
+++ b/packages/pi-search-hub/extensions/dispatch.ts
@@ -5,7 +5,7 @@
 import type { SearchResult, SearchResultWithBackend } from "./types.js";
 
 export type BackendStats = { success: boolean; count: number; error?: string };
-import { config, roundRobinIndex, incrementRoundRobin } from "./config.js";
+import { incrementRoundRobin } from "./config.js";
 import { scoreBackends } from "./scoring.js";
 
 // ---------------------------------------------------------------------------
@@ -27,8 +27,7 @@ export function selectBackendsForFallback(
 		}
 		case "round-robin": {
 			if (backends.length === 0) return [];
-			const index = roundRobinIndex % backends.length;
-			incrementRoundRobin();
+			const index = incrementRoundRobin() % backends.length;
 			const selected = backends[index];
 			// Put selected first, then the rest
 			return [selected, ...backends.filter((b) => b !== selected)];

--- a/packages/pi-search-hub/extensions/exa-usage.ts
+++ b/packages/pi-search-hub/extensions/exa-usage.ts
@@ -1,0 +1,191 @@
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, open, readFile, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { getExaUsagePath, getLegacyExaUsagePath } from "./paths.js";
+
+const EXA_MONTHLY_LIMIT = 1000;
+const EXA_WARNING_THRESHOLD = 800;
+const LOCK_STALE_MS = 30_000;
+const LOCK_WAIT_MS = 2_000;
+const LOCK_RETRY_MS = 25;
+const emittedNotices = new Set<string>();
+
+interface ExaUsageRecord {
+	count: number;
+	resetAt: string;
+}
+
+interface LockedUsage {
+	record?: ExaUsageRecord;
+	notices: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function currentMonthStart(): string {
+	const now = new Date();
+	return new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+}
+
+function parseUsage(text: string): { record: ExaUsageRecord; dropped: string[] } {
+	const value = JSON.parse(text) as unknown;
+	if (!isRecord(value)) throw new Error("the root value must be a JSON object");
+	if (typeof value.count !== "number" || !Number.isFinite(value.count) || value.count < 0) {
+		throw new Error("count must be a non-negative number");
+	}
+	if (typeof value.resetAt !== "string" || Number.isNaN(Date.parse(value.resetAt))) {
+		throw new Error("resetAt must be an ISO date string");
+	}
+	return {
+		record: { count: Math.floor(value.count), resetAt: value.resetAt },
+		dropped: Object.keys(value).filter((key) => key !== "count" && key !== "resetAt"),
+	};
+}
+
+function emitOnce(message: string): void {
+	if (emittedNotices.has(message)) return;
+	emittedNotices.add(message);
+	console.warn(message);
+}
+
+async function exists(file: string): Promise<boolean> {
+	try {
+		await stat(file);
+		return true;
+	} catch (error) {
+		if (isRecord(error) && error.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+async function atomicWriteUsage(file: string, record: ExaUsageRecord): Promise<void> {
+	const directory = dirname(file);
+	await mkdir(directory, { recursive: true, mode: 0o700 });
+	const temporary = join(directory, `.${randomUUID()}.tmp`);
+	try {
+		await writeFile(temporary, `${JSON.stringify(record, null, 2)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+		await rename(temporary, file);
+		await chmod(file, 0o600);
+	} finally {
+		await rm(temporary, { force: true });
+	}
+}
+
+async function withUsageLock<T>(fn: () => Promise<T>): Promise<T> {
+	const usagePath = getExaUsagePath();
+	const directory = dirname(usagePath);
+	await mkdir(directory, { recursive: true, mode: 0o700 });
+	const lockPath = join(directory, ".usage.lock");
+	const deadline = Date.now() + LOCK_WAIT_MS;
+	let handle: Awaited<ReturnType<typeof open>> | undefined;
+	while (!handle) {
+		try {
+			handle = await open(lockPath, "wx", 0o600);
+			await handle.writeFile(`${JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() })}\n`);
+		} catch (error) {
+			if (!isRecord(error) || error.code !== "EEXIST") throw error;
+			try {
+				if (Date.now() - (await stat(lockPath)).mtimeMs > LOCK_STALE_MS) {
+					await unlink(lockPath);
+					continue;
+				}
+			} catch (statError) {
+				if (isRecord(statError) && statError.code === "ENOENT") continue;
+				throw statError;
+			}
+			if (Date.now() >= deadline) throw new Error(`timed out waiting for ${lockPath}`);
+			await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_MS));
+		}
+	}
+	try {
+		return await fn();
+	} finally {
+		await handle.close();
+		await rm(lockPath, { force: true });
+	}
+}
+
+async function readUsageLocked(): Promise<LockedUsage> {
+	const target = getExaUsagePath();
+	const legacy = getLegacyExaUsagePath();
+	const notices: string[] = [];
+	if (await exists(target)) {
+		try {
+			const parsed = parseUsage(await readFile(target, "utf8"));
+			if (parsed.dropped.length > 0) {
+				await atomicWriteUsage(target, parsed.record);
+				notices.push(`Search Hub upgraded Exa usage state at ${target}; dropped fields: ${parsed.dropped.join(", ")}.`);
+			}
+			if (await exists(legacy)) notices.push(`Search Hub ignored conflicting legacy Exa usage state at ${legacy}.`);
+			return { record: parsed.record, notices };
+		} catch (error) {
+			return { notices: [`Search Hub could not read Exa usage state at ${target}: ${error instanceof Error ? error.message : String(error)}. The file was preserved.`] };
+		}
+	}
+	if (!(await exists(legacy))) return { record: { count: 0, resetAt: currentMonthStart() }, notices };
+	try {
+		const parsed = parseUsage(await readFile(legacy, "utf8"));
+		await atomicWriteUsage(target, parsed.record);
+		const verified = parseUsage(await readFile(target, "utf8")).record;
+		await unlink(legacy);
+		notices.push(`Search Hub migrated Exa usage state from ${legacy} to ${target}${parsed.dropped.length > 0 ? `; dropped fields: ${parsed.dropped.join(", ")}` : ""}.`);
+		return { record: verified, notices };
+	} catch (error) {
+		return { notices: [`Search Hub failed to migrate Exa usage state from ${legacy} to ${target}: ${error instanceof Error ? error.message : String(error)}. The legacy file was preserved.`] };
+	}
+}
+
+function quotaWarning(usage: ExaUsageRecord): string | null {
+	if (usage.resetAt !== currentMonthStart() || usage.count < EXA_WARNING_THRESHOLD) return null;
+	const remaining = EXA_MONTHLY_LIMIT - usage.count;
+	if (remaining <= 0) return `⚠️ Exa quota exhausted (${usage.count}/${EXA_MONTHLY_LIMIT}). Upgrade at https://exa.ai/pricing`;
+	return `⚠️ Exa quota low (${remaining} remaining of ${EXA_MONTHLY_LIMIT}/month)`;
+}
+
+export async function checkExaUsage(): Promise<string | null> {
+	try {
+		return await withUsageLock(async () => {
+			const loaded = await readUsageLocked();
+			for (const notice of loaded.notices) emitOnce(notice);
+			return loaded.notices[0] ?? (loaded.record ? quotaWarning(loaded.record) : null);
+		});
+	} catch (error) {
+		const warning = `Search Hub failed to check Exa usage: ${error instanceof Error ? error.message : String(error)}.`;
+		emitOnce(warning);
+		return warning;
+	}
+}
+
+export async function incrementExaUsage(): Promise<string | null> {
+	try {
+		return await withUsageLock(async () => {
+			const loaded = await readUsageLocked();
+			for (const notice of loaded.notices) emitOnce(notice);
+			if (!loaded.record) return loaded.notices[0] ?? "Search Hub could not update Exa usage state.";
+			const usage = loaded.record;
+			const month = currentMonthStart();
+			if (usage.resetAt !== month) {
+				usage.count = 0;
+				usage.resetAt = month;
+			}
+			usage.count++;
+			await atomicWriteUsage(getExaUsagePath(), usage);
+			if (loaded.notices.length > 0) return loaded.notices[0];
+			if (usage.count === EXA_WARNING_THRESHOLD) {
+				return `⚠️ Exa quota at ${EXA_WARNING_THRESHOLD}/${EXA_MONTHLY_LIMIT}. ${EXA_MONTHLY_LIMIT - usage.count} requests remaining this month.`;
+			}
+			if (usage.count > EXA_WARNING_THRESHOLD) return quotaWarning(usage);
+			return null;
+		});
+	} catch (error) {
+		const warning = `Search Hub failed to update Exa usage: ${error instanceof Error ? error.message : String(error)}.`;
+		emitOnce(warning);
+		return warning;
+	}
+}
+
+export function resetExaUsageNoticesForTests(): void {
+	emittedNotices.clear();
+}

--- a/packages/pi-search-hub/extensions/paths.ts
+++ b/packages/pi-search-hub/extensions/paths.ts
@@ -1,0 +1,32 @@
+import { CONFIG_DIR_NAME, getAgentDir } from "@earendil-works/pi-coding-agent";
+import { join } from "node:path";
+
+export const SEARCH_HUB_EXTENSION_ID = "pi-search-hub";
+
+export function getSearchHubDataDir(agentDir = getAgentDir()): string {
+	return join(agentDir, "extension-data", SEARCH_HUB_EXTENSION_ID);
+}
+
+export function getGlobalConfigPath(agentDir = getAgentDir()): string {
+	return join(getSearchHubDataDir(agentDir), "config.json");
+}
+
+export function getLegacyGlobalConfigPath(agentDir = getAgentDir()): string {
+	return join(agentDir, "extensions", "search.json");
+}
+
+export function getProjectConfigPath(cwd: string): string {
+	return join(cwd, CONFIG_DIR_NAME, "extension-data", SEARCH_HUB_EXTENSION_ID, "config.json");
+}
+
+export function getLegacyProjectConfigPath(cwd: string): string {
+	return join(cwd, CONFIG_DIR_NAME, "search.json");
+}
+
+export function getExaUsagePath(agentDir = getAgentDir()): string {
+	return join(getSearchHubDataDir(agentDir), "state", "exa-usage.json");
+}
+
+export function getLegacyExaUsagePath(agentDir = getAgentDir()): string {
+	return join(agentDir, "exa-usage.json");
+}

--- a/packages/pi-search-hub/extensions/search-hub.ts
+++ b/packages/pi-search-hub/extensions/search-hub.ts
@@ -52,7 +52,7 @@ import { fetchSofya } from "./backends/sofya.js";
 import { fetchFirecrawl } from "./backends/firecrawl.js";
 import { fetchExaContents } from "./backends/exa.js";
 import { fetchExaMCP } from "./backends/exa-mcp.js";
-import { config, refreshConfig, getActiveBackends, recordLatency, latencyMap } from "./config.js";
+import { getConfig, refreshConfig, getActiveBackends, recordLatency, latencyMap } from "./config.js";
 import { loadMigratedSearchConfig, saveSearchConfig } from "./config-storage.js";
 import {
 	getGlobalConfigPath,
@@ -180,6 +180,7 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
 			refreshConfig(ctx.cwd, ctx.isProjectTrusted(), false, notifyMigration(ctx));
+			const config = getConfig();
 			const numResults = Math.max(1, Math.min(params.numResults ?? 10, 20));
 			const requestedBackend = params.backend || "auto";
 			const combine = params.combine ?? false;
@@ -452,6 +453,7 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
 			refreshConfig(ctx.cwd, ctx.isProjectTrusted(), false, notifyMigration(ctx));
+			const config = getConfig();
 
 			const updateActivity = (status: string, reader: ReaderName) => {
 				onUpdate?.({
@@ -566,7 +568,7 @@ export default function (pi: ExtensionAPI) {
 			};
 		},
 	}), {
-		getCallPresentation: (args) => getWebReadCallPresentation(args, configuredReaderOrder(config)[0]),
+		getCallPresentation: (args) => getWebReadCallPresentation(args, configuredReaderOrder(getConfig())[0]),
 		getResultPresentation: getWebReadResultPresentation,
 	}));
 

--- a/packages/pi-search-hub/extensions/search-hub.ts
+++ b/packages/pi-search-hub/extensions/search-hub.ts
@@ -16,10 +16,10 @@
  *   searxng       — ✅ Self-hosted, 70+ aggregators. Needs instance URL
  *
  * Tools: web_search (auto-fallback + RRF combine modes), web_read (URL content)
- * Config: ~/.pi/agent/extensions/search.json + .pi/search.json (project wins)
+ * Config: $PI_CODING_AGENT_DIR/extension-data/pi-search-hub/config.json + .pi/extension-data/pi-search-hub/config.json
  * Credentials: env var refs (ALL_CAPS), shell commands (!command), or literal keys
  *
- * Example .pi/search.json:
+ * Example .pi/extension-data/pi-search-hub/config.json:
  *   {
  *     "defaultBackend": "auto",
  *     "backends": {
@@ -37,8 +37,6 @@
  *   }
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, rmSync } from "node:fs";
-import { join } from "node:path";
 import { defineTool, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { StringEnum } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
@@ -48,13 +46,20 @@ import {
 } from "../../pi-tool-display-intent/tool-display-api-consumer.js";
 
 import type { BackendConfig, ReaderName, SearchConfig, SearchResult, SearchResultWithBackend } from "./types.js";
-import { getAgentDir, timeoutSignal, sanitizeError, clearCooldowns, MISSING_KEY_HELP, validateUrl } from "./utils.js";
+import { timeoutSignal, sanitizeError, clearCooldowns, MISSING_KEY_HELP, validateUrl } from "./utils.js";
 import { resolveBackendKey, getKeySource, FALLBACK_ENV_MAP } from "./credentials.js";
 import { fetchSofya } from "./backends/sofya.js";
 import { fetchFirecrawl } from "./backends/firecrawl.js";
 import { fetchExaContents } from "./backends/exa.js";
 import { fetchExaMCP } from "./backends/exa-mcp.js";
 import { config, refreshConfig, getActiveBackends, recordLatency, latencyMap } from "./config.js";
+import { loadMigratedSearchConfig, saveSearchConfig } from "./config-storage.js";
+import {
+	getGlobalConfigPath,
+	getLegacyGlobalConfigPath,
+	getLegacyProjectConfigPath,
+	getProjectConfigPath,
+} from "./paths.js";
 import { BACKEND_DEFS, runBackend } from "./backends/registry.js";
 import { selectBackendsForFallback, reciprocalRankFusion, runTargetedCombine } from "./dispatch.js";
 import { formatResults, formatCombinedResults, formatResultsCompact, formatCombinedResultsCompact } from "./formatters.js";
@@ -134,7 +139,7 @@ export default function (pi: ExtensionAPI) {
 			"Auto mode tries enabled backends in order (DuckDuckGo is the free fallback)",
 			"Set combine=true to query enabled backends in parallel and merge/deduplicate results",
 			"Set combineMode=targeted in search.json to cap combine fan-out while still using multiple backends",
-			"Configure additional backends in .pi/search.json for better quality results",
+			"Configure additional backends in .pi/extension-data/pi-search-hub/config.json for better quality results",
 		],
 		parameters: Type.Object({
 			query: Type.String({
@@ -174,7 +179,7 @@ export default function (pi: ExtensionAPI) {
 			),
 		}),
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
-			refreshConfig(ctx.cwd);
+			refreshConfig(ctx.cwd, ctx.isProjectTrusted(), false, notifyMigration(ctx));
 			const numResults = Math.max(1, Math.min(params.numResults ?? 10, 20));
 			const requestedBackend = params.backend || "auto";
 			const combine = params.combine ?? false;
@@ -446,7 +451,7 @@ export default function (pi: ExtensionAPI) {
 			),
 		}),
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
-			refreshConfig(ctx.cwd);
+			refreshConfig(ctx.cwd, ctx.isProjectTrusted(), false, notifyMigration(ctx));
 
 			const updateActivity = (status: string, reader: ReaderName) => {
 				onUpdate?.({
@@ -569,51 +574,40 @@ export default function (pi: ExtensionAPI) {
 	// Commands
 	// -----------------------------------------------------------------------
 
-	const getGlobalConfigPath = () => join(getAgentDir(), "extensions", "search.json");
+	const notifyMigration = (ctx: ExtensionContext) => (message: string): void => {
+		if (ctx.hasUI === false) console.warn(message);
+		else ctx.ui.notify(message, "warning");
+	};
 
-	function readGlobalConfig(): SearchConfig {
-		const configPath = getGlobalConfigPath();
-		if (!existsSync(configPath)) return {};
-		try {
-			return JSON.parse(readFileSync(configPath, "utf-8")) as SearchConfig;
-		} catch {
-			return {};
-		}
+	function readGlobalConfig(ctx: ExtensionContext): SearchConfig {
+		return loadMigratedSearchConfig({
+			targetPath: getGlobalConfigPath(),
+			legacyPath: getLegacyGlobalConfigPath(),
+			scope: "global",
+			onNotice: notifyMigration(ctx),
+		});
 	}
 
 	function writeGlobalConfig(nextConfig: SearchConfig): void {
-		const configPath = getGlobalConfigPath();
-		const tempPath = `${configPath}.${process.pid}.${Date.now()}.tmp`;
-		const serialized = { ...nextConfig } as SearchConfig & Record<string, unknown>;
-		delete serialized.showStatus;
-		delete serialized.cacheTtl;
-		delete serialized.cacheMax;
-		mkdirSync(join(getAgentDir(), "extensions"), { recursive: true });
-		try {
-			writeFileSync(tempPath, JSON.stringify(serialized, null, 2) + "\n", { mode: 0o600 });
-			renameSync(tempPath, configPath);
-		} catch (error) {
-			rmSync(tempPath, { force: true });
-			throw error;
-		}
+		saveSearchConfig(getGlobalConfigPath(), nextConfig);
 	}
 
 	function cloneConfig(value: SearchConfig): SearchConfig {
 		return JSON.parse(JSON.stringify(value)) as SearchConfig;
 	}
 
-	function readProjectConfig(cwd: string): SearchConfig {
-		const projectPath = join(cwd, ".pi", "search.json");
-		if (!existsSync(projectPath)) return {};
-		try {
-			return JSON.parse(readFileSync(projectPath, "utf-8")) as SearchConfig;
-		} catch {
-			return {};
-		}
+	function readProjectConfig(ctx: ExtensionContext): SearchConfig {
+		if (!ctx.isProjectTrusted()) return {};
+		return loadMigratedSearchConfig({
+			targetPath: getProjectConfigPath(ctx.cwd),
+			legacyPath: getLegacyProjectConfigPath(ctx.cwd),
+			scope: "project",
+			onNotice: notifyMigration(ctx),
+		});
 	}
 
-	function effectiveDraftConfig(globalDraft: SearchConfig, cwd: string): SearchConfig {
-		const project = readProjectConfig(cwd);
+	function effectiveDraftConfig(globalDraft: SearchConfig, ctx: ExtensionContext): SearchConfig {
+		const project = readProjectConfig(ctx);
 		const globalBackends = { ...(globalDraft.backends ?? {}) } as Record<string, BackendConfig | undefined>;
 		const projectBackends = project.backends && typeof project.backends === "object"
 			? project.backends as Record<string, BackendConfig | undefined>
@@ -664,7 +658,7 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	function refreshRuntimeConfig(ctx: ExtensionContext): void {
-		refreshConfig(ctx.cwd, true);
+		refreshConfig(ctx.cwd, ctx.isProjectTrusted(), true, notifyMigration(ctx));
 	}
 
 	function authSourceLabel(source: string): string {
@@ -771,7 +765,7 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	function setupHomeTitle(ctx: ExtensionContext, state: SetupDraftState): string {
-		const effective = effectiveDraftConfig(state.draft, ctx.cwd);
+		const effective = effectiveDraftConfig(state.draft, ctx);
 		const active = activeBackendsFor(effective);
 		const defaultBackend = effective.defaultBackend && active.includes(effective.defaultBackend)
 			? effective.defaultBackend
@@ -828,7 +822,7 @@ export default function (pi: ExtensionAPI) {
 			state.original = cloneConfig(saved);
 			state.draft = cloneConfig(saved);
 			refreshRuntimeConfig(ctx);
-			const hasProjectOverrides = Object.keys(readProjectConfig(ctx.cwd)).length > 0;
+			const hasProjectOverrides = Object.keys(readProjectConfig(ctx)).length > 0;
 			ctx.ui.notify(
 				hasProjectOverrides
 					? "Search Hub configuration saved and applied. Current project overrides remain effective."
@@ -859,7 +853,7 @@ export default function (pi: ExtensionAPI) {
 		const globalEnabled = globalBackend?.enabled === true;
 		const codexAuth = piAuthDetail(ctx);
 		const globalState = backendStateSummary(backend, state.draft, activeBackendsFor(state.draft), codexAuth);
-		const effective = effectiveDraftConfig(state.draft, ctx.cwd);
+		const effective = effectiveDraftConfig(state.draft, ctx);
 		const effectiveState = backendStateSummary(backend, effective, activeBackendsFor(effective), codexAuth);
 		const title = [
 			def.label,
@@ -1077,7 +1071,7 @@ export default function (pi: ExtensionAPI) {
 
 	async function configureBackends(ctx: ExtensionContext, state: SetupDraftState): Promise<void> {
 		while (true) {
-			const effective = effectiveDraftConfig(state.draft, ctx.cwd);
+			const effective = effectiveDraftConfig(state.draft, ctx);
 			const active = activeBackendsFor(effective);
 			const codexAuth = piAuthDetail(ctx);
 			const backendEntries = Object.keys(BACKEND_DEFS).map((backend) => {
@@ -1121,7 +1115,7 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			refreshRuntimeConfig(ctx);
-			const original = readGlobalConfig();
+			const original = readGlobalConfig(ctx);
 			const state: SetupDraftState = {
 				original: cloneConfig(original),
 				draft: cloneConfig(original),

--- a/packages/pi-search-hub/extensions/utils.ts
+++ b/packages/pi-search-hub/extensions/utils.ts
@@ -2,8 +2,7 @@
  * Shared utilities for pi-search-hub extension.
  */
 
-import { join } from "node:path";
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+export { checkExaUsage, incrementExaUsage } from "./exa-usage.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -17,16 +16,8 @@ export const MISSING_KEY_HELP =
 	"Set the API key via env var (SEARCH_<BACKEND>_API_KEY), " +
 	"config reference (\"apiKey\": \"SOME_ENV_VAR\"), " +
 	"shell command (\"apiKey\": \"!pass show api/backend\"), " +
-	"or a literal key in ~/.pi/agent/extensions/search.json. " +
+	"or a literal key in $PI_CODING_AGENT_DIR/extension-data/pi-search-hub/config.json. " +
 	"DuckDuckGo needs no key. Marginalia uses a shared public key (optional)."
-
-// ---------------------------------------------------------------------------
-// Agent directory
-// ---------------------------------------------------------------------------
-
-export function getAgentDir(): string {
-	return join(process.env.HOME || process.env.USERPROFILE || "~", ".pi", "agent");
-}
 
 // ---------------------------------------------------------------------------
 // Per-backend cooldown
@@ -59,88 +50,6 @@ export function timeoutSignal(signal?: AbortSignal, timeoutMs?: number): AbortSi
 	const effectiveTimeout = timeoutMs ?? HTTP_TIMEOUT_MS;
 	if (!signal) return AbortSignal.timeout(effectiveTimeout);
 	return AbortSignal.any([signal, AbortSignal.timeout(effectiveTimeout)]);
-}
-
-// ---------------------------------------------------------------------------
-// Exa usage tracking (monthly quota)
-// ---------------------------------------------------------------------------
-
-const EXA_MONTHLY_LIMIT = 1000;
-const EXA_WARNING_THRESHOLD = 800; // warn at 80%
-
-interface ExaUsageRecord {
-	count: number;
-	resetAt: string; // ISO date string for month start
-}
-
-function getUsageFilePath(): string {
-	return join(getAgentDir(), "exa-usage.json");
-}
-
-function getCurrentMonthStart(): string {
-	const now = new Date();
-	return new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
-}
-
-function readUsage(): ExaUsageRecord {
-	try {
-		const data = readFileSync(getUsageFilePath(), "utf-8");
-		return JSON.parse(data) as ExaUsageRecord;
-	} catch {
-		return { count: 0, resetAt: getCurrentMonthStart() };
-	}
-}
-
-function writeUsage(record: ExaUsageRecord): void {
-	try {
-		const dir = getAgentDir();
-		mkdirSync(dir, { recursive: true });
-		writeFileSync(getUsageFilePath(), JSON.stringify(record, null, 2));
-	} catch {
-		// ignore write failures
-	}
-}
-
-/** Check Exa usage and return warning message if approaching quota, or null. */
-export function checkExaUsage(): string | null {
-	const usage = readUsage();
-	// Reset if new month
-	const currentMonth = getCurrentMonthStart();
-	if (usage.resetAt !== currentMonth) {
-		return null; // will be reset on next increment
-	}
-	if (usage.count >= EXA_WARNING_THRESHOLD) {
-		const remaining = EXA_MONTHLY_LIMIT - usage.count;
-		if (remaining <= 0) {
-			return `⚠️ Exa quota exhausted (${usage.count}/${EXA_MONTHLY_LIMIT}). Upgrade at https://exa.ai/pricing`;
-		}
-		return `⚠️ Exa quota low (${remaining} remaining of ${EXA_MONTHLY_LIMIT}/month)`;
-	}
-	return null;
-}
-
-/** Increment Exa usage count. Call after each successful request. */
-export function incrementExaUsage(): string | null {
-	const usage = readUsage();
-	const currentMonth = getCurrentMonthStart();
-	// Reset if new month
-	if (usage.resetAt !== currentMonth) {
-		usage.count = 0;
-		usage.resetAt = currentMonth;
-	}
-	usage.count++;
-	writeUsage(usage);
-	// Return warning if needed
-	if (usage.count >= EXA_WARNING_THRESHOLD) {
-		const remaining = EXA_MONTHLY_LIMIT - usage.count;
-		if (remaining <= 0) {
-			return `⚠️ Exa quota exhausted. Upgrade at https://exa.ai/pricing`;
-		}
-		if (usage.count === EXA_WARNING_THRESHOLD) {
-			return `⚠️ Exa quota at ${EXA_WARNING_THRESHOLD}/${EXA_MONTHLY_LIMIT}. ${remaining} requests remaining this month.`;
-		}
-	}
-	return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pi-search-hub/tests/exa-contents.test.ts
+++ b/packages/pi-search-hub/tests/exa-contents.test.ts
@@ -1,18 +1,26 @@
 /**
  * Unit tests for Exa Contents API fetch function.
  */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { fetchExaContents } from "../extensions/backends/exa.js";
 
 describe("fetchExaContents", () => {
 	let fetchSpy: ReturnType<typeof vi.spyOn>;
+	let root: string;
 
 	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "pi-search-exa-contents-"));
+		vi.stubEnv("PI_CODING_AGENT_DIR", root);
 		fetchSpy = vi.spyOn(global, "fetch");
 	});
 
 	afterEach(() => {
 		fetchSpy.mockRestore();
+		vi.unstubAllEnvs();
+		rmSync(root, { recursive: true, force: true });
 	});
 
 	it("sends x-api-key header", async () => {

--- a/packages/pi-search-hub/tests/setup.test.ts
+++ b/packages/pi-search-hub/tests/setup.test.ts
@@ -50,6 +50,7 @@ function createHarness(cwd: string, selections: Selection[] = [], inputs: Array<
 		hasUI: true,
 		mode: "tui",
 		cwd,
+		isProjectTrusted: () => true,
 		modelRegistry: {
 			getProviderAuthStatus() {
 				return { configured: false };
@@ -74,7 +75,7 @@ function pickOption(fragment: string): Selection {
 }
 
 function globalConfigPath(home: string): string {
-	return join(home, ".pi", "agent", "extensions", "search.json");
+	return join(home, ".pi", "agent", "extension-data", "pi-search-hub", "config.json");
 }
 
 function writeJson(path: string, value: unknown): void {

--- a/packages/pi-search-hub/tests/storage-migration.test.ts
+++ b/packages/pi-search-hub/tests/storage-migration.test.ts
@@ -2,7 +2,8 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync }
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { config, loadConfig, refreshConfig } from "../extensions/config.js";
+import { getConfig, loadConfig, refreshConfig } from "../extensions/config.js";
+import { resolveBackendKey } from "../extensions/credentials.js";
 import { resetSearchConfigMigrationNoticesForTests } from "../extensions/config-storage.js";
 import { incrementExaUsage, resetExaUsageNoticesForTests } from "../extensions/exa-usage.js";
 import {
@@ -42,13 +43,20 @@ describe("Search Hub storage migration", () => {
 		const target = getGlobalConfigPath();
 		writeJson(legacy, {
 			combine: true,
+			reader: "firecrawl",
 			obsolete: true,
-			backends: { serper: { enabled: true, apiKey: "SERPER_KEY", removed: 1 } },
+			backends: {
+				firecrawl: { enabled: true, apiKey: "fc-test-key" },
+				serper: { enabled: true, apiKey: "SERPER_KEY", removed: 1 },
+			},
 		});
 		const notices: string[] = [];
 
 		const loaded = loadConfig(cwd, false, (message) => notices.push(message));
 
+		expect(loaded.reader).toBe("firecrawl");
+		expect(loaded.backends?.firecrawl).toEqual({ enabled: true, apiKey: "fc-test-key" });
+		expect(resolveBackendKey("firecrawl", loaded)).toBe("fc-test-key");
 		expect(loaded.backends?.serper).toEqual({ enabled: true, apiKey: "SERPER_KEY" });
 		expect(readFileSync(target, "utf8")).not.toContain("obsolete");
 		expect(readFileSync(target, "utf8")).not.toContain("removed");
@@ -74,9 +82,9 @@ describe("Search Hub storage migration", () => {
 		writeJson(getProjectConfigPath(cwd), { compact: true });
 
 		refreshConfig(cwd, false, true);
-		expect(config.compact).toBe(false);
+		expect(getConfig().compact).toBe(false);
 		refreshConfig(cwd, true, false);
-		expect(config.compact).toBe(true);
+		expect(getConfig().compact).toBe(true);
 	});
 
 	it("preserves an unparsable legacy config", () => {

--- a/packages/pi-search-hub/tests/storage-migration.test.ts
+++ b/packages/pi-search-hub/tests/storage-migration.test.ts
@@ -1,0 +1,109 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { config, loadConfig, refreshConfig } from "../extensions/config.js";
+import { resetSearchConfigMigrationNoticesForTests } from "../extensions/config-storage.js";
+import { incrementExaUsage, resetExaUsageNoticesForTests } from "../extensions/exa-usage.js";
+import {
+	getExaUsagePath,
+	getGlobalConfigPath,
+	getLegacyExaUsagePath,
+	getLegacyGlobalConfigPath,
+	getLegacyProjectConfigPath,
+	getProjectConfigPath,
+} from "../extensions/paths.js";
+
+function writeJson(file: string, value: unknown): void {
+	mkdirSync(dirname(file), { recursive: true });
+	writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+describe("Search Hub storage migration", () => {
+	let root: string;
+	let cwd: string;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "pi-search-storage-"));
+		cwd = join(root, "project");
+		mkdirSync(cwd, { recursive: true });
+		vi.stubEnv("PI_CODING_AGENT_DIR", join(root, "agent"));
+		resetSearchConfigMigrationNoticesForTests();
+		resetExaUsageNoticesForTests();
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("migrates and upgrades global config while reporting discarded fields", () => {
+		const legacy = getLegacyGlobalConfigPath();
+		const target = getGlobalConfigPath();
+		writeJson(legacy, {
+			combine: true,
+			obsolete: true,
+			backends: { serper: { enabled: true, apiKey: "SERPER_KEY", removed: 1 } },
+		});
+		const notices: string[] = [];
+
+		const loaded = loadConfig(cwd, false, (message) => notices.push(message));
+
+		expect(loaded.backends?.serper).toEqual({ enabled: true, apiKey: "SERPER_KEY" });
+		expect(readFileSync(target, "utf8")).not.toContain("obsolete");
+		expect(readFileSync(target, "utf8")).not.toContain("removed");
+		expect(() => statSync(legacy)).toThrow();
+		expect(notices.join("\n")).toContain("obsolete");
+		expect(notices.join("\n")).toContain("backends.serper.removed");
+		expect(statSync(target).mode & 0o777).toBe(0o600);
+	});
+
+	it("migrates project config only when the project is trusted", () => {
+		const legacy = getLegacyProjectConfigPath(cwd);
+		writeJson(legacy, { compact: true });
+
+		expect(loadConfig(cwd, false).compact).toBeUndefined();
+		expect(readFileSync(legacy, "utf8")).toContain("compact");
+		expect(loadConfig(cwd, true).compact).toBe(true);
+		expect(readFileSync(getProjectConfigPath(cwd), "utf8")).toContain("compact");
+		expect(() => statSync(legacy)).toThrow();
+	});
+
+	it("keys the runtime cache by cwd and trust", () => {
+		writeJson(getGlobalConfigPath(), { compact: false });
+		writeJson(getProjectConfigPath(cwd), { compact: true });
+
+		refreshConfig(cwd, false, true);
+		expect(config.compact).toBe(false);
+		refreshConfig(cwd, true, false);
+		expect(config.compact).toBe(true);
+	});
+
+	it("preserves an unparsable legacy config", () => {
+		const legacy = getLegacyGlobalConfigPath();
+		mkdirSync(dirname(legacy), { recursive: true });
+		writeFileSync(legacy, "{");
+		const notices: string[] = [];
+
+		expect(loadConfig(cwd, false, (message) => notices.push(message)).backends).toEqual({});
+		expect(readFileSync(legacy, "utf8")).toBe("{");
+		expect(() => statSync(getGlobalConfigPath())).toThrow();
+		expect(notices.join("\n")).toContain("preserved");
+	});
+
+	it("migrates Exa usage and serializes concurrent increments", async () => {
+		writeJson(getLegacyExaUsagePath(), {
+			count: 10,
+			resetAt: new Date(new Date().getFullYear(), new Date().getMonth(), 1).toISOString(),
+			obsolete: true,
+		});
+
+		await Promise.all([incrementExaUsage(), incrementExaUsage()]);
+
+		const saved = JSON.parse(readFileSync(getExaUsagePath(), "utf8")) as { count: number; obsolete?: boolean };
+		expect(saved.count).toBe(12);
+		expect(saved.obsolete).toBeUndefined();
+		expect(() => statSync(getLegacyExaUsagePath())).toThrow();
+		expect(statSync(getExaUsagePath()).mode & 0o777).toBe(0o600);
+	});
+});

--- a/packages/pi-tool-display-intent/README.md
+++ b/packages/pi-tool-display-intent/README.md
@@ -80,10 +80,10 @@ Tool ownership and intent-schema changes take effect after `/reload`. Legacy `pr
 The global config is stored at:
 
 ```text
-$PI_CODING_AGENT_DIR/extensions/pi-tool-display-intent/config.json
+$PI_CODING_AGENT_DIR/extension-data/pi-tool-display-intent/config.json
 ```
 
-When `PI_CODING_AGENT_DIR` is unset, Pi's default agent directory is used. Extension enablement is managed through Pi package settings rather than another config switch. The v2 file is grouped by responsibility and stores only non-default values:
+When `PI_CODING_AGENT_DIR` is unset, Pi's default agent directory is used. Debug output, when explicitly enabled, is written to `$PI_CODING_AGENT_DIR/extension-data/pi-tool-display-intent/state/debug.log`. Extension enablement is managed through Pi package settings rather than another config switch. The v2 file is grouped by responsibility and stores only non-default values:
 
 ```json
 {
@@ -133,7 +133,7 @@ Model-written intent uses the theme's regular `accent` color without bold or bac
 
 ### Automatic legacy migration
 
-When the extension loads an old flat config without `version`, it normalizes it and atomically replaces `config.json` after a validated v2 round trip. The first migration keeps `config.legacy.json` as a backup. Key mappings are:
+On first load, the extension automatically moves the previous config path, legacy backup, and debug log into `extension-data`. An old flat config or pre-v2 version is normalized and atomically replaced after a validated v2 round trip. The first schema migration keeps `config.legacy.json` as a backup. Key mappings are:
 
 - `displaySummary` / `toolIntent` → `intent`;
 - `toolCallStyle` → `toolCalls.style`;
@@ -143,7 +143,7 @@ When the extension loads an old flat config without `version`, it normalizes it 
 - `customToolOverrides` → `tools.custom` without an `enabled` switch;
 - diff, transcript, hints, and debug → their corresponding sections.
 
-`bashCollapsedLines` is intentionally discarded because all previews now share `results.previewRows`. After migration, the Pi status bar tells the user to adjust that value if needed. Deprecated `displaySummary.required` and `displaySummary.showInTui` are also removed. Invalid JSON, unknown v2 fields, and invalid v2 values are never rewritten and are reported with exact field paths. Run `/reload` after editing the file directly.
+`bashCollapsedLines` is intentionally discarded because all previews now share `results.previewRows`. Deprecated `displaySummary.required`, `displaySummary.showInTui`, unknown fields, and invalid values that cannot be mapped are also discarded. The Pi status bar reports the exact affected field paths. Malformed JSON and unsupported future schema versions are preserved and use defaults instead. Run `/reload` after editing the file directly.
 
 When `intent.enabled` is on, `displaySummary` is required in owned built-in schemas and always shown in TUI. If an old or incomplete call omits it, the renderer shows a deterministic fallback and `prepareArguments` backfills the raw arguments. Since Pi emits the initial `tool_execution_start` before preparation, RPC clients should still provide their own fallback for that first event.
 

--- a/packages/pi-tool-display-intent/README.zh-CN.md
+++ b/packages/pi-tool-display-intent/README.zh-CN.md
@@ -80,10 +80,10 @@ pi --no-extensions -e ./packages/pi-tool-display-intent
 全局配置位置：
 
 ```text
-$PI_CODING_AGENT_DIR/extensions/pi-tool-display-intent/config.json
+$PI_CODING_AGENT_DIR/extension-data/pi-tool-display-intent/config.json
 ```
 
-未设置 `PI_CODING_AGENT_DIR` 时使用 Pi 默认 agent 目录。扩展启停统一通过 Pi package 设置管理，不再增加另一个配置开关。v2 按职责分组，只保存非默认值：
+未设置 `PI_CODING_AGENT_DIR` 时使用 Pi 默认 agent 目录。显式启用 debug 后，日志写入 `$PI_CODING_AGENT_DIR/extension-data/pi-tool-display-intent/state/debug.log`。扩展启停统一通过 Pi package 设置管理，不再增加另一个配置开关。v2 按职责分组，只保存非默认值：
 
 ```json
 {
@@ -133,7 +133,7 @@ $PI_CODING_AGENT_DIR/extensions/pi-tool-display-intent/config.json
 
 ### 历史配置自动迁移
 
-扩展加载没有 `version` 的旧 flat 配置时，会规范化配置，并在验证 v2 round-trip 后原子替换 `config.json`。首次迁移保留 `config.legacy.json`。主要映射：
+首次加载时，扩展会自动把旧配置路径、legacy backup 和 debug log 迁入 `extension-data`。没有 `version` 的旧 flat 配置或 v2 之前的版本会被规范化，并在验证 v2 round-trip 后原子替换 `config.json`。首次 schema 迁移保留 `config.legacy.json`。主要映射：
 
 - `displaySummary` / `toolIntent` → `intent`；
 - `toolCallStyle` → `toolCalls.style`；
@@ -143,7 +143,7 @@ $PI_CODING_AGENT_DIR/extensions/pi-tool-display-intent/config.json
 - `customToolOverrides` → 没有 `enabled` 开关的 `tools.custom`；
 - diff、transcript、hint 和 debug → 对应分组。
 
-`bashCollapsedLines` 会直接丢弃，因为所有预览统一使用 `results.previewRows`。迁移完成后，Pi 状态栏会提示用户按需调整该值。废弃的 `displaySummary.required` 和 `displaySummary.showInTui` 也会移除。无效 JSON、未知 v2 字段或错误的 v2 值不会被改写，并会报告准确字段路径。直接编辑配置后执行 `/reload` 重新读取。
+`bashCollapsedLines` 会直接丢弃，因为所有预览统一使用 `results.previewRows`。废弃的 `displaySummary.required`、`displaySummary.showInTui`、未知字段和无法映射的无效值也会被丢弃；Pi 状态栏会报告准确字段路径。格式损坏的 JSON 和未来版本 schema 会原样保留并回退默认值。直接编辑配置后执行 `/reload` 重新读取。
 
 启用 `intent.enabled` 后，`displaySummary` 在本 extension 持有的内置工具 Schema 中固定为必填并始终显示。旧 Session 或不完整 tool call 缺少字段时，renderer 会显示确定性 fallback，`prepareArguments` 也会在校验前回填参数。由于 Pi 在参数准备前发送第一次 `tool_execution_start`，RPC 客户端仍应为该初始事件自行 fallback。
 

--- a/packages/pi-tool-display-intent/src/config-store.ts
+++ b/packages/pi-tool-display-intent/src/config-store.ts
@@ -1,5 +1,6 @@
-import { resolvePiAgentDir } from "./agent-dir.js";
+import { randomUUID } from "node:crypto";
 import {
+	chmodSync,
 	existsSync,
 	mkdirSync,
 	readFileSync,
@@ -35,9 +36,10 @@ import {
 	normalizeToolDisplayMode,
 } from "./presets.js";
 import { toRecord } from "./tool-metadata.js";
+import { getToolDisplayConfigPath as resolveToolDisplayConfigPath } from "./storage-paths.js";
+import { finalizeToolDisplayStorageMigration, prepareToolDisplayStorageMigration, withToolDisplayStorageLock } from "./storage-migration.js";
 
-const CONFIG_DIR = join(resolvePiAgentDir(), "extensions", "pi-tool-display-intent");
-const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+const CONFIG_FILE = resolveToolDisplayConfigPath();
 const LEGACY_BACKUP_FILE_NAME = "config.legacy.json";
 
 interface LegacyToolDisplayConfigSource extends Record<string, unknown> {
@@ -499,6 +501,28 @@ function validateToolDisplayConfigV2(raw: unknown): string[] {
 	return errors;
 }
 
+function dropInvalidV2Settings(source: Record<string, unknown>, validationErrors: readonly string[]): Record<string, unknown> {
+	const sanitized = structuredClone(source);
+	const paths = validationErrors
+		.map((error) => error.slice(0, error.indexOf(":")))
+		.filter(Boolean)
+		.sort((left, right) => right.localeCompare(left, undefined, { numeric: true }));
+	for (const settingPath of paths) {
+		const parts = settingPath.split(".");
+		if (settingPath.endsWith("required section") || settingPath.endsWith("required setting")) continue;
+		let parent: unknown = sanitized;
+		for (const part of parts.slice(0, -1)) {
+			if (!parent || typeof parent !== "object") break;
+			parent = (parent as Record<string, unknown>)[part];
+		}
+		if (!parent || typeof parent !== "object") continue;
+		const key = parts.at(-1)!;
+		if (Array.isArray(parent) && /^\d+$/.test(key)) parent.splice(Number(key), 1);
+		else delete (parent as Record<string, unknown>)[key];
+	}
+	return sanitized;
+}
+
 function normalizeToolDisplayConfigV2(raw: unknown): ToolDisplayConfig {
 	const source = toRecord(raw);
 	const results = toRecord(source.results);
@@ -613,11 +637,12 @@ export function serializeToolDisplayConfigV2(rawConfig: ToolDisplayConfig): Reco
 }
 
 function writeConfigAtomically(configFile: string, serialized: Record<string, unknown>): void {
-	const tmpFile = `${configFile}.tmp`;
-	mkdirSync(dirname(configFile), { recursive: true });
+	const tmpFile = `${configFile}.${randomUUID()}.tmp`;
+	mkdirSync(dirname(configFile), { recursive: true, mode: 0o700 });
 	try {
-		writeFileSync(tmpFile, `${JSON.stringify(serialized, null, 2)}\n`, "utf-8");
+		writeFileSync(tmpFile, `${JSON.stringify(serialized, null, 2)}\n`, { encoding: "utf-8", mode: 0o600, flag: "wx" });
 		renameSync(tmpFile, configFile);
+		chmodSync(configFile, 0o600);
 	} catch (error) {
 		try {
 			if (existsSync(tmpFile)) unlinkSync(tmpFile);
@@ -628,9 +653,23 @@ function writeConfigAtomically(configFile: string, serialized: Record<string, un
 	}
 }
 
+const LEGACY_CONFIG_KEYS = new Set([
+	"version", "enabled", "debug", "displaySummary", "toolIntent", "registerToolOverrides", "registerReadToolOverride",
+	"customToolOverrides", "toolCallStyle", "bashCommandPreviewRows", "resultMode", "resultProfile", "readOutputMode",
+	"searchOutputMode", "mcpOutputMode", "bashOutputMode", "enableNativeUserMessageBox", "enableThinkingLabel", "previewRows",
+	"previewLines", "expandedPreviewMaxRows", "expandedPreviewMaxLines", "diffViewMode", "diffIndicatorMode", "diffSplitMinWidth",
+	"diffCollapsedRows", "diffCollapsedLines", "diffWordWrap", "showTruncationHints", "showRtkCompactionHints",
+	"bashCollapsedLines", "bashCollapsedRows",
+]);
+
+function collectUnknownLegacyFields(source: Record<string, unknown>): string[] {
+	return Object.keys(source).filter((key) => !LEGACY_CONFIG_KEYS.has(key));
+}
+
 function buildLegacyMigrationNotice(
 	source: Record<string, unknown>,
 	config: ToolDisplayConfig,
+	dropped: readonly string[] = collectUnknownLegacyFields(source),
 ): string | undefined {
 	const messages: string[] = [];
 	if (hasOwn(source, "bashCollapsedLines") || hasOwn(source, "bashCollapsedRows")) {
@@ -644,6 +683,7 @@ function buildLegacyMigrationNotice(
 	if (!resolveLegacyResultMode(source).exact) {
 		messages.push(`per-tool result settings were consolidated to results.mode=${config.resultMode}`);
 	}
+	if (dropped.length > 0) messages.push(`dropped unmappable fields: ${dropped.join(", ")}`);
 	return messages.length > 0
 		? `tool-display-intent migrated its config: ${messages.join("; ")}`
 		: undefined;
@@ -661,11 +701,14 @@ function migrateLegacyConfigFile(
 			throw new Error("v2 migration changed the normalized configuration");
 		}
 
-		const backupFile = join(dirname(configFile), LEGACY_BACKUP_FILE_NAME);
-		if (!existsSync(backupFile)) {
-			writeFileSync(backupFile, rawText, { encoding: "utf-8", flag: "wx" });
-		}
-		writeConfigAtomically(configFile, serialized);
+		withToolDisplayStorageLock(() => {
+			if (readFileSync(configFile, "utf8") !== rawText) throw new Error("config changed during migration; retrying on next load");
+			const backupFile = join(dirname(configFile), LEGACY_BACKUP_FILE_NAME);
+			if (!existsSync(backupFile)) {
+				writeFileSync(backupFile, rawText, { encoding: "utf-8", mode: 0o600, flag: "wx" });
+			}
+			writeConfigAtomically(configFile, serialized);
+		}, dirname(configFile));
 		return undefined;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -674,9 +717,16 @@ function migrateLegacyConfigFile(
 }
 
 export function loadToolDisplayConfig(configFile = CONFIG_FILE): ConfigLoadResult {
+	const usesDefaultPath = configFile === CONFIG_FILE;
+	const preparedStorage = usesDefaultPath ? prepareToolDisplayStorageMigration() : undefined;
 	const fingerprint = getConfigFingerprint(configFile);
 	if (cachedConfigResult && cachedConfigFile === configFile && cachedConfigFingerprint === fingerprint) {
-		return cloneLoadResult(cachedConfigResult);
+		const cached = cloneLoadResult(cachedConfigResult);
+		if (preparedStorage) {
+			const notices = finalizeToolDisplayStorageMigration(preparedStorage, !cached.error);
+			if (notices.length > 0) cached.notice = [cached.notice, ...notices].filter(Boolean).join(" ");
+		}
+		return cached;
 	}
 
 	let result: ConfigLoadResult;
@@ -690,24 +740,30 @@ export function loadToolDisplayConfig(configFile = CONFIG_FILE): ConfigLoadResul
 				throw new Error("root: expected object");
 			}
 			const source = parsed as Record<string, unknown>;
-			if (hasOwn(source, "version")) {
-				if (source.version !== TOOL_DISPLAY_CONFIG_VERSION) {
-					result = {
-						config: cloneDefaultConfig(),
-						error: `Unsupported tool display config version in ${configFile}: ${String(source.version)}`,
-					};
+			if (hasOwn(source, "version") && source.version === TOOL_DISPLAY_CONFIG_VERSION) {
+				const validationErrors = validateToolDisplayConfigV2(source);
+				const sanitizedSource = validationErrors.length > 0 ? dropInvalidV2Settings(source, validationErrors) : source;
+				const config = normalizeToolDisplayConfigV2(sanitizedSource);
+				if (validationErrors.length === 0) {
+					result = { config };
 				} else {
-					const validationErrors = validateToolDisplayConfigV2(source);
-					result = validationErrors.length > 0
-						? {
-							config: cloneDefaultConfig(),
-							error: `Invalid tool display v2 config in ${configFile}: ${validationErrors.join("; ")}`,
-						}
-						: { config: normalizeToolDisplayConfigV2(source) };
+					const migrationError = migrateLegacyConfigFile(configFile, rawText, config);
+					result = {
+						config,
+						...(migrationError ? { error: migrationError } : {}),
+						...(!migrationError ? { notice: `tool-display-intent upgraded its v2 config and dropped or normalized unmappable settings: ${validationErrors.join("; ")}` } : {}),
+					};
 				}
+			} else if (hasOwn(source, "version") && typeof source.version === "number" && source.version > TOOL_DISPLAY_CONFIG_VERSION) {
+				result = {
+					config: cloneDefaultConfig(),
+					error: `Unsupported tool display config version in ${configFile}: ${String(source.version)}`,
+				};
 			} else {
-				const config = normalizeToolDisplayConfig(source);
-				const notice = buildLegacyMigrationNotice(source, config);
+				const legacySource = { ...source };
+				delete legacySource.version;
+				const config = normalizeToolDisplayConfig(legacySource);
+				const notice = buildLegacyMigrationNotice(legacySource, config);
 				const migrationError = migrateLegacyConfigFile(configFile, rawText, config);
 				result = {
 					config,
@@ -724,19 +780,21 @@ export function loadToolDisplayConfig(configFile = CONFIG_FILE): ConfigLoadResul
 		}
 	}
 
+	if (preparedStorage) {
+		const notices = finalizeToolDisplayStorageMigration(preparedStorage, !result.error);
+		if (notices.length > 0) result.notice = [result.notice, ...notices].filter(Boolean).join(" ");
+	}
 	cachedConfigFile = configFile;
 	cachedConfigFingerprint = getConfigFingerprint(configFile);
 	cachedConfigResult = cloneLoadResult(result);
-	if (cachedConfigResult.notice) {
-		cachedConfigResult.notice = undefined;
-	}
+	if (cachedConfigResult.notice) cachedConfigResult.notice = undefined;
 	return result;
 }
 
 export function saveToolDisplayConfig(config: ToolDisplayConfig, configFile = CONFIG_FILE): ConfigSaveResult {
 	const normalized = normalizeToolDisplayConfig(config);
 	try {
-		writeConfigAtomically(configFile, serializeToolDisplayConfigV2(normalized));
+		withToolDisplayStorageLock(() => writeConfigAtomically(configFile, serializeToolDisplayConfigV2(normalized)), dirname(configFile));
 		cachedConfigFile = undefined;
 		cachedConfigFingerprint = undefined;
 		cachedConfigResult = undefined;

--- a/packages/pi-tool-display-intent/src/debug-logger.ts
+++ b/packages/pi-tool-display-intent/src/debug-logger.ts
@@ -1,17 +1,12 @@
 import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { appendFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
-import { resolvePiAgentDir } from "./agent-dir.js";
+import { dirname } from "node:path";
+import { getToolDisplayConfigPath, getToolDisplayDebugLogPath } from "./storage-paths.js";
 import { toRecord } from "./tool-metadata.js";
 
-const DEFAULT_DEBUG_CONFIG_FILE = join(
-  resolvePiAgentDir(),
-  "extensions",
-  "pi-tool-display-intent",
-  "config.json",
-);
-const DEFAULT_DEBUG_DIR = join(dirname(DEFAULT_DEBUG_CONFIG_FILE), "debug");
-const DEFAULT_DEBUG_LOG_FILE = join(DEFAULT_DEBUG_DIR, "debug.log");
+const DEFAULT_DEBUG_CONFIG_FILE = getToolDisplayConfigPath();
+const DEFAULT_DEBUG_LOG_FILE = getToolDisplayDebugLogPath();
+const DEFAULT_DEBUG_DIR = dirname(DEFAULT_DEBUG_LOG_FILE);
 
 const DEFAULT_DEBUG_CONFIG_CACHE_TTL_MS = 1_000;
 

--- a/packages/pi-tool-display-intent/src/index.ts
+++ b/packages/pi-tool-display-intent/src/index.ts
@@ -22,11 +22,15 @@ import {
 } from "./types.js";
 
 export function publishToolDisplayMigrationNotice(
-  ui: { setStatus(key: string, text: string | undefined): void },
+  ui: {
+    setStatus(key: string, text: string | undefined): void;
+    notify?(message: string, level: "warning"): void;
+  },
   notice: string | undefined,
 ): void {
   if (notice) {
     ui.setStatus("tool-display-intent-migration", notice);
+    ui.notify?.(notice, "warning");
   }
 }
 

--- a/packages/pi-tool-display-intent/src/storage-migration.ts
+++ b/packages/pi-tool-display-intent/src/storage-migration.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from "node:crypto";
+import {
+	closeSync,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import {
+	getLegacyToolDisplayConfigPath,
+	getLegacyToolDisplayDebugLogPath,
+	getLegacyToolDisplayLegacyBackupPath,
+	getToolDisplayConfigPath,
+	getToolDisplayDataDir,
+	getToolDisplayDebugLogPath,
+	getToolDisplayLegacyBackupPath,
+} from "./storage-paths.js";
+
+export interface PreparedToolDisplayMigration {
+	copiedLegacyConfig: boolean;
+	notices: string[];
+}
+
+const waitBuffer = new Int32Array(new SharedArrayBuffer(4));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function sleepSync(milliseconds: number): void {
+	Atomics.wait(waitBuffer, 0, 0, milliseconds);
+}
+
+export function withToolDisplayStorageLock<T>(fn: () => T, directory = getToolDisplayDataDir()): T {
+	mkdirSync(directory, { recursive: true, mode: 0o700 });
+	const lockPath = join(directory, ".storage-migration.lock");
+	const deadline = Date.now() + 1_000;
+	let descriptor: number | undefined;
+	while (descriptor === undefined) {
+		try {
+			descriptor = openSync(lockPath, "wx", 0o600);
+			writeFileSync(descriptor, `${JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() })}\n`);
+		} catch (error) {
+			if (!isRecord(error) || error.code !== "EEXIST") throw error;
+			try {
+				if (Date.now() - statSync(lockPath).mtimeMs > 30_000) {
+					unlinkSync(lockPath);
+					continue;
+				}
+			} catch (statError) {
+				if (isRecord(statError) && statError.code === "ENOENT") continue;
+				throw statError;
+			}
+			if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${lockPath}`);
+			sleepSync(20);
+		}
+	}
+	try {
+		return fn();
+	} finally {
+		closeSync(descriptor);
+		rmSync(lockPath, { force: true });
+	}
+}
+
+function copyAtomically(source: string, target: string): void {
+	const content = readFileSync(source);
+	const directory = dirname(target);
+	mkdirSync(directory, { recursive: true, mode: 0o700 });
+	const temporary = join(directory, `.${randomUUID()}.tmp`);
+	try {
+		writeFileSync(temporary, content, { mode: 0o600, flag: "wx" });
+		renameSync(temporary, target);
+		if (!readFileSync(target).equals(content)) throw new Error(`Verification failed for ${target}`);
+	} finally {
+		rmSync(temporary, { force: true });
+	}
+}
+
+export function prepareToolDisplayStorageMigration(): PreparedToolDisplayMigration {
+	const target = getToolDisplayConfigPath();
+	const legacy = getLegacyToolDisplayConfigPath();
+	const notices: string[] = [];
+	if (existsSync(target)) {
+		if (existsSync(legacy)) notices.push(`Ignored conflicting legacy tool-display-intent config at ${legacy}; canonical config is ${target}.`);
+		return { copiedLegacyConfig: false, notices };
+	}
+	if (!existsSync(legacy)) return { copiedLegacyConfig: false, notices };
+	try {
+		return withToolDisplayStorageLock(() => {
+			if (existsSync(target)) return { copiedLegacyConfig: false, notices };
+			copyAtomically(legacy, target);
+			return { copiedLegacyConfig: true, notices };
+		});
+	} catch (error) {
+		notices.push(`Failed to prepare tool-display-intent config migration from ${legacy} to ${target}: ${error instanceof Error ? error.message : String(error)}. The legacy file was preserved.`);
+		return { copiedLegacyConfig: false, notices };
+	}
+}
+
+function migrateAncillary(source: string, target: string, label: string, notices: string[]): void {
+	if (!existsSync(source)) return;
+	if (existsSync(target)) {
+		notices.push(`Kept conflicting legacy ${label} at ${source}; canonical file is ${target}.`);
+		return;
+	}
+	copyAtomically(source, target);
+	unlinkSync(source);
+	notices.push(`Migrated tool-display-intent ${label} from ${source} to ${target}.`);
+}
+
+export function finalizeToolDisplayStorageMigration(prepared: PreparedToolDisplayMigration, configValid: boolean): string[] {
+	const notices = [...prepared.notices];
+	try {
+		withToolDisplayStorageLock(() => {
+			if (prepared.copiedLegacyConfig) {
+				if (!configValid) {
+					notices.push(`Tool-display-intent config migration was not finalized because ${getToolDisplayConfigPath()} is invalid; ${getLegacyToolDisplayConfigPath()} was preserved.`);
+					return;
+				}
+				unlinkSync(getLegacyToolDisplayConfigPath());
+				notices.push(`Migrated tool-display-intent config from ${getLegacyToolDisplayConfigPath()} to ${getToolDisplayConfigPath()}.`);
+			}
+			migrateAncillary(getLegacyToolDisplayLegacyBackupPath(), getToolDisplayLegacyBackupPath(), "legacy config backup", notices);
+			migrateAncillary(getLegacyToolDisplayDebugLogPath(), getToolDisplayDebugLogPath(), "debug log", notices);
+		});
+	} catch (error) {
+		notices.push(`Failed to finalize tool-display-intent storage migration: ${error instanceof Error ? error.message : String(error)}.`);
+	}
+	return notices;
+}

--- a/packages/pi-tool-display-intent/src/storage-paths.ts
+++ b/packages/pi-tool-display-intent/src/storage-paths.ts
@@ -1,0 +1,30 @@
+import { dirname, join } from "node:path";
+import { resolvePiAgentDir } from "./agent-dir.js";
+
+export function getToolDisplayDataDir(agentDir = resolvePiAgentDir()): string {
+	return join(agentDir, "extension-data", "pi-tool-display-intent");
+}
+
+export function getToolDisplayConfigPath(agentDir = resolvePiAgentDir()): string {
+	return join(getToolDisplayDataDir(agentDir), "config.json");
+}
+
+export function getLegacyToolDisplayConfigPath(agentDir = resolvePiAgentDir()): string {
+	return join(agentDir, "extensions", "pi-tool-display-intent", "config.json");
+}
+
+export function getToolDisplayLegacyBackupPath(agentDir = resolvePiAgentDir()): string {
+	return join(getToolDisplayDataDir(agentDir), "config.legacy.json");
+}
+
+export function getLegacyToolDisplayLegacyBackupPath(agentDir = resolvePiAgentDir()): string {
+	return join(dirname(getLegacyToolDisplayConfigPath(agentDir)), "config.legacy.json");
+}
+
+export function getToolDisplayDebugLogPath(agentDir = resolvePiAgentDir()): string {
+	return join(getToolDisplayDataDir(agentDir), "state", "debug.log");
+}
+
+export function getLegacyToolDisplayDebugLogPath(agentDir = resolvePiAgentDir()): string {
+	return join(dirname(getLegacyToolDisplayConfigPath(agentDir)), "debug", "debug.log");
+}

--- a/packages/pi-tool-display-intent/tests/config-store.test.ts
+++ b/packages/pi-tool-display-intent/tests/config-store.test.ts
@@ -273,7 +273,7 @@ test("v2 serialization is sparse and round-trips the effective config", () => {
 	});
 });
 
-test("invalid or old v2 fields are reported with paths and never rewritten", () => {
+test("invalid or old v2 fields are dropped with paths and rewritten", () => {
 	withTempDir("pi-tool-display-config-invalid-v2-", (dir) => {
 		const configFile = join(dir, "config.json");
 		const original = `${JSON.stringify({
@@ -289,16 +289,18 @@ test("invalid or old v2 fields are reported with paths and never rewritten", () 
 		writeFileSync(configFile, original, "utf8");
 		const loaded = loadToolDisplayConfig(configFile);
 		assert.deepEqual(loaded.config, DEFAULT_TOOL_DISPLAY_CONFIG);
-		assert.match(loaded.error ?? "", /extension: unknown setting/);
-		assert.match(loaded.error ?? "", /toolCalls\.frame: unknown setting/);
-		assert.match(loaded.error ?? "", /toolCalls\.bashCommandPreviewRows: expected integer from 1 to 8/);
-		assert.match(loaded.error ?? "", /results\.profile: unknown setting/);
-		assert.match(loaded.error ?? "", /results\.mode: required setting/);
-		assert.equal(readFileSync(configFile, "utf8"), original);
+		assert.equal(loaded.error, undefined);
+		assert.match(loaded.notice ?? "", /extension: unknown setting/);
+		assert.match(loaded.notice ?? "", /toolCalls\.frame: unknown setting/);
+		assert.match(loaded.notice ?? "", /toolCalls\.bashCommandPreviewRows: expected integer from 1 to 8/);
+		assert.match(loaded.notice ?? "", /results\.profile: unknown setting/);
+		assert.match(loaded.notice ?? "", /results\.mode: required setting/);
+		assert.notEqual(readFileSync(configFile, "utf8"), original);
+		assert.equal(readFileSync(join(dir, "config.legacy.json"), "utf8"), original);
 	});
 });
 
-test("strict v2 validation rejects schema type, duplicate passthrough entries, and invalid custom tool names", () => {
+test("v2 upgrade drops invalid schema, duplicate passthrough entries, and invalid custom tool names", () => {
 	withTempDir("pi-tool-display-config-strict-v2-", (dir) => {
 		const configFile = join(dir, "config.json");
 		const original = `${JSON.stringify({
@@ -315,11 +317,15 @@ test("strict v2 validation rejects schema type, duplicate passthrough entries, a
 		}, null, 2)}\n`;
 		writeFileSync(configFile, original, "utf8");
 		const loaded = loadToolDisplayConfig(configFile);
-		assert.match(loaded.error ?? "", /\$schema: expected string/);
-		assert.match(loaded.error ?? "", /tools\.passthrough\.1: duplicate built-in tool/);
-		assert.match(loaded.error ?? "", /tools\.custom\.read: expected a non-empty trimmed non-built-in tool name/);
-		assert.match(loaded.error ?? "", /tools\.custom\. padded : expected a non-empty trimmed non-built-in tool name/);
-		assert.equal(readFileSync(configFile, "utf8"), original);
+		assert.equal(loaded.error, undefined);
+		assert.match(loaded.notice ?? "", /\$schema: expected string/);
+		assert.match(loaded.notice ?? "", /tools\.passthrough\.1: duplicate built-in tool/);
+		assert.match(loaded.notice ?? "", /tools\.custom\.read: expected a non-empty trimmed non-built-in tool name/);
+		assert.match(loaded.notice ?? "", /tools\.custom\. padded : expected a non-empty trimmed non-built-in tool name/);
+		const persisted = JSON.parse(readFileSync(configFile, "utf8")) as { tools?: { passthrough?: string[]; custom?: Record<string, unknown> } };
+		assert.deepEqual(persisted.tools?.passthrough, ["read"]);
+		assert.deepEqual(persisted.tools?.custom, undefined);
+		assert.equal(readFileSync(join(dir, "config.legacy.json"), "utf8"), original);
 	});
 });
 

--- a/packages/pi-tool-display-intent/tests/storage-migration.test.ts
+++ b/packages/pi-tool-display-intent/tests/storage-migration.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { finalizeToolDisplayStorageMigration, prepareToolDisplayStorageMigration } from "../src/storage-migration.js";
+import {
+	getLegacyToolDisplayConfigPath,
+	getLegacyToolDisplayDebugLogPath,
+	getLegacyToolDisplayLegacyBackupPath,
+	getToolDisplayConfigPath,
+	getToolDisplayDebugLogPath,
+	getToolDisplayLegacyBackupPath,
+} from "../src/storage-paths.js";
+
+function write(file: string, content: string): void {
+	mkdirSync(dirname(file), { recursive: true });
+	writeFileSync(file, content);
+}
+
+test("tool-display-intent migrates config, backup, and debug log into extension-data", () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-tool-display-storage-"));
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = root;
+	try {
+		write(getLegacyToolDisplayConfigPath(), '{"previewRows":7,"removed":true}\n');
+		write(getLegacyToolDisplayLegacyBackupPath(), '{"previewLines":5}\n');
+		write(getLegacyToolDisplayDebugLogPath(), "diagnostic\n");
+
+		const prepared = prepareToolDisplayStorageMigration();
+		assert.equal(prepared.copiedLegacyConfig, true);
+		assert.equal(existsSync(getLegacyToolDisplayConfigPath()), true, "legacy config stays until canonical validation succeeds");
+		assert.equal(readFileSync(getToolDisplayConfigPath(), "utf8"), '{"previewRows":7,"removed":true}\n');
+
+		const notices = finalizeToolDisplayStorageMigration(prepared, true);
+		assert.equal(existsSync(getLegacyToolDisplayConfigPath()), false);
+		assert.equal(existsSync(getLegacyToolDisplayLegacyBackupPath()), false);
+		assert.equal(existsSync(getLegacyToolDisplayDebugLogPath()), false);
+		assert.equal(readFileSync(getToolDisplayLegacyBackupPath(), "utf8"), '{"previewLines":5}\n');
+		assert.equal(readFileSync(getToolDisplayDebugLogPath(), "utf8"), "diagnostic\n");
+		assert.match(notices.join("\n"), /Migrated tool-display-intent config/);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		rmSync(root, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary

- unify bundled extension configuration and state under `$PI_CODING_AGENT_DIR/extension-data/<extension-id>/`
- automatically migrate and upgrade legacy global and trusted-project configuration, dropping unmappable fields with user-visible warnings while preserving malformed files
- add atomic writes and migration locks, including serialized Exa usage accounting, while keeping Plan Mode artifacts at `$PI_CODING_AGENT_DIR/plans/`
- avoid Jiti mutable-export snapshots by reading refreshed Search Hub config through accessors; also encapsulate round-robin state
- update bilingual documentation and add a Changeset for affected public packages

## Testing

- `pnpm check`
- `pnpm --filter @zhcsyncer/pi-search-hub check` (186 tests)
- `pnpm --filter @zhcsyncer/pi-recap check` (29 tests)
- `pnpm --filter @zhcsyncer/pi-tool-display-intent check` (739 tests)
- `pnpm --filter @zhcsyncer/pi-plan-mode check` (59 tests)
- `pnpm --filter @zhcsyncer/pi-glance check`
- `git diff --check`
