### PR TITLE
fix(pi-tool-display-intent): error visibility, path compacting, Bash framing

### DIFF
--- a/.changeset/compact-long-tool-paths.md
+++ b/.changeset/compact-long-tool-paths.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-tool-display-intent": patch
+---
+
+Keep path-bearing built-in tool call headers compact at narrow widths. Collapsed `read`, `grep`, `find`, `ls`, `edit`, and `write` calls now abbreviate middle path segments while preserving useful anchors and the basename; expanding tools with `Ctrl+O` restores the complete path.

--- a/.changeset/improve-bash-transcript.md
+++ b/.changeset/improve-bash-transcript.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-tool-display-intent": patch
+---
+
+Improve Bash transcript readability in Claude-style rendering. Separate command previews now emphasize their shell prompt, expanded commands use bounded Bash syntax highlighting, and Bash result gutters connect through the final row in collapsed and expanded views. The shared `results.previewRows` setting now exposes and enforces a minimum of two rows.

--- a/.changeset/restore-builtin-prompt-snippets.md
+++ b/.changeset/restore-builtin-prompt-snippets.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-tool-display-intent": patch
+---
+
+Restore built-in `promptSnippet` and `promptGuidelines` when overriding tools for display. Overrides now read metadata from Pi ToolDefinitions instead of wrapped AgentTools, so `read`, `write`, and the other owned tools reappear in the system prompt `Available tools` section.

--- a/.changeset/show-generic-tool-errors.md
+++ b/.changeset/show-generic-tool-errors.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-tool-display-intent": patch
+---
+
+Keep generic and MCP failures visible in every result mode. Failed tools now render one content-derived error summary even when compact mode hides successful output, while `Ctrl+O` reveals the complete error content through the existing expanded preview budget.

