### PR TITLE
fix(release): include pi-context7 in release reconciliation

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-This repository publishes seven public npm packages:
+This repository publishes eight public npm packages:
 
 - `@zhcsyncer/pi-extensions`
 - `@zhcsyncer/pi-recap`
@@ -8,6 +8,7 @@ This repository publishes seven public npm packages:
 - `@zhcsyncer/pi-todo`
 - `@zhcsyncer/pi-glance`
 - `@zhcsyncer/pi-plan-mode`
+- `@zhcsyncer/pi-context7`
 - `pi-provider-volcengine-agent-plan`
 
 Packages version independently. Because the aggregate root tarball embeds bundled child sources, every bundled child release must include a root release of at least the same bump level. The standalone `pi-provider-volcengine-agent-plan` package is excluded from the aggregate tarball and may release without the root. Unchanged siblings remain unreleased.

--- a/scripts/reconcile-release.sh
+++ b/scripts/reconcile-release.sh
@@ -8,6 +8,7 @@ PACKAGES=(
   "@zhcsyncer/pi-todo|packages/pi-todo/package.json|packages/pi-todo/CHANGELOG.md|pi-todo|child"
   "@zhcsyncer/pi-glance|packages/pi-glance/package.json|packages/pi-glance/CHANGELOG.md|pi-glance|child"
   "@zhcsyncer/pi-plan-mode|packages/pi-plan-mode/package.json|packages/pi-plan-mode/CHANGELOG.md|pi-plan-mode|child"
+  "@zhcsyncer/pi-context7|packages/pi-context7/package.json|packages/pi-context7/CHANGELOG.md|pi-context7|child"
   "pi-provider-volcengine-agent-plan|providers/pi-provider-volcengine-agent-plan/package.json|providers/pi-provider-volcengine-agent-plan/CHANGELOG.md|pi-provider-volcengine-agent-plan|child"
 )
 


### PR DESCRIPTION
## Summary
- Add `@zhcsyncer/pi-context7` to `scripts/reconcile-release.sh` so future publishes get package tags and GitHub Releases.
- Document the eighth public package in `RELEASING.md`.

## Note
The missing `@zhcsyncer/pi-context7@0.1.0` tag/release was created manually after the bootstrap-first publish.

## Test plan
- [x] Confirm npm has `@zhcsyncer/pi-context7@0.1.0` and `@zhcsyncer/pi-extensions@0.12.0`
- [x] Confirm GitHub Release `@zhcsyncer/pi-context7@0.1.0` exists
- [ ] CI validate