### PR TITLE
docs: record Pi gallery search discoverability red line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 - 不要直接运行版本升级或发布命令，也不要绕过 version PR 直接向 `main` 提交发版版本、推送发布 tag 或手动发布 npm 包。
 - 准备发布根包 `@zhcsyncer/pi-extensions` 时，先检查并处理 [`BACKLOG.md`](./BACKLOG.md) 中标记为下一次根包发布前完成的未勾选事项。
 - 发版前必须先向用户列出计划更新的包、当前版本和目标版本，并等待用户明确 review/确认；确认前不得将发版变更推送到 `main`、合并 version PR 或触发发布。
+- 公开包进 Pi gallery **能打开详情页 ≠ 能被搜索到**。gallery 检索依赖 npm search（`keywords:pi-package`）；npm `score.final = 0` 或 registry 未收录 README 时，包会在搜索中隐形。新包 bootstrap / 既有包发版后必须核验：registry 有 README 元数据、npm search 对该包 `score.final > 0`、`pi.dev/packages` 能搜到。不要为了刷索引单独发版；细则与未修项见 [`RELEASING.md`](./RELEASING.md) 与 [`BACKLOG.md`](./BACKLOG.md)。

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,3 +21,40 @@ Repository-level follow-up work that should remain discoverable across sessions.
   - Both language versions stay structurally aligned and link to one another.
   - Package file lists and pack checks include both language versions where applicable.
   - Add an appropriate changeset if the documentation update accompanies user-visible behavior changes.
+
+## Future packages
+
+- [ ] `pi-herdr-blocked`: companion extension that emits `herdr:blocked` events so HerdR shows `blocked` (not `working`) while Pi waits on ask-question / permission / plan-review prompts.
+
+  Requirement and design source: [`herdr-blocked-extension-design.md`](./herdr-blocked-extension-design.md).
+
+  Acceptance criteria: see the design doc's 验收标准 section (blocked visible via `herdr agent explain`, no stuck-blocked after interrupts, full `idle → working → blocked → working → idle` chain reproducible).
+
+## Next related package release
+
+- [ ] Fix npm / Pi Package Gallery search discoverability alongside the next otherwise-needed package change; do not cut a standalone release only to force reindexing.
+
+  Observed failure mode (2026-07-29):
+
+  - Direct pages and install commands already work, e.g. `https://pi.dev/packages/@zhcsyncer/pi-plan-mode` and `pi install npm:@zhcsyncer/pi-plan-mode`.
+  - Pi gallery search depends on the npm search API filtered by `keywords:pi-package`. A package with npm search `score.final = 0` is effectively invisible there even when the registry package and direct page exist.
+  - `@zhcsyncer/pi-plan-mode@0.3.0` and `@zhcsyncer/pi-context7@0.1.0` currently return search score `0` (author query `zhcsyncer`); they do not appear in `plan-mode` / `keywords:pi-package plan-mode` top results.
+  - For `@zhcsyncer/pi-plan-mode`, the published tarball contains `README.md`, but registry metadata has empty `readmeFilename` / no `readme` body. Search-index download counts also disagree with the downloads API. Treat this as broken search/README ingestion, not “unpublished”.
+  - Sibling packages such as `@zhcsyncer/pi-todo`, `@zhcsyncer/pi-recap`, and `@zhcsyncer/pi-extensions` currently have non-zero search scores and remain findable.
+
+  Acceptance criteria:
+
+  - While touching the affected packages for a real user-visible change, also repair discoverability signals:
+    - ensure publish leaves npm registry metadata with a non-empty root `README.md` (`readmeFilename` + `readme` body);
+    - keep/repair `keywords` including `pi-package` plus package-specific search terms;
+    - expand `@zhcsyncer/pi-todo` metadata with broader Pi/task-planning terms such as `pi`, `pi-coding-agent`, `task-management`, and `planning` if still thin;
+    - recheck `@zhcsyncer/pi-glance` and apply the same metadata/README fixes if its search score is zero or weak.
+  - Prioritize restoring non-zero search score for `@zhcsyncer/pi-plan-mode` and `@zhcsyncer/pi-context7`.
+  - Publish through the normal Changesets version PR flow together with the next related user-visible release; do not release solely to poke the npm indexer.
+  - After npm has had time to reindex the new versions, verify for each touched public package:
+    1. registry package metadata includes README;
+    2. npm search API returns the exact package with `score.final > 0` for author/name queries;
+    3. `keywords:pi-package <distinctive-term>` can surface it;
+    4. `pi.dev/packages/<name>` still works and gallery search can find it;
+    5. direct install commands still work.
+  - If a package still has search score `0` after reindexing evidence is solid, report upstream (npm and/or Pi gallery) with direct-page + score-0 evidence rather than repeatedly bumping versions.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -82,3 +82,14 @@ Do not push the release-bearing change to `main`, merge the generated version PR
 6. The workflow reconciles package tags and creates GitHub Releases for the packages published in that plan.
 
 Publishing and release reconciliation are idempotent. If npm publishing partially succeeds or GitHub Release creation fails, rerun the failed workflow job.
+
+## Post-publish discoverability check
+
+A working direct package page or `pi install npm:<name>` is not enough. The Pi package gallery search uses the npm search API (typically with `keywords:pi-package`). Packages can be fully installable and still invisible in search when npm's search score stays at `0` or registry metadata omits the README body.
+
+After bootstrap or any public package publish, once npm has had time to reindex:
+
+1. Confirm registry metadata for the new version includes a root `README.md` (`readmeFilename` and non-empty `readme`), not only a file inside the tarball.
+2. Query the npm search API for the exact package / author and require `score.final > 0`.
+3. Confirm a distinctive `keywords:pi-package …` query can surface the package, and that `https://pi.dev/packages/<name>` remains reachable from gallery search—not only by typed URL.
+4. If score remains `0` after solid reindex evidence, file an upstream indexing issue; do not cut versions solely to poke the indexer. Track outstanding cases in [`BACKLOG.md`](./BACKLOG.md).


### PR DESCRIPTION
## Summary
- Record that Pi gallery search visibility depends on npm search score, not just a working direct package page.
- Track `@zhcsyncer/pi-plan-mode` / `@zhcsyncer/pi-context7` score-0 follow-up in BACKLOG.
- Add a short release red line in AGENTS.md and a post-publish checklist in RELEASING.md.

## Test plan
- [x] Docs-only change; no package behavior impact.
- Commit includes `[skip ci]` intent via message on the original commit; validate may still be required by branch protection.