--- a/packages/pi-tool-display-intent/README.md
+++ b/packages/pi-tool-display-intent/README.md
@@ -127,6 +127,9 @@ Every content preview, including custom tools and bash live/error output, uses `
 
 `toolCalls.bashCommandPreviewRows` is a separate `1`–`8` wrapped-row budget for Bash command arguments and defaults to `1`. Short commands stay inline. Long or multiline commands collapse with exact line/size metadata; Claude-style calls keep intent in the header and put the command preview on its own row. `Ctrl+O` reveals the complete original command. This setting does not affect command output.
 
+Path-bearing `read`, `grep`, `find`, `ls`, `edit`, and `write` calls keep short paths unchanged. When a full call header would wrap, the collapsed view removes middle path segments while preserving useful leading directories and the basename. `Ctrl+O` restores every path segment and lets the full header wrap normally; home paths remain normalized with `~`.
+
+
 Model-written intent uses the theme's regular `accent` color without bold or background styling. Deterministic commands, paths, and queries use normal `text`; metadata, separators, and deterministic fallback intents remain `muted`.
 
 `tools.passthrough` lists built-in tools whose renderer should remain untouched; it does not disable those tools. A `tools.custom` entry exists only when decoration is enabled, for example: `"web_search": { "renderer": "generic", "mode": "summary" }`. The bundle-private Search Hub already uses the cooperative API, so it needs no such entry unless you want to pin a mode instead of inheriting `results.mode`.

--- a/packages/pi-tool-display-intent/README.md
+++ b/packages/pi-tool-display-intent/README.md
@@ -191,6 +191,8 @@ pi.registerTool(decorateToolForDisplay(tool, {
 
 `decorateToolForDisplay` adds shared call rendering. For `generic` tools, setting `outputMode` also adds shared result rendering: `inherit` follows the active global `results.mode`, while `hidden`, `summary`, and `preview` pin the tool to one result mode. Omitting `outputMode` leaves the tool's existing result renderer untouched. Providers can also return a primary target plus metadata from `getCallPresentation` to replace generic `(N args)` text, and return semantic status plus `previewStartLine` from `getResultPresentation` to show backend/count summaries while skipping duplicated raw headers inside the shared visual-row budget. Presentation text is sanitized to one line, and callback failures fall back to generic rendering.
 
+
+
 Pi 0.80.x exposes metadata, not complete arbitrary tool definitions, through `getAllTools()`. Therefore configuration-only discovery should not be treated as a reliable way to add intent schemas to unrelated extensions. Use the cooperative wrapper for schema and execution guarantees. `tools.custom` remains useful for presentation-only decoration where the definition is available.
 
 ## RPC and model context

--- a/packages/pi-tool-display-intent/README.md
+++ b/packages/pi-tool-display-intent/README.md
@@ -123,12 +123,11 @@ See [`config/config.example.json`](./config/config.example.json) for every confi
 | `summary` | Show counts or summaries | Show a line-count summary |
 | `preview` | Show content previews | Show a content preview |
 
-Every content preview, including custom tools and bash live/error output, uses `results.previewRows`. It counts terminal rows after wrapping, so a minified JSON object, base64 payload, or other long single line cannot bypass the limit. `advanced.expandedRows` separately caps expanded output.
+Every content preview, including custom tools and bash live/error output, uses `results.previewRows`. Its supported range is `2`–`80`, and it counts terminal rows after wrapping, so a minified JSON object, base64 payload, or other long single line cannot bypass the limit. A stored v2 value of `1` is migrated to `2`; `advanced.expandedRows` separately caps expanded output.
 
-`toolCalls.bashCommandPreviewRows` is a separate `1`–`8` wrapped-row budget for Bash command arguments and defaults to `1`. Short commands stay inline. Long or multiline commands collapse with exact line/size metadata; Claude-style calls keep intent in the header and put the command preview on its own row. `Ctrl+O` reveals the complete original command. This setting does not affect command output.
+`toolCalls.bashCommandPreviewRows` is a separate `1`–`8` wrapped-row budget for Bash command arguments and defaults to `1`. Short commands stay inline. Long or multiline commands collapse with exact line/size metadata; Claude-style calls keep intent in the header, put the command preview on its own row, and emphasize that row's shell prompt with the accent color. `Ctrl+O` reveals the complete original command and applies Bash syntax highlighting within safety limits. This setting does not affect command output. Claude-style Bash results use a connected left gutter through their final row in both collapsed and expanded views.
 
 Path-bearing `read`, `grep`, `find`, `ls`, `edit`, and `write` calls keep short paths unchanged. When a full call header would wrap, the collapsed view removes middle path segments while preserving useful leading directories and the basename. `Ctrl+O` restores every path segment and lets the full header wrap normally; home paths remain normalized with `~`.
-
 
 Model-written intent uses the theme's regular `accent` color without bold or background styling. Deterministic commands, paths, and queries use normal `text`; metadata, separators, and deterministic fallback intents remain `muted`.
 
@@ -194,7 +193,7 @@ pi.registerTool(decorateToolForDisplay(tool, {
 
 `decorateToolForDisplay` adds shared call rendering. For `generic` tools, setting `outputMode` also adds shared result rendering: `inherit` follows the active global `results.mode`, while `hidden`, `summary`, and `preview` pin the tool to one result mode. Omitting `outputMode` leaves the tool's existing result renderer untouched. Providers can also return a primary target plus metadata from `getCallPresentation` to replace generic `(N args)` text, and return semantic status plus `previewStartLine` from `getResultPresentation` to show backend/count summaries while skipping duplicated raw headers inside the shared visual-row budget. Presentation text is sanitized to one line, and callback failures fall back to generic rendering.
 
-
+For shared generic and MCP rendering, failed results always show one error-colored summary derived from the first meaningful `content` line, even when the active mode is `hidden`; `Ctrl+O` shows the complete error content within the normal expanded-row budget. Empty error content falls back to `Tool failed.` Successful `hidden` results remain hidden, and semantic result presentations never replace the content-derived failure reason.
 
 Pi 0.80.x exposes metadata, not complete arbitrary tool definitions, through `getAllTools()`. Therefore configuration-only discovery should not be treated as a reliable way to add intent schemas to unrelated extensions. Use the cooperative wrapper for schema and execution guarantees. `tools.custom` remains useful for presentation-only decoration where the definition is available.
 
@@ -215,7 +214,7 @@ The extension retains `displaySummary` in later model context. This small token 
 
 - There is no extra inference request; intent text uses a small number of tokens in the existing model response.
 - Intent text is untrusted model output. ANSI/OSC/control sequences, newlines, and excess length are sanitized before TUI display.
-- The extension always keeps deterministic paths/commands/patterns visible; intent text must not be used for authorization, auditing, or execution decisions.
+- The extension keeps deterministic paths/commands/patterns visible, with complete compacted paths available through `Ctrl+O`; intent text must not be used for authorization, auditing, or execution decisions.
 - Schema guidance asks the model not to include secrets or credentials, but sensitive tools should still be opted out when necessary.
 
 ## Local testing

--- a/packages/pi-tool-display-intent/README.zh-CN.md
+++ b/packages/pi-tool-display-intent/README.zh-CN.md
@@ -123,12 +123,11 @@ $PI_CODING_AGENT_DIR/extension-data/pi-tool-display-intent/config.json
 | `summary` | 显示数量或摘要 | 显示行数摘要 |
 | `preview` | 显示内容预览 | 显示内容预览 |
 
-所有内容预览，包括 custom tool、bash 流式和错误输出，都使用 `results.previewRows`。它统计终端折行后的视觉行，因此压缩 JSON、base64 或其他超长单行无法绕过限制。`advanced.expandedRows` 单独限制展开后的输出。
+所有内容预览，包括 custom tool、bash 流式和错误输出，都使用 `results.previewRows`，支持范围为 `2`–`80`。它统计终端折行后的视觉行，因此压缩 JSON、base64 或其他超长单行无法绕过限制。已有 v2 配置中的 `1` 会迁移为 `2`；`advanced.expandedRows` 单独限制展开后的输出。
 
-`toolCalls.bashCommandPreviewRows` 单独控制 Bash 命令参数折叠后的视觉行预算，可设为 `1`–`8`，默认是 `1`。短命令保持行内展示；长命令或多行命令会附带准确的行数和大小信息。Claude 风格会把 intent 留在标题行，并把命令预览放到独立行。按 `Ctrl+O` 可查看完整原始命令。该配置不影响命令输出。
+`toolCalls.bashCommandPreviewRows` 单独控制 Bash 命令参数折叠后的视觉行预算，可设为 `1`–`8`，默认是 `1`。短命令保持行内展示；长命令或多行命令会附带准确的行数和大小信息。Claude 风格会把 intent 留在标题行，把命令预览放到独立行，并使用 accent 色强调该行的 shell prompt。按 `Ctrl+O` 可查看完整原始命令，并在安全限制内应用 Bash 语法高亮。该配置不影响命令输出。Claude 风格的 Bash 结果无论折叠还是展开，左侧线框都会贯穿到最后一行。
 
 带路径的 `read`、`grep`、`find`、`ls`、`edit`、`write` 调用会原样保留短路径。如果完整调用标题即将折行，折叠视图会省略路径中段，同时保留有辨识度的开头目录和文件名。按 `Ctrl+O` 会恢复全部路径段，并允许完整标题正常折行；Home 路径仍统一显示为 `~`。
-
 
 模型生成的 intent 使用主题的常规 `accent` 色，不加粗、不加背景。确定性的命令、路径和 query 使用普通 `text`；元数据、分隔符和确定性 fallback intent 继续使用 `muted`。
 
@@ -215,7 +214,7 @@ extension 会在后续模型上下文中保留 `displaySummary`。这会增加�
 
 - 不会产生额外推理请求；只在已有模型响应中消耗少量额外 token。
 - 意图属于不可信模型输出。渲染前会清理 ANSI、OSC、控制字符、换行和超长内容。
-- TUI 始终保留真实路径、命令和 pattern；不得使用意图文本进行授权、审计或执行判断。
+- TUI 保留确定性的路径、命令和 pattern；缩略路径可通过 `Ctrl+O` 查看完整内容。不得使用意图文本进行授权、审计或执行判断。
 - Schema 会提示模型不要包含秘密或凭据，但敏感工具仍应根据需要关闭该能力。
 
 ## 本地测试

--- a/packages/pi-tool-display-intent/README.zh-CN.md
+++ b/packages/pi-tool-display-intent/README.zh-CN.md
@@ -127,6 +127,9 @@ $PI_CODING_AGENT_DIR/extension-data/pi-tool-display-intent/config.json
 
 `toolCalls.bashCommandPreviewRows` 单独控制 Bash 命令参数折叠后的视觉行预算，可设为 `1`–`8`，默认是 `1`。短命令保持行内展示；长命令或多行命令会附带准确的行数和大小信息。Claude 风格会把 intent 留在标题行，并把命令预览放到独立行。按 `Ctrl+O` 可查看完整原始命令。该配置不影响命令输出。
 
+带路径的 `read`、`grep`、`find`、`ls`、`edit`、`write` 调用会原样保留短路径。如果完整调用标题即将折行，折叠视图会省略路径中段，同时保留有辨识度的开头目录和文件名。按 `Ctrl+O` 会恢复全部路径段，并允许完整标题正常折行；Home 路径仍统一显示为 `~`。
+
+
 模型生成的 intent 使用主题的常规 `accent` 色，不加粗、不加背景。确定性的命令、路径和 query 使用普通 `text`；元数据、分隔符和确定性 fallback intent 继续使用 `muted`。
 
 `tools.passthrough` 表示继续使用原 renderer 的内置工具，不会禁用工具。`tools.custom` 条目存在即启用展示装饰，例如：`"web_search": { "renderer": "generic", "mode": "summary" }`。bundle 私有的 Search Hub 已使用合作式 API，因此无需该配置；只有想固定模式而不继承 `results.mode` 时才需要添加。

--- a/packages/pi-tool-display-intent/README.zh-CN.md
+++ b/packages/pi-tool-display-intent/README.zh-CN.md
@@ -191,6 +191,8 @@ pi.registerTool(decorateToolForDisplay(tool, {
 
 `decorateToolForDisplay` 提供统一的调用行渲染。对于 `generic` 工具，设置 `outputMode` 还会启用统一结果渲染：`inherit` 跟随全局 `results.mode`，`hidden`、`summary` 和 `preview` 则固定该工具的结果模式。不设置 `outputMode` 时会保留工具原有的结果 renderer。工具提供方还可以通过 `getCallPresentation` 返回主目标与元数据，用语义字段替代通用 `(N args)`；通过 `getResultPresentation` 返回结果状态与 `previewStartLine`，在共享视觉行预算内展示 backend、数量等摘要并跳过重复的原始头部。这些文本会被单行清理，回调失败时自动退回通用展示。
 
+对于共用的 generic 与 MCP renderer，失败结果即使处于 `hidden` 模式，也会从第一条有效 `content` 文本生成一行错误色摘要；按 `Ctrl+O` 后会在现有展开行预算内显示完整错误内容。错误 content 为空时回退为 `Tool failed.`。成功的 `hidden` 结果仍保持隐藏，语义 presentation 也不会覆盖由 content 提取的失败原因。
+
 Pi 0.80.x 的 `getAllTools()` 公开返回元数据，而不是任意工具的完整 definition。因此不能把“仅配置工具名”视为给其他 extension 添加意图 Schema 的可靠方式。需要 Schema 和执行保证时，应使用合作式 wrapper；definition 可用时，`tools.custom` 仍可用于纯展示装饰。
 
 ## RPC 与模型上下文

--- a/packages/pi-tool-display-intent/config/config.schema.json
+++ b/packages/pi-tool-display-intent/config/config.schema.json
@@ -58,7 +58,7 @@
         },
         "previewRows": {
           "type": "integer",
-          "minimum": 1,
+          "minimum": 2,
           "maximum": 80,
           "default": 8,
           "description": "Maximum rendered terminal rows shown by collapsed tool-result content previews after wrapping."

--- a/packages/pi-tool-display-intent/src/bash-display.ts
+++ b/packages/pi-tool-display-intent/src/bash-display.ts
@@ -1,4 +1,4 @@
-import { formatSize } from "@earendil-works/pi-coding-agent";
+import { formatSize, highlightCode } from "@earendil-works/pi-coding-agent";
 import {
 	Text,
 	truncateToWidth,
@@ -19,6 +19,8 @@ const BASH_SPINNER_INTERVAL_MS = 200;
 const BASH_SPINNER_STATE_KEY = "__piToolDisplayIntentBashSpinner";
 const BASH_SPINNER_TOOL_CALL_ID_KEY = "__piToolDisplayIntentBashSpinnerToolCallId";
 const MIN_COLLAPSED_COMMAND_COLUMNS = 8;
+const MAX_HIGHLIGHTED_COMMAND_CHARS = 50_000;
+const MAX_HIGHLIGHTED_COMMAND_LINES = 1_000;
 
 interface BashCallArgs {
 	command?: string;
@@ -214,6 +216,21 @@ function buildBashCallPresentation(
 	};
 }
 
+function highlightExpandedCommand(commandDisplay: string): string {
+	if (
+		commandDisplay.length > MAX_HIGHLIGHTED_COMMAND_CHARS ||
+		normalizeCommandLines(commandDisplay).length > MAX_HIGHLIGHTED_COMMAND_LINES
+	) {
+		return commandDisplay;
+	}
+
+	try {
+		return highlightCode(commandDisplay, "bash").join("\n");
+	} catch {
+		return commandDisplay;
+	}
+}
+
 function buildExpandedBashCallText(
 	presentation: BashCallPresentation,
 	theme: BashCallRenderTheme,
@@ -230,10 +247,14 @@ function buildExpandedBashCallText(
 		intentSuffix,
 	} = presentation;
 
+	const renderedCommand = context.expanded
+		? highlightExpandedCommand(commandDisplay)
+		: theme.fg("text", commandDisplay);
+
 	if (toolCallStyle === "claude") {
 		return formatClaudeToolCall(
 			"bash",
-			theme.fg("text", commandDisplay),
+			renderedCommand,
 			`${shellSuffix}${timeoutSuffix}${elapsedSuffix}`,
 			intentSuffix,
 			theme,
@@ -242,7 +263,7 @@ function buildExpandedBashCallText(
 		);
 	}
 
-	return `${spinnerPrefix}${theme.fg("toolTitle", theme.bold("$"))} ${theme.fg("text", commandDisplay)}${shellSuffix}${timeoutSuffix}${elapsedSuffix}${intentSuffix}`;
+	return `${spinnerPrefix}${theme.fg("toolTitle", theme.bold("$"))} ${renderedCommand}${shellSuffix}${timeoutSuffix}${elapsedSuffix}${intentSuffix}`;
 }
 
 function normalizeCommandLines(commandDisplay: string): string[] {
@@ -303,7 +324,7 @@ function buildCollapsedCommandRows(
 	rows[lastIndex] = `${truncateToWidth(rows[lastIndex] ?? "", lastContentWidth, "")}${suffix}`;
 
 	const firstPrefix = toolCallStyle === "claude"
-		? `${theme.fg("muted", "  ")}${theme.fg("toolTitle", theme.bold("$"))} `
+		? `${theme.fg("muted", "  ")}${theme.fg("accent", theme.bold("$"))} `
 		: `${presentation.spinnerPrefix}${theme.fg("toolTitle", theme.bold("$"))} `;
 	const continuationPrefix = theme.fg("muted", continuationPrefixPlain);
 

--- a/packages/pi-tool-display-intent/src/config-modal.ts
+++ b/packages/pi-tool-display-intent/src/config-modal.ts
@@ -22,7 +22,7 @@ interface ModalOverlayOptions {
 	margin: number;
 }
 
-const PREVIEW_ROW_VALUES = ["4", "8", "12", "20", "40"] as const;
+const PREVIEW_ROW_VALUES = ["2", "4", "8", "12", "20", "40"] as const;
 const BASH_COMMAND_PREVIEW_ROW_VALUES = ["1", "2", "3", "4"] as const;
 const MODE_COMMAND_HINT = RESULT_DISPLAY_MODES.join("|");
 
@@ -113,7 +113,7 @@ function buildInspectorSettings(
 				"A single long logical line consumes multiple rows instead of bypassing the limit.",
 			],
 			inspectorOptions: [
-				"Lower values keep transcripts dense and skimmable",
+				"2 — minimum supported preview for a dense transcript",
 				"Higher values show more read, search, MCP, custom, and bash output",
 			],
 			inspectorAdvanced: buildAdvancedNotes(config, capabilities, [

--- a/packages/pi-tool-display-intent/src/config-store.ts
+++ b/packages/pi-tool-display-intent/src/config-store.ts
@@ -320,7 +320,7 @@ export function normalizeToolDisplayConfig(raw: unknown): ToolDisplayConfig {
 		),
 		previewRows: clampNumber(
 			source.previewRows ?? source.previewLines,
-			1,
+			2,
 			80,
 			DEFAULT_TOOL_DISPLAY_CONFIG.previewRows,
 		),
@@ -445,7 +445,7 @@ function validateToolDisplayConfigV2(raw: unknown): string[] {
 	validateKnownKeys(results, ["mode", "previewRows"], "results.", errors);
 	if (!hasOwn(results, "mode")) errors.push("results.mode: required setting");
 	validateOptionalEnum(results, "mode", RESULT_DISPLAY_MODES, "results.", errors);
-	validateOptionalInteger(results, "previewRows", 1, 80, "results.", errors);
+	validateOptionalInteger(results, "previewRows", 2, 80, "results.", errors);
 
 	const diff = getV2Section(source, "diff", errors);
 	validateKnownKeys(diff, ["layout", "indicators", "splitMinWidth", "collapsedRows", "wordWrap"], "diff.", errors);
@@ -499,6 +499,25 @@ function validateToolDisplayConfigV2(raw: unknown): string[] {
 	validateOptionalBoolean(advanced, "rtkCompactionHints", "advanced.", errors);
 	validateOptionalBoolean(advanced, "debug", "advanced.", errors);
 	return errors;
+}
+
+function normalizeMappableV2Settings(source: Record<string, unknown>): {
+	source: Record<string, unknown>;
+	notices: string[];
+} {
+	const results = toRecord(source.results);
+	if (results.previewRows !== 1) {
+		return { source, notices: [] };
+	}
+
+	const normalized = structuredClone(source);
+	const normalizedResults = toRecord(normalized.results);
+	normalizedResults.previewRows = 2;
+	normalized.results = normalizedResults;
+	return {
+		source: normalized,
+		notices: ["results.previewRows: raised from 1 to the new minimum of 2"],
+	};
 }
 
 function dropInvalidV2Settings(source: Record<string, unknown>, validationErrors: readonly string[]): Record<string, unknown> {
@@ -741,17 +760,21 @@ export function loadToolDisplayConfig(configFile = CONFIG_FILE): ConfigLoadResul
 			}
 			const source = parsed as Record<string, unknown>;
 			if (hasOwn(source, "version") && source.version === TOOL_DISPLAY_CONFIG_VERSION) {
-				const validationErrors = validateToolDisplayConfigV2(source);
-				const sanitizedSource = validationErrors.length > 0 ? dropInvalidV2Settings(source, validationErrors) : source;
+				const normalizedV2 = normalizeMappableV2Settings(source);
+				const validationErrors = validateToolDisplayConfigV2(normalizedV2.source);
+				const sanitizedSource = validationErrors.length > 0
+					? dropInvalidV2Settings(normalizedV2.source, validationErrors)
+					: normalizedV2.source;
 				const config = normalizeToolDisplayConfigV2(sanitizedSource);
-				if (validationErrors.length === 0) {
+				const upgradeNotices = [...normalizedV2.notices, ...validationErrors];
+				if (upgradeNotices.length === 0) {
 					result = { config };
 				} else {
 					const migrationError = migrateLegacyConfigFile(configFile, rawText, config);
 					result = {
 						config,
 						...(migrationError ? { error: migrationError } : {}),
-						...(!migrationError ? { notice: `tool-display-intent upgraded its v2 config and dropped or normalized unmappable settings: ${validationErrors.join("; ")}` } : {}),
+						...(!migrationError ? { notice: `tool-display-intent upgraded its v2 config and dropped or normalized settings: ${upgradeNotices.join("; ")}` } : {}),
 					};
 				}
 			} else if (hasOwn(source, "version") && typeof source.version === "number" && source.version > TOOL_DISPLAY_CONFIG_VERSION) {

--- a/packages/pi-tool-display-intent/src/path-call.ts
+++ b/packages/pi-tool-display-intent/src/path-call.ts
@@ -1,0 +1,140 @@
+import { Text, visibleWidth, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
+import { compactPathForDisplay, shortenPath } from "./render-utils.js";
+
+export interface PathCallRenderContextLike {
+	expanded?: boolean;
+	lastComponent?: unknown;
+}
+
+interface PathCallViewState {
+	path?: string;
+	expanded: boolean;
+	buildLine(displayPath: string): string;
+}
+
+function normalizeRenderWidth(width: number): number {
+	return Number.isFinite(width) ? Math.max(0, Math.floor(width)) : 0;
+}
+
+const LEADING_SEPARATOR_PLACEHOLDER = "\uE000";
+
+interface ProtectedCallLine {
+	content: string;
+	placeholder?: string;
+}
+
+/**
+ * Pi TUI's word wrapper moves an overlong second token onto a fresh line. For
+ * Claude-style calls that can leave the one-character status marker orphaned.
+ * Temporarily make its separator non-whitespace so the long token is hard-wrapped
+ * together with the marker, then restore the visual space after rendering.
+ */
+function protectLeadingStatusSeparator(content: string, width: number): ProtectedCallLine {
+	const wrapped = wrapTextWithAnsi(content, width);
+	if (wrapped.length < 2 || visibleWidth(wrapped[0] ?? "") !== 1) {
+		return { content };
+	}
+
+	const separatorIndex = content.indexOf(" ");
+	if (separatorIndex < 0) {
+		return { content };
+	}
+
+	return {
+		content: `${content.slice(0, separatorIndex)}${LEADING_SEPARATOR_PLACEHOLDER}${content.slice(separatorIndex + 1)}`,
+		placeholder: LEADING_SEPARATOR_PLACEHOLDER,
+	};
+}
+
+function fitCollapsedPath(
+	fullPath: string,
+	width: number,
+	buildLine: (displayPath: string) => string,
+): string {
+	const fullLine = buildLine(fullPath);
+	if (visibleWidth(fullLine) <= width) {
+		return fullPath;
+	}
+
+	const marker = "x";
+	const fixedWidth = Math.max(0, visibleWidth(buildLine(marker)) - visibleWidth(marker));
+	let pathBudget = Math.max(1, width - fixedWidth);
+	let displayPath = compactPathForDisplay(fullPath, pathBudget);
+
+	while (pathBudget > 1 && visibleWidth(buildLine(displayPath)) > width) {
+		pathBudget--;
+		displayPath = compactPathForDisplay(fullPath, pathBudget);
+	}
+
+	return displayPath;
+}
+
+/**
+ * Width-aware call header for path-bearing tools.
+ *
+ * Collapsed tool rows compact only the path portion so metadata and intent stay
+ * readable on one line. Expanded rows restore the complete path and let Text
+ * perform normal wrapping when the terminal is narrower than that full value.
+ */
+export class PathCallComponent implements Component {
+	private renderedContent?: string;
+	private renderedText?: Text;
+
+	constructor(private viewState: PathCallViewState) {}
+
+	update(viewState: PathCallViewState): void {
+		this.viewState = viewState;
+	}
+
+	render(width: number): string[] {
+		const safeWidth = normalizeRenderWidth(width);
+		if (safeWidth === 0) {
+			return [];
+		}
+
+		const fullPath = shortenPath(this.viewState.path) || "...";
+		const displayPath = this.viewState.expanded
+			? fullPath
+			: fitCollapsedPath(fullPath, safeWidth, this.viewState.buildLine);
+		const content = this.viewState.buildLine(displayPath);
+		const protectedLine = this.viewState.expanded
+			? protectLeadingStatusSeparator(content, safeWidth)
+			: { content };
+
+		if (!this.renderedText) {
+			this.renderedText = new Text(protectedLine.content, 0, 0);
+			this.renderedContent = protectedLine.content;
+		} else if (this.renderedContent !== protectedLine.content) {
+			this.renderedText.setText(protectedLine.content);
+			this.renderedContent = protectedLine.content;
+		}
+
+		const lines = this.renderedText.render(safeWidth);
+		return protectedLine.placeholder
+			? lines.map((line) => line.replace(protectedLine.placeholder!, " "))
+			: lines;
+	}
+
+	invalidate(): void {
+		this.renderedText?.invalidate();
+		this.renderedText = undefined;
+		this.renderedContent = undefined;
+	}
+}
+
+export function renderPathCall(
+	path: string | undefined,
+	buildLine: (displayPath: string) => string,
+	context?: PathCallRenderContextLike,
+): PathCallComponent {
+	const viewState: PathCallViewState = {
+		path,
+		expanded: context?.expanded === true,
+		buildLine,
+	};
+	const component = context?.lastComponent instanceof PathCallComponent
+		? context.lastComponent
+		: new PathCallComponent(viewState);
+	component.update(viewState);
+	return component;
+}

--- a/packages/pi-tool-display-intent/src/render-utils.ts
+++ b/packages/pi-tool-display-intent/src/render-utils.ts
@@ -1,4 +1,5 @@
 import { homedir } from "node:os";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { sanitizeAnsiForThemedOutput } from "./ansi-utils.js";
 
 export { sanitizeAnsiForThemedOutput };
@@ -88,9 +89,109 @@ export function shortenPath(inputPath: string | undefined): string {
     return "";
   }
   const home = homedir();
-  return inputPath.startsWith(home)
+  const isHomePath = inputPath === home || inputPath.startsWith(`${home}/`) || inputPath.startsWith(`${home}\\`);
+  return isHomePath
     ? `~${inputPath.slice(home.length)}`
     : inputPath;
+}
+
+interface DisplayPathParts {
+  prefix: string;
+  separator: "/" | "\\";
+  segments: string[];
+}
+
+function splitDisplayPath(path: string): DisplayPathParts {
+  const separator: "/" | "\\" = path.includes("/") || !path.includes("\\") ? "/" : "\\";
+  let prefix = "";
+  let rest = path;
+
+  if (separator === "/") {
+    if (rest.startsWith("~/")) {
+      prefix = "~/";
+      rest = rest.slice(2);
+    } else if (rest.startsWith("/")) {
+      prefix = "/";
+      rest = rest.slice(1);
+    } else if (rest.startsWith("./")) {
+      prefix = "./";
+      rest = rest.slice(2);
+    } else {
+      while (rest.startsWith("../")) {
+        prefix += "../";
+        rest = rest.slice(3);
+      }
+    }
+  } else {
+    const drive = rest.match(/^[A-Za-z]:\\/u)?.[0];
+    if (drive) {
+      prefix = drive;
+      rest = rest.slice(drive.length);
+    } else if (rest.startsWith("\\\\")) {
+      prefix = "\\\\";
+      rest = rest.slice(2);
+    } else if (rest.startsWith(".\\")) {
+      prefix = ".\\";
+      rest = rest.slice(2);
+    } else {
+      while (rest.startsWith("..\\")) {
+        prefix += "..\\";
+        rest = rest.slice(3);
+      }
+    }
+  }
+
+  return {
+    prefix,
+    separator,
+    segments: rest.split(separator).filter((segment) => segment.length > 0),
+  };
+}
+
+function joinDisplayPath(prefix: string, separator: "/" | "\\", segments: string[]): string {
+  return `${prefix}${segments.join(separator)}`;
+}
+
+/** Compact the middle of a path while preserving its root, first directory, and basename. */
+export function compactPathForDisplay(inputPath: string | undefined, maxWidth: number): string {
+  const path = shortenPath(inputPath);
+  const safeWidth = Number.isFinite(maxWidth) ? Math.max(0, Math.floor(maxWidth)) : 0;
+  if (!path || safeWidth === 0) {
+    return "";
+  }
+  if (visibleWidth(path) <= safeWidth) {
+    return path;
+  }
+
+  const { prefix, separator, segments } = splitDisplayPath(path);
+  if (segments.length < 2) {
+    return truncateToWidth(path, safeWidth, "…");
+  }
+
+  const basename = segments.at(-1) ?? "";
+  const directories = segments.slice(0, -1);
+  const firstDirectory = directories[0];
+  const remainingDirectories = firstDirectory === undefined ? [] : directories.slice(1);
+
+  if (firstDirectory !== undefined) {
+    for (let tailCount = Math.max(0, remainingDirectories.length - 1); tailCount >= 0; tailCount--) {
+      const tail = tailCount > 0 ? remainingDirectories.slice(-tailCount) : [];
+      const candidate = joinDisplayPath(prefix, separator, [firstDirectory, "…", ...tail, basename]);
+      if (visibleWidth(candidate) <= safeWidth) {
+        return candidate;
+      }
+    }
+  }
+
+  for (let tailCount = Math.max(0, directories.length - 1); tailCount >= 0; tailCount--) {
+    const tail = tailCount > 0 ? directories.slice(-tailCount) : [];
+    const candidate = joinDisplayPath(prefix, separator, ["…", ...tail, basename]);
+    if (visibleWidth(candidate) <= safeWidth) {
+      return candidate;
+    }
+  }
+
+  return truncateToWidth(basename || path, safeWidth, "…");
 }
 
 export function extractTextOutput(result: ToolResultLike): string {

--- a/packages/pi-tool-display-intent/src/tool-call-style.ts
+++ b/packages/pi-tool-display-intent/src/tool-call-style.ts
@@ -70,17 +70,30 @@ function stripLegacyResultMarker(line: string): string {
 	return index < 0 ? line : `${line.slice(0, index)}${line.slice(index + marker.length)}`;
 }
 
+export interface ClaudeToolResultStyleOptions {
+	connectRows?: boolean;
+	theme?: Pick<ToolCallStyleTheme, "fg">;
+}
+
 export class ClaudeToolResultComponent implements Component {
-	constructor(private readonly child: Component) {}
+	constructor(
+		private readonly child: Component,
+		private readonly options: ClaudeToolResultStyleOptions = {},
+	) {}
 
 	render(width: number): string[] {
 		if (width <= 0) {
 			return [];
 		}
 
-		const firstPrefix = "  ⎿ ";
-		const continuationPrefix = "    ";
-		const prefixWidth = Math.max(visibleWidth(firstPrefix), visibleWidth(continuationPrefix));
+		const firstPrefix = this.options.connectRows ? "  │ " : "  ⎿ ";
+		const continuationPrefix = this.options.connectRows ? "  │ " : "    ";
+		const lastPrefix = this.options.connectRows ? "  └ " : continuationPrefix;
+		const prefixWidth = Math.max(
+			visibleWidth(firstPrefix),
+			visibleWidth(continuationPrefix),
+			visibleWidth(lastPrefix),
+		);
 		const contentWidth = Math.max(1, width - prefixWidth);
 		const childLines = this.child.render(contentWidth);
 		const firstContentLine = childLines.findIndex((line) => visibleWidth(line) > 0);
@@ -88,8 +101,12 @@ export class ClaudeToolResultComponent implements Component {
 			return [];
 		}
 
+		const lastContentLine = childLines.length - 1;
 		return childLines.map((rawLine, index) => {
-			const prefix = index === firstContentLine ? firstPrefix : continuationPrefix;
+			const plainPrefix = index === firstContentLine
+				? (this.options.connectRows && firstContentLine === lastContentLine ? lastPrefix : firstPrefix)
+				: (index === lastContentLine ? lastPrefix : continuationPrefix);
+			const prefix = this.options.theme?.fg("muted", plainPrefix) ?? plainPrefix;
 			const line = index === firstContentLine ? stripLegacyResultMarker(rawLine) : rawLine;
 			return truncateToWidth(`${prefix}${line}`, width, "");
 		});
@@ -100,9 +117,13 @@ export class ClaudeToolResultComponent implements Component {
 	}
 }
 
-export function applyToolResultStyle(component: unknown, style: ToolCallStyle): unknown {
+export function applyToolResultStyle(
+	component: unknown,
+	style: ToolCallStyle,
+	options: ClaudeToolResultStyleOptions = {},
+): unknown {
 	if (style !== "claude" || component instanceof ClaudeToolResultComponent || !isComponent(component)) {
 		return component;
 	}
-	return new ClaudeToolResultComponent(component);
+	return new ClaudeToolResultComponent(component, options);
 }

--- a/packages/pi-tool-display-intent/src/tool-overrides.ts
+++ b/packages/pi-tool-display-intent/src/tool-overrides.ts
@@ -48,11 +48,11 @@ import {
   extractTextOutput,
   isLikelyQuietCommand,
   pluralize,
-  shortenPath,
   splitLines,
 } from "./render-utils.js";
 import { renderEditDiffResult, renderWriteDiffResult } from "./diff-renderer.js";
 import { MAX_PREVIEW_LAYOUT_ROWS, PreviewText } from "./preview-text.js";
+import { renderPathCall } from "./path-call.js";
 import {
   buildPendingEditPreviewData,
   buildPendingWritePreviewData,
@@ -713,18 +713,18 @@ function resolvePendingDiffPreview(
 }
 
 function buildPendingDiffCallComponent(
-  summaryText: string,
+  summaryComponent: Component,
   previewData: PendingDiffPreviewData | undefined,
   context: ToolRenderContextLike | undefined,
   config: ToolDisplayConfig,
   theme: RenderTheme,
-): Text | Container {
+): Component {
   if (!context?.isPartial || !previewData) {
-    return textResult(summaryText);
+    return summaryComponent;
   }
 
   const container = new Container();
-  container.addChild(new Text(summaryText, 0, 0));
+  container.addChild(summaryComponent);
   if (config.toolCallStyle !== "claude") {
     container.addChild(new Spacer(1));
   }
@@ -1506,25 +1506,30 @@ function formatGenericToolCallLine(
   return new Text(line, 0, 0);
 }
 
-function getSearchScope(args: Record<string, unknown>): string {
-  return shortenPath((args.path as string) || ".");
+function getSearchPath(args: Record<string, unknown>): string {
+  return getStringField(args, "path") || ".";
 }
 
 function formatSearchCallLine(
   toolName: string,
-  accent: string,
-  mutedSuffix: string,
+  path: string,
+  buildTarget: (displayPath: string) => string,
   theme: RenderTheme,
   args: unknown,
   config: ToolDisplayConfig,
   context?: ToolRenderContextLike,
-): Text {
-  const target = `${theme.fg("text", accent)}${theme.fg("muted", mutedSuffix)}`;
+): Component {
   const intentSuffix = formatDisplaySummarySuffix(args, toolName, theme, config);
-  const line = config.toolCallStyle === "claude"
-    ? formatClaudeToolCall(toolName, target, "", intentSuffix, theme, context)
-    : `${theme.fg("toolTitle", theme.bold(toolName))} ${target}${intentSuffix}`;
-  return new Text(line, 0, 0);
+  return renderPathCall(
+    path,
+    (displayPath) => {
+      const target = buildTarget(displayPath);
+      return config.toolCallStyle === "claude"
+        ? formatClaudeToolCall(toolName, target, "", intentSuffix, theme, context)
+        : `${theme.fg("toolTitle", theme.bold(toolName))} ${target}${intentSuffix}`;
+    },
+    context,
+  );
 }
 
 function renderCustomToolResult(
@@ -1578,8 +1583,8 @@ function renderReadDisplayCall(
   adapter: ToolDisplayAdapter = {},
   config?: ToolDisplayConfig,
   context?: ToolRenderContextLike,
- ): Text {
-  const path = shortenPath(getAdapterPath(args, adapter));
+ ): Component {
+  const path = getAdapterPath(args, adapter);
   const offset = getNumericField(args, "offset");
   const limit = getNumericField(args, "limit");
   let suffix = "";
@@ -1588,12 +1593,17 @@ function renderReadDisplayCall(
     const to = limit !== undefined ? from + limit - 1 : undefined;
     suffix = to ? `:${from}-${to}` : `:${from}`;
   }
-  const target = `${theme.fg("text", path || "...")}${theme.fg("warning", suffix)}`;
   const intentSuffix = config ? formatDisplaySummarySuffix(args, "read", theme, config) : "";
-  const line = config?.toolCallStyle === "claude"
-    ? formatClaudeToolCall("read", target, "", intentSuffix, theme, context)
-    : `${theme.fg("toolTitle", theme.bold("read"))} ${target}${intentSuffix}`;
-  return textResult(line);
+  return renderPathCall(
+    path,
+    (displayPath) => {
+      const target = `${theme.fg("text", displayPath)}${theme.fg("warning", suffix)}`;
+      return config?.toolCallStyle === "claude"
+        ? formatClaudeToolCall("read", target, "", intentSuffix, theme, context)
+        : `${theme.fg("toolTitle", theme.bold("read"))} ${target}${intentSuffix}`;
+    },
+    context,
+  );
 }
 
 function renderReadDisplayResult(
@@ -1643,17 +1653,21 @@ function renderEditDisplayCall(
   context: ToolRenderContextLike | undefined,
   adapter: ToolDisplayAdapter = {},
   getConfig: ConfigGetter,
- ): Text | Container {
-  const path = shortenPath(getAdapterPath(args, adapter));
+ ): Component {
+  const path = getAdapterPath(args, adapter);
   const lineCount = adapter.getEditLineCount?.(args) ?? getEditLineCount(args);
   const config = getConfig();
   const lineCountSuffix = formatLineCountSuffix(lineCount, theme);
   const intentSuffix = formatDisplaySummarySuffix(args, "edit", theme, config);
-  const summaryText = config.toolCallStyle === "claude"
-    ? formatClaudeToolCall("edit", theme.fg("text", path || "..."), lineCountSuffix, intentSuffix, theme, context)
-    : `${theme.fg("toolTitle", theme.bold("edit"))} ${theme.fg("text", path || "...")}${lineCountSuffix}${intentSuffix}`;
+  const summaryComponent = renderPathCall(
+    path,
+    (displayPath) => config.toolCallStyle === "claude"
+      ? formatClaudeToolCall("edit", theme.fg("text", displayPath), lineCountSuffix, intentSuffix, theme, context)
+      : `${theme.fg("toolTitle", theme.bold("edit"))} ${theme.fg("text", displayPath)}${lineCountSuffix}${intentSuffix}`,
+    context,
+  );
   if (!context?.argsComplete || !context.isPartial) {
-    return textResult(summaryText);
+    return summaryComponent;
   }
 
   const previewKey = JSON.stringify({
@@ -1668,7 +1682,7 @@ function renderEditDisplayCall(
     previewKey,
     () => buildPendingEditPreviewData(args, context.cwd),
   );
-  return buildPendingDiffCallComponent(summaryText, previewData, context, getConfig(), theme);
+  return buildPendingDiffCallComponent(summaryComponent, previewData, context, getConfig(), theme);
 }
 
 function renderEditDisplayResult(
@@ -1949,8 +1963,8 @@ export function registerToolDisplayOverrides(
     return renderSearchResult(result as never, options, config, theme, unitLabel, result.details, pluralLabel);
   };
 
-  const buildSearchCallSuffix = (args: Record<string, unknown>): { scope: string; limitSuffix: string } => {
-    return { scope: getSearchScope(args), limitSuffix: args.limit !== undefined ? ` (limit ${args.limit})` : "" };
+  const buildSearchCallSuffix = (args: Record<string, unknown>): { path: string; limitSuffix: string } => {
+    return { path: getSearchPath(args), limitSuffix: args.limit !== undefined ? ` (limit ${args.limit})` : "" };
   };
 
   registerIfOwned("read", () => {
@@ -1973,11 +1987,19 @@ export function registerToolDisplayOverrides(
     label: "grep",
     ...createBuiltinToolBase("grep"),
     renderCall(args, theme, context) {
-      const scope = getSearchScope(args);
+      const path = getSearchPath(args);
       const globSuffix = args.glob ? ` (${args.glob})` : "";
       const limitSuffix =
         args.limit !== undefined ? ` limit ${args.limit}` : "";
-      return formatSearchCallLine("grep", `/${args.pattern}/`, ` in ${scope}${globSuffix}${limitSuffix}`, theme, args, getConfig(), context);
+      return formatSearchCallLine(
+        "grep",
+        path,
+        (displayPath) => `${theme.fg("text", `/${args.pattern}/`)}${theme.fg("muted", ` in ${displayPath}${globSuffix}${limitSuffix}`)}`,
+        theme,
+        args,
+        getConfig(),
+        context,
+      );
     },
     renderResult(result, options, theme) {
       return renderSearchToolResult(result, options, theme, "match", "matches");
@@ -1991,8 +2013,16 @@ export function registerToolDisplayOverrides(
     label: "find",
     ...createBuiltinToolBase("find"),
     renderCall(args, theme, context) {
-      const { scope, limitSuffix } = buildSearchCallSuffix(args);
-      return formatSearchCallLine("find", args.pattern as string, ` in ${scope}${limitSuffix}`, theme, args, getConfig(), context);
+      const { path, limitSuffix } = buildSearchCallSuffix(args);
+      return formatSearchCallLine(
+        "find",
+        path,
+        (displayPath) => `${theme.fg("text", args.pattern as string)}${theme.fg("muted", ` in ${displayPath}${limitSuffix}`)}`,
+        theme,
+        args,
+        getConfig(),
+        context,
+      );
     },
     renderResult(result, options, theme) {
       return renderSearchToolResult(result, options, theme, "result");
@@ -2006,8 +2036,16 @@ export function registerToolDisplayOverrides(
     label: "ls",
     ...createBuiltinToolBase("ls"),
     renderCall(args, theme, context) {
-      const { scope, limitSuffix } = buildSearchCallSuffix(args);
-      return formatSearchCallLine("ls", scope, limitSuffix, theme, args, getConfig(), context);
+      const { path, limitSuffix } = buildSearchCallSuffix(args);
+      return formatSearchCallLine(
+        "ls",
+        path,
+        (displayPath) => `${theme.fg("text", displayPath)}${theme.fg("muted", limitSuffix)}`,
+        theme,
+        args,
+        getConfig(),
+        context,
+      );
     },
     renderResult(result, options, theme) {
       return renderSearchToolResult(result, options, theme, "entry", "entries");
@@ -2067,7 +2105,7 @@ export function registerToolDisplayOverrides(
       const content = getToolContentArg(args);
       const lineCount = countWriteContentLines(content);
       const sizeBytes = getWriteContentSizeBytes(content);
-      const path = shortenPath(getToolPathArg(args));
+      const path = getToolPathArg(args);
       const suffix = shouldRenderWriteCallSummary({
         hasContent: content !== undefined,
         hasDetailedResultHeader: false,
@@ -2076,11 +2114,15 @@ export function registerToolDisplayOverrides(
         : "";
       const config = getConfig();
       const intentSuffix = formatDisplaySummarySuffix(args, "write", theme, config);
-      const summaryText = config.toolCallStyle === "claude"
-        ? formatClaudeToolCall("write", theme.fg("text", path || "..."), suffix, intentSuffix, theme, context)
-        : `${theme.fg("toolTitle", theme.bold("write"))} ${theme.fg("text", path || "...")}${suffix}${intentSuffix}`;
+      const summaryComponent = renderPathCall(
+        path,
+        (displayPath) => config.toolCallStyle === "claude"
+          ? formatClaudeToolCall("write", theme.fg("text", displayPath), suffix, intentSuffix, theme, context)
+          : `${theme.fg("toolTitle", theme.bold("write"))} ${theme.fg("text", displayPath)}${suffix}${intentSuffix}`,
+        context,
+      );
       if (!context.argsComplete || !context.isPartial) {
-        return textResult(summaryText);
+        return summaryComponent;
       }
 
       const previewKey = JSON.stringify({ path: getToolPathArg(args) ?? null, content: content ?? null });
@@ -2090,7 +2132,7 @@ export function registerToolDisplayOverrides(
         previewKey,
         () => buildPendingWritePreviewData(args, context.cwd),
       );
-      return buildPendingDiffCallComponent(summaryText, previewData, context, getConfig(), theme);
+      return buildPendingDiffCallComponent(summaryComponent, previewData, context, getConfig(), theme);
     },
     renderResult(result, options, theme, context) {
       const content = getToolContentArg(context?.args);

--- a/packages/pi-tool-display-intent/src/tool-overrides.ts
+++ b/packages/pi-tool-display-intent/src/tool-overrides.ts
@@ -252,7 +252,10 @@ function applyRuntimeToolCallStyle(
   if (typeof originalRenderResult === "function") {
     styledTool.renderResult = function renderStyledResult(result, options, theme, context) {
       const component = originalRenderResult.call(tool, result, options, theme, context);
-      return applyToolResultStyle(component, getConfig().toolCallStyle);
+      return applyToolResultStyle(component, getConfig().toolCallStyle, {
+        connectRows: tool.name === "bash",
+        theme,
+      });
     };
   }
 

--- a/packages/pi-tool-display-intent/src/tool-overrides.ts
+++ b/packages/pi-tool-display-intent/src/tool-overrides.ts
@@ -28,7 +28,7 @@ import {
   createWriteToolDefinition,
   formatSize,
 } from "@earendil-works/pi-coding-agent";
-import { Container, Spacer, Text, type Component } from "@earendil-works/pi-tui";
+import { Container, Spacer, Text, truncateToWidth, type Component } from "@earendil-works/pi-tui";
 import { resolvePiAgentDir } from "./agent-dir.js";
 import { renderBashCall } from "./bash-display.js";
 import {
@@ -893,8 +893,20 @@ function renderSearchPreview(ctx: PreviewHintContext, expandedOnly = false): Com
   return renderPreviewText(ctx.lines, ctx.config, ctx.theme, ctx.options, (p) => appendPreviewHints(p, ctx), expandedOnly);
 }
 
-function renderMcpPreview(ctx: McpPreviewHintContext, expandedOnly = false): Component {
-  return renderPreviewText(ctx.lines, ctx.config, ctx.theme, ctx.options, (p) => appendMcpPreviewHints(p, ctx), expandedOnly);
+function renderMcpPreview(
+  ctx: McpPreviewHintContext,
+  expandedOnly = false,
+  outputColor?: string,
+): Component {
+  return renderPreviewText(
+    ctx.lines,
+    ctx.config,
+    ctx.theme,
+    ctx.options,
+    (p) => appendMcpPreviewHints(p, ctx),
+    expandedOnly,
+    outputColor,
+  );
 }
 
 function formatRtkSummarySuffix(params: RtkHintParams): string {
@@ -986,6 +998,7 @@ function renderPreviewText(
   options: ToolRenderResultOptions,
   appendHints: (preview: string) => string,
   expandedOnly: boolean = false,
+  outputColor?: string,
 ): Component {
   const useExpanded = expandedOnly || options.expanded;
   return new PreviewText({
@@ -995,6 +1008,7 @@ function renderPreviewText(
       : config.previewRows,
     theme,
     expanded: useExpanded,
+    outputColor,
     emptyText: theme.fg("muted", "↳ (no output)"),
     expandedRowCap: useExpanded ? config.expandedPreviewMaxRows : undefined,
     appendHints,
@@ -1087,8 +1101,64 @@ type ToolRenderInput = {
   details?: unknown;
 };
 
+const TOOL_ERROR_SUMMARY_MAX_LENGTH = 240;
+
+class SingleLineResultText implements Component {
+  constructor(private readonly text: string) {}
+
+  render(width: number): string[] {
+    const safeWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : 0;
+    return safeWidth > 0 ? [truncateToWidth(this.text, safeWidth, "…")] : [];
+  }
+
+  invalidate(): void {
+    // Stateless component.
+  }
+}
+
 function textResult(text: string): Text {
   return new Text(text, 0, 0);
+}
+
+function getToolErrorSummary(rawOutput: string): string {
+  for (const line of rawOutput.replace(/\r/g, "").split("\n")) {
+    const summary = normalizeDisplaySummary(line, TOOL_ERROR_SUMMARY_MAX_LENGTH);
+    if (summary) {
+      return summary;
+    }
+  }
+  return "Tool failed.";
+}
+
+function renderToolErrorResult(
+  rawOutput: string,
+  options: ToolRenderResultOptions,
+  config: ToolDisplayConfig,
+  theme: RenderTheme,
+  details: unknown,
+): Component {
+  const summary = getToolErrorSummary(rawOutput);
+  if (!options.expanded) {
+    return new SingleLineResultText(
+      `${theme.fg("error", `↳ ${summary}`)}${formatExpandHint(theme)}`,
+    );
+  }
+
+  const lines = prepareOutputLines(rawOutput, options);
+  if (lines.length === 0) {
+    return new SingleLineResultText(theme.fg("error", `↳ ${summary}`));
+  }
+
+  const truncation = getMcpTruncationDetails(details);
+  const mcpCtx: McpPreviewHintContext = {
+    lines,
+    config,
+    theme,
+    options,
+    details,
+    truncation,
+  };
+  return renderMcpPreview(mcpCtx, true, "error");
 }
 
 function partialResultText(theme: RenderTheme, label: string): Text {
@@ -1291,6 +1361,7 @@ function renderMcpResult(
   options: ToolRenderResultOptions,
   config: ToolDisplayConfig,
   theme: RenderTheme,
+  context?: ToolRenderContextLike,
   presentation?: ToolDisplayResultPresentation,
 ): Component {
   const partial = handlePartialResult(options, theme, "running...");
@@ -1298,11 +1369,16 @@ function renderMcpResult(
     return partial;
   }
 
+  const rawOutput = extractTextOutput(result);
+  if (isToolError(result, context)) {
+    return renderToolErrorResult(rawOutput, options, config, theme, result.details);
+  }
+
   if (config.mcpOutputMode === "hidden") {
     return textResult("");
   }
 
-  const outputLines = prepareOutputLines(extractTextOutput(result), options);
+  const outputLines = prepareOutputLines(rawOutput, options);
   const previewStartLine = Math.min(
     outputLines.length,
     normalizePositiveInteger(presentation?.previewStartLine) ?? 0,
@@ -1457,6 +1533,7 @@ function renderCustomToolResult(
   config: ToolDisplayConfig,
   outputMode: CustomToolOverrideConfig["outputMode"],
   theme: RenderTheme,
+  context?: ToolRenderContextLike,
   adapter: ToolDisplayAdapter = {},
 ): Component {
   return renderMcpResult(
@@ -1464,6 +1541,7 @@ function renderCustomToolResult(
     options,
     { ...config, mcpOutputMode: outputMode },
     theme,
+    context,
     resolveResultPresentation(result, adapter),
   );
 }
@@ -1723,12 +1801,17 @@ function installToolDisplayApi(getConfig: ConfigGetter): ToolDisplayApi {
         (kind === "mcp" || (kind === "generic" && resolvedAdapter.outputMode !== undefined)) &&
         (overrideExisting || typeof decorated.renderResult !== "function")
       ) {
-        decorated.renderResult = (result: ToolRenderInput, options: ToolRenderResultOptions, theme: RenderTheme) => {
+        decorated.renderResult = (
+          result: ToolRenderInput,
+          options: ToolRenderResultOptions,
+          theme: RenderTheme,
+          context?: ToolRenderContextLike,
+        ) => {
           const config = getConfig();
           const outputMode = resolvedAdapter.outputMode === undefined || resolvedAdapter.outputMode === "inherit"
             ? config.mcpOutputMode
             : resolvedAdapter.outputMode;
-          return renderCustomToolResult(result, options, config, outputMode, theme, resolvedAdapter);
+          return renderCustomToolResult(result, options, config, outputMode, theme, context, resolvedAdapter);
         };
       }
 
@@ -2138,13 +2221,14 @@ export function registerToolDisplayOverrides(
           }
           return formatGenericToolCallLine(toolName, args, theme, getConfig(), context);
         },
-        renderResult(result, options, theme) {
+        renderResult(result, options, theme, context) {
           return renderCustomToolResult(
             result as ToolRenderInput,
             options,
             getConfig(),
             override.outputMode,
             theme,
+            context,
           );
         },
       },
@@ -2206,12 +2290,13 @@ export function registerToolDisplayOverrides(
         renderCall(args, theme, context) {
           return formatMcpCallLine(toolName, toolLabel, toRecord(args), theme, getConfig(), context);
         },
-        renderResult(result, options, theme) {
+        renderResult(result, options, theme, context) {
           return renderMcpResult(
             result as ToolRenderInput,
             options,
             getConfig(),
             theme,
+            context,
           );
         },
       },

--- a/packages/pi-tool-display-intent/src/tool-overrides.ts
+++ b/packages/pi-tool-display-intent/src/tool-overrides.ts
@@ -13,12 +13,19 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import {
   createBashTool,
+  createBashToolDefinition,
   createEditTool,
+  createEditToolDefinition,
   createFindTool,
+  createFindToolDefinition,
   createGrepTool,
+  createGrepToolDefinition,
   createLsTool,
+  createLsToolDefinition,
   createReadTool,
+  createReadToolDefinition,
   createWriteTool,
+  createWriteToolDefinition,
   formatSize,
 } from "@earendil-works/pi-coding-agent";
 import { Container, Spacer, Text, type Component } from "@earendil-works/pi-tui";
@@ -426,8 +433,58 @@ function createLazyToolRecord<T>(
   } as Record<keyof BuiltInTools, T>;
 }
 
-function createLazyPromptMetadata(bootstrapTools: BuiltInTools): Record<keyof BuiltInTools, ReturnType<typeof extractPromptMetadata>> {
-  return createLazyToolRecord(bootstrapTools, extractPromptMetadata);
+function createBuiltInToolDefinitions(cwd: string) {
+  return {
+    read: () => createReadToolDefinition(cwd),
+    grep: () => createGrepToolDefinition(cwd),
+    find: () => createFindToolDefinition(cwd),
+    ls: () => createLsToolDefinition(cwd),
+    bash: () => createBashToolDefinition(cwd, loadBashToolOverrideOptions()),
+    edit: () => createEditToolDefinition(cwd),
+    write: () => createWriteToolDefinition(cwd),
+  } as const;
+}
+
+/**
+ * Prompt metadata must come from ToolDefinition factories.
+ * `create*Tool()` goes through `wrapToolDefinition()`, which drops
+ * `promptSnippet` / `promptGuidelines`. Without those fields, Pi omits the
+ * overridden tools from the system prompt `Available tools` section.
+ */
+function createLazyPromptMetadata(
+  bootstrapTools: BuiltInTools,
+  cwd: string = process.cwd(),
+): Record<keyof BuiltInTools, ReturnType<typeof extractPromptMetadata>> {
+  const definitions = createBuiltInToolDefinitions(cwd);
+  const cache = new Map<keyof BuiltInTools, ReturnType<typeof extractPromptMetadata>>();
+  const get = (name: keyof BuiltInTools): ReturnType<typeof extractPromptMetadata> => {
+    const cached = cache.get(name);
+    if (cached) {
+      return cached;
+    }
+
+    const fromDefinition = extractPromptMetadata(definitions[name]());
+    const fallbackSnippet = buildPromptSnippetFromDescription(
+      bootstrapTools[name].description,
+      name,
+    );
+    const metadata = {
+      promptSnippet: fromDefinition.promptSnippet ?? fallbackSnippet,
+      promptGuidelines: fromDefinition.promptGuidelines,
+    };
+    cache.set(name, metadata);
+    return metadata;
+  };
+
+  return {
+    get read() { return get("read"); },
+    get grep() { return get("grep"); },
+    get find() { return get("find"); },
+    get ls() { return get("ls"); },
+    get bash() { return get("bash"); },
+    get edit() { return get("edit"); },
+    get write() { return get("write"); },
+  } as Record<keyof BuiltInTools, ReturnType<typeof extractPromptMetadata>>;
 }
 
 function createLazyClonedParameters(bootstrapTools: BuiltInTools): Record<keyof BuiltInTools, unknown> {

--- a/packages/pi-tool-display-intent/tests/bash-display.test.ts
+++ b/packages/pi-tool-display-intent/tests/bash-display.test.ts
@@ -171,6 +171,41 @@ test("renderBashCall gives collapsed Claude calls an intent-first header and com
 	);
 });
 
+test("renderBashCall highlights the separate Claude command prompt", () => {
+	const theme = {
+		fg: (color: string, text: string): string => `<${color}>${text}</${color}>`,
+		bold: (text: string): string => `<b>${text}</b>`,
+	};
+	const text = renderBashCall(
+		{ command: "printf one\nprintf two" },
+		theme,
+		makeContext(),
+		undefined,
+		"claude",
+	);
+
+	assert.match(renderedText(text, 200), /<accent><b>\$<\/b><\/accent>/);
+});
+
+test("renderBashCall keeps expanded shell syntax complete while using the highlighter path", () => {
+	const theme = {
+		fg: (color: string, text: string): string => `<${color}>${text}</${color}>`,
+		bold: (text: string): string => text,
+	};
+	const command = 'if test -f "$file"; then echo ok; fi';
+	const text = renderBashCall(
+		{ command },
+		theme,
+		makeContext({ expanded: true }),
+		undefined,
+		"claude",
+	);
+	const rendered = renderedText(text, 200);
+
+	assert.match(rendered, /if test -f .*; then echo ok; fi/);
+	assert.doesNotMatch(rendered, /<text>if test -f/);
+});
+
 test("renderBashCall respects the configured collapsed command row budget", () => {
 	const text = renderBashCall(
 		{ command: "printf one\nprintf two\nprintf three" },

--- a/packages/pi-tool-display-intent/tests/config-schema.test.ts
+++ b/packages/pi-tool-display-intent/tests/config-schema.test.ts
@@ -45,7 +45,8 @@ test("bundled JSON Schema exposes only the reviewed public field names", () => {
 	assert.equal(schema.$id, TOOL_DISPLAY_CONFIG_SCHEMA_URL);
 	assert.equal(schema.properties?.version?.const, TOOL_DISPLAY_CONFIG_VERSION);
 	assert.ok(schema.properties?.results?.properties?.mode);
-	assert.ok(schema.properties?.results?.properties?.previewRows);
+	const previewRows = schema.properties?.results?.properties?.previewRows as { minimum?: number } | undefined;
+	assert.equal(previewRows?.minimum, 2);
 	assert.equal(schema.properties?.results?.properties?.profile, undefined);
 	assert.equal(schema.properties?.results?.properties?.overrides, undefined);
 	assert.ok(schema.properties?.toolCalls?.properties?.style);

--- a/packages/pi-tool-display-intent/tests/config-store.test.ts
+++ b/packages/pi-tool-display-intent/tests/config-store.test.ts
@@ -54,6 +54,11 @@ test("legacy normalization maps result modes, clamps rows, and discards bashColl
 	assert.equal(config.diffWordWrap, false);
 });
 
+test("preview rows clamp to the supported minimum of two", () => {
+	assert.equal(normalizeToolDisplayConfig({ previewRows: 1 }).previewRows, 2);
+	assert.equal(normalizeToolDisplayConfig({ previewLines: -10 }).previewRows, 2);
+});
+
 test("legacy stored Profile names map to final result modes", () => {
 	assert.equal(normalizeToolDisplayConfig({ resultProfile: "minimal" }).resultMode, "compact");
 	assert.equal(normalizeToolDisplayConfig({ resultProfile: "balanced" }).resultMode, "summary");
@@ -297,6 +302,24 @@ test("invalid or old v2 fields are dropped with paths and rewritten", () => {
 		assert.match(loaded.notice ?? "", /results\.mode: required setting/);
 		assert.notEqual(readFileSync(configFile, "utf8"), original);
 		assert.equal(readFileSync(join(dir, "config.legacy.json"), "utf8"), original);
+	});
+});
+
+test("v2 preview rows of one migrate to the new minimum", () => {
+	withTempDir("pi-tool-display-config-preview-min-", (dir) => {
+		const configFile = join(dir, "config.json");
+		writeFileSync(configFile, `${JSON.stringify({
+			version: 2,
+			results: { mode: "compact", previewRows: 1 },
+		}, null, 2)}\n`, "utf8");
+
+		const loaded = loadToolDisplayConfig(configFile);
+		assert.equal(loaded.config.previewRows, 2);
+		assert.match(loaded.notice ?? "", /results\.previewRows: raised from 1 to the new minimum of 2/);
+		const persisted = JSON.parse(readFileSync(configFile, "utf8")) as {
+			results?: { previewRows?: number };
+		};
+		assert.equal(persisted.results?.previewRows, 2);
 	});
 });
 

--- a/packages/pi-tool-display-intent/tests/custom-tool-overrides.test.ts
+++ b/packages/pi-tool-display-intent/tests/custom-tool-overrides.test.ts
@@ -107,11 +107,17 @@ function renderToText(component: unknown): string {
 		.trim();
 }
 
-function renderToolResult(tool: RuntimeTool, text: string, options: Record<string, unknown> = {}): string {
+function renderToolResult(
+	tool: RuntimeTool,
+	text: string,
+	options: Record<string, unknown> = {},
+	context: Record<string, unknown> = {},
+): string {
 	return renderToolRawResult(
 		tool,
 		{ content: [{ type: "text", text }], details: {} },
 		options,
+		context,
 	);
 }
 
@@ -119,6 +125,7 @@ function renderToolRawResult(
 	tool: RuntimeTool,
 	result: Record<string, unknown>,
 	options: Record<string, unknown> = {},
+	context: Record<string, unknown> = {},
 ): string {
 	assert.equal(typeof tool.renderResult, "function", `expected ${tool.name} to have renderResult`);
 	return renderToText(
@@ -126,6 +133,7 @@ function renderToolRawResult(
 			result,
 			{ expanded: false, isPartial: false, ...options },
 			createTheme(),
+			context,
 		),
 	);
 }
@@ -242,6 +250,49 @@ test("custom generic tool override honors per-tool hidden output mode", async ()
 	await runLifecycle(eventHandlers);
 
 	assert.equal(renderToolResult(quietTool, "secret\nnoisy\noutput\n"), "");
+});
+
+test("generic custom tool errors stay visible in every output mode and expand from content", async () => {
+	const modes = ["hidden", "summary", "preview"] as const;
+	const tools = modes.map((mode) => ({
+		name: `generic_error_${mode}`,
+		description: `Generic ${mode} error probe.`,
+		parameters: {},
+		execute: () => {},
+	}));
+	const config = buildConfigWithCustomOverrides(
+		Object.fromEntries(modes.map((mode) => [`generic_error_${mode}`, { outputMode: mode }])),
+		{ previewRows: 2 },
+	);
+	const { api, eventHandlers } = createExtensionApiStub(tools);
+
+	registerToolDisplayOverrides(api, () => config);
+	await runLifecycle(eventHandlers);
+
+	for (const [index, mode] of modes.entries()) {
+		const tool = tools[index]!;
+		assert.equal(
+			renderToolResult(tool, "Remote request failed\nstack frame one\nstack frame two\n", {}, { isError: true }),
+			"↳ Remote request failed • Ctrl+O to expand",
+			`${mode} should show one collapsed error summary`,
+		);
+		assert.equal(
+			renderToolResult(
+				tool,
+				"Remote request failed\nstack frame one\nstack frame two\n",
+				{ expanded: true },
+				{ isError: true },
+			),
+			"Remote request failed\nstack frame one\nstack frame two",
+			`${mode} should show complete expanded error content`,
+		);
+	}
+
+	assert.equal(renderToolResult(tools[0]!, "successful but hidden"), "");
+	assert.equal(
+		renderToolRawResult(tools[0]!, { content: [], details: {} }, {}, { isError: true }),
+		"↳ Tool failed. • Ctrl+O to expand",
+	);
 });
 
 test("custom tool overrides ignore missing tools instead of registering phantom tools", async () => {

--- a/packages/pi-tool-display-intent/tests/index-integration.test.ts
+++ b/packages/pi-tool-display-intent/tests/index-integration.test.ts
@@ -391,15 +391,12 @@ test("overridden tools preserve promptSnippet and promptGuidelines from built-in
 
   const byName = new Map(capturedTools.map((t) => [t.name, t]));
 
-  // read (deferred) won't be registered immediately; it's deferred
-  // So we only check tools registered immediately
-  for (const name of ["find", "ls", "write"] as const) {
+  for (const name of ["read", "grep", "find", "ls", "bash", "edit", "write"] as const) {
     const tool = byName.get(name);
     assert.ok(tool, `${name} is registered`);
-    // promptSnippet should be a non-empty string or undefined
-    // (built-in tools may or may not have promptSnippet)
-    if (tool.promptSnippet !== undefined) {
-      assert.equal(typeof tool.promptSnippet, "string");
-    }
+    // Pi lists tools in Available tools only when promptSnippet is present.
+    assert.equal(typeof tool.promptSnippet, "string", `${name} promptSnippet type`);
+    const snippet = typeof tool.promptSnippet === "string" ? tool.promptSnippet.trim() : "";
+    assert.ok(snippet.length > 0, `${name} promptSnippet non-empty`);
   }
 });

--- a/packages/pi-tool-display-intent/tests/render-utils.test.ts
+++ b/packages/pi-tool-display-intent/tests/render-utils.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../src/line-width-safety.ts";
 import {
   compactOutputLines,
+  compactPathForDisplay,
   countNonEmptyLines,
   extractTextOutput,
   isLikelyQuietCommand,
@@ -129,6 +130,27 @@ test("shortenPath: path exactly matching homedir with trailing slash returns til
   const home = homedir();
   const result = shortenPath(`${home}/`);
   assert.equal(result, "~/");
+});
+
+test("shortenPath: a sibling prefix of homedir is not mistaken for home", () => {
+  const home = homedir();
+  assert.equal(shortenPath(`${home}-backup/file.txt`), `${home}-backup/file.txt`);
+});
+
+test("compactPathForDisplay preserves useful path anchors within its width", () => {
+  const path = `${homedir()}/.local/share/pnpm/store/v11/links/@earendil-works/pi-coding-agent/docs/rpc.md`;
+  const compacted = compactPathForDisplay(path, 44);
+
+  assert.ok([...compacted].length <= 44);
+  assert.match(compacted, /^~\//);
+  assert.match(compacted, /…/u);
+  assert.match(compacted, /rpc\.md$/u);
+  assert.doesNotMatch(compacted, /pnpm\/store\/v11\/links/u);
+});
+
+test("compactPathForDisplay leaves fitting and expanded paths untouched", () => {
+  assert.equal(compactPathForDisplay("src/docs/rpc.md", 80), "src/docs/rpc.md");
+  assert.equal(compactPathForDisplay("src/docs/rpc.md", 0), "");
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/pi-tool-display-intent/tests/tool-call-style.test.ts
+++ b/packages/pi-tool-display-intent/tests/tool-call-style.test.ts
@@ -48,6 +48,24 @@ test("Claude result wrapper replaces legacy arrows, indents continuations, and r
 	assert.doesNotThrow(() => wrapped.invalidate());
 });
 
+test("Claude Bash result wrapper connects every output row through the last line", () => {
+	const wrapped = applyToolResultStyle(
+		new Text("first output\nsecond output\nlast output", 0, 0),
+		"claude",
+		{ connectRows: true },
+	) as { render(width: number): string[] };
+
+	assert.deepEqual(
+		wrapped.render(24).map((line) => line.trimEnd()),
+		["  │ first output", "  │ second output", "  └ last output"],
+	);
+
+	const single = applyToolResultStyle(new Text("only output", 0, 0), "claude", { connectRows: true }) as {
+		render(width: number): string[];
+	};
+	assert.deepEqual(single.render(24).map((line) => line.trimEnd()), ["  └ only output"]);
+});
+
 test("Claude result wrapper hides empty result components and compact style is unchanged", () => {
 	const empty = applyToolResultStyle(new Text("", 0, 0), "claude") as { render(width: number): string[] };
 	assert.deepEqual(empty.render(80), []);

--- a/packages/pi-tool-display-intent/tests/tool-overrides-config.test.ts
+++ b/packages/pi-tool-display-intent/tests/tool-overrides-config.test.ts
@@ -523,6 +523,27 @@ test("bash summary and preview modes stay distinct while preview uses shared row
 	);
 });
 
+test("Claude Bash results keep a connected frame when collapsed and expanded", async () => {
+	const config = buildConfig({
+		toolCallStyle: "claude",
+		bashOutputMode: "preview",
+		previewRows: 2,
+	});
+	const { api, registeredTools, eventHandlers } = createExtensionApiStub();
+	registerToolDisplayOverrides(api, () => config);
+	await eventHandlers.before_agent_start?.();
+
+	const bashTool = registeredTools.find((tool) => tool.name === "bash");
+	assert.equal(
+		renderToolResult(bashTool, "alpha\nbeta\ngamma\n"),
+		"│ alpha\n  │ beta\n  └ ... (1 more line • Ctrl+O to expand)",
+	);
+	assert.equal(
+		renderToolResult(bashTool, { text: "alpha\nbeta\ngamma\n", expanded: true }),
+		"│ alpha\n  │ beta\n  └ gamma",
+	);
+});
+
 test("bash call spinner appears only while execution is active", async () => {
 	const config = buildConfig({
 		bashOutputMode: "summary",

--- a/packages/pi-tool-display-intent/tests/tool-overrides-config.test.ts
+++ b/packages/pi-tool-display-intent/tests/tool-overrides-config.test.ts
@@ -226,6 +226,48 @@ test("current local-style config keeps read/search/MCP output modes distinct", a
 	);
 });
 
+test("MCP errors stay visible in every output mode and expand from content", async () => {
+	for (const mode of ["hidden", "summary", "preview"] as const) {
+		const config = buildConfig({
+			mcpOutputMode: mode,
+			previewRows: 2,
+		});
+		const mcpTool: RegisteredToolLike & Record<string, unknown> = {
+			name: "mcp",
+			description: "Unified MCP gateway for status, discovery, reconnects, and proxy tool calls.",
+			parameters: {},
+			execute(): void {
+				// No-op test stub.
+			},
+		};
+		const { api, runtimeTools, eventHandlers } = createExtensionApiStub([mcpTool]);
+		registerToolDisplayOverrides(api, () => config);
+		await runLifecycle(eventHandlers);
+
+		const decoratedMcp = runtimeTools.find((tool) => tool.name === "mcp");
+		assert.equal(
+			renderToolResult(decoratedMcp, {
+				text: "Gateway timed out\nrequest id: 42\nretry exhausted\n",
+				isError: true,
+			}),
+			"↳ Gateway timed out • Ctrl+O to expand",
+			`${mode} should show one collapsed error summary`,
+		);
+		assert.equal(
+			renderToolResult(decoratedMcp, {
+				text: "Gateway timed out\nrequest id: 42\nretry exhausted\n",
+				isError: true,
+				expanded: true,
+			}),
+			"Gateway timed out\nrequest id: 42\nretry exhausted",
+			`${mode} should show complete expanded error content`,
+		);
+		if (mode === "hidden") {
+			assert.equal(renderToolResult(decoratedMcp, "successful but hidden"), "");
+		}
+	}
+});
+
 test("registerToolDisplayOverrides preserves MCP prompt metadata for proxy and direct wrappers", async () => {
 	const { api, runtimeTools, eventHandlers } = createExtensionApiStub([
 		{

--- a/packages/pi-tool-display-intent/tests/tool-overrides-registration.test.ts
+++ b/packages/pi-tool-display-intent/tests/tool-overrides-registration.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
@@ -27,6 +27,7 @@ import {
 } from "../tool-display-api-consumer.js";
 import { addDisplaySummaryParameter } from "../src/display-summary.js";
 import { registerToolDisplayOverrides } from "../src/tool-overrides.ts";
+import { shortenPath } from "../src/render-utils.ts";
 import { DEFAULT_TOOL_DISPLAY_CONFIG } from "../src/types.ts";
 
 const TOOL_DISPLAY_PENDING_DECORATIONS_KEY = Symbol.for("pi-tool-display-intent.pendingDecorations.v1");
@@ -254,6 +255,65 @@ test("registered built-ins expose intent in schemas and TUI while stripping it b
 	});
 });
 
+test("path-bearing built-ins compact long call paths and restore them when expanded", () => {
+	const { api, registeredTools } = createExtensionApiStub();
+	const config = {
+		...DEFAULT_TOOL_DISPLAY_CONFIG,
+		toolCallStyle: "claude" as const,
+	};
+	registerToolDisplayOverrides(api, () => config);
+
+	const longPath = `${homedir()}/.local/share/pnpm/store/v11/links/@earendil-works/pi-coding-agent/0.82.1/3f756669fd860ae9f8a03cb73678ac7de01add7dc08f75902c7f14389da37058/node_modules/@earendil-works/pi-coding-agent/docs/rpc.md`;
+	const expectedFullPath = shortenPath(longPath);
+	const theme = {
+		fg: (_color: string, text: string) => text,
+		bold: (text: string) => text,
+	};
+	const byName = new Map(registeredTools.map((tool) => [tool.name, tool]));
+	const cases: Array<{ name: string; args: Record<string, unknown> }> = [
+		{ name: "read", args: { path: longPath, offset: 1, limit: 2000 } },
+		{ name: "grep", args: { pattern: "systemPrompt", path: longPath } },
+		{ name: "find", args: { pattern: "*.md", path: longPath } },
+		{ name: "ls", args: { path: longPath } },
+		{ name: "edit", args: { path: longPath, edits: [{ oldText: "a", newText: "b" }] } },
+		{ name: "write", args: { path: longPath, content: "x" } },
+	];
+
+	for (const entry of cases) {
+		const tool = byName.get(entry.name);
+		assert.ok(tool?.renderCall, `${entry.name} has renderCall`);
+		const args = { ...entry.args, displaySummary: "Inspecting the RPC docs" };
+		const collapsedContext = {
+			argsComplete: false,
+			executionStarted: true,
+			expanded: false,
+			isPartial: false,
+		};
+		const collapsed = tool.renderCall(args, theme, collapsedContext) as { render(width: number): string[] };
+		const collapsedLines = collapsed.render(76).map((line) => line.trimEnd());
+		const collapsedText = collapsedLines.join("\n");
+
+		assert.equal(collapsedLines.length, 1, `${entry.name} collapsed header stays on one line`);
+		assert.ok(visibleWidth(collapsedLines[0] ?? "") <= 76, `${entry.name} respects available width`);
+		assert.match(collapsedText, /…/u, `${entry.name} shows a middle path ellipsis`);
+		assert.match(collapsedText, /rpc\.md/u, `${entry.name} preserves the basename`);
+		assert.doesNotMatch(collapsedText, /3f756669fd860ae9/u, `${entry.name} hides store hashes`);
+
+		const expanded = tool.renderCall(
+			args,
+			theme,
+			{ ...collapsedContext, expanded: true, lastComponent: collapsed },
+		) as { render(width: number): string[] };
+		assert.equal(expanded, collapsed, `${entry.name} reuses its call component`);
+		const expandedLines = expanded.render(76).map((line) => line.trimEnd());
+		assert.match(expandedLines[0] ?? "", /^● \S/u, `${entry.name} keeps its status marker with the call label`);
+		assert.ok(
+			expandedLines.join("").includes(expectedFullPath),
+			`${entry.name} restores the complete path when expanded`,
+		);
+	}
+});
+
 test("built-in renderers use accent for model intent and muted for fallback intent", () => {
 	const { api, registeredTools } = createExtensionApiStub();
 	registerToolDisplayOverrides(api, () => DEFAULT_TOOL_DISPLAY_CONFIG);
@@ -333,7 +393,6 @@ test("cooperative custom tools can share intent, execution stripping, and inheri
 	) as { render(width: number): string[] };
 	assert.match(resultComponent.render(160).join("\n"), /Remote · 2 values/);
 
-
 	const errorResult = {
 		content: [{ type: "text", text: "Remote content failure\nstack frame one\nstack frame two" }],
 		details: { summary: "presentation must not replace content" },
@@ -360,8 +419,6 @@ test("cooperative custom tools can share intent, execution stripping, and inheri
 		expandedError.render(160).map((line) => line.trimEnd()).join("\n"),
 		"Remote content failure\nstack frame one\nstack frame two",
 	);
-
-	
 
 	await customTool.execute("call-custom", args);
 	assert.deepEqual(executedArgs, { query: "alpha" });

--- a/packages/pi-tool-display-intent/tests/tool-overrides-registration.test.ts
+++ b/packages/pi-tool-display-intent/tests/tool-overrides-registration.test.ts
@@ -5,12 +5,19 @@ import { join } from "node:path";
 import test from "node:test";
 import {
 	createBashTool,
+	createBashToolDefinition,
 	createEditTool,
+	createEditToolDefinition,
 	createFindTool,
+	createFindToolDefinition,
 	createGrepTool,
+	createGrepToolDefinition,
 	createLsTool,
+	createLsToolDefinition,
 	createReadTool,
+	createReadToolDefinition,
 	createWriteTool,
+	createWriteToolDefinition,
 	type ExtensionAPI,
 } from "@earendil-works/pi-coding-agent";
 import {
@@ -108,6 +115,17 @@ test("registerToolDisplayOverrides copies built-in prompt metadata onto overridd
 
 	const byName = new Map(registeredTools.map((tool) => [tool.name, tool]));
 	const cwd = process.cwd();
+	// Prompt metadata lives on ToolDefinition. create*Tool() wraps through
+	// wrapToolDefinition() and drops promptSnippet/promptGuidelines.
+	const builtInDefinitions = {
+		read: createReadToolDefinition(cwd),
+		grep: createGrepToolDefinition(cwd),
+		find: createFindToolDefinition(cwd),
+		ls: createLsToolDefinition(cwd),
+		bash: createBashToolDefinition(cwd),
+		edit: createEditToolDefinition(cwd),
+		write: createWriteToolDefinition(cwd),
+	};
 	const builtInTools = {
 		read: createReadTool(cwd),
 		grep: createGrepTool(cwd),
@@ -118,18 +136,27 @@ test("registerToolDisplayOverrides copies built-in prompt metadata onto overridd
 		write: createWriteTool(cwd),
 	};
 
-	for (const [name, builtInTool] of Object.entries(builtInTools)) {
+	for (const [name, definition] of Object.entries(builtInDefinitions)) {
 		const registeredTool = byName.get(name);
-		const builtInMetadata = builtInTool as unknown as RegisteredToolLike;
+		const builtInTool = builtInTools[name as keyof typeof builtInTools] as unknown as RegisteredToolLike;
 		assert.ok(registeredTool, `expected '${name}' to be registered`);
-		assert.equal(registeredTool.description, builtInMetadata.description);
-		assert.equal(registeredTool.promptSnippet, builtInMetadata.promptSnippet);
+		assert.equal(registeredTool.description, builtInTool.description);
+		assert.equal(typeof definition.promptSnippet, "string");
+		assert.ok((definition.promptSnippet ?? "").trim().length > 0, `${name} definition has promptSnippet`);
+		assert.equal(registeredTool.promptSnippet, definition.promptSnippet);
 	}
 
+	// Regression: AgentTool wrappers drop prompt metadata. Overrides must not
+	// copy that loss, or Pi omits the tools from Available tools.
+	assert.equal((builtInTools.read as unknown as RegisteredToolLike).promptSnippet, undefined);
+	assert.notEqual(byName.get("read")?.promptSnippet, undefined);
+
 	const intentGuidelines = new Set<string>();
-	for (const [name, builtInTool] of Object.entries(builtInTools)) {
+	for (const [name, definition] of Object.entries(builtInDefinitions)) {
 		const registeredGuidelines = byName.get(name)?.promptGuidelines ?? [];
-		const builtInGuidelines = (builtInTool as unknown as RegisteredToolLike).promptGuidelines ?? [];
+		const builtInGuidelines = Array.isArray(definition.promptGuidelines)
+			? definition.promptGuidelines
+			: [];
 		assert.deepEqual(registeredGuidelines.slice(0, -1), builtInGuidelines);
 		const intentGuideline = registeredGuidelines.at(-1) ?? "";
 		assert.match(intentGuideline, /displaySummary/);

--- a/packages/pi-tool-display-intent/tests/tool-overrides-registration.test.ts
+++ b/packages/pi-tool-display-intent/tests/tool-overrides-registration.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import {
 	createBashTool,
 	createBashToolDefinition,
@@ -331,6 +332,36 @@ test("cooperative custom tools can share intent, execution stripping, and inheri
 		{},
 	) as { render(width: number): string[] };
 	assert.match(resultComponent.render(160).join("\n"), /Remote · 2 values/);
+
+
+	const errorResult = {
+		content: [{ type: "text", text: "Remote content failure\nstack frame one\nstack frame two" }],
+		details: { summary: "presentation must not replace content" },
+	};
+	const collapsedError = customTool.renderResult?.(
+		errorResult,
+		{ expanded: false, isPartial: false },
+		theme,
+		{ isError: true },
+	) as { render(width: number): string[] };
+	const collapsedErrorLines = collapsedError.render(32).map((line) => line.trimEnd());
+	assert.equal(collapsedErrorLines.length, 1);
+	assert.ok(visibleWidth(collapsedErrorLines[0] ?? "") <= 32);
+	assert.match(collapsedErrorLines[0] ?? "", /^↳ Remote content failure/u);
+	assert.doesNotMatch(collapsedErrorLines[0] ?? "", /Remote · 2 values/);
+
+	const expandedError = customTool.renderResult?.(
+		errorResult,
+		{ expanded: true, isPartial: false },
+		theme,
+		{ isError: true },
+	) as { render(width: number): string[] };
+	assert.equal(
+		expandedError.render(160).map((line) => line.trimEnd()).join("\n"),
+		"Remote content failure\nstack frame one\nstack frame two",
+	);
+
+	
 
 	await customTool.execute("call-custom", args);
 	assert.deepEqual(executedArgs, { query: "alpha" });


### PR DESCRIPTION
## Summary
Improve `pi-tool-display-intent` transcript readability and failure visibility as four focused commits:

1. **Restore built-in `promptSnippet`** on tool overrides.
2. **Force-visible error summary** for generic/MCP tools in every `results.mode` (including compact/hidden). Collapsed view shows one content-derived error line; `Ctrl+O` expands full error content. Successful compact output stays hidden. Built-in read/grep/find/ls are intentionally unchanged.
3. **Compact long paths** in built-in call headers at narrow widths; expand restores the full path.
4. **Claude-style Bash framing**: connected gutters, clearer command preview, `results.previewRows` minimum raised to 2.

## Test plan
- [x] `pnpm --filter @zhcsyncer/pi-tool-display-intent check` (751 tests)
- [ ] Spot-check in TUI: fail a `web_search` under `results.mode=compact` and confirm a one-line error appears; expand for details
- [ ] Spot-check long-path `read`/`grep` call headers collapse/expand
- [ ] Spot-check Claude-style Bash multi-line output gutters

## Notes
- Changesets included for each user-visible fix.
- Search Hub execute/timeout logic is not changed; it benefits via shared generic renderer.