### PR TITLE
feat(pi-subagents): fork tintinweb viewer with brief overlay and collapsible TUI

### DIFF
--- a/.changeset/pi-subagents-viewer-brief.md
+++ b/.changeset/pi-subagents-viewer-brief.md
@@ -2,4 +2,4 @@
 "@zhcsyncer/pi-subagents": minor
 ---
 
-Add a maintained fork of `@tintinweb/pi-subagents@0.14.3` with a ConversationViewer that defaults to dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps. Failed or cancelled bash executions show as error steps.
+Add a maintained fork of `@tintinweb/pi-subagents@0.14.3` with a ConversationViewer that defaults to dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps. Failed or cancelled bash executions show as error steps. Compact collapsible TUI for Agent / get_subagent_result / steer_subagent (Markdown when expanded).

--- a/.changeset/pi-subagents-viewer-brief.md
+++ b/.changeset/pi-subagents-viewer-brief.md
@@ -2,4 +2,4 @@
 "@zhcsyncer/pi-subagents": minor
 ---
 
-Add a maintained fork of `@tintinweb/pi-subagents@0.14.3` with a ConversationViewer that defaults to dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps. Failed or cancelled bash executions show as error steps. Compact collapsible TUI for Agent / get_subagent_result / steer_subagent (Markdown when expanded), with model and effort chips on tool call/result rows.
+Add a maintained fork of `@tintinweb/pi-subagents@0.14.3` with a ConversationViewer that defaults to dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps. Failed or cancelled bash executions show as error steps. Compact collapsible TUI for Agent / get_subagent_result / steer_subagent (Markdown when expanded), with model and effort chips on tool call/result rows. Honesty fixes: queued status/activity, failure `isError` shell mapping, resume chips from stored invocation, steered/stopped overlay chrome, dangling-step settle, stricter header peel and failure heuristics.

--- a/.changeset/pi-subagents-viewer-brief.md
+++ b/.changeset/pi-subagents-viewer-brief.md
@@ -1,5 +1,6 @@
 ---
+"@zhcsyncer/pi-extensions": minor
 "@zhcsyncer/pi-subagents": minor
 ---
 
-Add a maintained fork of `@tintinweb/pi-subagents@0.14.3` with a ConversationViewer that defaults to dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps. Failed or cancelled bash executions show as error steps. Compact collapsible TUI for Agent / get_subagent_result / steer_subagent (Markdown when expanded), with model and effort chips on tool call/result rows. Honesty fixes: queued status/activity, failure `isError` shell mapping, resume chips from stored invocation, steered/stopped overlay chrome, dangling-step settle, stricter header peel and failure heuristics.
+Add a maintained fork of `@tintinweb/pi-subagents@0.14.3` with a ConversationViewer that defaults to dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps. Failed or cancelled bash executions show as error steps. Compact collapsible TUI for Agent / get_subagent_result / steer_subagent (Markdown when expanded), with model and effort chips on tool call/result rows. Honesty fixes: queued status/activity, failure `isError` shell mapping, resume chips from stored invocation, steered/stopped overlay chrome, dangling-step settle, stricter header peel and failure heuristics. Embed and register the package in the root `@zhcsyncer/pi-extensions` bundle.

--- a/.changeset/pi-subagents-viewer-brief.md
+++ b/.changeset/pi-subagents-viewer-brief.md
@@ -2,4 +2,4 @@
 "@zhcsyncer/pi-subagents": minor
 ---
 
-Add a maintained fork of `@tintinweb/pi-subagents@0.14.3` with a ConversationViewer that defaults to dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps.
+Add a maintained fork of `@tintinweb/pi-subagents@0.14.3` with a ConversationViewer that defaults to dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps. Failed or cancelled bash executions show as error steps.

--- a/.changeset/pi-subagents-viewer-brief.md
+++ b/.changeset/pi-subagents-viewer-brief.md
@@ -1,0 +1,5 @@
+---
+"@zhcsyncer/pi-subagents": minor
+---
+
+Add a maintained fork of `@tintinweb/pi-subagents@0.14.3` with a ConversationViewer that defaults to dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps.

--- a/.changeset/pi-subagents-viewer-brief.md
+++ b/.changeset/pi-subagents-viewer-brief.md
@@ -2,4 +2,4 @@
 "@zhcsyncer/pi-subagents": minor
 ---
 
-Add a maintained fork of `@tintinweb/pi-subagents@0.14.3` with a ConversationViewer that defaults to dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps. Failed or cancelled bash executions show as error steps. Compact collapsible TUI for Agent / get_subagent_result / steer_subagent (Markdown when expanded).
+Add a maintained fork of `@tintinweb/pi-subagents@0.14.3` with a ConversationViewer that defaults to dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps. Failed or cancelled bash executions show as error steps. Compact collapsible TUI for Agent / get_subagent_result / steer_subagent (Markdown when expanded), with model and effort chips on tool call/result rows.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -35,3 +35,48 @@ Repository-level follow-up work that should remain discoverable across sessions.
   - Add the Ask User Question pair to the bilingual parity check so a missing or structurally divergent translation fails CI.
   - Add an explicit repository-wide rule to `AGENTS.md`: maintained user-facing package documentation is bilingual, with English in `README.md` and Simplified Chinese in `README.zh-CN.md`, unless a documented exception applies.
   - Add the appropriate package and root changeset because the corrected README is user-visible in both npm artifacts.
+
+## `@zhcsyncer/pi-subagents` (post honesty-fix residuals)
+
+Fork display work and adversarial-review P1/P2 honesty fixes are on the branch; these are **not** ship-blockers. Track here so they stay visible before first public cut / root-bundle inclusion.
+
+- [ ] **Redact sensitive args in parent TUI activity / Steps**
+
+  Default widget activity and overlay step summaries currently surface raw bash commands, URLs, and patterns from the child agent. Tokens, passwords, and signed URLs can land in the parent terminal, screenshots, and logs.
+
+  Acceptance criteria:
+
+  - Default collapsed views show a safe summary (e.g. executable + redacted args), not full command lines with secrets.
+  - Common secret shapes (bearer/token/password/authorization, obvious URL query secrets) are masked.
+  - Full args remain available only behind explicit expand (`o` / Ctrl+O), with no regression to false ✓/✗ status chrome.
+  - Unit coverage for at least one bash command containing a token-like value.
+
+- [ ] **Strip ANSI / terminal control sequences from child-sourced display text**
+
+  Tool args and outputs can carry ESC/OSC sequences into parent widget lines and step notes; pi-tui may pass them through.
+
+  Acceptance criteria:
+
+  - Paths that feed parent TUI (`formatActiveToolSummary`, step result notes, undetailed previews) strip C0/C1 and ESC sequences before render.
+  - Printable text and normal wide characters still display correctly.
+  - A regression test feeds an ESC/OSC payload and asserts it does not appear raw in the rendered line.
+
+- [ ] **Guard against double-loading upstream + fork**
+
+  README warns not to load `@tintinweb/pi-subagents` together with this fork; code does not detect duplicate `Agent` / FleetView registration.
+
+  Acceptance criteria:
+
+  - On extension load, if the same tool names are already registered (or a known upstream marker is present), emit a clear warning naming both packages.
+  - Does not hard-crash the session; warning is enough for operator recovery.
+  - Documented in package README try steps.
+
+- [ ] **Persist invocation snapshot for schedule / RPC spawns**
+
+  Agents started via schedule (and some RPC paths) may lack `record.invocation`, so `get_subagent_result` cannot show model/effort chips.
+
+  Acceptance criteria:
+
+  - Schedule (and RPC spawn if applicable) attach the same `AgentInvocation` shape as the Agent tool path.
+  - `get_subagent_result` call/result chips match a normally spawned background agent when model/thinking were configured on the job.
+  - Contract test covers schedule → get_result chip restore.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A collection of Pi extensions by zhcsyncer.
 - [`@zhcsyncer/pi-search-hub`](./packages/pi-search-hub) — bundle-private `web_search` and `web_read` tools integrated with intent-aware rendering.
 - [`@zhcsyncer/pi-context7`](./packages/pi-context7) — Context7 `resolve-library-id` / `query-docs` tools with compact self-contained TUI rendering and the full `context7-docs` skill.
 - [`@zhcsyncer/pi-ask-user-question`](./packages/pi-ask-user-question) — structured clarification questions with a non-overlay layout, context-aware number-key selection, centered previews, and readable post-interaction results.
+- [`@zhcsyncer/pi-subagents`](./packages/pi-subagents) — maintained fork of `@tintinweb/pi-subagents` with a brief ConversationViewer and collapsible tool TUI (model/effort chips). **Not** in the root bundle yet — load with `-e` (see below).
 
 ## Bundle-private Search Hub
 
@@ -26,6 +27,21 @@ This fork keeps upstream multi-backend search and page extraction while integrat
 `@zhcsyncer/pi-context7` is a maintained fork of Context7 documentation tools. It can be installed on its own or used through the root bundle, which embeds and registers the same extension and skill.
 
 This fork keeps upstream tool descriptions, model-facing result text, and the full skill while adding compact local `renderCall` / `renderResult` rows, AbortSignal-aware fetches, and HTTP error throwing for correct Pi tool-error marking. Set `CONTEXT7_API_KEY` for higher quotas. See the [Context7 documentation](./packages/pi-context7/README.md) or its [Simplified Chinese version](./packages/pi-context7/README.zh-CN.md).
+
+## Subagents (workspace fork, not in root bundle yet)
+
+`@zhcsyncer/pi-subagents` is a maintained fork of [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) 0.14.3. Upstream runtime (Agent / steer / resume / FleetView / notifications) is unchanged; this fork changes **how progress is shown**:
+
+- Conversation overlay defaults to **Prompt · one-line Steps · Result** (not a full toolResult dump)
+- Main-transcript tool rows are collapsible; expand uses Markdown; call/result rows show **model** and **effort**
+
+It is a workspace package at pre-release `0.0.0` and is **not** registered on the root `@zhcsyncer/pi-extensions` `pi.extensions` list yet. Do not expect `pi install npm:@zhcsyncer/pi-extensions` to load it. Try from the monorepo:
+
+```bash
+pi -e ./packages/pi-subagents/src/index.ts
+```
+
+If `~/.pi/agent/settings.json` already loads `@tintinweb/pi-subagents`, disable that entry for the trial session. Upstream pin and the full local-diff checklist: [`packages/pi-subagents/UPSTREAM_SOURCE.md`](./packages/pi-subagents/UPSTREAM_SOURCE.md). User-facing comparison tables: [English package README](./packages/pi-subagents/README.md) (default) / [简体中文](./packages/pi-subagents/README.zh-CN.md).
 
 ## Persistent extension data
 
@@ -114,9 +130,12 @@ pi --no-extensions -e ./packages/pi-plan-mode --list-models nope
 pi --no-extensions -e ./packages/pi-search-hub --list-models nope
 pi --no-extensions -e ./packages/pi-context7 --list-models nope
 pi --no-extensions -e ./packages/pi-ask-user-question --list-models nope
+pi --no-extensions -e ./packages/pi-subagents/src/index.ts
 ```
 
 When testing `pi-tool-display-intent`, do not load the original `pi-tool-display` or `pi-tool-display-summary` at the same time because all three can own the same built-in tool names.
+
+When testing `pi-subagents`, do not load `@tintinweb/pi-subagents` at the same time (duplicate `Agent` / FleetView registration).
 
 ## Releasing
 
@@ -143,3 +162,5 @@ MIT
 `pi-context7` is forked from MIT-licensed [`@upstash/context7-pi`](https://github.com/upstash/context7) 0.1.2 (`b250c2515694eee4b6df4db82fa056df9ed3e306`). The exact revision and preserved notices are recorded in [`packages/pi-context7/UPSTREAM_SOURCE.md`](./packages/pi-context7/UPSTREAM_SOURCE.md), [`LICENSE`](./packages/pi-context7/LICENSE), and [`UPSTREAM_LICENSE`](./packages/pi-context7/UPSTREAM_LICENSE).
 
 `pi-ask-user-question` is forked from MIT-licensed [`@juicesharp/rpiv-ask-user-question`](https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-ask-user-question) 2.4.0. The exact revision and preserved notices are recorded in [`packages/pi-ask-user-question/UPSTREAM_SOURCE.md`](./packages/pi-ask-user-question/UPSTREAM_SOURCE.md), [`LICENSE`](./packages/pi-ask-user-question/LICENSE), and [`UPSTREAM_LICENSE`](./packages/pi-ask-user-question/UPSTREAM_LICENSE).
+
+`pi-subagents` is forked from MIT-licensed [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) 0.14.3 (`c10b1836256e760da75296ccd4e57a77ada1325e`). The exact revision, local UI deltas, and preserved notices are recorded in [`packages/pi-subagents/UPSTREAM_SOURCE.md`](./packages/pi-subagents/UPSTREAM_SOURCE.md), [`LICENSE`](./packages/pi-subagents/LICENSE), and [`UPSTREAM_LICENSE`](./packages/pi-subagents/UPSTREAM_LICENSE).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A collection of Pi extensions by zhcsyncer.
 - [`@zhcsyncer/pi-search-hub`](./packages/pi-search-hub) — bundle-private `web_search` and `web_read` tools integrated with intent-aware rendering.
 - [`@zhcsyncer/pi-context7`](./packages/pi-context7) — Context7 `resolve-library-id` / `query-docs` tools with compact self-contained TUI rendering and the full `context7-docs` skill.
 - [`@zhcsyncer/pi-ask-user-question`](./packages/pi-ask-user-question) — structured clarification questions with a non-overlay layout, context-aware number-key selection, centered previews, and readable post-interaction results.
-- [`@zhcsyncer/pi-subagents`](./packages/pi-subagents) — maintained fork of `@tintinweb/pi-subagents` with a brief ConversationViewer and collapsible tool TUI (model/effort chips). **Not** in the root bundle yet — load with `-e` (see below).
+- [`@zhcsyncer/pi-subagents`](./packages/pi-subagents) — maintained fork of `@tintinweb/pi-subagents` with a brief ConversationViewer and collapsible tool TUI (model/effort chips). Also embedded in the root bundle.
 
 ## Bundle-private Search Hub
 
@@ -28,20 +28,14 @@ This fork keeps upstream multi-backend search and page extraction while integrat
 
 This fork keeps upstream tool descriptions, model-facing result text, and the full skill while adding compact local `renderCall` / `renderResult` rows, AbortSignal-aware fetches, and HTTP error throwing for correct Pi tool-error marking. Set `CONTEXT7_API_KEY` for higher quotas. See the [Context7 documentation](./packages/pi-context7/README.md) or its [Simplified Chinese version](./packages/pi-context7/README.zh-CN.md).
 
-## Subagents (workspace fork, not in root bundle yet)
+## Subagents
 
-`@zhcsyncer/pi-subagents` is a maintained fork of [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) 0.14.3. Upstream runtime (Agent / steer / resume / FleetView / notifications) is unchanged; this fork changes **how progress is shown**:
+`@zhcsyncer/pi-subagents` is a maintained fork of [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) 0.14.3. It can be installed on its own or used through the root bundle, which embeds and registers the same extension. Upstream runtime (Agent / steer / resume / FleetView / notifications) is unchanged; this fork changes **how progress is shown**:
 
 - Conversation overlay defaults to **Prompt · one-line Steps · Result** (not a full toolResult dump)
 - Main-transcript tool rows are collapsible; expand uses Markdown; call/result rows show **model** and **effort**
 
-It is a workspace package at pre-release `0.0.0` and is **not** registered on the root `@zhcsyncer/pi-extensions` `pi.extensions` list yet. Do not expect `pi install npm:@zhcsyncer/pi-extensions` to load it. Try from the monorepo:
-
-```bash
-pi -e ./packages/pi-subagents/src/index.ts
-```
-
-If `~/.pi/agent/settings.json` already loads `@tintinweb/pi-subagents`, disable that entry for the trial session. Upstream pin and the full local-diff checklist: [`packages/pi-subagents/UPSTREAM_SOURCE.md`](./packages/pi-subagents/UPSTREAM_SOURCE.md). User-facing comparison tables: [English package README](./packages/pi-subagents/README.md) (default) / [简体中文](./packages/pi-subagents/README.zh-CN.md).
+Do **not** load `@tintinweb/pi-subagents` at the same time (duplicate `Agent` / FleetView registration). Upstream pin and the full local-diff checklist: [`packages/pi-subagents/UPSTREAM_SOURCE.md`](./packages/pi-subagents/UPSTREAM_SOURCE.md). User-facing comparison tables: [English package README](./packages/pi-subagents/README.md) (default) / [简体中文](./packages/pi-subagents/README.zh-CN.md).
 
 ## Persistent extension data
 
@@ -63,7 +57,7 @@ pi -e git:github.com/zhcsyncer/pi-extensions
 
 ## Install from npm
 
-Install the complete bundle, including Glance, Plan Mode, Context7, structured user questions, and the private Search Hub fork:
+Install the complete bundle, including Glance, Plan Mode, Context7, Subagents, structured user questions, and the private Search Hub fork:
 
 ```bash
 pi install npm:@zhcsyncer/pi-extensions
@@ -111,6 +105,12 @@ Install only structured user questions:
 pi install npm:@zhcsyncer/pi-ask-user-question
 ```
 
+Install only Subagents:
+
+```bash
+pi install npm:@zhcsyncer/pi-subagents
+```
+
 ## Development
 
 Test the root bundle:
@@ -130,7 +130,7 @@ pi --no-extensions -e ./packages/pi-plan-mode --list-models nope
 pi --no-extensions -e ./packages/pi-search-hub --list-models nope
 pi --no-extensions -e ./packages/pi-context7 --list-models nope
 pi --no-extensions -e ./packages/pi-ask-user-question --list-models nope
-pi --no-extensions -e ./packages/pi-subagents/src/index.ts
+pi --no-extensions -e ./packages/pi-subagents --list-models nope
 ```
 
 When testing `pi-tool-display-intent`, do not load the original `pi-tool-display` or `pi-tool-display-summary` at the same time because all three can own the same built-in tool names.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,7 @@ zhcsyncer 维护的一组 Pi extensions。
 - [`@zhcsyncer/pi-search-hub`](./packages/pi-search-hub) — bundle 私有的 `web_search` 和 `web_read` 工具，集成 intent-aware 展示。
 - [`@zhcsyncer/pi-context7`](./packages/pi-context7) — Context7 `resolve-library-id` / `query-docs` 工具，自包含紧凑 TUI 渲染，并附带完整 `context7-docs` Skill。
 - [`@zhcsyncer/pi-ask-user-question`](./packages/pi-ask-user-question) — 结构化澄清问答，采用非浮层布局，支持上下文感知的数字键直选、居中预览和可读的交互后结果。
+- [`@zhcsyncer/pi-subagents`](./packages/pi-subagents) — `@tintinweb/pi-subagents` 维护 fork：摘要 ConversationViewer + 可折叠 tool TUI（model/effort）。**尚未**进根 bundle — 用 `-e` 加载（见下）。
 
 ## Bundle 私有 Search Hub
 
@@ -26,6 +27,21 @@ zhcsyncer 维护的一组 Pi extensions。
 `@zhcsyncer/pi-context7` 是维护中的 Context7 文档工具 fork。可以单独安装，也可以通过根 bundle 使用；根 bundle 会嵌入并注册同一扩展与 Skill。
 
 该 fork 保留上游工具描述、面向模型的结果文本和完整 Skill，同时加入本地紧凑 `renderCall` / `renderResult` 行、AbortSignal 感知的 fetch，以及非 2xx HTTP 抛错以便 Pi 正确标记 tool error。更高配额请设置 `CONTEXT7_API_KEY`。详见 [Context7 中文文档](./packages/pi-context7/README.zh-CN.md) 或其 [英文版本](./packages/pi-context7/README.md)。
+
+## Subagents（工作区 fork，尚未进根 bundle）
+
+`@zhcsyncer/pi-subagents` 是 [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) 0.14.3 的维护 fork。上游运行时（Agent / steer / resume / FleetView / 通知）不变；本 fork 主要改 **进展怎么显示**：
+
+- 对话 overlay 默认 **Prompt · 一行 Steps · Result**（不再 dump 整墙 toolResult）
+- 主 transcript tool 行可折叠；展开为 Markdown；调用/结果行显示 **model** 与 **effort**
+
+工作区包预发版 `0.0.0`，**尚未**写入根包 `@zhcsyncer/pi-extensions` 的 `pi.extensions`。`pi install npm:@zhcsyncer/pi-extensions` **不会**加载它。在 monorepo 中试用：
+
+```bash
+pi -e ./packages/pi-subagents/src/index.ts
+```
+
+若 `~/.pi/agent/settings.json` 已加载 `@tintinweb/pi-subagents`，试用会话请先去掉该条目。上游钉扎与差异清单：[`packages/pi-subagents/UPSTREAM_SOURCE.md`](./packages/pi-subagents/UPSTREAM_SOURCE.md)。对比表默认英文：[package README](./packages/pi-subagents/README.md) / [简体中文](./packages/pi-subagents/README.zh-CN.md)。
 
 ## 扩展持久化数据
 
@@ -114,9 +130,12 @@ pi --no-extensions -e ./packages/pi-plan-mode --list-models nope
 pi --no-extensions -e ./packages/pi-search-hub --list-models nope
 pi --no-extensions -e ./packages/pi-context7 --list-models nope
 pi --no-extensions -e ./packages/pi-ask-user-question --list-models nope
+pi --no-extensions -e ./packages/pi-subagents/src/index.ts
 ```
 
 测试 `pi-tool-display-intent` 时，不要同时加载原始 `pi-tool-display` 或 `pi-tool-display-summary`，因为三者都可能持有同名内置工具。
+
+测试 `pi-subagents` 时，不要同时加载 `@tintinweb/pi-subagents`（会双注册 `Agent` / FleetView）。
 
 ## 发版
 
@@ -143,3 +162,5 @@ MIT
 `pi-context7` fork 自 MIT 许可的 [`@upstash/context7-pi`](https://github.com/upstash/context7) 0.1.2（`b250c2515694eee4b6df4db82fa056df9ed3e306`）。准确 revision 和保留声明见 [`packages/pi-context7/UPSTREAM_SOURCE.md`](./packages/pi-context7/UPSTREAM_SOURCE.md)、[`LICENSE`](./packages/pi-context7/LICENSE) 与 [`UPSTREAM_LICENSE`](./packages/pi-context7/UPSTREAM_LICENSE)。
 
 `pi-ask-user-question` fork 自 MIT 许可的 [`@juicesharp/rpiv-ask-user-question`](https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-ask-user-question) 2.4.0。准确 revision 和保留声明见 [`packages/pi-ask-user-question/UPSTREAM_SOURCE.md`](./packages/pi-ask-user-question/UPSTREAM_SOURCE.md)、[`LICENSE`](./packages/pi-ask-user-question/LICENSE) 与 [`UPSTREAM_LICENSE`](./packages/pi-ask-user-question/UPSTREAM_LICENSE)。
+
+`pi-subagents` fork 自 MIT 许可的 [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) 0.14.3（`c10b1836256e760da75296ccd4e57a77ada1325e`）。准确 revision、本地 UI 差异与保留声明见 [`packages/pi-subagents/UPSTREAM_SOURCE.md`](./packages/pi-subagents/UPSTREAM_SOURCE.md)、[`LICENSE`](./packages/pi-subagents/LICENSE) 与 [`UPSTREAM_LICENSE`](./packages/pi-subagents/UPSTREAM_LICENSE)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ zhcsyncer 维护的一组 Pi extensions。
 - [`@zhcsyncer/pi-search-hub`](./packages/pi-search-hub) — bundle 私有的 `web_search` 和 `web_read` 工具，集成 intent-aware 展示。
 - [`@zhcsyncer/pi-context7`](./packages/pi-context7) — Context7 `resolve-library-id` / `query-docs` 工具，自包含紧凑 TUI 渲染，并附带完整 `context7-docs` Skill。
 - [`@zhcsyncer/pi-ask-user-question`](./packages/pi-ask-user-question) — 结构化澄清问答，采用非浮层布局，支持上下文感知的数字键直选、居中预览和可读的交互后结果。
-- [`@zhcsyncer/pi-subagents`](./packages/pi-subagents) — `@tintinweb/pi-subagents` 维护 fork：摘要 ConversationViewer + 可折叠 tool TUI（model/effort）。**尚未**进根 bundle — 用 `-e` 加载（见下）。
+- [`@zhcsyncer/pi-subagents`](./packages/pi-subagents) — `@tintinweb/pi-subagents` 维护 fork：摘要 ConversationViewer + 可折叠 tool TUI（model/effort）。也嵌入根 bundle。
 
 ## Bundle 私有 Search Hub
 
@@ -28,20 +28,14 @@ zhcsyncer 维护的一组 Pi extensions。
 
 该 fork 保留上游工具描述、面向模型的结果文本和完整 Skill，同时加入本地紧凑 `renderCall` / `renderResult` 行、AbortSignal 感知的 fetch，以及非 2xx HTTP 抛错以便 Pi 正确标记 tool error。更高配额请设置 `CONTEXT7_API_KEY`。详见 [Context7 中文文档](./packages/pi-context7/README.zh-CN.md) 或其 [英文版本](./packages/pi-context7/README.md)。
 
-## Subagents（工作区 fork，尚未进根 bundle）
+## Subagents
 
-`@zhcsyncer/pi-subagents` 是 [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) 0.14.3 的维护 fork。上游运行时（Agent / steer / resume / FleetView / 通知）不变；本 fork 主要改 **进展怎么显示**：
+`@zhcsyncer/pi-subagents` 是 [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) 0.14.3 的维护 fork。可单独安装，也可通过根 bundle 使用；根 bundle 会嵌入并注册同一扩展。上游运行时（Agent / steer / resume / FleetView / 通知）不变；本 fork 主要改 **进展怎么显示**：
 
 - 对话 overlay 默认 **Prompt · 一行 Steps · Result**（不再 dump 整墙 toolResult）
 - 主 transcript tool 行可折叠；展开为 Markdown；调用/结果行显示 **model** 与 **effort**
 
-工作区包预发版 `0.0.0`，**尚未**写入根包 `@zhcsyncer/pi-extensions` 的 `pi.extensions`。`pi install npm:@zhcsyncer/pi-extensions` **不会**加载它。在 monorepo 中试用：
-
-```bash
-pi -e ./packages/pi-subagents/src/index.ts
-```
-
-若 `~/.pi/agent/settings.json` 已加载 `@tintinweb/pi-subagents`，试用会话请先去掉该条目。上游钉扎与差异清单：[`packages/pi-subagents/UPSTREAM_SOURCE.md`](./packages/pi-subagents/UPSTREAM_SOURCE.md)。对比表默认英文：[package README](./packages/pi-subagents/README.md) / [简体中文](./packages/pi-subagents/README.zh-CN.md)。
+**不要**与 `@tintinweb/pi-subagents` 同时加载（会双注册 `Agent` / FleetView）。上游钉扎与差异清单：[`packages/pi-subagents/UPSTREAM_SOURCE.md`](./packages/pi-subagents/UPSTREAM_SOURCE.md)。对比表默认英文：[package README](./packages/pi-subagents/README.md) / [简体中文](./packages/pi-subagents/README.zh-CN.md)。
 
 ## 扩展持久化数据
 
@@ -63,7 +57,7 @@ pi -e git:github.com/zhcsyncer/pi-extensions
 
 ## 从 npm 安装
 
-安装包含 Glance、Plan Mode、Context7、结构化问答，以及私有 Search Hub fork 的完整 bundle：
+安装包含 Glance、Plan Mode、Context7、Subagents、结构化用户问答，以及私有 Search Hub fork 的完整 bundle：
 
 ```bash
 pi install npm:@zhcsyncer/pi-extensions
@@ -130,7 +124,7 @@ pi --no-extensions -e ./packages/pi-plan-mode --list-models nope
 pi --no-extensions -e ./packages/pi-search-hub --list-models nope
 pi --no-extensions -e ./packages/pi-context7 --list-models nope
 pi --no-extensions -e ./packages/pi-ask-user-question --list-models nope
-pi --no-extensions -e ./packages/pi-subagents/src/index.ts
+pi --no-extensions -e ./packages/pi-subagents --list-models nope
 ```
 
 测试 `pi-tool-display-intent` 时，不要同时加载原始 `pi-tool-display` 或 `pi-tool-display-summary`，因为三者都可能持有同名内置工具。

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-This repository publishes eight public npm packages:
+This repository publishes ten public npm packages:
 
 - `@zhcsyncer/pi-extensions`
 - `@zhcsyncer/pi-recap`
@@ -9,7 +9,10 @@ This repository publishes eight public npm packages:
 - `@zhcsyncer/pi-glance`
 - `@zhcsyncer/pi-plan-mode`
 - `@zhcsyncer/pi-context7`
+- `@zhcsyncer/pi-ask-user-question`
+- `@zhcsyncer/pi-subagents`
 - `pi-provider-volcengine-agent-plan`
+
 
 Packages version independently. Because the aggregate root tarball embeds bundled child sources, every bundled child release must include a root release of at least the same bump level. The standalone `pi-provider-volcengine-agent-plan` package is excluded from the aggregate tarball and may release without the root. Unchanged siblings remain unreleased.
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,15 @@
     "packages/pi-ask-user-question/UPSTREAM_SOURCE.md",
     "!packages/pi-ask-user-question/**/*.test.ts",
     "!packages/pi-ask-user-question/test-support.ts",
-    "!packages/pi-ask-user-question/test-fixtures.ts"
+    "!packages/pi-ask-user-question/test-fixtures.ts",
+    "packages/pi-subagents/package.json",
+    "packages/pi-subagents/examples/**/*",
+    "packages/pi-subagents/CHANGELOG.md",
+    "packages/pi-subagents/UPSTREAM_README.md",
+    "packages/pi-subagents/UPSTREAM_CHANGELOG.md",
+    "packages/pi-subagents/UPSTREAM_SOURCE.md",
+    "!packages/pi-subagents/**/*.test.ts",
+    "!packages/pi-subagents/test/**"
   ],
   "publishConfig": {
     "access": "public"
@@ -108,7 +116,8 @@
       "./packages/pi-plan-mode/extensions/plan-mode.ts",
       "./packages/pi-search-hub/extensions/search-hub.ts",
       "./packages/pi-context7/extensions/context7.ts",
-      "./packages/pi-ask-user-question/index.ts"
+      "./packages/pi-ask-user-question/index.ts",
+      "./packages/pi-subagents/src/index.ts"
     ],
     "skills": [
       "./packages/pi-context7/skills"
@@ -116,6 +125,9 @@
   },
   "dependencies": {
     "@juicesharp/rpiv-config": "2.4.0",
+    "@sinclair/typebox": "^0.34.49",
+    "croner": "^10.0.1",
+    "nanoid": "^5.0.0",
     "typebox": "1.1.24",
     "wreq-js": "2.3.1"
   },

--- a/packages/pi-subagents/CHANGELOG.md
+++ b/packages/pi-subagents/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial maintained fork of `@tintinweb/pi-subagents@0.14.3` as `@zhcsyncer/pi-subagents`.
+- ConversationViewer default overlay shows dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps. Press `o` to expand step detail.

--- a/packages/pi-subagents/CHANGELOG.md
+++ b/packages/pi-subagents/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## 0.1.0
+## Unreleased
 
-### Minor Changes
-
-- Initial maintained fork of `@tintinweb/pi-subagents@0.14.3` as `@zhcsyncer/pi-subagents`.
-- ConversationViewer default overlay shows dispatch prompt, one-line tool step summaries, and final/current result instead of full tool-result dumps. Press `o` to expand step detail.
+Initial public release will be cut by Changesets from `0.0.0`.

--- a/packages/pi-subagents/CONTRIBUTING.md
+++ b/packages/pi-subagents/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to @tintinweb/pi-subagents
+
+This guide exists to save both sides time.
+
+## Philosophy
+
+`pi-subagents` is a [pi](https://pi.dev) extension, and it tries to stay focused:
+spawn and orchestrate autonomous sub-agents that feel native to pi, and do that
+well. Features that don't serve that goal, or that bolt on unrelated complexity,
+are likely to be declined. When in doubt, open an issue and discuss the idea
+before writing the code.
+
+The extension deliberately mirrors Claude Code's tool names, calling
+conventions, and UI patterns. Changes should respect that compatibility unless
+there's a good reason to diverge.
+
+## The One Rule
+
+**You must understand your code.** If you cannot explain what your changes do and
+how they interact with the rest of the system, the PR will be closed.
+
+Using AI to write code is fine. Submitting AI-generated slop without
+understanding it is not.
+
+## Filing Issues
+
+Keep issues short, concrete, and worth reading.
+
+- Keep it concise. If it does not fit on one screen, it is too long.
+- Write in your own voice. If you used an LLM to draft it, review and shape it
+  yourself before posting.
+- State the bug or request clearly, and explain why it matters.
+- For bugs, include a minimal repro: pi version, this extension's version, your
+  agent/config, the steps, and the actual vs. expected behavior.
+- If you want to implement the change yourself, say so.
+
+For security issues, do **not** open a public issue — see [SECURITY.md](SECURITY.md).
+
+## Before Submitting a PR
+
+For anything beyond a trivial fix, open an issue first so we can agree on the
+approach before you invest the time.
+
+Make sure the full check suite passes locally:
+
+```bash
+npm run lint        # biome
+npm run typecheck   # tsc --noEmit
+npm run test        # vitest
+npm run build       # tsc
+```
+
+All four must pass. `npm run lint:fix` will auto-fix most style issues, and
+`npm run test:e2e` runs the end-to-end suite if your change touches that surface.
+
+Other guidelines:
+
+- Keep PRs focused — one logical change per PR. Unrelated refactors make review
+  harder and are likely to be split out or declined.
+- Add or update tests for behavior you change.
+- Match the surrounding code style (enforced by biome).
+- Do not edit `CHANGELOG.md`. Changelog entries are added by the maintainer.
+- Update the README when you add or change user-facing behavior.
+
+## Questions?
+
+Open an [issue](https://github.com/tintinweb/pi-subagents/issues) — questions and
+discussion are welcome.

--- a/packages/pi-subagents/LICENSE
+++ b/packages/pi-subagents/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 tintinweb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -41,7 +41,8 @@ Keys (unchanged unless noted):
 
 `Agent`, `get_subagent_result`, and `steer_subagent` use compact custom renderers:
 
-- **Collapsed (default):** status/stats + one-line result preview — no full transcript wall
+- **Call line:** type/description plus **model** and **effort** chips (`model: inherit` when unset; `effort:` maps from tool/frontmatter `thinking`)
+- **Collapsed (default):** status/stats (model, effort, tools, tokens, …) + one-line result preview — no full transcript wall
 - **Expanded (`Ctrl+O` / tools expand):** status header + **Markdown** body
 
 ## Package scripts

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -17,11 +17,11 @@ This fork keeps upstream **runtime** behavior (spawn, steer, resume, FleetView w
 | --- | --- | --- |
 | **Conversation overlay** (FleetView / agent list → Enter) | Full conversation dump: user / assistant / toolResult walls (tool bodies truncated ~500 chars but still large) | **Scheme A brief view**: **Prompt** → **Steps** (one line per tool) → **Result**; tool bodies folded by default |
 | Overlay step detail | N/A (everything dumped) | Press **`o`** to expand/fold tool args + results |
-| Overlay on agent **error / aborted / stopped** | Last messages still dominate the dump | **Result** prefers `record.error` (or stopped/aborted label); mid-run assistant text is demoted to a dim footnote |
+| Overlay on agent **error / aborted / stopped / steered** | Last messages still dominate the dump | **Result** prefers `record.error`; `steered` shows turn-limit; header icons match chrome; terminal records settle dangling running steps |
 | Overlay **bashExecution** | Shown as command + output dump | One step line; **`exitCode` / `cancelled`** → `✗` (not a false `✓`) |
-| **Main transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` has Claude Code chrome; **`get_subagent_result` has no custom `renderResult`** → Pi dumps full payload | Same **Claude Code chrome** for all three tools: `▸ Type  desc` / `✓ stats` + `⎿ Done` (running: `⠹` + `⎿ activity`); **Ctrl+O** expands Markdown body without dumping by default |
-| Tool **model / effort** | Model often omitted when same as parent; thinking only in tags if set | **Result stats** always include effective model (`haiku (inherit)` when inherited) + `effort:` from `thinking`; call line only adds chips when args explicitly set model/thinking/bg |
-| Validation / not-found tool failures | Plain text result (with custom Agent renderer missing details → easy to misread after collapse work) | `error` details (or undetailed fallback that **never** paints success `✓`) |
+| **Main transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` has Claude Code chrome; **`get_subagent_result` has no custom `renderResult`** → Pi dumps full payload | Same **Claude Code chrome** for all three; queued is honest (`queued…`); **Ctrl+O** expands Markdown without dumping by default |
+| Tool **model / effort** | Model often omitted when same as parent; thinking only in tags if set | **Result stats** always include effective model (`haiku (inherit)` when inherited) + `effort:`; resume chips come from stored invocation |
+| Validation / not-found tool failures | Plain text result (with custom Agent renderer missing details → easy to misread after collapse work) | `error` details + `tool_result` → Pi `isError` (error shell); undetailed success paths never heuristic-red |
 | Packaging | Standalone npm package | Workspace package `@zhcsyncer/pi-subagents` at **`0.0.0`** until Changesets cuts the first release; **not** registered in the root `@zhcsyncer/pi-extensions` bundle yet — load with `-e` (below) |
 
 ### What did *not* change

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -1,49 +1,80 @@
 # @zhcsyncer/pi-subagents
 
-Maintained fork of [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) with a **brief ConversationViewer**: dispatch prompt, one-line tool step summaries, and final result — instead of dumping full tool-result walls in the overlay.
-
-Upstream documentation is preserved in [`UPSTREAM_README.md`](./UPSTREAM_README.md). Source pin and local deltas: [`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md).
+Maintained fork of [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) (`v0.14.3` / `@tintinweb/pi-subagents@0.14.3`).
 
 > Chinese: [README.zh-CN.md](./README.zh-CN.md)
 
+**Full upstream docs** (features, Agent tool, schedules, settings): [`UPSTREAM_README.md`](./UPSTREAM_README.md)  
+**Pin + license trail**: [`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md) · [`UPSTREAM_LICENSE`](./UPSTREAM_LICENSE)
+
+---
+
+## Differences from upstream (read this first)
+
+This fork keeps upstream **runtime** behavior (spawn, steer, resume, FleetView wiring, notifications, schedules). The changes are almost entirely **how progress and tool results are shown** in the TUI — so you can scan subagent work without drowning in dumps.
+
+| Area | Upstream (`@tintinweb/pi-subagents`) | This fork (`@zhcsyncer/pi-subagents`) |
+| --- | --- | --- |
+| **Conversation overlay** (FleetView / agent list → Enter) | Full conversation dump: user / assistant / toolResult walls (tool bodies truncated ~500 chars but still large) | **Scheme A brief view**: **Prompt** → **Steps** (one line per tool) → **Result**; tool bodies folded by default |
+| Overlay step detail | N/A (everything dumped) | Press **`o`** to expand/fold tool args + results |
+| Overlay on agent **error / aborted / stopped** | Last messages still dominate the dump | **Result** prefers `record.error` (or stopped/aborted label); mid-run assistant text is demoted to a dim footnote |
+| Overlay **bashExecution** | Shown as command + output dump | One step line; **`exitCode` / `cancelled`** → `✗` (not a false `✓`) |
+| **Main transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` has compact Claude-ish rows; **`get_subagent_result` has no custom `renderResult`** → Pi dumps the full model-facing payload and expand does not help | Shared collapsible renderers: default **one-line preview**; **Ctrl+O** expands to status header + **Markdown** body |
+| Tool call **model / effort** | Model often omitted when same as parent; thinking only buried in tags if set | Call + result rows always show **effective model** (`haiku (inherit)` when parent-inherited) and **`effort:`** (from tool/frontmatter `thinking`) |
+| Validation / not-found tool failures | Plain text result (with custom Agent renderer missing details → easy to misread after collapse work) | `error` details (or undetailed fallback that **never** paints success `✓`) |
+| Packaging | Standalone npm package | Workspace package `@zhcsyncer/pi-subagents` at **`0.0.0`** until Changesets cuts the first release; **not** registered in the root `@zhcsyncer/pi-extensions` bundle yet — load with `-e` (below) |
+
+### What did *not* change
+
+- Tool names and contracts: `Agent`, `get_subagent_result`, `steer_subagent`
+- Background completion **followUp** notifications (`triggerTurn`)
+- FleetView list navigation, Enter steer, `x` `x` stop, Esc/q close
+- Custom agents, worktrees, schedules, settings menus, RPC
+
+Upstream remains the source of truth for those behaviors — start from [`UPSTREAM_README.md`](./UPSTREAM_README.md).
+
+---
+
 ## Try locally (this monorepo)
 
-Do **not** change global `~/.pi/agent/settings.json` unless you intend to replace `@tintinweb/pi-subagents` permanently. For a side-by-side trial from this worktree:
+Do **not** change global `~/.pi/agent/settings.json` unless you intend to replace `@tintinweb/pi-subagents` permanently.
 
 ```bash
-# from the monorepo root
+# monorepo root
 pnpm install
 pi -e ./packages/pi-subagents/src/index.ts
 ```
 
-If another copy of `pi-subagents` is already loaded from settings, temporarily disable/remove that entry for the trial session so only this fork registers the `Agent` tools and FleetView UI.
+If settings already load another `pi-subagents`, temporarily remove that entry for the trial session so only this fork registers the tools and UI.
 
 ### Conversation overlay (scheme A)
 
 Open FleetView / agent list, select a subagent, press Enter:
 
-1. **Header** — name / status / duration / tools / tokens (unchanged)
+1. **Header** — name / status / duration / tools / tokens (upstream)
 2. **Prompt** — first meaningful user (dispatch) message
-3. **Steps** — one line per tool call (`✓ read path`, `⠹ bash …`, `✗ grep …`); results folded by default
-4. **Result** — last non-empty assistant text, or `(running…)` while in flight
-
-Keys (unchanged unless noted):
+3. **Steps** — one line per tool (`✓ read path`, `⠹ bash …`, `✗ grep …`); results folded
+4. **Result** — final assistant text, running indicator, or **error** on terminal failure
 
 | Key | Action |
 | --- | --- |
-| `Esc` / `q` | Close overlay |
+| `Esc` / `q` | Close |
 | `↑↓` / PgUp/PgDn | Scroll |
-| `Enter` | Steer (running agents) |
+| `Enter` | Steer (running) |
 | `x` `x` | Arm + confirm stop |
-| `o` | Toggle expanded tool args/results (**fork**) |
+| `o` | Expand/fold step detail (**fork**) |
 
 ### Tool TUI (main transcript)
 
-`Agent`, `get_subagent_result`, and `steer_subagent` use compact custom renderers:
+| State | What you see |
+| --- | --- |
+| **Call** | `▸ Explore  desc  haiku · effort: high · bg` (`model: inherit` if unset at call time) |
+| **Collapsed** | Status/stats (model, effort, tools, tokens, …) + one-line preview |
+| **Expanded** (`Ctrl+O`) | Status header + **Markdown** body |
 
-- **Call line:** type/description plus **model** and **effort** chips (`model: inherit` when unset; `effort:` maps from tool/frontmatter `thinking`)
-- **Collapsed (default):** status/stats (model, effort, tools, tokens, …) + one-line result preview — no full transcript wall
-- **Expanded (`Ctrl+O` / tools expand):** status header + **Markdown** body
+`effort` is display wording for the existing `thinking` parameter/frontmatter field.
+
+---
 
 ## Package scripts
 
@@ -55,4 +86,4 @@ pnpm --filter @zhcsyncer/pi-subagents typecheck
 
 ## License
 
-MIT — see [LICENSE](./LICENSE) and upstream [UPSTREAM_LICENSE](./UPSTREAM_LICENSE).
+MIT — [LICENSE](./LICENSE) and upstream [UPSTREAM_LICENSE](./UPSTREAM_LICENSE).

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -1,0 +1,50 @@
+# @zhcsyncer/pi-subagents
+
+Maintained fork of [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) with a **brief ConversationViewer**: dispatch prompt, one-line tool step summaries, and final result — instead of dumping full tool-result walls in the overlay.
+
+Upstream documentation is preserved in [`UPSTREAM_README.md`](./UPSTREAM_README.md). Source pin and local deltas: [`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md).
+
+> Chinese: [README.zh-CN.md](./README.zh-CN.md)
+
+## Try locally (this monorepo)
+
+Do **not** change global `~/.pi/agent/settings.json` unless you intend to replace `@tintinweb/pi-subagents` permanently. For a side-by-side trial from this worktree:
+
+```bash
+# from the monorepo root
+pnpm install
+pi -e ./packages/pi-subagents/src/index.ts
+```
+
+If another copy of `pi-subagents` is already loaded from settings, temporarily disable/remove that entry for the trial session so only this fork registers the `Agent` tools and FleetView UI.
+
+### Conversation overlay (scheme A)
+
+Open FleetView / agent list, select a subagent, press Enter:
+
+1. **Header** — name / status / duration / tools / tokens (unchanged)
+2. **Prompt** — first meaningful user (dispatch) message
+3. **Steps** — one line per tool call (`✓ read path`, `⠹ bash …`, `✗ grep …`); results folded by default
+4. **Result** — last non-empty assistant text, or `(running…)` while in flight
+
+Keys (unchanged unless noted):
+
+| Key | Action |
+| --- | --- |
+| `Esc` / `q` | Close overlay |
+| `↑↓` / PgUp/PgDn | Scroll |
+| `Enter` | Steer (running agents) |
+| `x` `x` | Arm + confirm stop |
+| `o` | Toggle expanded tool args/results (**fork**) |
+
+## Package scripts
+
+```bash
+pnpm --filter @zhcsyncer/pi-subagents check
+pnpm --filter @zhcsyncer/pi-subagents test
+pnpm --filter @zhcsyncer/pi-subagents typecheck
+```
+
+## License
+
+MIT — see [LICENSE](./LICENSE) and upstream [UPSTREAM_LICENSE](./UPSTREAM_LICENSE).

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -19,8 +19,8 @@ This fork keeps upstream **runtime** behavior (spawn, steer, resume, FleetView w
 | Overlay step detail | N/A (everything dumped) | Press **`o`** to expand/fold tool args + results |
 | Overlay on agent **error / aborted / stopped** | Last messages still dominate the dump | **Result** prefers `record.error` (or stopped/aborted label); mid-run assistant text is demoted to a dim footnote |
 | Overlay **bashExecution** | Shown as command + output dump | One step line; **`exitCode` / `cancelled`** → `✗` (not a false `✓`) |
-| **Main transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` has compact Claude-ish rows; **`get_subagent_result` has no custom `renderResult`** → Pi dumps the full model-facing payload and expand does not help | Shared collapsible renderers: default **one-line preview**; **Ctrl+O** expands to status header + **Markdown** body |
-| Tool call **model / effort** | Model often omitted when same as parent; thinking only buried in tags if set | Call + result rows always show **effective model** (`haiku (inherit)` when parent-inherited) and **`effort:`** (from tool/frontmatter `thinking`) |
+| **Main transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` has Claude Code chrome; **`get_subagent_result` has no custom `renderResult`** → Pi dumps full payload | Same **Claude Code chrome** for all three tools: `▸ Type  desc` / `✓ stats` + `⎿ Done` (running: `⠹` + `⎿ activity`); **Ctrl+O** expands Markdown body without dumping by default |
+| Tool **model / effort** | Model often omitted when same as parent; thinking only in tags if set | **Result stats** always include effective model (`haiku (inherit)` when inherited) + `effort:` from `thinking`; call line only adds chips when args explicitly set model/thinking/bg |
 | Validation / not-found tool failures | Plain text result (with custom Agent renderer missing details → easy to misread after collapse work) | `error` details (or undetailed fallback that **never** paints success `✓`) |
 | Packaging | Standalone npm package | Workspace package `@zhcsyncer/pi-subagents` at **`0.0.0`** until Changesets cuts the first release; **not** registered in the root `@zhcsyncer/pi-extensions` bundle yet — load with `-e` (below) |
 
@@ -64,15 +64,26 @@ Open FleetView / agent list, select a subagent, press Enter:
 | `x` `x` | Arm + confirm stop |
 | `o` | Expand/fold step detail (**fork**) |
 
-### Tool TUI (main transcript)
+### Tool TUI (main transcript) — Claude Code chrome
+
+Matches upstream’s documented shape ([UPSTREAM_README](./UPSTREAM_README.md) “Individual agent results”):
+
+```text
+▸ Explore  Find auth files
+⠹ haiku · effort: high · ↻3 · 3 tool uses · 12.4k token
+  ⎿  searching…
+✓ haiku · effort: high · ↻8 · 5 tool uses · 33.8k token · 12.3s
+  ⎿  Done
+```
 
 | State | What you see |
 | --- | --- |
-| **Call** | `▸ Explore  desc  haiku · effort: high · bg` (`model: inherit` if unset at call time) |
-| **Collapsed** | Status/stats (model, effort, tools, tokens, …) + one-line preview |
-| **Expanded** (`Ctrl+O`) | Status header + **Markdown** body |
+| **Call** | `▸ Type  description` (+ dim chips only if call args set `model` / `thinking` / `bg`) |
+| **Running** | `⠹` + stats / `⎿` activity |
+| **Completed** | `✓` + stats · duration / `⎿ Done` (or Wrapped up / Stopped / Error) |
+| **Expanded** (`Ctrl+O`) | Same chrome + **Markdown** body (no default dump) |
 
-`effort` is display wording for the existing `thinking` parameter/frontmatter field.
+`effort` is display wording for the existing `thinking` parameter/frontmatter field. Effective **model** (including parent inherit) is always on the **result** stats line when known.
 
 ---
 

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -37,6 +37,13 @@ Keys (unchanged unless noted):
 | `x` `x` | Arm + confirm stop |
 | `o` | Toggle expanded tool args/results (**fork**) |
 
+### Tool TUI (main transcript)
+
+`Agent`, `get_subagent_result`, and `steer_subagent` use compact custom renderers:
+
+- **Collapsed (default):** status/stats + one-line result preview — no full transcript wall
+- **Expanded (`Ctrl+O` / tools expand):** status header + **Markdown** body
+
 ## Package scripts
 
 ```bash

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -1,8 +1,10 @@
 # @zhcsyncer/pi-subagents
 
+[简体中文](./README.zh-CN.md)
+
 Maintained fork of [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) (`v0.14.3` / `@tintinweb/pi-subagents@0.14.3`).
 
-> Chinese: [README.zh-CN.md](./README.zh-CN.md)
+This package publishes on its own and is also embedded in the aggregate `@zhcsyncer/pi-extensions` bundle.
 
 **Full upstream docs** (features, Agent tool, schedules, settings): [`UPSTREAM_README.md`](./UPSTREAM_README.md)  
 **Pin + license trail**: [`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md) · [`UPSTREAM_LICENSE`](./UPSTREAM_LICENSE)
@@ -22,7 +24,7 @@ This fork keeps upstream **runtime** behavior (spawn, steer, resume, FleetView w
 | **Main transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` has Claude Code chrome; **`get_subagent_result` has no custom `renderResult`** → Pi dumps full payload | Same **Claude Code chrome** for all three; queued is honest (`queued…`); **Ctrl+O** expands Markdown without dumping by default |
 | Tool **model / effort** | Model often omitted when same as parent; thinking only in tags if set | **Result stats** always include effective model (`haiku (inherit)` when inherited) + `effort:`; resume chips come from stored invocation |
 | Validation / not-found tool failures | Plain text result (with custom Agent renderer missing details → easy to misread after collapse work) | `error` details + `tool_result` → Pi `isError` (error shell); undetailed success paths never heuristic-red |
-| Packaging | Standalone npm package | Workspace package `@zhcsyncer/pi-subagents` at **`0.0.0`** until Changesets cuts the first release; **not** registered in the root `@zhcsyncer/pi-extensions` bundle yet — load with `-e` (below) |
+| Packaging | Standalone npm package | Standalone `@zhcsyncer/pi-subagents` **and** embedded/registered in root `@zhcsyncer/pi-extensions` |
 
 ### What did *not* change
 
@@ -35,17 +37,31 @@ Upstream remains the source of truth for those behaviors — start from [`UPSTRE
 
 ---
 
-## Try locally (this monorepo)
+## Install
 
-Do **not** change global `~/.pi/agent/settings.json` unless you intend to replace `@tintinweb/pi-subagents` permanently.
+Standalone:
+
+```bash
+pi install npm:@zhcsyncer/pi-subagents
+```
+
+Or via the root bundle (registers the same extension):
+
+```bash
+pi install npm:@zhcsyncer/pi-extensions
+```
+
+If `~/.pi/agent/settings.json` already loads `@tintinweb/pi-subagents`, remove that entry — both packages register `Agent` / FleetView and must not run together.
+
+## Try locally (this monorepo)
 
 ```bash
 # monorepo root
 pnpm install
-pi -e ./packages/pi-subagents/src/index.ts
+pi --no-extensions -e ./packages/pi-subagents
+# or load the whole root bundle:
+pi -e .
 ```
-
-If settings already load another `pi-subagents`, temporarily remove that entry for the trial session so only this fork registers the tools and UI.
 
 ### Conversation overlay (scheme A)
 

--- a/packages/pi-subagents/README.zh-CN.md
+++ b/packages/pi-subagents/README.zh-CN.md
@@ -1,0 +1,50 @@
+# @zhcsyncer/pi-subagents
+
+[`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) 的维护向 fork。ConversationViewer 默认改为 **步骤摘要视图**：派发 prompt、一行一步的 tool 摘要、最终结果，而不再默认倾倒大段 toolResult 原文。
+
+完整上游说明见 [`UPSTREAM_README.md`](./UPSTREAM_README.md)；版本钉扎与本地差异见 [`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md)。
+
+> English: [README.md](./README.md)
+
+## 本地试用（本 monorepo）
+
+**不要**为了试用去改全局 `~/.pi/agent/settings.json`（留给人工决定是否替换 `@tintinweb/pi-subagents`）。在本 worktree 里：
+
+```bash
+# monorepo 根目录
+pnpm install
+pi -e ./packages/pi-subagents/src/index.ts
+```
+
+若 settings 里已经加载了另一份 `pi-subagents`，试用会话请先临时去掉该条目，避免双注册。
+
+### 对话 overlay（方案 A）
+
+FleetView / agent 列表选中子 agent 后回车：
+
+1. **Header** — 名称 / 状态 / 时长 / tools / tokens（保留）
+2. **Prompt** — 第一条有意义的 user（派发）消息
+3. **Steps** — 每个 tool 调用一行摘要；toolResult 默认折叠
+4. **Result** — 最后一条非空 assistant 文本；仍在跑则 `(running…)`
+
+快捷键：
+
+| 键 | 行为 |
+| --- | --- |
+| `Esc` / `q` | 关闭 |
+| `↑↓` / PgUp/PgDn | 滚动 |
+| `Enter` | Steer（运行中） |
+| `x` `x` | 二次确认停止 |
+| `o` | 展开/折叠 tool 参数与结果（**本 fork**） |
+
+## 脚本
+
+```bash
+pnpm --filter @zhcsyncer/pi-subagents check
+pnpm --filter @zhcsyncer/pi-subagents test
+pnpm --filter @zhcsyncer/pi-subagents typecheck
+```
+
+## License
+
+MIT — 见 [LICENSE](./LICENSE) 与上游 [UPSTREAM_LICENSE](./UPSTREAM_LICENSE)。

--- a/packages/pi-subagents/README.zh-CN.md
+++ b/packages/pi-subagents/README.zh-CN.md
@@ -37,6 +37,13 @@ FleetView / agent 列表选中子 agent 后回车：
 | `x` `x` | 二次确认停止 |
 | `o` | 展开/折叠 tool 参数与结果（**本 fork**） |
 
+### 主会话 tool TUI
+
+`Agent` / `get_subagent_result` / `steer_subagent` 使用紧凑自定义渲染：
+
+- **折叠（默认）**：状态/统计 + 一行结果预览，不再整段 transcript 占屏
+- **展开（`Ctrl+O`）**：状态头 + **Markdown** 正文
+
 ## 脚本
 
 ```bash

--- a/packages/pi-subagents/README.zh-CN.md
+++ b/packages/pi-subagents/README.zh-CN.md
@@ -1,14 +1,43 @@
 # @zhcsyncer/pi-subagents
 
-[`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) 的维护向 fork。ConversationViewer 默认改为 **步骤摘要视图**：派发 prompt、一行一步的 tool 摘要、最终结果，而不再默认倾倒大段 toolResult 原文。
-
-完整上游说明见 [`UPSTREAM_README.md`](./UPSTREAM_README.md)；版本钉扎与本地差异见 [`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md)。
+[`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) 的维护向 fork（基线 `v0.14.3` / `@tintinweb/pi-subagents@0.14.3`）。
 
 > English: [README.md](./README.md)
 
+**完整上游说明**（功能、Agent 工具、调度、设置）：[`UPSTREAM_README.md`](./UPSTREAM_README.md)  
+**版本钉扎与许可证**：[`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md) · [`UPSTREAM_LICENSE`](./UPSTREAM_LICENSE)
+
+---
+
+## 与上游的差异（先看这里）
+
+本 fork **保留上游运行时行为**（spawn / steer / resume、FleetView 接线、完成通知、调度等）。改动几乎都在 **TUI 如何呈现进展与 tool 结果**，避免大段 dump 淹没主会话。
+
+| 区域 | 上游 `@tintinweb/pi-subagents` | 本 fork `@zhcsyncer/pi-subagents` |
+| --- | --- | --- |
+| **对话 overlay**（FleetView / 列表 → Enter） | 全文 dump：user / assistant / toolResult 墙（tool 体约 500 字截断仍很大） | **方案 A 摘要视图**：**Prompt** → **Steps**（一行一步）→ **Result**；tool 体默认折叠 |
+| Overlay 步骤详情 | 无（全摊开） | **`o`** 展开/折叠 tool 参数与结果 |
+| Overlay 在 agent **error / aborted / stopped** | 仍以消息流为主 | **Result 优先 `record.error`**（或 stopped/aborted 文案）；中途 assistant 碎语降为 dim 附注 |
+| Overlay **bashExecution** | 命令 + 输出 dump | 一步一行；**`exitCode` / `cancelled`** → `✗`（不会误标 ✓） |
+| **主 transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` 有紧凑行；**`get_subagent_result` 无自定义 `renderResult`** → Pi 整段 dump 且无法靠 expand 收起 | 统一可折叠渲染：默认 **一行预览**；**Ctrl+O** 展开为状态头 + **Markdown** 正文 |
+| Tool 节点 **model / effort** | 与父模型相同时常不显示 model；thinking 仅偶尔进 tags | 调用行与结果行始终显示 **有效模型**（继承则 `haiku (inherit)`）与 **`effort:`**（来自 `thinking`） |
+| 校验失败 / 找不到 agent 等 | 纯文本 result（折叠改造后易误读成成功） | 带 `error` details（或 undetailed 回退 **永不**画绿 ✓） |
+| 发包 | 独立 npm 包 | 工作区包 `@zhcsyncer/pi-subagents`，版本 **`0.0.0`** 直至 Changesets 切首版；**尚未**挂进根包 `@zhcsyncer/pi-extensions` bundle — 用下面的 `-e` 试用 |
+
+### 未改动的部分
+
+- 工具名与契约：`Agent`、`get_subagent_result`、`steer_subagent`
+- 后台完成 **followUp** 通知（`triggerTurn`）
+- FleetView 导航、Enter steer、`x` `x` stop、Esc/q 关闭
+- 自定义 agent、worktree、调度、设置菜单、RPC
+
+行为细节仍以上游文档为准：[`UPSTREAM_README.md`](./UPSTREAM_README.md)。
+
+---
+
 ## 本地试用（本 monorepo）
 
-**不要**为了试用去改全局 `~/.pi/agent/settings.json`（留给人工决定是否替换 `@tintinweb/pi-subagents`）。在本 worktree 里：
+**不要**为了试用去改全局 `~/.pi/agent/settings.json`（是否永久替换上游留给人工决定）。
 
 ```bash
 # monorepo 根目录
@@ -16,18 +45,16 @@ pnpm install
 pi -e ./packages/pi-subagents/src/index.ts
 ```
 
-若 settings 里已经加载了另一份 `pi-subagents`，试用会话请先临时去掉该条目，避免双注册。
+若 settings 已加载另一份 `pi-subagents`，试用会话请先临时去掉该条目，避免双注册。
 
 ### 对话 overlay（方案 A）
 
 FleetView / agent 列表选中子 agent 后回车：
 
-1. **Header** — 名称 / 状态 / 时长 / tools / tokens（保留）
+1. **Header** — 名称 / 状态 / 时长 / tools / tokens（上游）
 2. **Prompt** — 第一条有意义的 user（派发）消息
-3. **Steps** — 每个 tool 调用一行摘要；toolResult 默认折叠
-4. **Result** — 最后一条非空 assistant 文本；仍在跑则 `(running…)`
-
-快捷键：
+3. **Steps** — 每个 tool 一行摘要；结果默认折叠
+4. **Result** — 最终 assistant 文本、运行中指示，或终态 **error**
 
 | 键 | 行为 |
 | --- | --- |
@@ -35,15 +62,19 @@ FleetView / agent 列表选中子 agent 后回车：
 | `↑↓` / PgUp/PgDn | 滚动 |
 | `Enter` | Steer（运行中） |
 | `x` `x` | 二次确认停止 |
-| `o` | 展开/折叠 tool 参数与结果（**本 fork**） |
+| `o` | 展开/折叠步骤详情（**本 fork**） |
 
 ### 主会话 tool TUI
 
-`Agent` / `get_subagent_result` / `steer_subagent` 使用紧凑自定义渲染：
+| 状态 | 呈现 |
+| --- | --- |
+| **调用行** | `▸ Explore  desc  haiku · effort: high · bg`（调用时未指定模型则 `model: inherit`） |
+| **折叠** | 状态/统计（model、effort、tools、tokens…）+ 一行预览 |
+| **展开**（`Ctrl+O`） | 状态头 + **Markdown** 正文 |
 
-- **调用行**：类型/描述 + **model** / **effort** 芯片（未指定模型显示 `model: inherit`；`effort` 对应工具/frontmatter 的 `thinking`）
-- **折叠（默认）**：状态/统计（model、effort、tools、tokens…）+ 一行结果预览
-- **展开（`Ctrl+O`）**：状态头 + **Markdown** 正文
+`effort` 是展示名，对应工具/frontmatter 的 `thinking` 字段。
+
+---
 
 ## 脚本
 
@@ -55,4 +86,4 @@ pnpm --filter @zhcsyncer/pi-subagents typecheck
 
 ## License
 
-MIT — 见 [LICENSE](./LICENSE) 与上游 [UPSTREAM_LICENSE](./UPSTREAM_LICENSE)。
+MIT — [LICENSE](./LICENSE) 与上游 [UPSTREAM_LICENSE](./UPSTREAM_LICENSE)。

--- a/packages/pi-subagents/README.zh-CN.md
+++ b/packages/pi-subagents/README.zh-CN.md
@@ -19,8 +19,8 @@
 | Overlay 步骤详情 | 无（全摊开） | **`o`** 展开/折叠 tool 参数与结果 |
 | Overlay 在 agent **error / aborted / stopped** | 仍以消息流为主 | **Result 优先 `record.error`**（或 stopped/aborted 文案）；中途 assistant 碎语降为 dim 附注 |
 | Overlay **bashExecution** | 命令 + 输出 dump | 一步一行；**`exitCode` / `cancelled`** → `✗`（不会误标 ✓） |
-| **主 transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` 有紧凑行；**`get_subagent_result` 无自定义 `renderResult`** → Pi 整段 dump 且无法靠 expand 收起 | 统一可折叠渲染：默认 **一行预览**；**Ctrl+O** 展开为状态头 + **Markdown** 正文 |
-| Tool 节点 **model / effort** | 与父模型相同时常不显示 model；thinking 仅偶尔进 tags | 调用行与结果行始终显示 **有效模型**（继承则 `haiku (inherit)`）与 **`effort:`**（来自 `thinking`） |
+| **主 transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` 有 Claude Code 样式；**`get_subagent_result` 无自定义 `renderResult`** → 整段 dump | 三者统一 **Claude Code chrome**：`▸ Type  desc` / `✓ stats` + `⎿ Done`（运行中 `⠹` + `⎿ activity`）；**Ctrl+O** 展开 Markdown，默认不 dump |
+| Tool **model / effort** | 与父模型相同时常不显示；thinking 只在 tags | **结果 stats** 始终含有效模型（继承则 `haiku (inherit)`）与 `effort:`；调用行仅在 args 显式带 model/thinking/bg 时附加芯片 |
 | 校验失败 / 找不到 agent 等 | 纯文本 result（折叠改造后易误读成成功） | 带 `error` details（或 undetailed 回退 **永不**画绿 ✓） |
 | 发包 | 独立 npm 包 | 工作区包 `@zhcsyncer/pi-subagents`，版本 **`0.0.0`** 直至 Changesets 切首版；**尚未**挂进根包 `@zhcsyncer/pi-extensions` bundle — 用下面的 `-e` 试用 |
 
@@ -64,15 +64,26 @@ FleetView / agent 列表选中子 agent 后回车：
 | `x` `x` | 二次确认停止 |
 | `o` | 展开/折叠步骤详情（**本 fork**） |
 
-### 主会话 tool TUI
+### 主会话 tool TUI — Claude Code chrome
+
+对齐上游文档中的呈现（见 [UPSTREAM_README](./UPSTREAM_README.md)）：
+
+```text
+▸ Explore  Find auth files
+⠹ haiku · effort: high · ↻3 · 3 tool uses · 12.4k token
+  ⎿  searching…
+✓ haiku · effort: high · ↻8 · 5 tool uses · 33.8k token · 12.3s
+  ⎿  Done
+```
 
 | 状态 | 呈现 |
 | --- | --- |
-| **调用行** | `▸ Explore  desc  haiku · effort: high · bg`（调用时未指定模型则 `model: inherit`） |
-| **折叠** | 状态/统计（model、effort、tools、tokens…）+ 一行预览 |
-| **展开**（`Ctrl+O`） | 状态头 + **Markdown** 正文 |
+| **调用行** | `▸ Type  description`（仅当 args 显式带 model/thinking/bg 时附加 dim 芯片） |
+| **运行中** | `⠹` + stats / `⎿` activity |
+| **完成** | `✓` + stats · duration / `⎿ Done`（或 Wrapped up / Stopped / Error） |
+| **展开**（`Ctrl+O`） | 同上 chrome + **Markdown** 正文 |
 
-`effort` 是展示名，对应工具/frontmatter 的 `thinking` 字段。
+`effort` 对应 `thinking`。有效 **model**（含继承）在**结果** stats 中展示。
 
 ---
 

--- a/packages/pi-subagents/README.zh-CN.md
+++ b/packages/pi-subagents/README.zh-CN.md
@@ -41,7 +41,8 @@ FleetView / agent 列表选中子 agent 后回车：
 
 `Agent` / `get_subagent_result` / `steer_subagent` 使用紧凑自定义渲染：
 
-- **折叠（默认）**：状态/统计 + 一行结果预览，不再整段 transcript 占屏
+- **调用行**：类型/描述 + **model** / **effort** 芯片（未指定模型显示 `model: inherit`；`effort` 对应工具/frontmatter 的 `thinking`）
+- **折叠（默认）**：状态/统计（model、effort、tools、tokens…）+ 一行结果预览
 - **展开（`Ctrl+O`）**：状态头 + **Markdown** 正文
 
 ## 脚本

--- a/packages/pi-subagents/README.zh-CN.md
+++ b/packages/pi-subagents/README.zh-CN.md
@@ -17,11 +17,11 @@
 | --- | --- | --- |
 | **对话 overlay**（FleetView / 列表 → Enter） | 全文 dump：user / assistant / toolResult 墙（tool 体约 500 字截断仍很大） | **方案 A 摘要视图**：**Prompt** → **Steps**（一行一步）→ **Result**；tool 体默认折叠 |
 | Overlay 步骤详情 | 无（全摊开） | **`o`** 展开/折叠 tool 参数与结果 |
-| Overlay 在 agent **error / aborted / stopped** | 仍以消息流为主 | **Result 优先 `record.error`**（或 stopped/aborted 文案）；中途 assistant 碎语降为 dim 附注 |
+| Overlay 在 agent **error / aborted / stopped / steered** | 仍以消息流为主 | **Result 优先 `record.error`**；`steered` 标明 turn-limit；头部图标对齐 chrome；终态收敛悬空 running step |
 | Overlay **bashExecution** | 命令 + 输出 dump | 一步一行；**`exitCode` / `cancelled`** → `✗`（不会误标 ✓） |
-| **主 transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` 有 Claude Code 样式；**`get_subagent_result` 无自定义 `renderResult`** → 整段 dump | 三者统一 **Claude Code chrome**：`▸ Type  desc` / `✓ stats` + `⎿ Done`（运行中 `⠹` + `⎿ activity`）；**Ctrl+O** 展开 Markdown，默认不 dump |
-| Tool **model / effort** | 与父模型相同时常不显示；thinking 只在 tags | **结果 stats** 始终含有效模型（继承则 `haiku (inherit)`）与 `effort:`；调用行仅在 args 显式带 model/thinking/bg 时附加芯片 |
-| 校验失败 / 找不到 agent 等 | 纯文本 result（折叠改造后易误读成成功） | 带 `error` details（或 undetailed 回退 **永不**画绿 ✓） |
+| **主 transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` 有 Claude Code 样式；**`get_subagent_result` 无自定义 `renderResult`** → 整段 dump | 三者统一 **Claude Code chrome**；queued 真话；**Ctrl+O** 展开 Markdown，默认不 dump |
+| Tool **model / effort** | 与父模型相同时常不显示；thinking 只在 tags | **结果 stats** 始终含有效模型（继承则 `haiku (inherit)`）与 `effort:`；resume 用存储的 invocation |
+| 校验失败 / 找不到 agent 等 | 纯文本 result（折叠改造后易误读成成功） | `error` details + `tool_result`→`isError`（错误外壳）；undetailed 成功路径不启发式染红 |
 | 发包 | 独立 npm 包 | 工作区包 `@zhcsyncer/pi-subagents`，版本 **`0.0.0`** 直至 Changesets 切首版；**尚未**挂进根包 `@zhcsyncer/pi-extensions` bundle — 用下面的 `-e` 试用 |
 
 ### 未改动的部分

--- a/packages/pi-subagents/README.zh-CN.md
+++ b/packages/pi-subagents/README.zh-CN.md
@@ -1,8 +1,10 @@
 # @zhcsyncer/pi-subagents
 
+[English](./README.md)
+
 [`@tintinweb/pi-subagents`](https://github.com/tintinweb/pi-subagents) 的维护向 fork（基线 `v0.14.3` / `@tintinweb/pi-subagents@0.14.3`）。
 
-> English: [README.md](./README.md)
+本包可单独发布，也会嵌入聚合包 `@zhcsyncer/pi-extensions`。
 
 **完整上游说明**（功能、Agent 工具、调度、设置）：[`UPSTREAM_README.md`](./UPSTREAM_README.md)  
 **版本钉扎与许可证**：[`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md) · [`UPSTREAM_LICENSE`](./UPSTREAM_LICENSE)
@@ -22,7 +24,7 @@
 | **主 transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` 有 Claude Code 样式；**`get_subagent_result` 无自定义 `renderResult`** → 整段 dump | 三者统一 **Claude Code chrome**；queued 真话；**Ctrl+O** 展开 Markdown，默认不 dump |
 | Tool **model / effort** | 与父模型相同时常不显示；thinking 只在 tags | **结果 stats** 始终含有效模型（继承则 `haiku (inherit)`）与 `effort:`；resume 用存储的 invocation |
 | 校验失败 / 找不到 agent 等 | 纯文本 result（折叠改造后易误读成成功） | `error` details + `tool_result`→`isError`（错误外壳）；undetailed 成功路径不启发式染红 |
-| 发包 | 独立 npm 包 | 工作区包 `@zhcsyncer/pi-subagents`，版本 **`0.0.0`** 直至 Changesets 切首版；**尚未**挂进根包 `@zhcsyncer/pi-extensions` bundle — 用下面的 `-e` 试用 |
+| 发包 | 独立 npm 包 | 独立包 `@zhcsyncer/pi-subagents`，**并**嵌入/注册进根包 `@zhcsyncer/pi-extensions` |
 
 ### 未改动的部分
 
@@ -35,17 +37,31 @@
 
 ---
 
-## 本地试用（本 monorepo）
+## 安装
 
-**不要**为了试用去改全局 `~/.pi/agent/settings.json`（是否永久替换上游留给人工决定）。
+单独安装：
+
+```bash
+pi install npm:@zhcsyncer/pi-subagents
+```
+
+或通过根 bundle（注册同一扩展）：
+
+```bash
+pi install npm:@zhcsyncer/pi-extensions
+```
+
+若 `~/.pi/agent/settings.json` 已加载 `@tintinweb/pi-subagents`，请先去掉该条目——两边都会注册 `Agent` / FleetView，不能并存。
+
+## 本地试用（本 monorepo）
 
 ```bash
 # monorepo 根目录
 pnpm install
-pi -e ./packages/pi-subagents/src/index.ts
+pi --no-extensions -e ./packages/pi-subagents
+# 或加载整个根 bundle：
+pi -e .
 ```
-
-若 settings 已加载另一份 `pi-subagents`，试用会话请先临时去掉该条目，避免双注册。
 
 ### 对话 overlay（方案 A）
 

--- a/packages/pi-subagents/SECURITY.md
+++ b/packages/pi-subagents/SECURITY.md
@@ -1,0 +1,95 @@
+# Security Policy
+
+This document explains the security model behind `@tintinweb/pi-subagents` and
+where the boundaries are.
+
+`pi-subagents` is a [pi](https://pi.dev) extension. It spawns and orchestrates
+autonomous sub-agents that run locally within the same security boundary as the
+user running pi, and inherit pi's trust model. It is the responsibility of the
+user to monitor those agents' operations or to contain them within a container,
+virtual machine, or other sandbox solution.
+
+Sub-agents run with the local user account's privileges and can use the tools
+they are granted (reading and writing files, running commands, network access,
+etc.). They treat the local user account and files writable by that account as
+inside the same trust boundary as the pi process itself. If an attacker can
+modify files under the user's home directory, workspace, shell startup files,
+environment, pi configuration, or this extension's configuration, they can
+generally influence pi, its sub-agents, or other local developer tools. Reports
+that depend on such prior local write access are not security vulnerabilities
+unless they demonstrate how `pi-subagents` grants that write access or crosses an
+operating-system privilege boundary.
+
+`pi-subagents` relies on the user only loading trustworthy agent definitions
+(`.pi/agents/*.md`, `.agents/agents/*.md`, and global agents), skills, and
+tools, and only using pi within trusted repositories. Files like `AGENTS.md`,
+custom agent frontmatter/system prompts, preloaded skills, or instructions
+embedded in repository content and comments can be used to prompt-inject the
+coding agent and its sub-agents trivially, and this cannot be protected against.
+
+## Reporting a Vulnerability
+
+If you believe you found a security vulnerability in `pi-subagents`, please
+report it privately by opening a draft advisory through
+[GitHub Security Advisories](https://github.com/tintinweb/pi-subagents/security/advisories/new)
+for this repository.
+
+Please include:
+
+- A description of the issue and its impact
+- Steps to reproduce, proof of concept, or relevant logs
+- Affected version, commit, or configuration
+- Any known mitigations
+
+Do not open a public issue for security-sensitive reports. Reports will be
+reviewed and disclosure coordinated as appropriate.
+
+## Scope
+
+Security issues in the published npm package and the code in this repository are
+in scope — for example, a flaw in `pi-subagents` that crosses an
+operating-system privilege boundary, or that causes the extension to bypass a
+tool restriction, denylist, or agent boundary it claims to enforce.
+
+## Out Of Scope
+
+- Local code execution or sandboxing behavior (sub-agents intentionally do not
+  have a sandbox and run with the user's privileges)
+- Behavior of pi itself, or of other pi extensions, skills, or tools installed by
+  the user (report those to their respective projects)
+- Risks from working in untrusted repositories
+- Risks from installing or loading untrusted agent definitions, skills,
+  extensions, packages, or tools
+- Issues caused by non-trustworthy MITM proxies
+- Public internet exposure of a pi installation
+- Prompt injection attacks (including via `AGENTS.md`, agent frontmatter, custom
+  system prompts, preloaded skills, repository content, or context inheritance)
+- Exposed secrets that are third-party/user-controlled credentials
+- Reports requiring the ability to create, modify, delete, or replace files,
+  directories, symlinks, environment variables, shell configuration, or other
+  user-controlled local state on the target machine. This includes `.pi/agents/`,
+  `.agents/agents/`, agent and extension configuration, persistent agent memory,
+  workspace files, `AGENTS.md`, skills, dotfiles, and files synchronized through NFS, roaming
+  profiles, or dotfile managers, unless the report shows how `pi-subagents`
+  itself grants that access.
+- Issues caused by intentionally weakened user configuration
+- Resource/DOS claims that require trusted local input/config
+- Reports about malicious model output
+- User-approved or user-initiated local actions presented as vulnerabilities
+
+## Notes for Reporters
+
+The most useful reports show a current, reproducible security boundary bypass
+with demonstrated impact. Reports that only show expected local-agent behavior,
+prompt injection, or a malicious trusted agent definition/skill are not security
+vulnerabilities under this model.
+
+For example, a report showing that malicious contents written to a trusted agent
+definition or extension configuration cause a sub-agent to execute commands, load
+attacker-controlled tools, or send credentials to an attacker-controlled endpoint
+is out of scope.
+
+When possible, include the exact affected path, package version or commit SHA,
+configuration, and a proof of concept against the latest release or latest
+`master`. For dependency reports, include evidence that the shipped dependency is
+affected and that the issue is reachable through `pi-subagents`.

--- a/packages/pi-subagents/UPSTREAM_CHANGELOG.md
+++ b/packages/pi-subagents/UPSTREAM_CHANGELOG.md
@@ -1,0 +1,638 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.14.3] - 2026-07-23
+
+### Fixed
+- **Subagents can use extension tools that register asynchronously, e.g. over MCP** ([#141](https://github.com/tintinweb/pi-subagents/pull/141) — thanks [@philipmw](https://github.com/philipmw)). MCP-backed extensions usually can't enumerate their tools until their servers connect, so they call `registerTool` from `session_start` (pi-mcp) or `before_agent_start` (context-mode) rather than at load — eagerly connecting during extension discovery would orphan child processes on pi's non-agent code paths (`--help`, config, trust probing). The agent runner, however, snapshotted `extension.tools` into a static `tools:` allowlist immediately after `loader.reload()` and *before* `bindExtensions()` fired `session_start`. Because pi's `allowedToolNames` gates tool **registration** — not merely the initial active set — a name missing from that snapshot was dropped permanently, so those tools never reached a subagent even though the main agent had them. The runner now leaves the allowlist unset so pi's live gate admits tools whenever they register, and expresses the name-stable part of the scope (this extension's own orchestration tools, built-ins the agent didn't ask for, `disallowed_tools:`) as a denylist that pi re-applies on every registry refresh. `extensions: false` / `isolated: true` keep the static allowlist unchanged — nothing can register asynchronously there, and a hard registry gate is the right boundary.
+- **`ext:` selectors keep narrowing correctly when tools register late** (fixes [#125](https://github.com/tintinweb/pi-subagents/issues/125)). Admitting late-registered tools is only half the problem: an `ext:` selector is an *allowlist*, and a not-yet-registered tool cannot be listed in one — which is why `tools: "*, ext:context-mode/ctx_execute"`, the exact configuration reported in #125, still saw nothing. `ext:` narrowing is now enforced on the **active** tool set (what the model actually sees) rather than the registry, re-derived from the loader's live extension maps — the same maps `registerTool` writes into — so a tool is judged against the selectors whenever it appears. Scope is re-applied on every `turn_end`, and the hooks live on the session rather than the spawning call, so steered and resumed turns stay scoped too. Turn 1 is guarded at call time instead: `before_agent_start` fires *inside* `prompt()` and can widen the tool set after that turn's tools are already snapshotted, leaving no window to narrow in, so an out-of-scope call there is refused rather than executed. Selecting a lazy extension (`ext:mcp`) now surfaces its tools; leaving one out still mutes it, no matter when it registers. Vetoing a call means wrapping the `beforeToolCall` hook pi installs on the session (pi exposes the veto to *extensions* as `pi.on("tool_call")`, but there is no equivalent for an SDK caller constructing a child session); the wrapper chains to pi's own hook so extension `tool_call` handlers still fire, and a `pi@latest` CI job guards that the hook stays reachable, so a future pi that moves it surfaces as a test failure rather than a silently missing veto.
+- **FleetView selection markers now match the rest of the UI** ([#155](https://github.com/tintinweb/pi-subagents/pull/155) — thanks [@xz-dev](https://github.com/xz-dev), closes [#122](https://github.com/tintinweb/pi-subagents/issues/122)). FleetView was the only view using `⏺` (U+23FA) / `◯` (U+25EF) for its selected/unselected rows; everywhere else — the conversation viewer and agent widget — uses `●` / `○` (U+25CF/U+25CB), the base geometric circles with the broadest terminal-font coverage (`◯` renders visibly oversized in many fonts). Selection is already carried by the accent-vs-dim color, so the exotic glyphs added nothing. FleetView now uses `●` selected / `○` unselected, converging on the codebase's existing pair.
+- **`get_subagent_result(wait: true)` is now cancellable** ([#159](https://github.com/tintinweb/pi-subagents/pull/159) — thanks [@exoulster](https://github.com/exoulster), fixes [#158](https://github.com/tintinweb/pi-subagents/issues/158)). The tool received the tool-call `AbortSignal` but ignored it, so pressing `Esc` during a wait couldn't cancel it — the call stayed blocked until the child finished, and pi could log a spurious `No running process to background.`. Cancelling now stops **only** the wait: the background agent keeps running, its result stays unconsumed, and its normal completion notification still arrives. Queued waits are abortable the same way. Because the wait no longer pre-marks the result consumed (a cancelled wait never consumes it), a successful wait still suppresses its own redundant notification by cancelling the held nudge on completion — the queued-wait poll interval was tightened so that cancellation reliably lands inside the notification hold window.
+- **User-scope agent memory honors `PI_CODING_AGENT_DIR`** ([#166](https://github.com/tintinweb/pi-subagents/pull/166) — thanks [@biowaffeln](https://github.com/biowaffeln)). The `user` memory scope hardcoded `~/.pi/agent-memory/<name>`, ignoring `PI_CODING_AGENT_DIR` even though every other config consumer (custom agents, enabled models, settings, skills) already routes through `getAgentDir()` — so anyone who relocated their config dir got a stray `~/.pi` resurrected the first time a `memory: user` agent ran. User-scope memory now resolves to `<agentDir>/agent-memory/<name>` (default `~/.pi/agent/agent-memory/`). Existing memories aren't orphaned: when the legacy `~/.pi/agent-memory/<name>` directory exists and the new location doesn't, it keeps being used — symlinked legacy dirs are ignored, consistent with the file's other symlink defenses — and once the new location exists it wins. Lazy fallback rather than auto-migration, so no files are moved.
+
+## [0.14.2] - 2026-07-17
+
+### Added
+- **`output_transcript` frontmatter + `outputTranscript` project setting — opt out of a subagent's `.output` transcript** ([#146](https://github.com/tintinweb/pi-subagents/pull/146) — thanks [@Thoughts-One](https://github.com/Thoughts-One)). Every subagent streams its full conversation to a per-subagent JSON-lines transcript under the OS temp dir (`<tmpdir>/pi-subagents-<uid>/…/<agent-id>.output`, owner-only `0700`, cleared on reboot); until now that write was unconditional. Set `output_transcript: false` on a custom agent to write no transcript file or path for it, or `outputTranscript: false` in `subagents.json` to make transcripts opt-in for the whole project (a custom agent's frontmatter overrides the project default). Useful when run transcripts shouldn't sit on disk for backup or DLP tooling to ingest. Scope is deliberately narrow — it governs only the `.output` transcript, not the persisted pi session (`persist_session`), worktree commits (`isolation: worktree`), or memory files — so keeping a run fully off disk means setting those too. Default is unchanged: with neither flag set, transcripts are written exactly as before. The write decision is centralized on `record.outputFile`, so every downstream consumer (streaming, notifications, the transcript footer) keys off a single gate.
+
+### Fixed
+- **Bordered conversation-viewer rows stay exact-width at double-width truncation boundaries** ([#153](https://github.com/tintinweb/pi-subagents/pull/153) — thanks [@xz-dev](https://github.com/xz-dev)). The conversation viewer pre-pads each row to the inner width and truncates it to fit between the `│` borders, but `truncateToWidth` was called without its `pad` flag — so when a truncation boundary fell mid-way through a double-width character (CJK, wide emoji), the result came back one column short and the right border shifted left by a column on that row. The row builder now truncates with padding on, restoring the trailing column, so every bordered row renders at exactly the box width regardless of where a wide glyph lands. A regression test sweeps a double-width character across every truncation boundary and asserts each rendered line is exactly the requested width.
+- **Isolated subagents keep extension-registered custom providers on pi 0.80.8+** (fixes [#151](https://github.com/tintinweb/pi-subagents/issues/151) via [#152](https://github.com/tintinweb/pi-subagents/pull/152) — thanks [@0xbentang](https://github.com/0xbentang)). pi 0.80.8 replaced `createAgentSession`'s `modelRegistry` option with `modelRuntime`, and the agent runner still passed the now-ignored `modelRegistry` — so pi built a *fresh* model runtime from disk for the child session. Because isolation also disables extension loading, that fresh runtime had neither the extension-registered custom provider nor its auth: an `isolated: true` agent pinned to such a provider failed preflight with `No API key found for <provider>`, while the same agent with `isolated: false` — or on any pi <0.80.8 — worked. The runner now forwards the parent session's `ModelRuntime` (read off the `ModelRegistry` facade on `ctx.modelRegistry`) as `modelRuntime` when the running pi exposes one, and still passes `modelRegistry` for the pre-0.80.8 range — so the fix spans the whole `>=0.80.0` peer range without changing it: older pi omits the new field and takes the legacy path, 0.80.8+ inherits the parent runtime. Extensions and tools stay isolated exactly as before — only the model providers and their auth are inherited. A `pi@latest` CI job guards the reachability of that runtime accessor (a `private` field the fix reaches through), so a future pi that renames or hides it surfaces as a test failure instead of a silent return of this bug.
+
+## [0.14.1] - 2026-07-14
+
+### Added
+- **`max` thinking level is now advertised in the frontmatter/tool/wizard choices** ([#147](https://github.com/tintinweb/pi-subagents/issues/147) — thanks [@justin-ramirez-gametime](https://github.com/justin-ramirez-gametime)). pi 0.80 added `max` to its `ThinkingLevel`, and the extension already forwarded the value unchanged, but the Agent tool description, generated-agent template, `/agents` creation wizard, and README all stopped at `xhigh` — hiding a valid capability. Those four surfaces now come from one shared list so they can't drift behind pi again. Actual availability still depends on the host pi version and the selected model; pi clamps unsupported levels down.
+
+### Fixed
+- **Runs whose final assistant turn failed are now reported as `error`, not `completed` with an empty result** (fixes [#144](https://github.com/tintinweb/pi-subagents/issues/144) — thanks [@possibilities](https://github.com/possibilities) for the diagnosis). pi resolves an exhausted-retries provider failure normally — the final assistant message carries `stopReason: "error"` plus an `errorMessage`, no rejection — so the manager mapped such runs to `completed` and every consumer (foreground tool result, `get_subagent_result`, background notifications, resume, scheduler, RPC events) saw a clean success reading `No output.` — or worse, an *earlier* turn's text presented as the fresh answer, since the history fallback walks past empty messages. The runner now inspects the final assistant message and reports a failure in two cases: the turn stopped with `stopReason "error"`, or it hit the output-token ceiling (`stopReason "length"`) having produced no text at all — a silent max-token death that reproduced the same empty-`No output.` symptom. Status still derives from how the final turn stopped, never from whether earlier turns produced text: empty-but-clean finals (tool-call-only or thinking-only endings) stay `completed`, a `length` stop that *did* produce text is a legitimate truncated answer and stays `completed`, partial-text provider errors are still failures, and the walk-back fallback keeps preserving partial output for aborted/steered runs. (An `aborted` final turn needs no special-casing here — the manager's hard-abort flag and `stopped` guard already surface it as `aborted`/`stopped`.) The response-text collector also no longer resets on user/tool-result `message_start` events (it tracked the last *message*, not the last *assistant* message). A failed run still surfaces any output it *did* produce: the tool result shows `Agent failed: <error>` followed by that text under a `Partial output before the failure:` label — and the history fallback is now bounded to the current invocation, so a failed **resume** no longer returns the *previous* turn's answer as this run's result (it returns empty). **Behavior change:** runs that previously ended `completed` with an empty result now end `error` carrying the provider message, and `subagents:failed` fires where `subagents:completed` did; scheduled jobs record `lastStatus "error"` for them.
+- **A subagent can allowlist a package-installed extension by its package name, not just its source directory** (fixes [#143](https://github.com/tintinweb/pi-subagents/issues/143) — thanks [@possibilities](https://github.com/possibilities)). Our extension-scoping (`extensions:` / `exclude_extensions:` / `tools: ext:…`) named an extension from its file path, and for an `index.ts` entry it used the parent directory — so a package installed via `pi.extensions: ["./src/index.ts"]` (like this one) only ever matched as `src`, an unstable, collision-prone name that no user would guess; `extensions: [pi-subagents]` silently matched nothing. An extension now also answers to its package's unscoped short name (`@tintinweb/pi-subagents` → `pi-subagents`), read from the nearest `package.json` whose `pi.extensions` manifest actually declares that entry. This is an **added alias** — the path-derived name keeps working, so nothing that already matched `src` breaks — and it fires only for genuinely manifest-declared package entries, so a loose extension is never misattributed to a co-located project's name.
+- **A pi-subagents activation that a child session filtered out no longer advertises or answers cross-extension RPC** (fixes [#142](https://github.com/tintinweb/pi-subagents/issues/142) — thanks [@possibilities](https://github.com/possibilities)). pi runs every extension factory *before* applying an agent's `extensions:` filter and only delivers lifecycle events (`session_start`, …) to the survivors, but the `pi.events` bus is shared with the filtered-out activations too. Because we registered the RPC handlers and emitted `subagents:ready` at factory time, a child agent whose `extensions:` omitted pi-subagents still saw a `subagents:ready` broadcast and a successful `subagents:rpc:ping`, yet every `subagents:rpc:spawn` failed with `No active session` — its `session_start` never fired, so the spawn handler had no context. The RPC handler registration and the `subagents:ready` broadcast now happen on the first bound `session_start` instead of at factory time, so a session that excludes pi-subagents stays completely silent on the RPC channels — behaving like a session where it was never installed, rather than advertising a spawn service it can't provide. Emitting readiness after all factories have loaded also closes a latent race where a consumer whose factory ran after ours could miss the event. No change for sessions that do load pi-subagents: `subagents:ready` still fires and RPC still works, just at `session_start`.
+
+## [0.14.0] - 2026-07-13
+
+### Added
+- **Project custom agents are also discovered from `.agents/agents/<name>.md`** ([#133](https://github.com/tintinweb/pi-subagents/pull/133) — thanks [@wenerme](https://github.com/wenerme); closes [#132](https://github.com/tintinweb/pi-subagents/issues/132)). Projects that keep their agent assets in the shared cross-tool `.agents` workspace (the same convention this extension already reads for `.agents/skills/`) can now define subagents there instead of duplicating files into `.pi/agents/`. Discovery precedence is `global < .agents/agents < .pi/agents`: on a name clash between the two project locations, **`.pi/agents/` wins** — `.pi` remains the project authority, and the `/agents` create/eject/disable flows keep writing there; `.agents/agents/` is a read location only.
+
+### Changed
+- **BREAKING: Dev/test toolchain now tracks pi 0.80.x; pi peer floor raised to `>=0.80.0`** (as diagnosed by [@philipmw](https://github.com/philipmw) in [#129](https://github.com/tintinweb/pi-subagents/pull/129)). The committed lockfile had pinned the `@earendil-works/pi-*` peers to 0.75.5 (the latest published when it was generated), so tests and typecheck exercised an older API surface than the pi that actually runs the extension — including 22 tests that silently never ran on 0.75.5 and now do (suite skip count 26 → 4 between the two lockfiles). The lockfile now resolves the peers to 0.80.6, and the test suite imports pi-ai's relocated faux/model helpers (`registerFauxProvider`, `getModel` — `/compat`-only since pi-ai 0.80) through a single re-export module, `test/helpers/pi-ai.ts`, so the next relocation touches one file. Because the test surface no longer resolves on ≤0.75.x, `peerDependencies` move from `>=0.74.0` to `>=0.80.0` to match what is actually tested. Migration: installs under pi <0.80 may emit unmet-peer warnings (or fail under strict peer resolution such as `npm --strict-peer-deps` / pnpm defaults) — upgrade pi to ≥0.80; runtime behavior itself is unchanged on any pi version, since pi substitutes its own bundled modules for extension imports at load time. Live-mode e2e (`PI_E2E_LIVE=1`) now fails fast with a clear error when the pinned `PI_PROVIDER`/`PI_MODEL` isn't in pi-ai's builtin catalog, instead of silently letting the session resolve a different model.
+
+### Fixed
+- **Output-file streaming survives session compaction** (fixes [#145](https://github.com/tintinweb/pi-subagents/issues/145) — thanks [@possibilities](https://github.com/possibilities) for the diagnosis). Compaction replaces `session.messages` with a shorter, summarized array, which stranded the streamer's write index past the new end — the flush loop never matched again and the agent's output file silently froze for the rest of the run, exactly on the long background runs that auto-compact. The streamer now flushes any not-yet-written tail when compaction starts and re-anchors its index to the rebuilt array after a successful compaction — deferred one microtask, because on the overflow-retry path pi trims the trailing error assistant message *after* emitting `compaction_end`, and a synchronous anchor would skip the first post-compaction message. Aborted and failed compactions leave the session untouched and change nothing. Verified against a real pi `AgentSession` driving a real `session.compact()` in the new e2e regression.
+- **FleetView no longer steals arrow/Enter/Esc keys from other interactive components** (fixes [#123](https://github.com/tintinweb/pi-subagents/issues/123) — thanks [@TommyC81](https://github.com/TommyC81) for the report). pi delivers terminal input to extension listeners *before* the focused component, and selector/input dialogs (`ctx.ui.select` & co.) swap the prompt editor out while `getEditorText()` still reads the detached — empty — editor. So while subagents were running, FleetView's empty-prompt gate passed and it consumed the navigation keys that belonged to whatever dialog was actually focused: other extensions' pickers (e.g. rpiv-ask-user-question), pi's own menus, and even `/agents → Settings` itself. FleetView now checks that pi's prompt editor is the focused component before touching any key (pi's editor is an `Editor` subclass; every dialog is not), and an in-progress list navigation is dropped the moment something else takes focus. Unknowable focus errs toward the editor, so list activation keeps working; non-`Editor` custom editor components simply flow keys through untouched.
+- **Widget and viewer lines keep their dim styling after nested color annotations** ([#136](https://github.com/tintinweb/pi-subagents/pull/136) — thanks [@xz-dev](https://github.com/xz-dev)). pi themes close a foreground color with a bare `\x1b[39m`, so the threshold-colored context-fill percent inside `formatSessionTokens` (warning at ≥70%, error at ≥85%) also terminated the surrounding dim style — the closing `)` and any following text on the widget's running-agent line and the conversation-viewer header bled to the terminal's default color. A small `fgPreservingNestedStyles` helper re-opens the outer color after each nested reset (derived from the theme itself, so it stays theme-agnostic and is a no-op under `NO_COLOR`).
+- **`get_subagent_result` with `wait: true` now waits for queued agents** ([#127](https://github.com/tintinweb/pi-subagents/pull/127) — thanks [@benrhodeland](https://github.com/benrhodeland)). A background agent past the concurrency ceiling sits in the queue with no run promise yet, so the wait path (gated on `status === "running" && record.promise`) skipped it and returned `No output.` immediately — the orchestrator read a queued agent as "finished with nothing". The wait now also covers `queued`: it polls until the queue starts (or stops) the agent, then awaits the run like any running agent. Most visible with parallel background spawns in one message, where spawns beyond `maxConcurrent` (default 4) queue.
+- **Subagent activations no longer clobber the `Symbol.for("pi-subagents:manager")` registry** ([#128](https://github.com/tintinweb/pi-subagents/pull/128) — thanks [@benrhodeland](https://github.com/benrhodeland)). Child sessions re-activate the extension in the same process (`session.bindExtensions` in the agent runner), and every activation overwrote the global registry slot — pointing cross-package consumers (RPC extensions, headless hosts) at a short-lived child manager whose shutdown could then delete the root session's entry entirely. The first activation now claims the slot, child activations leave it alone, and only the owning activation releases it (identity-checked) on shutdown.
+
+## [0.13.0] - 2026-06-30
+
+### Added
+- **Steer a running agent from the conversation viewer.** The live conversation overlay (FleetView's `Enter`, or `/agents → Running agents`) now lets you redirect an agent without leaving the view: press `Enter` to open an inline composer, type a message, `Enter` to send — `Esc` or an empty submit just returns. The message is delivered through the same path as the `steer_subagent` tool (`AgentManager.steer()` → `session.steer`, or queued onto `pendingSteers` if the session isn't ready yet), so it appears as a user message and redirects the agent after its current tool execution; feedback is the message showing up in the live transcript you're already watching. The affordance is offered only while the agent is still running/queued (mirrors the `x`/stop affordance), and the viewer stays modal — every existing shortcut (`x`/`x` stop, arrows/`j`/`k` scroll, `q` close) is untouched, and `Enter` was previously inert here so nothing is overridden. The idle footer was reorganized to actions-left / navigation-right so the full scroll-key hint (`↑↓ scroll · PgUp/PgDn or Shift+↑↓ · Esc close`) stays fully visible down to 80-column terminals; the `N lines · %` readout returns on the left whenever there's spare width.
+- **Forgiving model resolution for agent `model:` pins.** `resolveModel` now tolerates cosmetic id variations and falls back across providers, so a qualified or date-pinned config resolves widely instead of silently dropping to the parent model: `.` and `-` are treated as equivalent in version numbers (`claude-haiku-4.5` ≡ `claude-haiku-4-5`); a trailing `-YYYYMMDD` date stamp is optional (`anthropic/claude-haiku-4-5-20251001` matches an undated registry id); and a `provider/modelId` that isn't available under the named provider retries the bare id against every provider (the named provider is still preferred when present). An exact match still wins over a tolerant one, so dated snapshots aren't conflated — the precedence is exact → fuzzy-under-named-provider → same model under any provider → unavailable.
+- **`/agents → Agent types` shows each agent's full description and what its model resolves to.** The list now renders with `SettingsList` (like the Settings menu) instead of a flat selector: the highlighted agent's full description shows on its own line below the list, so long descriptions no longer wrap and push the agent names out of alignment. The model column shows the configured model, flags it `(unavailable, fallback: inherit)` when it can't be resolved against the registry (it would silently inherit the parent model at runtime), and surfaces the resolved target `(→ provider/id)` when resolution lands on a different provider or version than configured.
+- **`widgetMode` setting — control what the above-editor widget shows: `all` / `background` / `off`** ([#117](https://github.com/tintinweb/pi-subagents/pull/117) — thanks [@Alan-TheGentleman](https://github.com/Alan-TheGentleman); fixes [#118](https://github.com/tintinweb/pi-subagents/issues/118)). Foreground agents already render inline as the `Agent` tool result, so also listing them in the persistent widget double-rendered the same run (most visible in tmux/zellij). `widgetMode` (via `/agents → Settings → Widget`, or `subagents.json`) selects the widget's contents: `all` shows every agent (the previous behavior), `background` shows background/queued/scheduled/RPC runs but hides foreground, and `off` hides the widget entirely (agents still appear inline and in FleetView). Applied live — toggling refreshes immediately. Filtering keys off a new tri-state `AgentRecord.isBackground` captured at spawn (`true` = background, `false` = foreground, `undefined` = undeclared, e.g. a cross-extension RPC spawn), independent of the UI-only `invocation` snapshot — so scheduler- and RPC-spawned background agents stay visible instead of vanishing; only runs *known* to be foreground are dropped. The running-status line was also refactored from one multiline `Text` into two component rows, so rapid partial updates replace cleanly instead of leaving stale rows behind in terminal multiplexers — identical on-screen output, no more ghost lines.
+
+### Changed
+- **The built-in `Explore` agent's model pin is now `anthropic/claude-haiku-4-5`** (was `…-4-5-20251001`). The stale date stamp is dropped to match the `anthropic/claude-sonnet-4-6` / `anthropic/claude-opus-4-6` convention used by the create-agent wizard; combined with the forgiving resolution above, `Explore` now picks up its fast/cheap model across registry variations (dated, undated, dotted, or under a non-`anthropic` provider) instead of silently falling back to the parent model.
+- **The above-editor widget now hides foreground agents by default** (`widgetMode` defaults to `background`). Foreground runs still render inline as the `Agent` tool result (and in FleetView); set `/agents → Settings → Widget` to `all` to restore the previous show-everything view, or `off` to hide the widget. Existing `subagents.json` files load unchanged (absent → `background`).
+
+## [0.12.0] - 2026-06-24
+
+### Added
+- **FleetView — a Claude Code-style subagent navigator below the editor.** A persistent, navigable list of `main` + every active subagent renders beneath the editor whenever agents are running — **auto-shown, no keypress needed** — mirroring Claude Code's bottom fleet bar: `⏺`/`◯` selection markers, agent type + description, right-aligned `elapsed · ↓ tokens`, and a `↓ N more` overflow once past five rows. Press `↓` (or `←`) at an **empty prompt** to move focus into the list, `↑`/`↓` to select, `Enter` to open the selected agent's live, auto-updating conversation overlay, and `Esc` (or `↑` above `main`) to return to the prompt. Implemented as a `belowEditor` widget with all key handling routed through `onTerminalInput` (which fires before the editor); it only captures arrow keys at an empty prompt — and acts on key-**press** only (kitty-protocol release events are ignored, otherwise each tap moved twice) — so typing, history, and cursor movement are untouched. Rows are ordered **earliest-launched first**; only openable agents (those with a session) are shown, so pending/queued agents appear once they start and `Enter` never dead-ends; **finished agents linger ~4s** before dropping out (their elapsed freezes at completion); and a viewer **stays open through its agent's completion** so the final output remains readable. Selection follows the viewed agent by id, so closing a viewer returns you to the same agent even if the list reordered while it was open. Every rendered line is width-clamped — the narrow-terminal crash/flicker class previously fixed in v0.2.7 and [#7](https://github.com/tintinweb/pi-subagents/issues/7). Toggle via `/agents → Settings → Fleet view` (default on; pure-UI, so no LLM-context cost).
+
+## [0.11.0] - 2026-06-23
+
+### Added
+- **`persist_session` / `session_dir` agent frontmatter — persist a subagent as a real pi session** ([#111](https://github.com/tintinweb/pi-subagents/pull/111) — thanks [@codesoda](https://github.com/codesoda)). `persist_session: true` runs the subagent through `SessionManager.create(...)` instead of `SessionManager.inMemory(...)`, so its full transcript is written to pi's normal session location (`~/.pi/agent/sessions`) — inspectable and resumable after the fact, like a top-level session — rather than living in memory only. Useful for long-running, multi-round orchestrations (plan → review → implement → verify) where each subagent's conversation is worth keeping. `session_dir` optionally overrides where the persisted session is written (absolute, `~`, or agent-cwd-relative path); omitted, persistence follows pi's own precedence — `PI_CODING_AGENT_SESSION_DIR`, then the settings manager's `getSessionDir()`, then pi's default location. Both default off/unset, so existing agents are unchanged: the in-memory path is byte-identical to before, and the sidechain `.output` transcript is still written either way.
+
+## [0.10.4] - 2026-06-23
+
+### Fixed
+- **Background agent records lost before result is read** ([#108](https://github.com/tintinweb/pi-subagents/issues/108) — thanks [@philipmw](https://github.com/philipmw)). On session switch or `/new`/`/resume`, `clearCompleted()` removed completed agent records regardless of whether the LLM had retrieved the result, causing `get_subagent_result` to return "Agent not found" for agents that had finished but hadn't been checked yet. `clearCompleted()` now accepts a `skipUnconsumed` flag; session event handlers pass `true`, so records with `resultConsumed=false` are preserved across session transitions. The 10-minute cleanup timer handles eventual eviction. Note: a full session shutdown (`session_shutdown`) calls `dispose()` which clears all records unconditionally — that path is not affected by this fix.
+
+### Added
+- **Foreground agent lifecycle completion and conversation logging** ([#105](https://github.com/tintinweb/pi-subagents/pull/105) — thanks [@benrhodeland](https://github.com/benrhodeland)). Two gaps closed: (1) **`onComplete` now fires for foreground agents**, emitting `subagents:completed` / `subagents:failed` lifecycle events and writing a `subagents:record` entry to the parent JSONL — previously only background agents emitted these, leaving cross-extension observers with an orphaned `subagents:started` event and no matching completion. `resultConsumed` is pre-set so the callback skips notifications (the result is returned inline); no change to the tool's return value. (2) **Foreground agent conversations are now streamed to `.output` files** (same `.pi/output/agent-<id>.jsonl` path as background agents) — inline subagent transcripts were previously permanently lost after `spawnAndWait` returned.
+
+## [0.10.3] - 2026-06-12
+
+### Added
+- **`SpawnOptions.cwd` — spawn a subagent in a different working directory** ([#96](https://github.com/tintinweb/pi-subagents/issues/96) — thanks [@madeleineostoja](https://github.com/madeleineostoja)). For RPC/programmatic callers (not exposed on the `Agent` tool — the LLM-visible surface is unchanged). The agent's tools operate in the target directory and the prompt's environment block describes it, but **`.pi` config keeps loading from the parent session's project** (new `RunOptions.configCwd` split): the target's `.pi` extensions never execute, and its agents/skills/settings/memory are not picked up — spawning into an untrusted directory sends a worker there with the parent's toolbox, rather than "opening pi there." Composes with `isolation: "worktree"`: the worktree is created *from* the target directory's repo, the agent works at the equivalent subdirectory inside the copy (a monorepo-package cwd keeps its scoping instead of silently widening to the repo root — new `WorktreeInfo.workPath`), and the resulting `pi-agent-*` branch lands in that repo, with the completion message naming it so the orchestrator merges in the right place. Validation is strict, typed, and early — non-strings, relative paths, nonexistent paths, and files all throw curated errors at `spawn()` (before queueing) and are re-checked at queue drain, surfacing as RPC error envelopes (`null` is treated as unset). On dispose, worktree registrations are pruned in every repo that received one; only a hard crash can leave a stale entry (then: `git worktree prune` in the target repo).
+
+## [0.10.2] - 2026-06-10
+
+### Added
+- **`exclude_extensions:` agent frontmatter — extension denylist for subagents** ([#94](https://github.com/tintinweb/pi-subagents/issues/94) — thanks [@ramhaidar](https://github.com/ramhaidar)). Applied after the `extensions:` include set; exclude wins, including over `tools: ext:` selectors (an excluded extension never loads, so its `ext:` reference becomes the usual orphan warning). The key use case: `extensions: true` + `exclude_extensions: pi-notify` — all extensions except a noisy one, without hand-maintaining an allowlist. Plain canonical names only (case-insensitive); paths, `*`, and unmatched names fire `extension-error:…` warnings (warn-not-abort, as with `extensions:` mismatches); `extensions: false` + an exclude warns that the exclude has no effect. **Not a sandbox:** excluded extensions' factory code still executes once during loading — exclusion suppresses handler binding and tool registration, not load-time side effects. The negation syntax `extensions: ["*", "!name"]` was deliberately rejected: an unquoted `!name` is a YAML tag and silently mis-parses.
+- **`toolDescriptionMode` setting — opt-in compact Agent tool description** ([#91](https://github.com/tintinweb/pi-subagents/issues/91) — thanks [@tiberiuichim](https://github.com/tiberiuichim)). The full Claude Code-style description costs ~1,400 tokens with the default agents and grows with each custom agent (the type list embeds full agent descriptions) — significant for small/local models. `toolDescriptionMode: "compact"` (via `/agents → Settings → Tool description` or `subagents.json`) swaps in a ~75% smaller description: one-line type list (first sentence of each agent description), terse usage notes, per-option details left to the parameter descriptions. Default `"full"` is byte-identical to before — the rich description's guardrails are deliberately load-bearing and stay the default. A third mode, `"custom"`, registers a user-authored description from `<cwd>/.pi/agent-tool-description.md` (project) or `<agentDir>/agent-tool-description.md` (global; project wins), with `{{placeholder}}` substitution keeping the dynamic parts live — `{{typeList}}`, `{{compactTypeList}}`, `{{agentDir}}`, `{{scheduleGuideline}}` — so a hand-written description can't drift out of sync with the registered agents (the advertised-vs-spawnable staleness [#92](https://github.com/tintinweb/pi-subagents/issues/92) just fixed). Unknown placeholders are left verbatim with a stderr warning; a missing/empty file falls back to `"full"`. Only the prose is customizable — the parameter schema stays code-owned. A ready-made starting point ships at `examples/agent-tool-description.md`, reproducing the full description exactly (CI-enforced byte-identical, so the example can't go stale). Like `schedulingEnabled`, the mode is read at tool registration — changing it applies on the next pi session. The issue's original ask (move the description to a skill) isn't possible in pi: tools must register their description in the tool schema for the model to call them; skills are lazily-loaded instructions, not tool registrations.
+
+### Fixed
+- **Conversation viewer honors custom `tui.select.*` keybindings** ([#99](https://github.com/tintinweb/pi-subagents/issues/99) — thanks [@owenniles](https://github.com/owenniles)). The viewer hardcoded its scroll keys and discarded the `KeybindingsManager` pi injects into `ctx.ui.custom()`, so user bindings (e.g. emacs-style `ctrl+p`/`ctrl+n` on `tui.select.up`/`down`) worked in pi core selectors but not here. Scrolling now resolves through `tui.select.up`/`down`/`pageUp`/`pageDown`; the viewer-specific `k`/`j` and `shift+arrow` aliases still work alongside, and behavior without custom bindings is unchanged (the `tui.select.*` defaults are the previously hardcoded keys).
+
+## [0.10.1] - 2026-06-10
+
+### Added
+- **`disableDefaultAgents` setting** ([#92](https://github.com/tintinweb/pi-subagents/issues/92) — thanks [@TommyC81](https://github.com/TommyC81)). When on, the three built-in default agents (general-purpose, Explore, Plan) are skipped at registration — only user-defined `.pi/agents/*.md` agents are advertised and spawnable. User agents are unaffected, including ones overriding a default by name; with no user agents defined, spawning falls back to the hardcoded generic config. Off by default; toggle via `/agents → Settings → Disable defaults` or `disableDefaultAgents` in `subagents.json`. Like `schedulingEnabled`, the Agent tool's type list reflects the change on the next pi session (tool schema is registered at startup).
+
+### Fixed
+- **Agents with `enabled: false` are no longer advertised in the Agent tool description** ([#92](https://github.com/tintinweb/pi-subagents/issues/92)). `buildTypeListText` listed every registered agent, including disabled ones that `isValidType` then refused to spawn — the LLM was offered types it could never use. The type list now filters through `getAvailableTypes()`, matching the `subagent_type` parameter description.
+- **Agent tool type list no longer built from pre-settings state.** The description text was captured into a variable before persisted settings were applied; it's now built at tool-registration time, after `subagents:settings_loaded`.
+- **Committed work from `isolation: "worktree"` subagents is now preserved** ([#68](https://github.com/tintinweb/pi-subagents/pull/68) — thanks [@rylwin](https://github.com/rylwin)). If an isolated subagent creates its own commit, cleanup previously saw a clean `git status`, treated it as "no changes", and removed the detached worktree — silently discarding the commits. The worktree now records its base SHA at creation, and cleanup creates the expected `pi-agent-*` branch whenever HEAD moved past it, even with a clean tree.
+- **Automatic commits in isolated worktrees skip local Git hooks** ([#68](https://github.com/tintinweb/pi-subagents/pull/68)). The preservation commit at worktree cleanup now uses `--no-verify`, so a failing local pre-commit hook can't abort it (which previously surfaced as `hasChanges: false` — the agent's work lost).
+
+## [0.10.0] - 2026-06-01
+
+> **⚠️ Breaking: `extensions:` and `tools:` in agent frontmatter semantics changed.** The `extensions: [...]` array now selects which extensions *load*, not which tool names surface. Agents that previously used the array form will behave differently — see migration below. The `tools:` field also grew new `ext:` and `*` selector forms; existing `tools:` values without these selectors are unchanged.
+> - `extensions: [...]` is now an **extension allowlist applied at load time**, not a tool-name substring filter. Each entry is an extension *name*, a *path* (absolute, `~/`-prefixed, or relative-to-cwd), or `"*"`. **Migration:** `extensions: ["mcp"]` previously loaded *every* extension and then surfaced only tools whose names contained `mcp`. To keep all extensions, use `extensions: true` or `extensions: "*"`. To narrow, name the extensions or point at their files. `"*"` composes: `extensions: "*, /abs/path/extra-ext.ts"` is all defaults plus one path-loaded.
+> - `tools:` now accepts `ext:` selectors and `*`. **Gotcha:** a `tools:` value containing **only** `ext:` entries yields **zero built-in tools** — add `*` (e.g. `tools: "*, ext:foo"`) to keep the built-ins. And **any** `ext:` entry flips extension tools to an explicit allowlist (non-listed extensions stay loaded but expose no tools). A `tools:` with no `ext:` entries is unchanged.
+> - **`extensions:` is the sole loading authority.** `ext:foo` only narrows tool *exposure* within the already-loaded set; it cannot pull an extension in. `extensions: false` + `tools: "ext:foo"` loads nothing and warns that `ext:foo` is orphaned. To expose one extension's tool from an otherwise-narrow agent, name the extension explicitly: `extensions: [foo]` + `tools: "ext:foo/bar"`.
+
+> **⚠️ Heads-up — widget glyphs changed (visual only):** turn count now renders as `↻N` (was `⟳N`) and compaction count as `⇊N` (was `↻N`). Fix for [#84](https://github.com/tintinweb/pi-subagents/issues/84) — `⟳` overflowed its cell in common monospace fonts. **No API, behavior, or output-format changes — only the glyphs.** If you grep agent stats lines or pipe widget output through scripts, update your patterns: `⟳` → `↻` (turns), `↻` → `⇊` (compactions).
+
+### Added
+- **`tools:` accepts `ext:` extension-tool selectors and a `*` built-in wildcard.** Entries in the `tools:` CSV are now partitioned: plain names are the built-in allowlist (unchanged); `*` expands to all built-ins (symmetric with `extensions: "*"`); `ext:foo` / `ext:foo/bar` select extension tools. **Any `ext:` entry flips extension tools to an explicit allowlist** — only tools named by an `ext:` selector reach the LLM, and extensions not named stay loaded (their `session_start` etc. handlers still fire) but expose no tools. `ext:foo` exposes all of `foo`'s tools; `ext:foo/bar` narrows `foo` to just `bar` (multiple `ext:foo/x` entries union; a bare `ext:foo` alongside `ext:foo/bar` lets narrowing win). `ext:` is **narrowing-only** — it does not load extensions. `extensions:` remains the sole loading authority; an `ext:foo` against an extension that `extensions:` excluded (including `extensions: false`) is orphaned and warns via `onToolActivity` (`extension-error:ext:foo …`). With no `ext:` entry present, extension-tool behaviour is unchanged. `ext:` is name-only (matched by canonical name, so it composes with path-loaded extensions); paths still go in `extensions:`. `isolated: true` ignores `ext:` selectors.
+- **Stop a running agent from the conversation viewer.** In `/agents → Running agents`, select an agent and press `x` (then `x` again to confirm) to abort it. The two-press guard prevents an accidental kill; the footer shows `x stop` → `x again to STOP`. This works for **background** agents — which a global `Esc` can't unambiguously target — while `Esc` still stops a blocking foreground `Agent` call. Wires the existing `AgentManager.abort(id)` to the viewer (`onStop` callback); the affordance only appears while the agent is `running`/`queued`. Addresses the common "how do I stop a background subagent?" question ([#88](https://github.com/tintinweb/pi-subagents/issues/88)).
+
+### Changed
+- **BREAKING: `extensions: [...]` in agent frontmatter is now a loader-level extension allowlist, not a tool-name filter.** Previously a `string[]` value filtered exposed *tool names* by substring (`t.startsWith(e) || t.includes(e)`) while every discovered extension still loaded and ran its handlers. Now each entry selects an *extension*: a bare name keeps the matching default-discovered extension, a path (absolute, `~/`-prefixed, or relative-to-cwd) loads that extension fresh via `additionalExtensionPaths`, and `"*"` keeps all default-discovered extensions. Entries compose — `["*", "/abs/foo.ts"]` is all defaults plus foo, `["mcp", "/abs/foo.ts"]` is just those two. Excluded extensions no longer bind handlers or register tools (their factory still runs once during `reload()`). Directory extensions (`foo/index.ts`) match by the parent directory name. **Extension names match case-insensitively** (`extensions: [Mcp]` resolves the same as `[mcp]`); tool names within `ext:foo/bar` selectors remain case-sensitive (they're matched against pi-mono's registered identifiers). Unmatched names and failed paths warn via `onToolActivity` but do not abort the subagent (see the heads-up above for migration).
+- **Non-normal subagent outcomes are now stated explicitly in the text delivered to the parent**, so the orchestrator can't mistake a stopped/incomplete agent for a completed one. The foreground `Agent` result, `get_subagent_result`, and the `<task-notification>` summary all append a clear note for `stopped` (user abort) → `(STOPPED BY THE USER before completion — output is partial; the task was NOT finished)`, `aborted` (turn limit) → `(aborted — hit the turn limit before completion; output may be incomplete)`, and `steered` → `(wrapped up at the turn limit — output may be partial)`. `stopped` (human intervention) is kept distinct from `aborted` (turn-budget cutoff); a clean `completed` adds no note. Extracted as `getStatusNote` in `src/status-note.ts`.
+- **`BUILTIN_TOOL_NAMES` is derived from pi's tool factories** (`createCodingTools` + `createReadOnlyTools`) rather than a hardcoded list, so the built-in set tracks pi-mono automatically. Internal; no behavior change (the resolved set is the same seven names).
+
+### Fixed
+- **Turn-count glyph in the agent widget no longer overflows its monospace cell** ([#84](https://github.com/tintinweb/pi-subagents/issues/84) — thanks [@linozen](https://github.com/linozen)). `formatTurns` used `⟳` (U+27F3 CLOCKWISE GAPPED CIRCLE ARROW) from the Miscellaneous Mathematical Symbols-A block, where common monospace fonts (Iosevka Nerd Font Mono, Menlo, SF Mono, JetBrains Mono) draw the glyph visually wider than one cell despite its Neutral East Asian Width — making the next character (the digit) overlap the glyph. Replaced with `↻` (U+21BB CLOCKWISE OPEN CIRCLE ARROW) from the standard Arrows block, which renders cleanly at one cell in those fonts. To avoid colliding with the existing compaction indicator (which previously also used `↻`), the compaction glyph moves to `⇊` (U+21CA DOWNWARDS PAIRED ARROWS) — same Arrows block, also single-cell, visually distinct. Widget vocabulary now reads: `↻5≤30` for turns, `⇊2` for compactions. Pi UI consumers / scripts grepping for the glyph in stats lines must update.
+- **`tools: none` now actually yields zero built-in tools.** `getToolNamesForType` treated an explicit empty `builtinToolNames` (`[]`, produced by `tools: none`) as "unspecified" and fell back to all 7 built-ins. It now distinguishes an omitted field (`undefined` → all built-ins, for default agents) from an explicit empty list (`[]` → zero), consistent with `getConfig`. Same fix makes `tools:` values containing only `ext:` selectors yield zero built-ins as documented.
+- **`tools:` typos no longer silently break tool-calling** ([#75](https://github.com/tintinweb/pi-subagents/issues/75)). Two parts: (a) `all` was previously parsed as a literal tool name, producing a one-element allowlist of the non-existent tool `"all"` — the model then returned an empty response or emitted raw XML tool calls, all with `status: completed` and no error. `parseToolsField` now treats `all` (case-insensitive) as an alias for the `*` wildcard, both standalone and inside a CSV. (b) Plain entries in `tools:` are expected to be built-in names (extension tools route through `ext:`), so an unknown name there is unambiguously a typo. `runAgent` now emits a `tools-error:tool "X" requested by agent "Y" is not a known built-in` event via `onToolActivity` for each unrecognized plain entry — same surfacing channel as the existing `extension-error:` warnings.
+- **Subagents with `extensions: true` now actually expose extension-registered tools (MCP, etc.)** ([#47](https://github.com/tintinweb/pi-subagents/issues/47)). `runAgent` previously passed only the built-in tool names as the `tools:` allowlist to `createAgentSession`, so pi-mono's `allowedToolNames` gate rejected every extension-registered tool at registration — `extensions: true` agents silently got only the 7 built-ins. `runAgent` now enumerates extension tool names from the resource loader after `reload()` and builds the full master allowlist (built-ins + permitted extension tools), so pi-mono's gate admits them from the first instant of the session. `disallowedTools` and the internal `Agent`/`get_subagent_result`/`steer_subagent` exclusions are applied uniformly to built-in and extension tools at construction — no post-construction `setActiveToolsByName` narrowing.
+- **Append-mode subagents no longer defeat the LLM's KV cache** ([#73](https://github.com/tintinweb/pi-subagents/pull/73) — reported by [@jeffutter](https://github.com/jeffutter)). The assembled child prompt placed the per-spawn-varying `<active_agent>` tag and `# Environment` block *before* the ~8k-token inherited parent prompt, and wrapped the parent prompt in `<inherited_system_prompt>` tags. Because KV caches key on a byte-identical prefix, every subagent spawn reprocessed all ~8k shared tokens from scratch (~40s on slower hardware). The parent prompt is now emitted **verbatim at the start** of the prompt (wrapper dropped), so it forms an identical, cacheable prefix with the parent session and across every spawn; the static `<sub_agent_context>` bridge follows, then the varying `<active_agent>` tag and env block. `replace` mode is unchanged (it inherits no parent prefix). The `<active_agent>` tag stays present and is parsed position-independently, so downstream permission resolution is unaffected. Mirrors the fix in [gotgenes/pi-packages#180](https://github.com/gotgenes/pi-packages/issues/180).
+
+## [0.9.1] - 2026-05-30
+
+### Added
+- **`Agent`, `get_subagent_result`, and `steer_subagent` now surface in pi's default system prompt** ([#87](https://github.com/tintinweb/pi-subagents/pull/87) — thanks [@that-yolanda](https://github.com/that-yolanda)). Adds `promptSnippet` to all three (a line in the prompt's `Available tools:` section) and `promptGuidelines` to `Agent` (bullets in `Guidelines:`). The tools were always callable via the tool-call API; this only adds system-prompt reinforcement for prompt-following models. No schema or tool-call changes.
+
+## [0.9.0] - 2026-05-30
+
+> **Heads-up — orchestrator behavior may shift.** This release substantially rewrites the `Agent` tool description and the three default-agent descriptions (`general-purpose`, `Explore`, `Plan`) to mirror Claude Code's upstream wording. No API, schema, or tool-call shape changes — purely a prompt-engineering shift, but a load-bearing one:
+> - **Agent selection may drift.** The new agent descriptions carry richer positive ("Use it to …") and negative ("Do NOT use it for …") guidance plus search-breadth hints for `Explore` (`"quick"` / `"medium"` / `"very thorough"`). For ambiguous tasks where the orchestrator previously picked one default agent, it may now pick another — typically more correctly, but the choice may differ from prior releases.
+> - **Subagent briefings will skew longer and more contextual.** The restored upstream guardrails and the new `## Writing the prompt` section actively coach "smart colleague who just walked into the room"-style prompts. Expect more context, more constraint, more upfront framing in the `prompt:` field the orchestrator passes to subagents.
+> - **Parallel/background patterns more strongly enforced.** The merged bullet on parallel execution now explicitly says `run_in_background: true` is required on each tool call for actual concurrency, and that the orchestrator MUST send a single message with multiple tool uses when the user says "in parallel." Workflows relying on sequential-foreground default behavior are unaffected.
+> - If you have tests or workflows that depend on the prior agent-selection or briefing behavior, pin to a v0.7.x release.
+
+### Added
+- **`scopeModels` setting — opt-in subagent model-scope enforcement** (off by default). New setting toggleable via `/agents → Settings → Scope models`. When enabled, the *effective* model of each subagent spawn is validated against `enabledModels` from pi's settings (which pi manages via its own `/scoped-models` UI; pi-subagents only reads it). **Both pi settings files are honored**: global `<agentDir>/settings.json` plus project-local `<cwd>/.pi/settings.json`, with project overriding global — mirrors pi's `SettingsManager` deep-merge and our own `subagents.json` precedence. Out-of-scope handling depends on source: caller-supplied via `Agent({ model: "..." })` → hard error to the orchestrator with the allowed list; frontmatter-pinned or parent-inherited → warning toast + the agent runs anyway (preserves "frontmatter is authoritative" guarantee from v0.5.1; `scopeModels` is a guardrail against runtime LLM choices, not user-level config). Limitation: only exact `provider/modelId` entries in `enabledModels` are honored — globs (`*sonnet*`), bare model IDs, and `:thinking` suffixes that pi itself supports are silently dropped here. Matches pi's `/scoped-models` picker output, so the limitation is invisible to UI users.
+
+### Changed
+- **`Agent` tool prompt restructured to mirror Claude Code's upstream Agent tool description format.** Section headings now match upstream (`## When not to use`, `## Usage notes`, `## Writing the prompt`); the auto-generated agent list renders as a flat list (no `Default agents:` / `Custom agents:` sub-headers) with a per-agent `(Tools: …)` suffix derived from each agent's `builtinToolNames` (or `*` when the agent has the full built-in set). Restored upstream's load-bearing guardrails that were missing or compressed in the old prompt: "result is not visible to the user → summarize", "trust but verify", "fresh agent / self-contained prompt" on resume, "tell the agent whether to write code or do research", "use proactively when the description says so", "MUST send a single message for parallel", and the worktree auto-cleanup behavior detail. The three redundant "Use Explore / Plan / general-purpose for …" shorthand bullets were dropped — the agent descriptions themselves now carry the canonical (and richer) selection guidance. Upstream's two `<example>` blocks at the end of "Writing the prompt" are also intentionally omitted: the per-orchestrator-turn token cost is recurring, the abstract guidance + the now-rich agent descriptions cover the same pedagogical ground, and the examples embed Anthropic-specific `<thinking>` framing that doesn't generalize across pi-ai's provider surface (OpenAI, Bedrock, Gemini, Mistral, …). All pi-specific bullets (`resume`, `steer_subagent`, `model`, `thinking`, `inherit_context`, `isolation: "worktree"`, `${scheduleGuideline}`) preserved.
+- **Default agent descriptions (`general-purpose`, `Explore`, `Plan`) replaced with upstream Claude Code's verbatim wording.** Previously one-line labels (e.g. `"Fast codebase exploration agent (read-only)"`); now multi-sentence descriptions that include positive ("Use it to …") and negative ("Do NOT use it for …") guidance plus, for Explore, search-breadth hints (`"quick"` / `"medium"` / `"very thorough"`). The LLM-facing selection signal is now substantially stronger.
+- **`/agents → Eject` now emits YAML-safe `description:` frontmatter.** The new Explore description contains a `: ` colon-space pattern (the search-breadth hint) and embedded quote characters — emitting it raw would have produced malformed frontmatter that the `yaml` parser would mis-parse. `ejectAgent` now wraps the description with `JSON.stringify` (a valid YAML 1.2 double-quoted scalar), so any description string round-trips cleanly through eject → re-load. Latent bug: previously unreachable because old descriptions were YAML-plain-safe.
+- **`/agents → Settings` UI rewritten to inline-editable `SettingsList`.** Replaces the previous modal `ctx.ui.select` chain. All settings visible at once; `↑`/`↓` to navigate, `Space` to cycle preset values on numerics (`Max concurrency`, `Default max turns`, `Grace turns`), `Enter` to type a custom value, `Esc` to exit. Functionally equivalent — same fields, same valid ranges, same persistence behavior — but the interaction model is different. Users scripting against the old screen flow may notice.
+- **`.gitignore` additions.** Added `.pi/subagents.json` (project-local subagents settings — written by `/agents → Settings`, shouldn't be committed) plus pi-runtime working files (`progress.md`, `AGENTS.md`, `CLAUDE.md`). **Migration:** if you previously committed `.pi/subagents.json` to your repo, run `git rm --cached .pi/subagents.json` to untrack — gitignore only blocks new additions.
+
+## [0.8.0] - 2026-05-26
+
+> **⚠️ Breaking: peer dependencies moved from `@mariozechner/pi-*` to `@earendil-works/pi-*`.** The upstream Pi runtime relocated npm scopes on 2026-05-07; the `@mariozechner/pi-*` packages are deprecated. This release pins `@earendil-works/pi-{ai,coding-agent,tui}` at `>=0.74.0`. Hosts on the old scope must update their pi installation first (`pi update --self` handles the rename automatically) before installing this version.
+>
+> **Note on Node:** this release is tested against `@earendil-works/pi-coding-agent@latest` (currently `0.75.x`), which requires Node `>=22.19.0` because its bundled `undici` calls Node 22+ APIs. CI runs on Node 22. The peer range (`>=0.74.0`) technically also matches the upstream `legacy-node20` line (`0.74.x`, Node 20 compatible) and this extension contains no Node 22+ API calls of its own, but the legacy line is not exercised in CI — consumers pinning it do so at their own risk.
+
+### Changed
+- **Peer deps migrated from `@mariozechner/pi-*` to `@earendil-works/pi-*`** ([#76](https://github.com/tintinweb/pi-subagents/issues/76) — thanks [@SEHANTA](https://github.com/SEHANTA) for the report). On **2026-05-07** the upstream Pi runtime moved npm scopes — `@mariozechner/pi-coding-agent@0.73.1` was the final publish (now deprecated on npm), and `@earendil-works/pi-coding-agent@0.74.0` shipped 30 minutes later from the same monorepo (same author, same code). `peerDependencies` now target `@earendil-works/pi-{ai,coding-agent,tui}` at `>=0.74.0`, and all `src/**` and `test/**` imports are renamed to the new scope — pure rename, no API changes. Consumers pinning the new scope no longer hit the peer-dep conflict warnings reported in [#76](https://github.com/tintinweb/pi-subagents/issues/76).
+- **`ThinkingLevel` now imported from `@earendil-works/pi-ai` instead of `…/pi-agent-core`.** `src/types.ts` previously reached past the public API into `pi-agent-core` (an internal package), which only resolved because npm flat-hoisted it as a transitive of `pi-coding-agent` — under pnpm or strict-resolver setups the import failed (`TS2307: Cannot find module '@mariozechner/pi-agent-core'`). `pi-ai` re-exports `ThinkingLevel` from its public surface (`export * from "./types.ts"`), so the import goes through the documented entry point and no extra peer dep is needed.
+
+### Fixed
+- **`.pi/subagent-schedules/` is no longer created in every working directory.** `ScheduleStore`'s constructor previously ran `mkdirSync` unconditionally, so any session with scheduling enabled left an empty `.pi/subagent-schedules/` dir behind even when nothing was ever scheduled. Directory creation is now lazy — deferred to a new private `ensureDir()` invoked at the top of `withLock`, so the dir (and its `<sessionId>.json`) appear only when a job is actually persisted. Additionally, `update`/`remove` now short-circuit on an unknown id (in-memory `jobs.has(id)` check) before taking the lock, so no-op mutations never touch disk. Read-only use (`list`/`get`/`hasName`) and constructing the store never create the dir. Pre-existing leftover dirs are not cleaned up — remove them manually.
+
+## [0.7.3] - 2026-05-14
+
+### Added
+- **`<active_agent name="…"/>` tag prepended to every child system prompt** ([#73](https://github.com/tintinweb/pi-subagents/pull/73) — thanks [@chris-lasher](https://github.com/chris-lasher)). `buildAgentPrompt` now emits `<active_agent name="${config.name}"/>` as the first line of the assembled prompt in both `replace` and `append` modes, before the env block. Downstream extensions (e.g. permission/policy systems) can parse it from inside the child session to resolve per-agent policy. The tag uses the agent's `config.name` verbatim — no escaping or normalization — and does not couple this extension to any specific downstream consumer; ignoring it is harmless.
+
+### Changed
+- **Subagent sessions now get a stable, type-derived name with an id suffix for parallel spawns** ([#51](https://github.com/tintinweb/pi-subagents/pull/51) — thanks [@forcepushdev](https://github.com/forcepushdev)). `runAgent` calls `session.setSessionName(agentConfig?.name ?? type)`, and when the manager assigns an `agentId` (always, in production), the name is suffixed with an 8-char slice — e.g. `Explore#a1b2c3d4` — so concurrent spawns of the same agent type are distinguishable in the overlay instead of all collapsing onto the same bare name. Direct `runAgent` callers without an `agentId` (e.g. tests) get the bare name.
+
+### Fixed
+- **Cross-extension spawn RPC now accepts a string `options.model`** ([#59](https://github.com/tintinweb/pi-subagents/pull/59), fixes [#60](https://github.com/tintinweb/pi-subagents/issues/60)). Cross-extension callers (e.g. `@tintinweb/pi-tasks@>=0.4.3`'s `TaskExecute`) naturally forward `model` as a serializable `"provider/modelId"` string. Previously the spawn handler passed strings straight through to `runAgent()`, which expects a `Model` object — the spawned agent then crashed with `No API key found for undefined`. The handler now resolves strings via the same `resolveModel(ctx.modelRegistry)` path the scheduler uses; `Model` objects pass through unchanged. Unresolved strings surface the human-readable `Model not found: "…"` error instead of the auth-lookup crash. Thanks @any-victor.
+
+## [0.7.2] - 2026-05-12
+
+> **Heads-up — behavior changes in skill preloading:**
+> - **`.txt` and extensionless flat skill files are no longer loaded.** Only `<name>.md` flat files and `<name>/SKILL.md` directory skills resolve now. Rename any `<name>.txt` or extensionless skill files to `<name>.md`.
+
+### Added
+- **Pi-standard `<name>/SKILL.md` directory layout** is now discovered alongside flat `<name>.md` files. Top-level and nested matches both resolve via BFS — for skill `foo`, the loader checks `<root>/foo/SKILL.md`, then recursively descends looking for `*/.../foo/SKILL.md`. Recursion skips dotfile directories and `node_modules`; a directory that itself contains `SKILL.md` is treated as a single skill (Pi's "skills don't nest" rule).
+- **Five discovery roots**, checked in precedence order:
+  - `<cwd>/.pi/skills/` (project, Pi)
+  - `<cwd>/.agents/skills/` (project, [Agent Skills spec](https://agentskills.io/integrate-skills))
+  - `$PI_CODING_AGENT_DIR/skills/` — default `~/.pi/agent/skills/` (user, Pi)
+  - `~/.agents/skills/` (user, Agent Skills spec)
+  - `~/.pi/skills/` (legacy global, kept for backward compatibility)
+- **Symlink rejection broadened** to the new layouts: symlinked skill roots, nested skill directories, and `SKILL.md` files inside otherwise-real directories are all rejected (intentional deviation from Pi, which follows symlinks).
+- **Deterministic traversal order** — entries are sorted byte-order so collisions resolve identically across filesystems. Pi's iteration order is `readdirSync`-dependent.
+- **Resolved spawn args are now shown in the dedicated conversation viewer** ([#62](https://github.com/tintinweb/pi-subagents/issues/62)). Open `/subagent` → Running Agents → select an agent: a second header row displays the effective invocation — model override (when different from parent), `thinking: <level>`, `isolated`, `worktree`, `inherit context`, `background`, and `max turns: N`. Tags appear when the resolved value is notable (e.g. `isolated: true`), not just when the caller explicitly set it; `max turns` is the one exception and shows only when explicitly configured. Lets you verify the parent agent honored your spawn instructions without scrolling back through the chat. Snapshot stored on the new `AgentRecord.invocation` field. The same tag set is also surfaced on the `Agent` tool-call result render (which previously showed a narrower subset).
+- **`Shift+↑` / `Shift+↓` scroll a full page in the conversation viewer** — same behavior as `PgUp` / `PgDn`. Note: some terminal emulators intercept Shift+arrows for text selection or tab switching, in which case `PgUp`/`PgDn` remain available.
+
+### Changed
+- **`.txt` and extensionless flat skill files are no longer loaded.** Pi only supports `.md`; we now match. **Migration:** rename any `<name>.txt` / `<name>` skill files to `<name>.md`.
+- **Conversation viewer no longer fills the full screen.** The overlay is now capped at 70% of terminal height (90% width unchanged), and the viewer's internal viewport mirrors that cap so the footer/scroll indicator can't be clipped.
+
+## [0.7.1] - 2026-05-07
+
+> **Heads-up — behavior change:**
+> - `isolation: "worktree"` now fails loud (returns an error) instead of silently falling back to the main tree. Affects users running pi in a non-git directory or a fresh repo with no commits.
+
+### Changed
+- **`isolation: "worktree"` now fails loud instead of silently falling back.** Previously when `createWorktree` returned undefined (not a git repo, no commits yet, or `git worktree add` failed), the agent ran in the main `cwd` with a `[WARNING: ...]` block prepended to its prompt — visible only to the LLM, never surfaced to the caller. Now the failure throws a structured error that propagates back to the `Agent` tool response; no agent record is created. Failed scheduled fires are recorded as `lastStatus: "error"` with the reason in the `subagents:scheduled` error event. Queued background spawns whose worktree creation fails when they dequeue are marked terminal-error and don't block the rest of the queue.
+
+### Fixed
+
+- **Headless `pi --print` runs no longer hang or crash after background
+subagents complete.** Cleanup timers no longer keep the process alive, and
+stale completion notifications are treated as best-effort shutdown side
+effects.
+
+## [0.7.0] - 2026-05-04
+
+> **Heads-up — behavior changes:**
+> - `subagents:completed`/`failed` event `tokens.total` now excludes `cacheRead` (previously double-counted across turns) — see Fixed [#38].
+> - Cron `?` is now a wildcard (same as `*`), not "current time value" — affects Quartz-style expressions only.
+
+### Changed
+- **`@mariozechner/pi-{ai,coding-agent,tui}` moved to `peerDependencies` (`>=0.70.5`).** Avoids duplicate framework instances when the host loads this extension.
+- **`@sinclair/typebox` pinned from `latest` to `^0.34.49`** so installs are reproducible.
+- **`croner` bumped 8 → 10.** Heads-up: in cron strings, `?` now means wildcard (same as `*`) instead of "current time value" — affects Quartz-style expressions only.
+
+### Added
+- **Master switch for scheduling** — new `schedulingEnabled` setting (default `true`) under `/agents → Settings → Scheduling`. When set to `false`: the `schedule` parameter and its guideline are stripped from the `Agent` tool spec at registration (zero LLM-context cost), the scheduler does not bind to the session, the `/agents → Scheduled jobs` menu entry is hidden, and any in-flight scheduler is stopped immediately. The schema-level removal applies on next pi session; the runtime kill (menu, fire path) takes effect immediately. Persisted at `<cwd>/.pi/subagents.json`.
+- **Schedule subagent spawns** — the `Agent` tool now accepts an optional `schedule` parameter. When set, the spawn registers a job that fires later instead of running immediately. Three formats: 6-field cron (`"0 0 9 * * 1"` — 9am every Monday), interval (`"5m"`, `"1h"`), or one-shot (`"+10m"` or ISO timestamp). Returns the job ID. Schedules are session-scoped — they reset on `/new`, restore on `/resume` (mirrors the persistence model of pi-chonky-tasks). Storage at `<cwd>/.pi/subagent-schedules/<sessionId>.json`, with PID-based file locking + atomic temp+rename for concurrent-instance safety. **Result delivery is identical to today's background-spawn completions**: when the scheduled agent finishes, the existing `subagent-notification` followUp path emits the result to the conversation — no new delivery code, no new message types. **Concurrency**: scheduled fires bypass `maxConcurrent` so a 5-minute interval can't be deferred behind 4 long-running manual agents. **Management**: `/agents` → "Scheduled jobs" lists active jobs and lets you cancel any one of them. Creation is via the `Agent` tool only — no parallel manual-create wizard in this iteration. **Events**: `subagents:scheduled` ({ type: "added" | "removed" | "updated" | "fired" | "error", … }) and `subagents:scheduler_ready` for cross-extension consumers. **Restrictions**: `schedule` is incompatible with `inherit_context` (no parent at fire time) and `resume` (schedules create fresh agents); forces `run_in_background: true`. Scheduler engine mirrors `pi-cron-schedule` (`croner` for cron, `setInterval`/`setTimeout` for interval/once); past one-shot timestamps and invalid cron expressions are caught at create time.
+- **Context-window utilization indicator in the subagent overlay** — token count is now followed by a colored `(NN%)` showing how full the subagent's context is right now (`estimateContextTokens(messages) / model.contextWindow * 100`, sourced from upstream `contextUsage.percent`). Threshold colors: <70% dim, 70–85% warning, ≥85% error. Gracefully omitted when the model has no `contextWindow` declared, or right after compaction before the next assistant turn (`tokens` is `null` in that window). The same annotation slot also surfaces a compaction count `↻N` when the agent has compacted at least once — e.g. `12.3k token (84% · ↻3)` (percent + compactions joined with `·`), `12.3k token (↻1)` (compactions only, immediately post-compaction while percent is still null). The compaction glyph stays dim regardless; the percent's threshold color carries the urgency signal. Two live overlays get the annotations (running stats line; inspect-overlay header); post-completion notifications and result/event payloads only get the count (the indicator is no longer actionable once the agent is done).
+- **Token usage and context% exposed to the parent agent** at every interaction surface — `get_subagent_result` adds `Context: NN%` to its stats line; `steer_subagent` returns a `Current state: 12.3k token · 5 tool uses · context 72% full` line so the steering agent knows whether it has room before sending more context; `task-notification` XML adds `<context_percent>NN</context_percent>` (omitted when null). All plain-text, no ANSI codes — designed for LLM consumption, not human display.
+- **New `subagents:compacted` lifecycle event** fires when a subagent's session successfully compacts. Payload: `{ id, type, description, reason: "manual" | "threshold" | "overflow", tokensBefore, compactionCount }` — `tokensBefore` is upstream's pre-compaction context size estimate; `compactionCount` is the running total for this agent (also persisted on `AgentRecord.compactionCount` and surfaced in `get_subagent_result` / `steer_subagent` / `task-notification` when > 0). Aborted compactions don't fire. Routed through a new manager-level `onCompact` constructor callback, matching the existing `onStart` / `onComplete` pattern.
+
+### Fixed
+- **Subagent token count was inflated 5–15× and reset mid-run** ([#38](https://github.com/tintinweb/pi-subagents/issues/38)). Two distinct bugs in the same field. (1) Upstream `getSessionStats().tokens.total` sums per-turn `cacheRead` across every assistant message — but each turn's `cacheRead` is the *cumulative* cached prefix re-read on that one API call, so summing N turns counts the prefix N times (quadratic inflation, very visible on long sessions). (2) Even with that fixed, anything derived from `session.state.messages` resets at compaction because upstream replaces the array via `this.agent.state.messages = sessionContext.messages`. Fix replaces all six display readers with a lifetime accumulator (`AgentRecord.lifetimeUsage` and `AgentActivity.lifetimeUsage` — `{ input, output, cacheWrite }`) fed by a new `onAssistantUsage` callback dispatched from `message_end` events in both `runAgent` and `resumeAgent`. The accumulator is independent of `state.messages` mutation, so it survives compaction; total = input + output + cacheWrite by construction (cacheRead deliberately excluded — same prefix-double-counting reason). The `subagents:completed`/`failed` event payload's `tokens` field is now also lifetime-accumulated for `input`, `output`, and `total` together (was: `total` lifetime, `input`/`output` session-derived → inconsistent after compaction).
+- **ESC during a foreground `Agent` call now actually stops the subagent** ([#44](https://github.com/tintinweb/pi-subagents/pull/44) — thanks [@Zeng-Zer](https://github.com/Zeng-Zer)). Pi's interrupt path is `esc → agent.abort()` on the parent → `AbortSignal` delivered to every tool's `execute(toolCallId, params, signal, …)`, but the `Agent` tool dropped that signal on the floor: subagents ran on their own independent `AbortController` inside `AgentManager`, so the parent abort was invisible and the subagent kept running until natural completion or `max_turns`. Fix threads `signal` through `Agent.execute` → `manager.spawnAndWait()` → `SpawnOptions.signal`, and `AgentManager.startAgent()` now attaches an `{ once: true }` `"abort"` listener that calls `this.abort(id)` (which sets `status: "stopped"` and aborts the child controller). The listener is detached in both `.then` and `.catch` to avoid leaking on natural settle. **Scope:** foreground only — background agents intentionally outlive the parent tool call, so their spawn deliberately does not forward `signal`. Resume path (`AgentManager.resume()`) has the same blind spot and is tracked as a follow-up.
+
+## [0.6.3] - 2026-04-28
+
+### Fixed
+- **`run_in_background: true` (and `inherit_context`, `isolated`) silently ignored on default agents** ([#37](https://github.com/tintinweb/pi-subagents/issues/37) — thanks [@kylesnowschwartz](https://github.com/kylesnowschwartz) for the diagnosis). The three built-in defaults (`general-purpose`, `Explore`, `Plan`) baked `runInBackground: false`, `inheritContext: false`, and `isolated: false` into their configs. `resolveAgentInvocationConfig` uses `agentConfig?.field ?? params.field ?? false`, and `??` only falls through on `null`/`undefined` — so an explicit `false` from the agent config silently won over the caller's `true`. Calling `Agent({ subagent_type: "general-purpose", run_in_background: true })` returned the result inline instead of backgrounding, blocking the parent UI for the agent's full runtime. Fix drops the three lines from each default (and from the unreachable defensive fallback in `agent-runner.ts`) — the type already declared each as `field?: boolean` with JSDoc *"undefined = caller decides"*, so the runtime now matches the documented contract. **Behavior:** custom agents that explicitly set these fields in frontmatter still lock as before (the v0.5.1 "frontmatter is authoritative" guarantee is preserved); the fix only stops *defaults* from spuriously claiming an opinion on callsite-strategy fields they don't actually have. The unreachable fallback now spreads `DEFAULT_AGENTS.get("general-purpose")` instead of duplicating the config inline, so future drift is impossible.
+
+## [0.6.2] - 2026-04-28
+
+### Fixed
+- **`Agent` tool fails on Windows with `ENOENT` creating output directory** ([#27](https://github.com/tintinweb/pi-subagents/issues/27) — thanks [@sixnathan](https://github.com/sixnathan) for the diagnosis). The cwd-encoding regex in `output-file.ts` only handled POSIX `/` separators, so on Windows `cwd = "C:\\Users\\foo\\project"` survived unchanged and `path.join(tmpRoot, encoded, …)` produced an invalid nested-absolute path. Now extracts a small `encodeCwd()` helper that handles both `/` and `\\` separators, strips the Windows drive-letter prefix, and preserves UNC server/share segments. The `chmodSync(root, 0o700)` call is also wrapped in a try/catch that swallows errors only on Windows (where chmod is a no-op and can throw on some filesystems); on Unix the error still propagates so umask-defeating `0o700` enforcement is preserved.
+
+## [0.6.1] - 2026-04-25
+
+### Added
+- **Persistent `/agents` → Settings** ([#24](https://github.com/tintinweb/pi-subagents/issues/24)) — the four runtime tuning values (`maxConcurrent`, `defaultMaxTurns`, `graceTurns`, `defaultJoinMode`) now survive pi restarts via a two-file dual-scope model mirroring pi's own `SettingsManager`. Global `~/.pi/agent/subagents.json` provides machine-wide defaults (edit by hand; the menu never writes here); project `<cwd>/.pi/subagents.json` holds per-project overrides (written by `/agents` → Settings). Load merges both with project winning on conflicts. Invalid fields are silently dropped per field; malformed JSON emits a warning to stderr and falls back to defaults so startup always proceeds; write failures downgrade the settings toast to a warning with `(session only; failed to persist)` so changes aren't silently reverted on next restart.
+- **New lifecycle events** — `subagents:settings_loaded` (emitted once at extension init with the merged settings) and `subagents:settings_changed` (emitted on each `/agents` → Settings mutation with the new snapshot and a `persisted: boolean` flag so listeners can react to write failures).
+
+### Fixed
+- **`AGENTS.md` / `CLAUDE.md` / `APPEND_SYSTEM.md` no longer leak into sub-agent prompts** ([#26](https://github.com/tintinweb/pi-subagents/pull/26) — thanks [@mikeyobrien](https://github.com/mikeyobrien) for the diagnosis). Upstream `buildSystemPrompt()` re-appends `contextFiles` and `appendSystemPrompt` *after* our `systemPromptOverride` runs, which silently defeated `prompt_mode: replace` and `isolated: true` — parent project context (e.g. autoresearch-mode blocks) was bleeding into fresh `Explore` / custom sub-agents regardless of frontmatter. Fix uses upstream's `noContextFiles: true` flag (skips the load entirely, introduced in pi 0.68) plus `appendSystemPromptOverride: () => []` (no flag equivalent for append sources). **Behavior change:** subagents no longer implicitly inherit parent `AGENTS.md`/`CLAUDE.md`/`APPEND_SYSTEM.md`. To get parent project context into a subagent, use `prompt_mode: append` (parent's already-built system prompt flows in via `systemPromptOverride`), or `inherit_context: true` (parent conversation), or inline the content into the agent's own frontmatter.
+- **Custom agent discovery respects `PI_CODING_AGENT_DIR`** ([#35](https://github.com/tintinweb/pi-subagents/pull/35), closes [#23](https://github.com/tintinweb/pi-subagents/issues/23) — thanks [@Amolith](https://github.com/Amolith) for the diagnosis). Two remaining hardcoded `~/.pi/agent/agents/` paths in `custom-agents.ts` and `index.ts` bypassed the env var, so users who relocated their agent directory (e.g. via `PI_CODING_AGENT_DIR`) still had global agents loaded from the default location and help text referencing the wrong path. Both now use upstream `getAgentDir()`, consistent with `agent-runner.ts` and `settings.ts`; tilde expansion is handled by upstream.
+
+## [0.6.0] - 2026-04-24
+
+> **⚠️ Breaking: drops support for `pi` < 0.68.** The upstream `pi-coding-agent` package shipped breaking API changes in v0.68 (and further ones in v0.70). This release migrates to `^0.70.2` and is **not** backward-compatible with hosts on `pi` 0.62–0.67. Users on those versions must upgrade their `pi` installation (`npm install -g @mariozechner/pi-coding-agent@latest`) before updating this extension.
+
+### Changed
+- **Bumped peer `@mariozechner/pi-coding-agent` to `^0.70.2`** ([#28](https://github.com/tintinweb/pi-subagents/pull/28)) — crosses the v0.68 breaking-change line upstream. Specifically: tools are now passed as `string[]` (was `Tool[]`); `cwd`/`agentDir` are mandatory on `SettingsManager.create()` and `DefaultResourceLoader`; `session_switch` event renamed to `session_before_switch`; `ToolDefinition.params` widens to `unknown` under contextual typing, requiring `defineTool(...)`.
+- **Tool registrations wrapped with `defineTool(...)`** — preserves `TParams` inference so `execute` handlers get properly-typed `params` instead of `unknown`. Applies to the `Agent`, `get_subagent_result`, and `steer_subagent` tools.
+
+### Removed
+- **Cwd-bound tool factory registry** — the internal `TOOL_FACTORIES` closure table and `create{Bash,Edit,Read,Write,Grep,Find,Ls}Tool` imports are gone. Exported helpers renamed: `getToolsForType(type, cwd)` → `getToolNamesForType(type)`, `getMemoryTools(cwd, set)` → `getMemoryToolNames(set)`, `getReadOnlyMemoryTools(cwd, set)` → `getReadOnlyMemoryToolNames(set)` — all returning `string[]` instead of `Tool[]`. The host binds cwd when resolving tool names, so the extension no longer instantiates tools directly.
+
+### Fixed
+- **Subagent `SettingsManager` read wrong project settings in worktree mode** ([#30](https://github.com/tintinweb/pi-subagents/pull/30)) — `SettingsManager.create()` was called without arguments, defaulting `cwd` to `process.cwd()`. When the subagent's effective cwd differed (worktree isolation or explicit `cwd` override), its settings manager read `.pi/settings.json` from the parent's cwd rather than its own, diverging from the loader and session manager. Now passes `effectiveCwd` and `agentDir` explicitly, keeping all three managers consistent.
+
+## [0.5.2] - 2026-03-26
+
+### Fixed
+- **Extension `session_start` handlers now fire in subagent sessions** ([#20](https://github.com/tintinweb/pi-subagents/issues/20)) — `bindExtensions()` was never called on subagent sessions, so extensions that initialize state in `session_start` (e.g. loading credentials, setting up connections) silently failed at runtime. Tools appeared registered but were non-functional. Now calls `session.bindExtensions()` after tool filtering and before prompting, matching the lifecycle used by pi's interactive, print, and RPC modes. Also triggers `extendResourcesFromExtensions("startup")` so extension-provided skills and prompts are discovered.
+
+## [0.5.1] - 2026-03-24
+
+### Changed
+- **Agent config is authoritative** — frontmatter values for `model`, `thinking`, `max_turns`, `inherit_context`, `run_in_background`, `isolated`, and `isolation` now take precedence over `Agent` tool-call parameters. Tool-call params only fill fields the agent config leaves unspecified.
+- **`join_mode` is now a global setting only** — removed the per-call `join_mode` parameter from the `Agent` tool. Join behavior is configured via `/agents` → Settings → Join mode.
+- **`max_turns: 0` means unlimited** — agent files can now explicitly set `max_turns: 0` to lock unlimited turns. Previously `0` was silently clamped to `1`.
+
+### Fixed
+- **Final subagent text preserved from non-streaming providers** — agents using providers that return the final message without streaming `text_delta` events no longer return empty results. Falls back to extracting text from the completed session history.
+- **`effectiveMaxTurns` passed to spawn calls** — previously `params.max_turns` was passed raw to both foreground and background spawn, bypassing the agent config entirely.
+
+## [0.5.0] - 2026-03-22
+
+### Added
+- **RPC stop handler** — new `subagents:rpc:stop` event bus RPC allows other extensions to stop running subagents by agent ID. Returns structured error ("Agent not found") on failure.
+- **`abort` in `SpawnCapable` interface** — cross-extension RPC consumers can now stop agents, not just spawn them.
+- **Live turn counter** — all agents now show a live turn count in the widget, inline result, and completion notification. With a turn limit: `⟳5≤30` (5 of 30 turns). Without: `⟳5`. Updates in real time as turns progress via `onTurnEnd` callback.
+- **Biome linting** — added [Biome](https://biomejs.dev/) for correctness linting (unused imports, suspicious patterns). Style rules disabled. Run `npm run lint` to check, `npm run lint:fix` to auto-fix.
+- **CI workflow** — GitHub Actions runs lint, typecheck, and tests on push to master and PRs.
+- **Auto-trigger parent turn on background completion** — background agent completion notifications now use `triggerTurn: true`, automatically prompting the parent agent to process results instead of waiting for user input.
+
+### Changed
+- **Standardized RPC envelope** — cross-extension RPC handlers (`ping`, `spawn`, `stop`) now use a `handleRpc` wrapper that emits structured envelopes (`{ success: true, data }` / `{ success: false, error }`), matching pi-mono's `RpcResponse` convention.
+- **Protocol versioning via ping** — ping reply now includes `{ version: PROTOCOL_VERSION }` (currently v2). Callers can detect version mismatches and warn users to update.
+- **Default max turns is now unlimited** — subagents no longer have a 50-turn default cap. The default is unlimited (no turn limit), matching Claude Code's main loop behavior. Users can still set explicit limits per-agent via `max_turns` frontmatter or the Agent tool parameter, or globally via `/agents` → Settings (`0` = unlimited).
+- **Stale dist in published package** — added `prepublishOnly` hook to build fresh `dist/` on every `npm publish`.
+
+### Fixed
+- **Tool name display** — `getAgentConversation` now reads `ToolCall.name` (the correct property) instead of `toolName`, resolving `[Tool: unknown]` in conversation viewer and verbose output.
+- **Env test CI failure** — `detectEnv` test assumed a branch name exists, but CI checks out detached HEAD. Split into separate tests for repo detection and branch detection with a controlled temp repo.
+
+## [0.4.9] - 2026-03-18
+
+### Fixed
+- **Conversation viewer crash in narrow terminals** ([#7](https://github.com/tintinweb/pi-subagents/issues/7)) — `buildContentLines()` in the live conversation viewer could return lines wider than the terminal when `wrapTextWithAnsi()` misjudged visible width on ANSI-heavy input (e.g. tool output with embedded escape codes, long URLs, wide tables). All content lines are now clamped with `truncateToWidth()` before returning. Same class of bug as the widget fix in v0.2.7, different component.
+
+### Added
+- **Conversation viewer width-safety tests** — 17 tests covering `render()` and `buildContentLines()` across varied content (plain text, ANSI codes, unicode, tables, long URLs, narrow terminals). Includes mock-based regression tests that simulate upstream `wrapTextWithAnsi` returning overwidth lines, ensuring the safety net catches them.
+
+## [0.4.8] - 2026-03-18
+
+### Added
+- **Cross-extension RPC** — other pi extensions can spawn subagents via `pi.events` event bus (`subagents:rpc:ping`, `subagents:rpc:spawn`). Emits `subagents:ready` on load.
+- **Session persistence for agent records** — completed agent records are persisted via `pi.appendEntry("subagents:record", ...)` for cross-extension history reconstruction.
+
+### Fixed
+- **Background agent notification race condition** — `pi.sendMessage()` is fire-and-forget, so completion notifications sent eagerly from `onComplete` could not be retracted when `get_subagent_result` was called in the same turn. Notifications are now held behind a 200ms cancellable timer; `get_subagent_result` cancels the pending timer before it fires, eliminating duplicate notifications. Group notifications also re-check `resultConsumed` at send time so consumed agents are filtered out.
+
+## [0.4.7] - 2026-03-17
+
+### Added
+- **Custom notification renderer** — background agent completion notifications now render as styled, themed boxes instead of raw XML. Uses `pi.registerMessageRenderer()` with the `"subagent-notification"` custom message type. The LLM continues to receive `<task-notification>` XML via `content`; only the user-facing display changes.
+- **Group notification rendering** — group completions render each agent as its own styled block (icon, description, stats, result preview) instead of showing only the first agent.
+- **Output file streaming for background agents** — background agents now get the same output file transcript as foreground agents, with `onSessionCreated` wiring and proper cleanup on completion/error.
+- `NotificationDetails` type in `types.ts` — structured details for the notification renderer, with optional `others` array for group notifications.
+- `buildNotificationDetails()` helper — extracts renderer-facing details from an `AgentRecord`.
+
+### Changed
+- **Notification delivery** — `sendIndividualNudge` and group notification now use `pi.sendMessage()` (custom message) instead of `pi.sendUserMessage()` (plain text), enabling renderer-controlled display.
+- **Steered status rendering** — steered agents show "completed (steered)" in the notification box instead of plain "completed".
+
+### Fixed
+- **Output file cleanup on completion** — `agent-manager.ts` now calls `record.outputCleanup()` in both the success and error paths of agent completion, ensuring the streaming subscription is flushed and released.
+
+## [0.4.6] - 2026-03-16
+
+### Fixed
+- **Graceful shutdown aborts agents instead of blocking** — `session_shutdown` now calls `abortAll()` instead of `waitForAll()`, so the process exits immediately instead of hanging until all background agents complete. Agent results are undeliverable after shutdown anyway.
+
+### Added
+- `abortAll()` method on `AgentManager` — stops all queued and running agents at once, returning the count of affected agents.
+
+## [0.4.5] - 2026-03-16
+
+### Changed
+- **Widget render-once pattern** — the widget callback is now registered once via `setWidget()` and subsequent updates use `requestRender()` instead of re-registering the entire widget on every `update()` call. Eliminates layout thrashing from repeated widget teardown/setup cycles.
+- **Status bar dedup** — `setStatus()` is now only called when the status text actually changes, avoiding redundant TUI updates.
+- **UICtx change detection** — `setUICtx()` detects context changes and forces widget re-registration, correctly handling session switches.
+
+### Refactored
+- Extracted `renderWidget()` private method — moves all widget content rendering out of the `update()` closure into a standalone method that reads live state on each call.
+- `update()` is now a lightweight coordinator: counts agents, manages registration lifecycle, and triggers re-renders.
+
+## [0.4.4] - 2026-03-16
+
+### Fixed
+- **Race condition in `get_subagent_result` with `wait: true`** — `resultConsumed` is now set before `await record.promise`, preventing a redundant follow-up notification. Previously the `onComplete` callback (attached at spawn time via `.then()`) always fired before the await resumed, seeing `resultConsumed` as false.
+- **Stale agent records across sessions** — new `clearCompleted()` method removes all completed/stopped/errored agent records on `session_start` and `session_switch` events, so tasks from a prior session don't persist into a new one.
+- **`steer_subagent` race on freshly launched agents** — steering an agent before its session initialized silently dropped the message. Now steers are queued on the record and flushed once `onSessionCreated` fires.
+
+### Changed
+- Extracted `removeRecord()` private helper in `AgentManager` — deduplicates dispose+delete logic between `cleanup()` and `clearCompleted()`.
+
+### Added
+- 8 new tests covering `resultConsumed` race condition and `clearCompleted` behavior (185 total).
+
+## [0.4.3] - 2026-03-13
+
+### Added
+- **Persistent agent memory** — new `memory` frontmatter field with three scopes: `"user"` (global `~/.pi/`), `"project"` (per-project `.pi/`), `"local"` (gitignored `.pi/`). Agents with write/edit tools get full read-write memory; read-only agents get a read-only fallback that injects existing MEMORY.md content without granting write access or creating directories.
+- **Git worktree isolation** — new `isolation: "worktree"` frontmatter field and Agent tool parameter. Creates a temporary `git worktree` so agents work on an isolated copy of the repo. On completion, changes are auto-committed to a `pi-agent-<id>` branch; clean worktrees are removed. Includes crash recovery via `pruneWorktrees()`.
+- **Skill preloading** — `skills` frontmatter now accepts a comma-separated list of skill names (e.g. `skills: planning, review`). Reads from `.pi/skills/` (project) then `~/.pi/skills/` (global), tries `.md`/`.txt`/bare extensions. Content injected into the system prompt as `# Preloaded Skill: {name}`.
+- **Tool denylist** — new `disallowed_tools` frontmatter field (e.g. `disallowed_tools: bash, write`). Blocks specified tools even if `builtinToolNames` or extensions would provide them. Enforced for both extension-enabled and extension-disabled agents.
+- **Prompt extras system** — new `PromptExtras` interface in `prompts.ts`; `buildAgentPrompt()` accepts optional memory and skill blocks appended in both `replace` and `append` modes.
+- `getMemoryTools()`, `getReadOnlyMemoryTools()` in `agent-types.ts`.
+- `buildMemoryBlock()`, `buildReadOnlyMemoryBlock()`, `isSymlink()`, `safeReadFile()` in `memory.ts`.
+- `preloadSkills()` in `skill-loader.ts`.
+- `createWorktree()`, `cleanupWorktree()`, `pruneWorktrees()` in `worktree.ts`.
+- `MemoryScope`, `IsolationMode` types; `memory`, `isolation`, `disallowedTools` fields on `AgentConfig`; `worktree`, `worktreeResult` fields on `AgentRecord`.
+- 177 total tests across 8 test files (41 new tests).
+
+### Fixed
+- **Read-only agents no longer escalated to read-write** — enabling `memory` on a read-only agent (e.g. Explore) previously auto-added `write`/`edit` tools. Now the runner detects write capability and branches: read-write agents get full memory tools, read-only agents get read-only memory prompt with only the `read` tool added.
+- **Denylist-aware memory detection** — write capability check now accounts for `disallowedTools`. An agent with `tools: write` + `disallowed_tools: write` correctly gets read-only memory instead of broken read-write instructions.
+- **Worktree requires commits** — repos with no commits (empty HEAD) are now rejected early with a warning instead of failing silently at `git worktree add`.
+- **Worktree failure warning** — when worktree creation fails, a warning is prepended to the agent's prompt instead of silently falling through to the main cwd.
+- **No force-branch overwrite** — worktree cleanup appends a timestamp suffix on branch name conflict instead of using `git branch -f`.
+
+### Security
+- **Whitelist name validation** — agent/skill names must match `^[a-zA-Z0-9][a-zA-Z0-9._-]*$`, max 128 chars. Rejects path traversal, leading dots, spaces, and special characters.
+- **Symlink protection** — `safeReadFile()` and `isSymlink()` reject symlinks in memory directories, MEMORY.md files, and skill files, preventing arbitrary file reads.
+- **Symlink-safe directory creation** — `ensureMemoryDir()` throws on symlinked directories.
+
+### Changed
+- `agent-runner.ts`: tool/extension/skill resolution moved before memory detection; `ctx.cwd` → `effectiveCwd` throughout.
+- `custom-agents.ts`: extracted `parseCsvField()` helper; added `csvListOptional()` and `parseMemory()`.
+- `skill-loader.ts`: uses `safeReadFile()` from `memory.ts` instead of raw `readFileSync`.
+- Agent tool schema updated with `isolation` parameter and help text for `memory`, `isolation`, `disallowed_tools`, and skill list.
+
+## [0.4.2] - 2026-03-12
+
+### Added
+- **Event bus** — agent lifecycle events emitted via `pi.events.emit()`, enabling other extensions to react to sub-agent activity:
+  - `subagents:created` — background agent registered (includes `id`, `type`, `description`, `isBackground`)
+  - `subagents:started` — agent transitions to running (includes queued→running)
+  - `subagents:completed` — agent finished successfully (includes `durationMs`, `tokens`, `toolUses`, `result`)
+  - `subagents:failed` — agent errored, stopped, or aborted (same payload as completed)
+  - `subagents:steered` — steering message sent to a running agent
+- `OnAgentStart` callback and `onStart` constructor parameter on `AgentManager`.
+- **Cross-package manager** now also exposes `spawn()` and `getRecord()` via the `Symbol.for("pi-subagents:manager")` global.
+
+## [0.4.1] - 2026-03-11
+
+### Fixed
+- **Graceful shutdown in headless mode** — the CLI now waits for all running and queued background agents to complete before exiting (`waitForAll` on `session_shutdown`). Previously, background agents could be silently killed mid-execution when the session ended. Only affects headless/non-interactive mode; interactive sessions already kept the process alive.
+
+### Added
+- `hasRunning()` / `waitForAll()` methods on `AgentManager`.
+- **Cross-package manager access** — agent manager exposed via `Symbol.for("pi-subagents:manager")` on `globalThis` for other extensions to check status or await completion.
+
+## [0.4.0] - 2026-03-11
+
+### Added
+- **XML-delimited prompt sections** — append-mode agents now wrap inherited content in `<inherited_system_prompt>`, `<sub_agent_context>`, and `<agent_instructions>` XML tags, giving the model explicit structure to distinguish inherited rules from sub-agent-specific instructions. Replace mode is unchanged.
+- **Token count in agent results** — foreground agent results, background completion notifications, and `get_subagent_result` now include the token count alongside tool uses and duration (e.g. `Agent completed in 4.2s (12 tool uses, 33.8k token)`).
+- **Widget overflow cap** — the running agents widget now caps at 12 lines. When exceeded, running agents are prioritized over finished ones and an overflow summary line shows hidden counts (e.g. `+3 more (1 running, 2 finished)`).
+
+### Changed - **changing behavior**
+- **General-purpose agent inherits parent prompt** — the default `general-purpose` agent now uses `promptMode: "append"` with an empty system prompt, making it a "parent twin" that inherits the full parent system prompt (including CLAUDE.md rules, project conventions, and safety guardrails). Previously it used a standalone prompt that duplicated a subset of the parent's rules. Explore and Plan are unchanged (standalone prompts). To customize: eject via `/agents` → select `general-purpose` → Eject, then edit the resulting `.md` file. Set `prompt_mode: replace` to go back to a standalone prompt, or keep `prompt_mode: append` and add extra instructions in the body.
+- **Append-mode agents receive parent system prompt** — `buildAgentPrompt` now accepts the parent's system prompt and threads it into append-mode agents (env header + parent prompt + sub-agent context bridge + optional custom instructions). Replace-mode agents are unchanged.
+- **Prompt pipeline simplified** — removed `systemPromptOverride`/`systemPromptAppend` from `SpawnOptions` and `RunOptions`. These were a separate code path where `index.ts` pre-resolved the prompt mode and passed raw strings into the runner, bypassing `buildAgentPrompt`. Now all prompt assembly flows through `buildAgentPrompt` using the agent's `promptMode` config — one code path, no special cases.
+
+### Removed
+- Deprecated backwards-compat aliases: `registerCustomAgents`, `getCustomAgentConfig`, `getCustomAgentNames` (use `registerAgents`, `getAgentConfig`, `getUserAgentNames`).
+- `resolveCustomPrompt()` helper in index.ts — no longer needed now that prompt routing is config-driven.
+
+## [0.3.1] - 2026-03-09
+
+### Added
+- **Live conversation viewer** — selecting a running (or completed) agent in `/agents` → "Running agents" now opens a scrollable overlay showing the agent's full conversation in real time. Auto-scrolls to follow new content; scroll up to pause, End to resume. Press Esc to close.
+
+## [0.3.0] - 2026-03-08
+
+### Added
+- **Case-insensitive agent type lookup** — `"explore"`, `"EXPLORE"`, and `"Explore"` all resolve to the same agent. LLMs frequently lowercase type names; this prevents validation failures.
+- **Unknown type fallback** — unrecognized agent types fall back to `general-purpose` with a note, instead of hard-rejecting. Matches Claude Code behavior.
+- **Dynamic tool list for general-purpose** — `builtinToolNames` is now optional in `AgentConfig`. When omitted, the agent gets all tools from `TOOL_FACTORIES` at lookup time, so new tools added upstream are automatically available.
+- **Agent source indicators in `/agents` menu** — `•` (project), `◦` (global), `✕` (disabled) with legend. Defaults are unmarked.
+- **Disabled agents visible in UI** — disabled agents now show in the "Agent types" list (marked `✕`) with an Enable action, instead of being invisible.
+- **Enable action** — re-enable a disabled agent from the `/agents` menu. Stub files are auto-cleaned.
+- **Disable action for all agent types** — custom and ejected default agents can now be disabled from the UI, not just built-in defaults.
+- `resolveType()` export — case-insensitive type name resolution for external use.
+- `getAllTypes()` export — returns all agent names including disabled (for UI listing).
+- `source` field on `AgentConfig` — tracks where an agent was loaded from (`"default"`, `"project"`, `"global"`).
+
+### Fixed
+- **Model resolver checks auth for exact matches** — `resolveModel("anthropic/claude-haiku-4-5-20251001")` now fails gracefully when no Anthropic API key is configured, instead of returning a model that errors at the API call. Explore silently falls back to the parent model on non-Anthropic setups.
+
+### Changed
+- **Unified agent registry** — built-in and custom agents now use the same `AgentConfig` type and a single registry. No more separate code paths for built-in vs custom agents.
+- **Default agents are overridable** — creating a `.md` file with the same name as a default agent (e.g. `.pi/agents/Explore.md`) overrides it.
+- **`/agents` menu** — "Agent types" list shows defaults and custom agents together with source indicators. Default agents get Eject/Disable actions; overridden defaults get Reset to default.
+- **Eject action** — export a default agent's embedded config as a `.md` file to project or personal location for customization.
+- **Model labels** — provider-agnostic: strips `provider/` prefix and `-YYYYMMDD` date suffix (e.g. `anthropic/claude-haiku-4-5-20251001` → `claude-haiku-4-5`). Works for any provider.
+- **New frontmatter fields** — `display_name` (UI display name) and `enabled` (default: true; set to false to disable).
+- **Menu navigation** — Esc in agent detail returns to agent list (not main menu).
+
+### Removed
+- **`statusline-setup` and `claude-code-guide` agents** — removed as built-in types (never spawned programmatically). Users can recreate them as custom agents if needed.
+- `BuiltinSubagentType` union type, `SUBAGENT_TYPES` array, `DISPLAY_NAMES` map, `SubagentTypeConfig` interface — replaced by unified `AgentConfig`.
+- `buildSystemPrompt()` switch statement — replaced by config-driven `buildAgentPrompt()`.
+- `HAIKU_MODEL_IDS` fallback array — Explore's haiku default is now just the `model` field in its config.
+- `BUILTIN_MODEL_LABELS` — model labels now derived from config.
+- `ALL_TOOLS` hardcoded constant — general-purpose now derives tools dynamically.
+
+### Added
+- `src/default-agents.ts` — embedded default configs for general-purpose, Explore, and Plan.
+
+## [0.2.7] - 2026-03-08
+
+### Fixed
+- **Widget crash in narrow terminals** — agent widget lines were not truncated to terminal width, causing `doRender` to throw when the tmux pane was narrower than the rendered content. All widget lines are now truncated using `truncateToWidth()` with the actual terminal column count.
+
+## [0.2.6] - 2026-03-07
+
+### Added
+- **Background task join strategies** — smart grouping of background agent completion notifications
+  - `smart` (default): 2+ background agents spawned in the same turn are auto-grouped into a single consolidated notification instead of individual nudges
+  - `async`: each agent notifies individually on completion (previous behavior)
+  - `group`: force grouping even for solo agents
+  - 30s timeout after first completion delivers partial results; 15s straggler re-batch window for remaining agents
+- **`join_mode` parameter** on the `Agent` tool — override join strategy per agent (`"async"` or `"group"`)
+- **Join mode setting** in `/agents` → Settings — configure the default join mode at runtime
+- New `src/group-join.ts` — `GroupJoinManager` class for batched completion notifications
+
+### Changed
+- `AgentRecord` now includes optional `groupId`, `joinMode`, and `resultConsumed` fields
+- Background agent completion routing refactored: individual nudge logic extracted to `sendIndividualNudge()`, group delivery via `GroupJoinManager`
+
+### Fixed
+- **Debounce window race** — agents that complete during the 100ms batch debounce window are now deferred and retroactively fed into the group once it's registered, preventing split notifications (one individual + one partial group) and zombie groups
+- **Solo agent swallowed notification** — if only one agent was spawned (no group formed) but it completed during the debounce window, its deferred notification is now sent when the batch finalizes
+- **Duplicate notifications after polling** — calling `get_subagent_result` on a completed agent now marks its result as consumed, suppressing the subsequent completion notification (both individual and group)
+
+## [0.2.5] - 2026-03-06
+
+### Added
+- **Interactive `/agents` menu** — single command replaces `/agent` and `/agents` with a full management wizard
+  - Browse and manage running agents
+  - Custom agents submenu — edit or delete existing agents
+  - Create new custom agents via manual wizard or AI-generated (with comprehensive frontmatter documentation for the generator)
+  - Settings: configure max concurrency, default max turns, and grace turns at runtime
+  - Built-in agent types shown with model info (e.g. `Explore · haiku`)
+  - Aligned formatting for agent lists
+- **Configurable turn limits** — `defaultMaxTurns` and `graceTurns` are now runtime-adjustable via `/agents` → Settings
+- Sub-menus return to main menu instead of exiting
+
+### Removed
+- `/agent <type> <prompt>` command (use `Agent` tool directly, or create custom agents via `/agents`)
+
+## [0.2.4] - 2026-03-06
+
+### Added
+- **Global custom agents** — agents in `~/.pi/agent/agents/*.md` are now discovered automatically and available across all projects
+- Two-tier discovery hierarchy: project-level (`.pi/agents/`) overrides global (`~/.pi/agent/agents/`)
+
+## [0.2.3] - 2026-03-05
+
+### Added
+- Screenshot in README
+
+## [0.2.2] - 2026-03-05
+
+### Changed
+- Renamed package to `@tintinweb/pi-subagents`
+- Fuzzy model resolver now only matches models with auth configured (prevents selecting unconfigured providers)
+- Custom agents hot-reload on each `Agent` tool call (no restart needed for new `.pi/agents/*.md` files)
+- Updated pi dependencies to 0.56.1
+
+### Refactored
+- Extracted `createActivityTracker()` — eliminates duplicated tool activity wiring between foreground and background paths
+- Extracted `safeFormatTokens()` — replaces 4 repeated try-catch blocks
+- Extracted `buildDetails()` — consolidates AgentDetails construction
+- Extracted `getStatusLabel()` / `getStatusNote()` — consolidates 3 duplicated status formatting chains
+- Shared `extractText()` — consolidated duplicate from context.ts and agent-runner.ts
+- Added `ERROR_STATUSES` constant in widget for consistent status checks
+- `getDisplayName()` now delegates to `getConfig()` instead of separate lookups
+- Removed unused `Tool` type export from agent-types
+
+## [0.2.1] - 2026-03-05
+
+### Added
+- **Persistent above-editor widget** — tree view of all running/queued/finished agents with animated spinners and live stats
+- **Concurrency queue** — configurable max concurrent background agents (default: 4), auto-drain
+- **Queued agents** collapsed to single summary line in widget
+- **Turn-based widget linger** — completed agents clear after 1 turn, errors/aborted linger for 2 extra turns
+- **Colored status icons** — themed rendering via `setWidget` callback form (`✓` green, `✓` yellow, `✗` red, `■` dim)
+- **Live response streaming** — `onTextDelta` shows truncated agent response text instead of static "thinking..."
+
+### Changed
+- Tool names match Claude Code: `Agent`, `get_subagent_result`, `steer_subagent`
+- Labels use "Agent" / "Agents" (not "Subagent")
+- Widget heading: `●` when active, `○` when only lingering finished agents
+- Extracted all UI code to `src/ui/agent-widget.ts`
+
+## [0.2.0] - 2026-03-05
+
+### Added
+- **Claude Code-style UI rendering** — `renderCall`/`renderResult`/`onUpdate` for live streaming progress
+  - Live activity descriptions: "searching, reading 3 files…"
+  - Token count display: "33.8k token"
+  - Per-agent tool use counter
+  - Expandable completed results (ctrl+o)
+  - Distinct states: running, background, completed, error, aborted
+- **Async environment detection** — replaced `execSync` with `pi.exec()` for non-blocking git/platform detection
+- **Status bar integration** — running background agent count shown in pi's status bar
+- **Fuzzy model selection** — `"haiku"`, `"sonnet"` resolve to best matching available model
+
+### Changed
+- Tool label changed from "Spawn Agent" to "Agent" (matches Claude Code style)
+- `onToolUse` callback replaced with richer `onToolActivity` (includes tool name + start/end)
+- `onSessionCreated` callback for accessing session stats (token counts)
+- `env.ts` now requires `ExtensionAPI` parameter (async `pi.exec()` instead of `execSync`)
+
+## [0.1.0] - 2026-03-05
+
+Initial release.
+
+### Added
+- **Autonomous sub-agents** — spawn specialized agents via tool call, each running in an isolated pi session
+- **Built-in agent types** — general-purpose, Explore (defaults to haiku), Plan, statusline-setup, claude-code-guide
+- **Custom user-defined agents** — define agents in `.pi/agents/<name>.md` with YAML frontmatter + system prompt body
+- **Frontmatter configuration** — tools, extensions, skills, model, thinking, max_turns, prompt_mode, inherit_context, run_in_background, isolated
+- **Graceful max_turns** — steer message at limit, 5 grace turns, then hard abort
+- **Background execution** — `run_in_background` with completion notifications
+- **`get_subagent_result` tool** — check status, wait for completion, verbose conversation output
+- **`steer_subagent` tool** — inject steering messages into running agents mid-execution
+- **Agent resume** — continue a previous agent's session with a new prompt
+- **Context inheritance** — fork the parent conversation into the sub-agent
+- **Model override** — per-agent model selection
+- **Thinking level** — per-agent extended thinking control
+- **`/agent` and `/agents` commands**
+
+[0.6.3]: https://github.com/tintinweb/pi-subagents/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/tintinweb/pi-subagents/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/tintinweb/pi-subagents/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/tintinweb/pi-subagents/compare/v0.5.2...v0.6.0
+[0.5.2]: https://github.com/tintinweb/pi-subagents/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/tintinweb/pi-subagents/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/tintinweb/pi-subagents/compare/v0.4.9...v0.5.0
+[0.4.9]: https://github.com/tintinweb/pi-subagents/compare/v0.4.8...v0.4.9
+[0.4.8]: https://github.com/tintinweb/pi-subagents/compare/v0.4.7...v0.4.8
+[0.4.7]: https://github.com/tintinweb/pi-subagents/compare/v0.4.6...v0.4.7
+[0.4.6]: https://github.com/tintinweb/pi-subagents/compare/v0.4.5...v0.4.6
+[0.4.5]: https://github.com/tintinweb/pi-subagents/compare/v0.4.4...v0.4.5
+[0.4.4]: https://github.com/tintinweb/pi-subagents/compare/v0.4.3...v0.4.4
+[0.4.3]: https://github.com/tintinweb/pi-subagents/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/tintinweb/pi-subagents/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/tintinweb/pi-subagents/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/tintinweb/pi-subagents/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/tintinweb/pi-subagents/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/tintinweb/pi-subagents/compare/v0.2.7...v0.3.0
+[0.2.7]: https://github.com/tintinweb/pi-subagents/compare/v0.2.6...v0.2.7
+[0.2.6]: https://github.com/tintinweb/pi-subagents/compare/v0.2.5...v0.2.6
+[0.2.5]: https://github.com/tintinweb/pi-subagents/compare/v0.2.4...v0.2.5
+[0.2.4]: https://github.com/tintinweb/pi-subagents/compare/v0.2.3...v0.2.4
+[0.2.3]: https://github.com/tintinweb/pi-subagents/compare/v0.2.2...v0.2.3
+[0.2.2]: https://github.com/tintinweb/pi-subagents/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/tintinweb/pi-subagents/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/tintinweb/pi-subagents/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/tintinweb/pi-subagents/releases/tag/v0.1.0

--- a/packages/pi-subagents/UPSTREAM_LICENSE
+++ b/packages/pi-subagents/UPSTREAM_LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 tintinweb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-subagents/UPSTREAM_README.md
+++ b/packages/pi-subagents/UPSTREAM_README.md
@@ -1,0 +1,640 @@
+# @tintinweb/pi-subagents
+
+A [pi](https://pi.dev) extension that brings **Claude Code-style autonomous sub-agents** to pi. Spawn specialized agents that run in isolated sessions — each with its own tools, system prompt, model, and thinking level. Run them in foreground or background, steer them mid-run, resume completed sessions, and define your own custom agent types.
+
+<img width="600" alt="pi-subagents screenshot" src="https://github.com/tintinweb/pi-subagents/raw/master/media/screenshot.png" />
+
+
+https://github.com/user-attachments/assets/8685261b-9338-4fea-8dfe-1c590d5df543
+
+
+## Features
+
+- **Claude Code look & feel** — same tool names, calling conventions, and UI patterns (`Agent`, `get_subagent_result`, `steer_subagent`) — feels native
+- **Parallel background agents** — spawn multiple agents that run concurrently with automatic queuing (configurable concurrency limit, default 4) and smart group join (consolidated notifications)
+- **Live widget UI** — persistent above-editor widget with animated spinners, live tool activity, token counts, and colored status icons. Configurable via `/agents → Settings → Widget`: `all` (every agent), `background` (default — hides foreground runs, which already render inline as the `Agent` tool result), or `off`
+- **FleetView** — Claude Code-style navigable list of `main` + every running subagent rendered below the editor (earliest-launched first). Press `↓` (or `←`) at an empty prompt to jump in, `↑`/`↓` to move the selection, `Enter` to open the selected agent's live, auto-updating conversation, `Esc` to return. Finished agents linger briefly before dropping out, and a viewer stays open through completion so you can read the final output. Toggle via `/agents → Settings → Fleet view`
+- **Conversation viewer** — select any agent in `/agents` to open a live-scrolling overlay of its full conversation (auto-follows new content, scroll up to pause). Steer a running agent inline by pressing `Enter` to open a composer, typing, then `Enter` to send (`Esc` or an empty submit returns) — the message appears as a user message and redirects the agent after its current tool. Stop a still-running agent by pressing `x` (then `x` again to confirm) — both work for background agents too
+- **Custom agent types** — define agents in `.pi/agents/<name>.md` or `.agents/agents/<name>.md` (project) or globally, with YAML frontmatter: custom system prompts, model selection, thinking levels, tool restrictions
+- **Mid-run steering** — inject messages into running agents to redirect their work without restarting
+- **Session resume** — pick up where an agent left off, preserving full conversation context
+- **Graceful turn limits** — agents get a "wrap up" warning before hard abort, producing clean partial results instead of cut-off output
+- **Case-insensitive agent types** — `"explore"`, `"Explore"`, `"EXPLORE"` all work. Unknown types fall back to general-purpose with a note
+- **Fuzzy model selection** — specify models by name (`"haiku"`, `"sonnet"`) instead of full IDs, with automatic filtering to only available/configured models
+- **Context inheritance** — optionally fork the parent conversation into a sub-agent so it knows what's been discussed
+- **Persistent agent memory** — three scopes (project, local, user) with automatic read-only fallback for agents without write tools
+- **Git worktree isolation** — run agents in isolated repo copies; changes auto-committed to branches on completion
+- **Skill preloading** — inject named skills into agent system prompts, discovered from `.pi/skills/`, `.agents/skills/`, and global locations (Pi-standard `<name>/SKILL.md` directory layout supported)
+- **Tool denylist** — block specific tools via `disallowed_tools` frontmatter
+- **Styled completion notifications** — background agent results render as themed, compact notification boxes (icon, stats, result preview) instead of raw XML. Expandable to show full output. Group completions render each agent individually
+- **Event bus** — lifecycle events (`subagents:created`, `started`, `completed`, `failed`, `steered`, `compacted`) emitted via `pi.events`, enabling other extensions to react to sub-agent activity
+- **Cross-extension RPC** — other pi extensions can spawn and stop subagents via the `pi.events` event bus (`subagents:rpc:ping`, `subagents:rpc:spawn`, `subagents:rpc:stop`). Standardized reply envelopes with protocol versioning. Emits `subagents:ready` on session start
+- **Schedule subagents** — pass `schedule` to the `Agent` tool to fire on cron / interval / one-shot. Session-scoped jobs with PID-locked persistence; results land via the same `subagent-notification` followUp path as manual background completions; manage via `/agents → Scheduled jobs`
+- **Model scope enforcement** — opt-in validation that subagent model choices stay within your pi `enabledModels` allowlist (sourced from `/scoped-models`, with both global and project-local pi settings honored). Caller-supplied out-of-scope → hard error to orchestrator; frontmatter-pinned out-of-scope → warning + runs anyway (frontmatter authoritative). Toggle via `/agents → Settings → Scope models`
+
+## Install
+
+```bash
+pi install npm:@tintinweb/pi-subagents
+```
+
+Or load directly for development:
+
+```bash
+pi -e ./src/index.ts
+```
+
+## Quick Start
+
+The parent agent spawns sub-agents using the `Agent` tool:
+
+```
+Agent({
+  subagent_type: "Explore",
+  prompt: "Find all files that handle authentication",
+  description: "Find auth files",
+  run_in_background: true,
+})
+```
+
+Foreground agents block until complete and return results inline. Background agents return an ID immediately and notify you on completion.
+
+### Scheduling
+
+Add a `schedule` field to register the agent to fire later instead of running now:
+
+```
+Agent({
+  subagent_type: "Explore",
+  prompt: "Look at recent commits and summarize what changed since last week",
+  description: "Weekly commit review",
+  schedule: "0 0 9 * * 1",   // 9am every Monday (6-field cron)
+})
+```
+
+Schedule formats:
+
+- **Cron** — 6-field (`second minute hour day-of-month month day-of-week`), e.g. `"0 0 9 * * 1"` for 9am every Monday, `"0 */15 * * * *"` for every 15 minutes.
+- **Interval** — `"5m"`, `"1h"`, `"30s"`, `"2d"`. Fires repeatedly at that interval.
+- **One-shot relative** — `"+10m"`, `"+2h"`, `"+1d"`. Fires once at that future time.
+- **One-shot absolute** — full ISO timestamp, e.g. `"2026-12-25T09:00:00.000Z"`.
+
+When a schedule fires, the spawn runs in background and its completion notification arrives in the conversation through the same `subagent-notification` followUp path as a manually-spawned background agent — your parent agent reasons about the result the same way.
+
+Schedules are **session-scoped**: they reset on `/new` and restore on `/resume`. List and cancel via `/agents → Scheduled jobs` (creation is the `Agent` tool's job — there is no parallel manual-create wizard). Storage at `<cwd>/.pi/subagent-schedules/<sessionId>.json` with PID-based file locking for cross-instance safety.
+
+**Disable the feature entirely**: `/agents → Settings → Scheduling → disabled` removes `schedule` from the `Agent` tool spec (no LLM-context cost), hides the menu entry, and stops any active scheduler. The schema-level removal takes effect on the next pi session; the runtime kill is immediate. Re-enable from the same menu.
+
+Restrictions:
+- `schedule` cannot be combined with `inherit_context` (no parent conversation exists at fire time) or `resume` (schedules create fresh agents).
+- `run_in_background` is forced to `true`.
+- Scheduled fires bypass the `maxConcurrent` queue so a 5-minute interval cannot be deferred behind long-running manual agents.
+- **Headless `pi -p` doesn't wait for scheduled subagents.**
+
+## UI
+
+The extension renders a persistent widget above the editor showing active agents. By default it shows background runs only (`widgetMode: background`) — foreground agents already render inline as the `Agent` tool result, so the widget would otherwise double-render them. Switch to `all` (every agent) or `off` (hide the widget) via `/agents → Settings → Widget`:
+
+```
+● Agents
+├─ ⠹ Agent  Refactor auth module · ↻5≤30 · 5 tool uses · 33.8k token (62%) · 12.3s
+│    ⎿  editing 2 files…
+├─ ⠹ Explore  Find auth files · ↻3 · 3 tool uses · 12.4k token (8%) · 4.1s
+│    ⎿  searching…
+├─ ⠹ Agent  Long-running task · ↻42 · 38 tool uses · 91.0k token (84% · ⇊2) · 2m17s
+│    ⎿  reading…
+└─ 2 queued
+```
+
+The token field is annotated with two optional signals inside parens:
+- **`NN%`** — context-window utilization (color-coded: <70% dim, 70–85% warning, ≥85% error). Omitted when the model has no declared `contextWindow`, or briefly right after compaction.
+- **`⇊N`** — number of times the session has compacted, when > 0. Stays dim; the percent's color carries urgency.
+
+### FleetView
+
+While subagents are running, a Claude Code-style navigable list renders **below** the editor:
+
+```
+  esc to interrupt · ← for agents · ↓ to manage
+
+  ● main
+  ○ general-purpose  Sleep then report 1                                11s · ↓ 13.1k tokens
+  ○ general-purpose  Sleep then report 2                                11s · ↓ 13.1k tokens
+                                                                                   ↓ 3 more
+```
+
+The list is ordered earliest-launched first, and only shows agents you can actually open (pending/queued agents with no session yet appear once they start). At an **empty prompt**, press `↓` (or `←`) to move focus from the prompt into the list — the selected row is marked `●`, the rest `○`. `↑`/`↓` move the selection, `Enter` opens the selected agent's live conversation overlay (it auto-updates as the agent works), and `Esc` (or `↑` above `main`) returns to the prompt. Selecting `main` returns to the normal view. Inside the overlay, press `Enter` to steer the running agent — type a message and `Enter` to send it (`Esc` or an empty submit returns), and it redirects the agent the same way the `steer_subagent` tool does. A viewer stays open when its agent finishes so you can read the final output, and finished agents linger in the list for a few seconds before dropping out. Typing anything at a non-empty prompt behaves normally — the list only captures arrow keys when the prompt is empty. Disable it entirely via `/agents → Settings → Fleet view`.
+
+Individual agent results render Claude Code-style in the conversation:
+
+| State | Example |
+|-------|---------|
+| **Running** | `⠹ ↻3≤30 · 3 tool uses · 12.4k token (8%)` / `⎿ searching, reading 3 files…` |
+| **Completed** | `✓ ↻8 · 5 tool uses · 33.8k token (62%) · 12.3s` / `⎿ Done` |
+| **Wrapped up** | `✓ ↻50≤50 · 50 tool uses · 89.1k token (84% · ⇊2) · 45.2s` / `⎿ Wrapped up (turn limit)` |
+| **Stopped** | `■ ↻3 · 3 tool uses · 12.4k token (8%)` / `⎿ Stopped` |
+| **Error** | `✗ ↻3 · 3 tool uses · 12.4k token (8%)` / `⎿ Error: timeout` |
+| **Aborted** | `✗ ↻55≤50 · 55 tool uses · 102.3k token (95% · ⇊3)` / `⎿ Aborted (max turns exceeded)` |
+
+Completed results can be expanded (ctrl+o in pi) to show the full agent output inline.
+
+By default, foreground and background agents each stream their full conversation to a per-subagent transcript — a JSON-lines file at `<os-tmpdir>/pi-subagents-<uid>/<cwd>/<session>/tasks/<agent-id>.output` (owner-only `0700`, cleared on reboot). Set `output_transcript: false` on a custom agent to write no transcript path or file for it, or set `outputTranscript: false` in `subagents.json` to make transcripts opt-in for the whole project (frontmatter overrides the project default). This governs **only** the transcript: it is independent of `persist_session` (the pi session on disk), and it does not affect `isolation: worktree` (which commits the agent's work to a git branch) or `memory:` (durable files) — set those accordingly if the goal is to keep a run off disk entirely. Background agent completion notifications render as styled boxes:
+
+```
+✓ Find auth files completed
+  ↻3 · 3 tool uses · 12.4k token · 4.1s
+  ⎿  Found 5 files related to authentication...
+  transcript: .pi/output/agent-abc123.jsonl
+```
+
+Group completions render each agent as a separate block. The LLM receives structured `<task-notification>` XML for parsing, while the user sees the themed visual.
+
+## Default Agent Types
+
+| Type | Tools | Model | Prompt Mode | Description |
+|------|-------|-------|-------------|-------------|
+| `general-purpose` | all 7 | inherit | `append` (parent twin) | Inherits the parent's full system prompt — same rules, CLAUDE.md, project conventions |
+| `Explore` | read, bash, grep, find, ls | haiku (falls back to inherit) | `replace` (standalone) | Fast codebase exploration (read-only) |
+| `Plan` | read, bash, grep, find, ls | inherit | `replace` (standalone) | Software architect for implementation planning (read-only) |
+
+The `general-purpose` agent is a **parent twin** — it receives the parent's entire system prompt plus a sub-agent context bridge, so it follows the same rules the parent does. Explore and Plan use standalone prompts tailored to their read-only roles.
+
+Default agents can be **ejected** (`/agents` → select agent → Eject) to export them as `.md` files for customization, **overridden** by creating a `.md` file with the same name (e.g. `.pi/agents/general-purpose.md`), or **disabled** per-project with `enabled: false` frontmatter.
+
+## Custom Agents
+
+Define custom agent types by creating `.md` files. The filename becomes the agent type name. Any name is allowed — using a default agent's name overrides it.
+
+Agents are discovered from three locations (higher priority wins):
+
+| Priority | Location | Scope |
+|----------|----------|-------|
+| 1 (highest) | `.pi/agents/<name>.md` | Project — pi's config dir; authoritative, and where `/agents` writes |
+| 2 | `.agents/agents/<name>.md` | Project — the shared cross-tool `.agents` workspace (same convention as `.agents/skills/`) |
+| 3 | `$PI_CODING_AGENT_DIR/agents/<name>.md` (default `~/.pi/agent/agents/<name>.md`) | Global — available everywhere |
+
+Project-level agents override global ones with the same name, so you can customize a global agent for a specific project. If both project locations define the same name, **`.pi/agents/` wins** — `.pi` stays the project authority; `.agents/agents/` is an additional read location for projects that keep their agent assets in the `.agents` workspace. The global location follows the upstream `PI_CODING_AGENT_DIR` env var — set it to relocate all pi-coding-agent state (agents, skills, settings) to a custom directory.
+
+### Example: `.pi/agents/auditor.md`
+
+```markdown
+---
+description: Security Code Reviewer
+tools: read, grep, find, bash
+model: anthropic/claude-opus-4-6
+thinking: high
+max_turns: 30
+---
+
+You are a security auditor. Review code for vulnerabilities including:
+- Injection flaws (SQL, command, XSS)
+- Authentication and authorization issues
+- Sensitive data exposure
+- Insecure configurations
+
+Report findings with file paths, line numbers, severity, and remediation advice.
+```
+
+Then spawn it like any built-in type:
+
+```
+Agent({ subagent_type: "auditor", prompt: "Review the auth module", description: "Security audit" })
+```
+
+### Frontmatter Fields
+
+All fields are optional — sensible defaults for everything.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `description` | filename | Agent description shown in tool listings |
+| `display_name` | — | Display name for UI (e.g. widget, agent list) |
+| `tools` | all 7 | Which tools the agent can call. Built-in names (`read, grep, …`), `*` / `all` (all built-ins), `none`, and `ext:<extension>` / `ext:<extension>/<tool>` selectors for extension tools. See [Tool & extension scoping](#tool--extension-scoping) below |
+| `extensions` | `true` | Which extensions to load for the agent. `true` (all defaults), `false` (none), or an explicit list: `[mcp, "/abs/path.ts", "*"]`. See [Tool & extension scoping](#tool--extension-scoping) below |
+| `exclude_extensions` | — | Extension denylist applied after `extensions:` — exclude wins. Plain names only (case-insensitive), no paths or `*`. Useful with `extensions: true` to drop one extension (e.g. `pi-notify`) |
+| `skills` | `true` | Inherit skills from parent. Can be a comma-separated list of skill names to preload (see [Skill Preloading](#skill-preloading) for discovery locations) |
+| `memory` | — | Persistent agent memory scope: `project`, `local`, or `user`. Auto-detects read-only agents |
+| `disallowed_tools` | — | Comma-separated tools to deny even if extensions provide them |
+| `isolation` | — | Set to `worktree` to run in an isolated git worktree |
+| `model` | inherit parent | Model — `provider/modelId` or fuzzy name (`"haiku"`, `"sonnet"`). Resolved tolerantly (`.`/`-` and a trailing date stamp are interchangeable) and falls back to the same model under another provider if the named one doesn't have it |
+| `thinking` | inherit | off, minimal, low, medium, high, xhigh, max — actual availability depends on your pi version and model; pi clamps unsupported levels down |
+| `max_turns` | unlimited | Max agentic turns before graceful shutdown. `0` or omit for unlimited |
+| `persist_session` | `false` | Persist this subagent as a normal pi session instead of keeping the session in memory only. The subagent's `.output` transcript is still written either way unless `output_transcript: false` |
+| `output_transcript` | `true` (or `subagents.json` `outputTranscript`) | Write this subagent's `.output` transcript; when set, overrides the `subagents.json` `outputTranscript` default. Set `false` to write no transcript file or path. Governs only the transcript — independent of `persist_session`, `isolation: worktree`, and `memory:` |
+| `session_dir` | pi default | Optional session directory when `persist_session: true`; omitted uses pi's normal session location, and relative paths resolve from the agent cwd |
+| `prompt_mode` | `replace` | `replace`: body is the full system prompt (no AGENTS.md / CLAUDE.md inheritance). `append`: body appended to parent's prompt (agent acts as a "parent twin" — inherits parent's AGENTS.md / CLAUDE.md) |
+| `inherit_context` | `false` | Fork parent conversation into agent |
+| `run_in_background` | `false` | Run in background by default |
+| `isolated` | `false` | Hermetic specialist mode: forces `extensions: false` + `skills: false` + drops `ext:` selectors. Only built-in tools. Distinct from `isolation: worktree` (filesystem) |
+| `enabled` | `true` | Set to `false` to disable an agent (useful for hiding a default agent per-project) |
+
+Frontmatter is authoritative. If an agent file sets `model`, `thinking`, `max_turns`, `inherit_context`, `run_in_background`, `isolated`, or `isolation`, those values are locked for that agent. `Agent` tool parameters only fill fields the agent config leaves unspecified.
+
+**Forgiving `model:` resolution.** A `model:` pin is matched against pi's model registry tolerantly, so cosmetic id variations don't silently drop the agent back to the parent's model: `.` and `-` are treated as equivalent in version numbers (`claude-haiku-4.5` ≡ `claude-haiku-4-5`), a trailing `-YYYYMMDD` date stamp is optional (`anthropic/claude-haiku-4-5-20251001` matches an undated registry id and vice-versa), and a `provider/modelId` whose named provider doesn't carry that model retries the bare id against every provider. Precedence is **exact → fuzzy under the named provider → same model under any provider → unavailable**, so an exact match always wins and dated snapshots aren't conflated. If nothing resolves, the pin can't run and the agent inherits the parent model — `/agents → Agent types` flags this case as `(unavailable, fallback: inherit)` and shows the resolved target `(→ provider/id)` when resolution lands on a different provider or version than configured. (This is distinct from [Model Scope](#model-scope) enforcement, which matches the `enabledModels` allowlist by *exact* entry.)
+
+### Tool & extension scoping
+
+`extensions:` decides **which extensions load**, `tools:` decides **which tools surface to the LLM**. They compose:
+
+```yaml
+# Default (both omitted): all extensions load, all 7 built-ins surface
+
+tools: read, grep, find           # narrow to listed built-ins; extensions still load
+tools: "*"                        # all 7 built-ins (alias: `all`)
+tools: none                       # zero built-ins (alias: `""`)
+tools: "*, ext:mcp/search"        # built-ins plus one extension tool
+
+extensions: false                 # no extensions load
+extensions: [mcp]                 # only mcp loads
+extensions: ["*", "/abs/foo.ts"]  # all defaults plus one path-loaded extension
+
+exclude_extensions: pi-notify     # everything except pi-notify (with extensions: true)
+
+# Specialist: load one extension, expose only one of its tools, keep built-ins
+extensions: [mcp]
+tools: "*, ext:mcp/search"
+
+isolated: true                    # hermetic: built-ins only, no extensions/skills/context
+```
+
+A few rules the examples don't make obvious:
+
+- `extensions:` is the sole loading authority. `ext:foo` in `tools:` narrows what surfaces; it can't load `foo` on its own. Mismatches fire `extension-error:…` warnings.
+- Any `ext:` entry flips extension tools to an explicit allowlist — unnamed extensions still load (handlers fire) but expose no tools. So `tools: "*, ext:mcp/search"` exposes only `search` from `mcp`, nothing from any other extension.
+- Extension names match case-insensitively (`[Mcp]` = `[mcp]`); tool names in `ext:foo/bar` stay case-sensitive.
+- Extensions that register tools **lazily** work too. MCP-backed extensions typically can't enumerate their tools until their servers connect, so they register from `session_start` or `before_agent_start` rather than at load. Subagent scoping is re-derived as tools appear, so these surface normally — including under `ext:` selectors, which keep narrowing correctly no matter when a tool shows up.
+- An installed **package** extension matches by its package short name (`@scope/pi-subagents` → `[pi-subagents]`), in addition to its path-derived name (a package whose entry is `src/index.ts` also answers to `[src]`). Prefer the package name — the path-derived one is incidental.
+- Plain `tools:` typos fail loudly: `tools: reed, grep` fires `tools-error:…` instead of silently producing an under-tooled agent.
+- `exclude_extensions:` wins over `extensions:` and over `ext:` selectors — an excluded extension never loads and a `tools: ext:` entry can't pull it back. Plain names only (no paths, no `*`); a name matching nothing fires an `extension-error:…` warning.
+- `exclude_extensions:` is **not a sandbox**: excluded extensions' factory code still executes once during loading. Exclusion suppresses their tools and their bound lifecycle hooks (`pi.on` handlers like `session_start` only fire for extensions bound to the session), but not other load-time side effects — a factory that subscribes directly to the shared `pi.events` bus stays live. Don't rely on it to contain an untrusted extension.
+- Array and string forms are equivalent: `[a, b]` == `"a, b"`.
+
+## Tools
+
+### `Agent`
+
+Launch a sub-agent.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `prompt` | string | yes | The task for the agent |
+| `description` | string | yes | Short 3-5 word summary (shown in UI) |
+| `subagent_type` | string | yes | Agent type (built-in or custom) |
+| `model` | string | no | Model — `provider/modelId` or fuzzy name (`"haiku"`, `"sonnet"`). Resolved tolerantly (`.`/`-` and a trailing date stamp interchangeable) with provider fallback |
+| `thinking` | string | no | Thinking level: off, minimal, low, medium, high, xhigh, max (availability depends on pi version and model) |
+| `max_turns` | number | no | Max agentic turns. Omit for unlimited (default) |
+| `run_in_background` | boolean | no | Run without blocking |
+| `resume` | string | no | Agent ID to resume a previous session |
+| `isolated` | boolean | no | No extension/MCP tools |
+| `isolation` | `"worktree"` | no | Run in an isolated git worktree |
+| `inherit_context` | boolean | no | Fork parent conversation into agent |
+
+### `get_subagent_result`
+
+Check status and retrieve results from a background agent.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agent_id` | string | yes | Agent ID to check |
+| `wait` | boolean | no | Wait for completion |
+| `verbose` | boolean | no | Include full conversation log |
+
+Cancelling a `wait: true` call (for example, with `Esc`) stops only the wait. The background agent keeps running, and its completion notification still arrives normally.
+
+### `steer_subagent`
+
+Send a steering message to a running agent. The message interrupts after the current tool execution.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agent_id` | string | yes | Agent ID to steer |
+| `message` | string | yes | Message to inject into agent conversation |
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/agents` | Interactive agent management menu |
+
+The `/agents` command opens an interactive menu:
+
+```
+Running agents (2) — 1 running, 1 done     ← only shown when agents exist
+Agent types (6)                             ← unified list: defaults + custom
+Create new agent                            ← manual wizard or AI-generated
+Settings                                    ← max concurrency, max turns, grace turns, join mode
+```
+
+- **Running agents** — select one to open its live conversation viewer. While it's still running, press `Enter` to open the steering composer, then `Enter` again to send a message that redirects the agent (same mechanism as the `steer_subagent` tool; `Esc` or an empty submit returns), or press `x` (then `x` again to confirm) to stop/abort it — including **background** agents, which a global Esc can't unambiguously target (Esc still stops a blocking foreground `Agent` call). A stopped agent reports its partial output flagged as incomplete, not as a completion.
+- **Agent types** — unified list with source indicators: `•` (project), `◦` (global), `✕` (disabled). Each row shows the agent's model, and the highlighted agent's full description appears below the list. The model column flags `(unavailable, fallback: inherit)` when a configured model can't be resolved (it would silently inherit the parent model), and shows `(→ provider/id)` when it resolves to a different provider or version than configured. Select an agent to manage it:
+  - **Default agents** (no override): Eject (export as `.md`), Disable
+  - **Default agents** (ejected/overridden): Edit, Disable, Reset to default, Delete
+  - **Custom agents**: Edit, Disable, Delete
+  - **Disabled agents**: Enable, Edit, Delete
+- **Eject** — writes the embedded default config as a `.md` file to project or personal location, so you can customize it
+- **Disable/Enable** — toggle agent availability. Disabled agents stay visible in the list (marked `✕`) and can be re-enabled
+- **Create new agent** — choose project/personal location, then manual wizard (step-by-step prompts for name, tools, model, thinking, system prompt) or AI-generated (describe what the agent should do and a sub-agent writes the `.md` file). Any name is allowed, including default agent names (overrides them)
+- **Settings** — configure max concurrency, default max turns, grace turns, and join mode at runtime
+
+## Graceful Max Turns
+
+Instead of hard-aborting at the turn limit, agents get a graceful shutdown:
+
+1. At `max_turns` — steering message: *"Wrap up immediately — provide your final answer now."*
+2. Up to 5 grace turns to finish cleanly
+3. Hard abort only after the grace period
+
+| Status | Meaning | Icon |
+|--------|---------|------|
+| `completed` | Finished naturally | `✓` green |
+| `steered` | Hit limit, wrapped up in time | `✓` yellow |
+| `aborted` | Grace period exceeded | `✗` red |
+| `stopped` | User-initiated abort | `■` dim |
+
+## Concurrency
+
+Background agents are subject to a configurable concurrency limit (default: 4). Excess agents are automatically queued and start as running agents complete. The widget shows queued agents as a collapsed count.
+
+Foreground agents bypass the queue — they block the parent anyway.
+
+## Join Strategies
+
+When background agents complete, they notify the main agent. The **join mode** controls how these notifications are delivered. It applies only to background agents.
+
+| Mode | Behavior |
+|------|----------|
+| `smart` (default) | 2+ background agents spawned in the same turn are auto-grouped into a single consolidated notification. Solo agents notify individually. |
+| `async` | Each agent sends its own notification on completion (original behavior). Best when results need incremental processing. |
+| `group` | Force grouping even when spawning a single agent. Useful when you know more agents will follow. |
+
+**Timeout behavior:** When agents are grouped, a 30-second timeout starts after the first agent completes. If not all agents finish in time, a partial notification is sent with completed results and remaining agents continue with a shorter 15-second re-batch window for stragglers.
+
+**Configuration:**
+- Configure join mode in `/agents` → Settings → Join mode
+
+## Model Scope
+
+**Opt-in:** off by default. Enable via `/agents → Settings → Scope models`.
+
+When on, each subagent spawn's effective model is validated against pi's own `enabledModels` list (configured via pi's `/scoped-models` UI). pi-subagents reads that list; it doesn't manage it. Both of pi's settings files are honored: global `~/.pi/agent/settings.json` and project-local `<cwd>/.pi/settings.json`. **Project overrides global** — mirrors pi's `SettingsManager` deep-merge, so a tighter per-project scope (hand-edited into the project settings) is respected.
+
+**Out-of-scope handling depends on source:**
+
+| Model source | Out-of-scope behavior |
+|---|---|
+| Caller-supplied via `Agent({ model: "..." })` | Hard error returned to the orchestrator, listing allowed models |
+| Pinned in agent frontmatter | Warning toast + the pinned model runs (frontmatter is authoritative) |
+| Parent-inherited (neither set) | Warning toast + parent's model runs |
+
+**Design:** `scopeModels` is a guardrail against the orchestrator picking unexpected models at runtime, not a hard policy against user-level config. The "frontmatter is authoritative" guarantee from v0.5.1 still holds for `model:` — caller params can't override frontmatter, and frontmatter pins run even when out of scope (with a visible warning).
+
+**Pattern format:** only exact `provider/modelId` entries are honored (e.g. `anthropic/claude-haiku-4-5-20251001`). Glob patterns (`*sonnet*`), bare model IDs, and `:thinking` suffixes — which pi itself supports — are silently dropped here. pi's `/scoped-models` picker writes exact entries, so the limitation is invisible if you configure scope through the UI. Hand-edited globs produce an empty allowed set (scope check becomes a no-op).
+
+**No-op safety:** if `enabledModels` is missing or empty in pi's settings, scope check skips entirely — no false positives, no spurious errors.
+
+## Persistent Settings
+
+Runtime tuning values set via `/agents` → Settings (max concurrency, default max turns, grace turns, default join mode, scheduling on/off, scope models on/off, disable defaults on/off, output transcript on/off, tool description full/compact/custom, widget all/background/off) persist across pi restarts. Two files, merged on load:
+
+- **Global:** `~/.pi/agent/subagents.json` — your machine-wide defaults. Edit by hand; the `/agents` menu never writes here.
+- **Project:** `<cwd>/.pi/subagents.json` — per-project overrides. Written by `/agents` → Settings.
+
+**Precedence:** project overrides global on any field present in both. Missing fields fall back to the hardcoded defaults (max concurrency `4`, default max turns unlimited, grace turns `5`, join mode `smart`, defaults enabled).
+
+**Disable defaults** (`disableDefaultAgents`, default `false`): when on, the three built-in agents (general-purpose, Explore, Plan) are not registered — only your project/global custom agents are advertised and spawnable. User-defined agents are unaffected, including ones that override a default by name. The Agent tool's type list updates on the next pi session (the tool schema is registered at startup).
+
+**Output transcript** (`outputTranscript`, default `true`): the project/global default for writing each subagent's `.output` transcript. Toggle via `/agents → Settings → Output transcript`, or set `false` in `subagents.json` to make transcripts opt-in project-wide — useful when run transcripts shouldn't sit on disk for backup or DLP tooling to pick up. A custom agent's `output_transcript` frontmatter overrides this per agent. Applied live at spawn time. Governs only the transcript, not `persist_session`, worktree commits, or memory files.
+
+**Tool description** (`toolDescriptionMode`, default `"full"`): which Agent tool description the LLM sees. `"full"` is the rich Claude Code-style prompt (~1,400 tokens with the default agents); `"compact"` is ~75% smaller — one-line agent type list, terse usage notes — for small/local models where tool-spec tokens are expensive. Per-option details stay in the parameter descriptions in every mode (the parameter schema is never customizable). Applies on the next pi session.
+
+`"custom"` registers your own description from `<cwd>/.pi/agent-tool-description.md` (project) or `<agentDir>/agent-tool-description.md` (global; project wins). The file is read once at tool registration, so edits also apply on the next pi session. Dynamic parts stay live via placeholders — a static agent list would go stale the moment you add a custom agent:
+
+```markdown
+Launch an autonomous agent. Available types:
+{{typeList}}
+
+Custom agents live in .pi/agents/ or {{agentDir}}/agents/.
+```
+
+Placeholders: `{{typeList}}` (full per-agent descriptions), `{{compactTypeList}}` (first sentence each), `{{agentDir}}`, `{{scheduleGuideline}}` (expands with its own leading newline + `- ` bullet when scheduling is on — place it directly after your last rule line; empty when scheduling is off). Unknown placeholders are left verbatim with a stderr warning; a missing or empty file falls back to `"full"` with a warning. Note the usual trust umbrella: a project-level file shapes the orchestrator's prompt, same as project agents and extensions do.
+
+**Starting point:** copy [`examples/agent-tool-description.md`](examples/agent-tool-description.md) — it reproduces the default full description exactly (a CI test keeps it in sync), so you can trim from a known-good baseline instead of writing from scratch.
+
+**Example — global defaults for a beefy machine:**
+
+```bash
+mkdir -p ~/.pi/agent
+cat > ~/.pi/agent/subagents.json <<'EOF'
+{
+  "maxConcurrent": 16,
+  "graceTurns": 10
+}
+EOF
+```
+
+Every project now starts with concurrency 16 and grace 10, without ever touching the menu. Individual projects can still override via `/agents` → Settings.
+
+**Failure behavior:** missing file is silent; malformed JSON logs a `[pi-subagents] Ignoring malformed settings at …` warning to stderr; invalid/out-of-range field values are dropped per-field; write failures downgrade the `/agents` toast to a warning with `(session only; failed to persist)`.
+
+## Events
+
+Agent lifecycle events are emitted via `pi.events.emit()` so other extensions can react:
+
+| Event | When | Key fields |
+|-------|------|------------|
+| `subagents:created` | Background agent registered | `id`, `type`, `description`, `isBackground` |
+| `subagents:started` | Agent transitions to running (including queued→running) | `id`, `type`, `description` |
+| `subagents:completed` | Agent finished successfully (background and foreground) | `id`, `type`, `durationMs`, `tokens` (lifetime `{ input, output, total }`), `toolUses`, `result` |
+| `subagents:failed` | Agent errored, stopped, or aborted (background and foreground) | same as completed + `error`, `status` |
+| `subagents:steered` | Steering message sent | `id`, `message` |
+| `subagents:compacted` | Agent's session successfully compacted | `id`, `type`, `description`, `reason` (`"manual"` / `"threshold"` / `"overflow"`), `tokensBefore`, `compactionCount` |
+| `subagents:scheduled` | Schedule lifecycle change | `{ type: "added" \| "removed" \| "updated" \| "fired" \| "error", … }` (job/agentId/error fields per type) |
+| `subagents:scheduler_ready` | Scheduler bound to session, enabled jobs armed | `sessionId`, `jobCount` |
+| `subagents:ready` | RPC handlers registered and armed — fired on session start; not emitted in a session that excludes pi-subagents | — |
+| `subagents:settings_loaded` | Persisted settings applied at extension init | `settings` (merged global + project) |
+| `subagents:settings_changed` | `/agents` → Settings mutation was applied | `settings`, `persisted` (`boolean` — `false` on write failure) |
+
+`tokens.total` = `input + output + cacheWrite`. `cacheRead` is excluded — each turn's `cacheRead` is the cumulative cached prefix re-read on that one API call, so summing per-message would over-count it. Use `contextUsage.percent` (surfaced as `(NN%)` in the widget) for current context size.
+
+## Cross-Extension RPC
+
+Other pi extensions can spawn and stop subagents programmatically via the `pi.events` event bus, without importing this package directly.
+
+All RPC replies use a standardized envelope: `{ success: true, data?: T }` on success, `{ success: false, error: string }` on failure.
+
+### Discovery
+
+Listen for `subagents:ready` to know when RPC handlers are available:
+
+```typescript
+pi.events.on("subagents:ready", () => {
+  // RPC handlers are registered — safe to call ping/spawn/stop
+});
+```
+
+`subagents:ready` fires only when pi-subagents is actually loaded **and bound** in the current session. A session that excludes it (via an agent's `extensions:`) emits no `subagents:ready` and does not answer the RPC channels — exactly as if pi-subagents were not installed. Treat "no `subagents:ready`" as "not available here" and give discovery a timeout rather than waiting indefinitely.
+
+### Ping
+
+Check if the subagents extension is loaded and get the protocol version:
+
+```typescript
+const requestId = crypto.randomUUID();
+const unsub = pi.events.on(`subagents:rpc:ping:reply:${requestId}`, (reply) => {
+  unsub();
+  if (reply.success) console.log("Protocol version:", reply.data.version);
+});
+pi.events.emit("subagents:rpc:ping", { requestId });
+```
+
+### Spawn
+
+Spawn a subagent and receive its ID:
+
+```typescript
+const requestId = crypto.randomUUID();
+const unsub = pi.events.on(`subagents:rpc:spawn:reply:${requestId}`, (reply) => {
+  unsub();
+  if (!reply.success) {
+    console.error("Spawn failed:", reply.error);
+  } else {
+    console.log("Agent ID:", reply.data.id);
+  }
+});
+pi.events.emit("subagents:rpc:spawn", {
+  requestId,
+  type: "general-purpose",
+  prompt: "Do something useful",
+  options: { description: "My task", run_in_background: true },
+});
+```
+
+`options.model` accepts either a `Model` object (e.g. `ctx.model`) or a `"provider/modelId"` string — strings are resolved against `ctx.modelRegistry` at the RPC boundary, so cross-extension callers can forward serializable values without losing auth context.
+
+`options.cwd` (absolute path to an existing directory — anything else returns an error envelope; `null` means unset) runs the agent in a different working directory than the parent session. Its tools operate there and the prompt's environment block describes it, but **`.pi` config still loads from the parent session's project** — the target directory's `.pi` extensions never execute, and its agents/skills/settings are not picked up. Combined with `isolation: "worktree"`, the worktree is created *from* the target directory's repo, the agent works at the equivalent subdirectory inside the copy (a monorepo-package cwd stays scoped to that package), and the resulting `pi-agent-*` branch lands in that repo — the completion message names it. On session end, worktree registrations are pruned in every repo that received one; only a hard crash can leave a stale entry (then: `git worktree prune` in the target repo). Agents with `memory:` keep reading/writing the parent project's memory.
+
+### Stop
+
+Stop a running agent by ID:
+
+```typescript
+const requestId = crypto.randomUUID();
+const unsub = pi.events.on(`subagents:rpc:stop:reply:${requestId}`, (reply) => {
+  unsub();
+  if (!reply.success) console.error("Stop failed:", reply.error);
+});
+pi.events.emit("subagents:rpc:stop", { requestId, agentId: "agent-id-here" });
+```
+
+Reply channels are scoped per `requestId`, so concurrent requests don't interfere.
+
+## Persistent Agent Memory
+
+Agents can have persistent memory across sessions. Set `memory` in frontmatter to enable:
+
+```yaml
+---
+memory: project   # project | local | user
+---
+```
+
+| Scope | Location | Use case |
+|-------|----------|----------|
+| `project` | `.pi/agent-memory/<name>/` | Shared across the team (committed) |
+| `local` | `.pi/agent-memory-local/<name>/` | Machine-specific (gitignored) |
+| `user` | `<agentDir>/agent-memory/<name>/` (default `~/.pi/agent/agent-memory/`, honors `PI_CODING_AGENT_DIR`) | Global personal memory |
+
+The `user` scope previously hardcoded `~/.pi/agent-memory/`. If that legacy directory exists for an agent and the new location doesn't, it keeps being used — existing memories aren't orphaned.
+
+Memory uses a `MEMORY.md` index file and individual memory files with frontmatter. Agents with write tools get full read-write access. **Read-only agents** (no `write`/`edit` tools) automatically get read-only memory — they can consume memories written by other agents but cannot modify them. This prevents unintended tool escalation.
+
+The `disallowed_tools` field is respected when determining write capability — an agent with `tools: write` + `disallowed_tools: write` correctly gets read-only memory.
+
+## Worktree Isolation
+
+Set `isolation: worktree` to run an agent in a temporary git worktree:
+
+```
+Agent({ subagent_type: "refactor", prompt: "...", isolation: "worktree" })
+```
+
+The agent gets a full, isolated copy of the repository. On completion:
+- **No changes:** worktree is cleaned up automatically
+- **Changes made:** changes are committed to a new branch (`pi-agent-<id>`) and returned in the result
+- **Agent committed its own work:** the branch is created at the agent's HEAD, preserving its commits (uncommitted leftovers are committed on top first)
+
+The automatic preservation commit uses `--no-verify`, so local pre-commit hooks can't block it — the commit is local-only and never pushed, and pre-push/server-side hooks still apply.
+
+If the worktree cannot be created (not a git repo, no commits, or `git worktree add` fails), the `Agent` tool returns a clear error instead of running unisolated — `isolation: "worktree"` is a strict guarantee, not a hint. Initialize git and commit at least once, or omit `isolation`.
+
+## Skill Preloading
+
+Skills can be preloaded by name and injected into the agent's system prompt:
+
+```yaml
+---
+skills: api-conventions, error-handling
+---
+```
+
+**Discovery roots** (checked in this order, first match wins):
+
+| Scope | Path | Source |
+|---|---|---|
+| Project | `<cwd>/.pi/skills/` | Pi-standard |
+| Project | `<cwd>/.agents/skills/` | [Agent Skills spec](https://agentskills.io/integrate-skills) |
+| User | `$PI_CODING_AGENT_DIR/skills/` (default `~/.pi/agent/skills/`) | Pi-standard |
+| User | `~/.agents/skills/` | [Agent Skills spec](https://agentskills.io/integrate-skills) |
+| User | `~/.pi/skills/` | Legacy (pre-Pi) |
+
+**Per root, a skill named `foo` resolves to the first of:**
+
+- `<root>/foo.md` — flat file at the top level
+- `<root>/foo/SKILL.md` — directory skill (top-level)
+- `<root>/*/.../foo/SKILL.md` — directory skill, found by recursive descent
+
+Recursion skips dotfile directories and `node_modules`. A directory that itself contains a `SKILL.md` is treated as a single skill — we don't descend into it. Traversal is byte-order sorted for deterministic resolution across filesystems.
+
+**Security:** symlinks are rejected at every layer (root, flat file, skill directory, `SKILL.md` inside a skill directory) — intentional deviation from Pi, which follows symlinks. Skill names with path-traversal characters (`..`, `/`, `\`, spaces, leading dot, >128 chars) are rejected.
+
+## Tool Denylist
+
+Block specific tools from an agent even if extensions provide them:
+
+```yaml
+---
+tools: read, bash, grep, write
+disallowed_tools: write, edit
+---
+```
+
+This is useful for creating agents that inherit extension tools but should not have write access.
+
+## Architecture
+
+```
+src/
+  index.ts            # Extension entry: tool/command registration, rendering
+  types.ts            # Type definitions (AgentConfig, AgentRecord, etc.)
+  default-agents.ts   # Embedded default agent configs (general-purpose, Explore, Plan)
+  agent-types.ts      # Unified agent registry (defaults + user), tool name resolution
+  agent-runner.ts     # Session creation, execution, graceful max_turns, steer/resume
+  agent-manager.ts    # Agent lifecycle, concurrency queue, completion notifications
+  cross-extension-rpc.ts # RPC handlers for cross-extension spawn/ping via pi.events
+  group-join.ts       # Group join manager: batched completion notifications with timeout
+  custom-agents.ts    # Load user-defined agents from .pi/agents/, .agents/agents/, and global agents
+  memory.ts           # Persistent agent memory (resolve, read, build prompt blocks)
+  skill-loader.ts     # Preload skills (Pi-standard + Agent Skills spec layouts)
+  output-file.ts      # Streaming output file transcripts for agent sessions
+  worktree.ts         # Git worktree isolation (create, cleanup, prune)
+  prompts.ts          # Config-driven system prompt builder
+  context.ts          # Parent conversation context for inherit_context
+  env.ts              # Environment detection (git, platform)
+  ui/
+    agent-widget.ts       # Persistent widget: spinners, activity, status icons, theming
+    conversation-viewer.ts # Live conversation overlay for viewing agent sessions
+```
+
+## License
+
+MIT — [tintinweb](https://github.com/tintinweb)

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -39,6 +39,7 @@ Stable “why” only — implementation detail lives in code/tests.
   - Expanded (Ctrl+O): same chrome + **Markdown** body — never dump full payload by default (`src/ui/tool-render.ts`)
 - Result stats always surface **effective model** (including parent inherit) and **effort** (from `thinking`).
 - Widget last line shows the **current tool step** (e.g. `reading src/a.ts`) from `tool_execution_start` args, not only bare `thinking…` when tools are in flight.
+- `AgentInvocation.modelInherited` is persisted on the record so `get_subagent_result` restores the same `model (inherit)` chip as the original Agent tool row.
 - Validation / not-found failures carry **error** details; undetailed fallback never assumes `completed` / green ✓.
 - `resultBodyText` peels only **recognized status headers** so multi-paragraph errors keep the first line.
 

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -54,8 +54,8 @@ Stable “why” only — implementation detail lives in code/tests.
 ### Engineering / packaging
 
 - Package name `@zhcsyncer/pi-subagents`; monorepo path `packages/pi-subagents/`.
-- Pre-release version **`0.0.0`** until Changesets cuts the first public version.
-- Not registered on the root `@zhcsyncer/pi-extensions` `pi.extensions` list yet — local trial via `pi -e ./packages/pi-subagents/src/index.ts`.
+- Publishes standalone **and** is embedded/registered on the root `@zhcsyncer/pi-extensions` `pi.extensions` list (`./packages/pi-subagents/src/index.ts`).
+- Root tarball carries subagents sources plus runtime deps (`@sinclair/typebox`, `croner`, `nanoid`).
 - `agent-runner`: skip null parent `modelRuntime` for stricter Pi `ModelRuntime` typings.
 
 ### Intentionally unchanged vs upstream

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -45,6 +45,7 @@ Stable “why” only — implementation detail lives in code/tests.
 - Result stats always surface **effective model** (including parent inherit) and **effort** (from `thinking`).
 - Widget last line shows the **current tool step** (e.g. `reading src/a.ts`) from `tool_execution_start` args, not only bare `thinking…` when tools are in flight.
 - `AgentInvocation.modelInherited` is persisted on the record so `get_subagent_result` restores the same `model (inherit)` chip as the original Agent tool row.
+- Status bar (`setStatus("subagents")`) is **auto**: cleared while the above-editor widget is on; compact `N running` text only when `widgetMode: off`.
 - Resume details come from the **stored invocation** (old session model/effort) — not the current parent tool args.
 - Validation / not-found failures carry **error** details; a `tool_result` hook maps `details.status` ∈ {error,aborted,stopped} → Pi `isError` so the default shell uses error background (not green success).
 - Undetailed fallback: explicit `isError=false` never heuristic-reds; free-word scans of user text removed.

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -24,10 +24,14 @@ Stable “why” only — implementation detail lives in code/tests.
 ### ConversationViewer (scheme A)
 
 - Default overlay is **Prompt · Steps · Result**, not a full message dump.
-- Steps are one line per tool call; tool results folded by default; **`o`** expands args/results.
+- Steps are one line per tool call; tool results folded by default; **`o`** expands args/results (expanded bodies hard-capped).
 - Intermediate assistant chatter omitted from the default path.
 - On `error` / `aborted` / `stopped`, Result prefers **`record.error`** (or status label); last assistant text is a demoted footnote.
+- On `steered` (turn-limit wrap-up), Result shows **Wrapped up (turn limit)** — not silent Done.
+- Header icons align with tool chrome: running ● / queued ○ / completed ✓ / steered warning ✓ / error·aborted ✗ / stopped ■.
+- Terminal records settle dangling `running` steps (unmatched toolCall) so spinners do not survive stop/error.
 - `bashExecution` honors **`exitCode` / `cancelled`** → error step (`✗`).
+- `inherit_context` prompts keep the **tail** when truncating (dispatch task lives after parent context).
 - Pure `messages → brief` helpers: `src/ui/conversation-brief.ts`.
 
 ### Main-transcript tool TUI
@@ -35,13 +39,16 @@ Stable “why” only — implementation detail lives in code/tests.
 - Custom `renderCall` / `renderResult` for **`Agent`**, **`get_subagent_result`**, **`steer_subagent`** using **Claude Code chrome** (upstream README shape):
   - Call: `▸ Type  description` (+ chips only when args explicitly set model/thinking/bg)
   - Running: `⠹ stats` / `⎿ activity`
+  - Queued: real `status: "queued"` + `queued…` (never "Running in background" / thinking…)
   - Done: `✓ stats · duration` / `⎿ Done` (Wrapped up / Stopped / Error variants)
   - Expanded (Ctrl+O): same chrome + **Markdown** body — never dump full payload by default (`src/ui/tool-render.ts`)
 - Result stats always surface **effective model** (including parent inherit) and **effort** (from `thinking`).
 - Widget last line shows the **current tool step** (e.g. `reading src/a.ts`) from `tool_execution_start` args, not only bare `thinking…` when tools are in flight.
 - `AgentInvocation.modelInherited` is persisted on the record so `get_subagent_result` restores the same `model (inherit)` chip as the original Agent tool row.
-- Validation / not-found failures carry **error** details; undetailed fallback never assumes `completed` / green ✓.
-- `resultBodyText` peels only **recognized status headers** so multi-paragraph errors keep the first line.
+- Resume details come from the **stored invocation** (old session model/effort) — not the current parent tool args.
+- Validation / not-found failures carry **error** details; a `tool_result` hook maps `details.status` ∈ {error,aborted,stopped} → Pi `isError` so the default shell uses error background (not green success).
+- Undetailed fallback: explicit `isError=false` never heuristic-reds; free-word scans of user text removed.
+- `resultBodyText` peels only **strict** status headers (`Type: … | Status: …`); does not drop unknown-agent notes or agent-authored `Agent:/Type:` reports.
 
 ### Engineering / packaging
 
@@ -52,4 +59,5 @@ Stable “why” only — implementation detail lives in code/tests.
 
 ### Intentionally unchanged vs upstream
 
-- Tool contracts, background followUp notifications, FleetView navigation/steer/stop, custom agents, worktrees, schedules, settings, RPC.
+- Tool contracts (names/params), background followUp notifications, FleetView navigation/steer/stop, custom agents, worktrees, schedules, settings, RPC.
+- Note: queued `get_subagent_result` copy and failure `isError` flag are model-visible deltas kept for honesty; runtime spawn/steer/resume behavior is otherwise upstream-aligned.

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -22,3 +22,5 @@ The production source and upstream tests were copied from that tag before local 
 - `agent-runner` skips a null parent `modelRuntime` when constructing `createAgentSession` options so typecheck passes against stricter Pi `ModelRuntime` typings.
 - `bashExecution` steps honor `exitCode` / `cancelled` so failed or aborted shell runs render as `✗`, not `✓`.
 - `Agent` / `get_subagent_result` / `steer_subagent` tool TUI: collapsed one-line preview (honors expand toggle); expanded body renders as Markdown under a status header. `get_subagent_result` attaches `AgentDetails` so the renderer does not dump the model-facing transcript by default.
+- Validation/not-found tool failures return `error` details (or undetailed fallback never assumes `completed`/✓). `resultBodyText` only peels recognized status headers so multi-paragraph errors keep their first line.
+- ConversationViewer Result prefers `record.error` on error/aborted/stopped over intermediate assistant chatter.

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -20,3 +20,4 @@ The production source and upstream tests were copied from that tag before local 
 - Optional `o` toggles expanded tool argument/result detail for all steps.
 - Pure `messages → brief view model` helpers live in `src/ui/conversation-brief.ts` with unit tests.
 - `agent-runner` skips a null parent `modelRuntime` when constructing `createAgentSession` options so typecheck passes against stricter Pi `ModelRuntime` typings.
+- `bashExecution` steps honor `exitCode` / `cancelled` so failed or aborted shell runs render as `✗`, not `✓`.

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -21,3 +21,4 @@ The production source and upstream tests were copied from that tag before local 
 - Pure `messages → brief view model` helpers live in `src/ui/conversation-brief.ts` with unit tests.
 - `agent-runner` skips a null parent `modelRuntime` when constructing `createAgentSession` options so typecheck passes against stricter Pi `ModelRuntime` typings.
 - `bashExecution` steps honor `exitCode` / `cancelled` so failed or aborted shell runs render as `✗`, not `✓`.
+- `Agent` / `get_subagent_result` / `steer_subagent` tool TUI: collapsed one-line preview (honors expand toggle); expanded body renders as Markdown under a status header. `get_subagent_result` attaches `AgentDetails` so the renderer does not dump the model-facing transcript by default.

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -24,3 +24,4 @@ The production source and upstream tests were copied from that tag before local 
 - `Agent` / `get_subagent_result` / `steer_subagent` tool TUI: collapsed one-line preview (honors expand toggle); expanded body renders as Markdown under a status header. `get_subagent_result` attaches `AgentDetails` so the renderer does not dump the model-facing transcript by default.
 - Validation/not-found tool failures return `error` details (or undetailed fallback never assumes `completed`/✓). `resultBodyText` only peels recognized status headers so multi-paragraph errors keep their first line.
 - ConversationViewer Result prefers `record.error` on error/aborted/stopped over intermediate assistant chatter.
+- Tool call/result TUI always surfaces **effective model** (including parent inherit) and **effort** (from `thinking`) on Agent / get_subagent_result nodes.

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -1,0 +1,22 @@
+# Upstream source
+
+This package was forked from `@tintinweb/pi-subagents` 0.14.3.
+
+- Repository: https://github.com/tintinweb/pi-subagents
+- Tag: `v0.14.3`
+- Commit: `c10b1836256e760da75296ccd4e57a77ada1325e`
+- npm package: `@tintinweb/pi-subagents@0.14.3`
+- License: MIT
+
+The production source and upstream tests were copied from that tag before local modifications. The local install under `~/.pi/agent/npm/node_modules/@tintinweb/pi-subagents` was used as the primary version pin; the GitHub tag matched that tree.
+
+## Local differences
+
+- ConversationViewer default overlay shows a **brief progress view** instead of a full conversation dump:
+  - **Prompt** — first meaningful user message (long prompts truncated with a note)
+  - **Steps** — one-line tool-call summaries with status icons; tool results folded by default
+  - **Result** — last non-empty assistant text, or a running indicator while still in flight
+- Intermediate assistant chatter is omitted from the default view to reduce noise.
+- Optional `o` toggles expanded tool argument/result detail for all steps.
+- Pure `messages → brief view model` helpers live in `src/ui/conversation-brief.ts` with unit tests.
+- `agent-runner` skips a null parent `modelRuntime` when constructing `createAgentSession` options so typecheck passes against stricter Pi `ModelRuntime` typings.

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -32,9 +32,12 @@ Stable “why” only — implementation detail lives in code/tests.
 
 ### Main-transcript tool TUI
 
-- Custom `renderCall` / `renderResult` for **`Agent`**, **`get_subagent_result`**, **`steer_subagent`**.
-- Collapsed = one-line preview (expand toggle honored); expanded = status header + **Markdown** body (`src/ui/tool-render.ts`).
-- Always surface **effective model** (including parent inherit) and **effort** (from `thinking`) on call/result rows.
+- Custom `renderCall` / `renderResult` for **`Agent`**, **`get_subagent_result`**, **`steer_subagent`** using **Claude Code chrome** (upstream README shape):
+  - Call: `▸ Type  description` (+ chips only when args explicitly set model/thinking/bg)
+  - Running: `⠹ stats` / `⎿ activity`
+  - Done: `✓ stats · duration` / `⎿ Done` (Wrapped up / Stopped / Error variants)
+  - Expanded (Ctrl+O): same chrome + **Markdown** body — never dump full payload by default (`src/ui/tool-render.ts`)
+- Result stats always surface **effective model** (including parent inherit) and **effort** (from `thinking`).
 - Validation / not-found failures carry **error** details; undetailed fallback never assumes `completed` / green ✓.
 - `resultBodyText` peels only **recognized status headers** so multi-paragraph errors keep the first line.
 

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -38,6 +38,7 @@ Stable “why” only — implementation detail lives in code/tests.
   - Done: `✓ stats · duration` / `⎿ Done` (Wrapped up / Stopped / Error variants)
   - Expanded (Ctrl+O): same chrome + **Markdown** body — never dump full payload by default (`src/ui/tool-render.ts`)
 - Result stats always surface **effective model** (including parent inherit) and **effort** (from `thinking`).
+- Widget last line shows the **current tool step** (e.g. `reading src/a.ts`) from `tool_execution_start` args, not only bare `thinking…` when tools are in flight.
 - Validation / not-found failures carry **error** details; undetailed fallback never assumes `completed` / green ✓.
 - `resultBodyText` peels only **recognized status headers** so multi-paragraph errors keep the first line.
 

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -1,27 +1,50 @@
 # Upstream source
 
-This package was forked from `@tintinweb/pi-subagents` 0.14.3.
+This package was forked from `@tintinweb/pi-subagents` **0.14.3**.
 
-- Repository: https://github.com/tintinweb/pi-subagents
-- Tag: `v0.14.3`
-- Commit: `c10b1836256e760da75296ccd4e57a77ada1325e`
-- npm package: `@tintinweb/pi-subagents@0.14.3`
-- License: MIT
+| | |
+| --- | --- |
+| Repository | https://github.com/tintinweb/pi-subagents |
+| Tag | `v0.14.3` |
+| Commit | `c10b1836256e760da75296ccd4e57a77ada1325e` |
+| npm | `@tintinweb/pi-subagents@0.14.3` |
+| License | MIT |
 
-The production source and upstream tests were copied from that tag before local modifications. The local install under `~/.pi/agent/npm/node_modules/@tintinweb/pi-subagents` was used as the primary version pin; the GitHub tag matched that tree.
+Production source and upstream tests were copied from that tag before local modifications. The install under `~/.pi/agent/npm/node_modules/@tintinweb/pi-subagents` matched the GitHub tag and was used as the version pin.
 
-## Local differences
+**Human-oriented diff summary** (tables, try steps): package [`README.md`](./README.md) / [`README.zh-CN.md`](./README.zh-CN.md) — section **Differences from upstream**.  
+**Full upstream product docs**: [`UPSTREAM_README.md`](./UPSTREAM_README.md).
 
-- ConversationViewer default overlay shows a **brief progress view** instead of a full conversation dump:
-  - **Prompt** — first meaningful user message (long prompts truncated with a note)
-  - **Steps** — one-line tool-call summaries with status icons; tool results folded by default
-  - **Result** — last non-empty assistant text, or a running indicator while still in flight
-- Intermediate assistant chatter is omitted from the default view to reduce noise.
-- Optional `o` toggles expanded tool argument/result detail for all steps.
-- Pure `messages → brief view model` helpers live in `src/ui/conversation-brief.ts` with unit tests.
-- `agent-runner` skips a null parent `modelRuntime` when constructing `createAgentSession` options so typecheck passes against stricter Pi `ModelRuntime` typings.
-- `bashExecution` steps honor `exitCode` / `cancelled` so failed or aborted shell runs render as `✗`, not `✓`.
-- `Agent` / `get_subagent_result` / `steer_subagent` tool TUI: collapsed one-line preview (honors expand toggle); expanded body renders as Markdown under a status header. `get_subagent_result` attaches `AgentDetails` so the renderer does not dump the model-facing transcript by default.
-- Validation/not-found tool failures return `error` details (or undetailed fallback never assumes `completed`/✓). `resultBodyText` only peels recognized status headers so multi-paragraph errors keep their first line.
-- ConversationViewer Result prefers `record.error` on error/aborted/stopped over intermediate assistant chatter.
-- Tool call/result TUI always surfaces **effective model** (including parent inherit) and **effort** (from `thinking`) on Agent / get_subagent_result nodes.
+---
+
+## Local differences (maintenance checklist)
+
+Stable “why” only — implementation detail lives in code/tests.
+
+### ConversationViewer (scheme A)
+
+- Default overlay is **Prompt · Steps · Result**, not a full message dump.
+- Steps are one line per tool call; tool results folded by default; **`o`** expands args/results.
+- Intermediate assistant chatter omitted from the default path.
+- On `error` / `aborted` / `stopped`, Result prefers **`record.error`** (or status label); last assistant text is a demoted footnote.
+- `bashExecution` honors **`exitCode` / `cancelled`** → error step (`✗`).
+- Pure `messages → brief` helpers: `src/ui/conversation-brief.ts`.
+
+### Main-transcript tool TUI
+
+- Custom `renderCall` / `renderResult` for **`Agent`**, **`get_subagent_result`**, **`steer_subagent`**.
+- Collapsed = one-line preview (expand toggle honored); expanded = status header + **Markdown** body (`src/ui/tool-render.ts`).
+- Always surface **effective model** (including parent inherit) and **effort** (from `thinking`) on call/result rows.
+- Validation / not-found failures carry **error** details; undetailed fallback never assumes `completed` / green ✓.
+- `resultBodyText` peels only **recognized status headers** so multi-paragraph errors keep the first line.
+
+### Engineering / packaging
+
+- Package name `@zhcsyncer/pi-subagents`; monorepo path `packages/pi-subagents/`.
+- Pre-release version **`0.0.0`** until Changesets cuts the first public version.
+- Not registered on the root `@zhcsyncer/pi-extensions` `pi.extensions` list yet — local trial via `pi -e ./packages/pi-subagents/src/index.ts`.
+- `agent-runner`: skip null parent `modelRuntime` for stricter Pi `ModelRuntime` typings.
+
+### Intentionally unchanged vs upstream
+
+- Tool contracts, background followUp notifications, FleetView navigation/steer/stop, custom agents, worktrees, schedules, settings, RPC.

--- a/packages/pi-subagents/biome.json
+++ b/packages/pi-subagents/biome.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"style": {
+				"recommended": false
+			},
+			"suspicious": {
+				"noExplicitAny": "off",
+				"noControlCharactersInRegex": "off",
+				"noEmptyInterface": "off"
+			}
+		}
+	},
+	"formatter": {
+		"enabled": false
+	},
+	"files": {
+		"includes": [
+			"src/**/*.ts",
+			"test/**/*.ts"
+		]
+	}
+}

--- a/packages/pi-subagents/examples/agent-tool-description.md
+++ b/packages/pi-subagents/examples/agent-tool-description.md
@@ -1,0 +1,42 @@
+Launch a new agent to handle complex, multi-step tasks autonomously. Each agent type has specific capabilities and tools available to it.
+
+Available agent types and the tools they have access to:
+{{typeList}}
+
+Custom agents can be defined in .pi/agents/<name>.md (project) or {{agentDir}}/agents/<name>.md (global) — they are picked up automatically. Project-level agents override global ones. Creating a .md file with the same name as a default agent overrides it.
+
+When using the Agent tool, specify a subagent_type parameter to select which agent type to use.
+
+## When not to use
+
+If the target is already known, use a direct tool — `read` for a known path, `grep`/`find` for a specific symbol or string. Reserve this tool for open-ended questions that span the codebase, or tasks that match an available agent type.
+
+## Usage notes
+
+- Always include a short (3-5 word) description summarizing what the agent will do (shown in UI).
+- When you launch multiple agents for independent work, send them in a single message with multiple tool uses, with run_in_background: true on each, so they run concurrently. If the user specifies that they want agents run "in parallel", you MUST send a single message with multiple tool calls. Foreground calls run sequentially — only one executes at a time.
+- When the agent is done, it returns a single message back to you. The result is not visible to the user — to show the user, send a text message with a concise summary.
+- Trust but verify: an agent's summary describes what it intended to do, not necessarily what it did. When an agent writes or edits code, check the actual changes before reporting work as done.
+- Use run_in_background for work you don't need immediately. You will be notified when it completes — do NOT poll or sleep waiting for it. Continue with other work or respond to the user instead.
+- Foreground vs background: use foreground (default) when you need the agent's results before you can proceed. Use background when you have genuinely independent work to do in parallel.
+- Use resume with an agent ID to continue a previous agent's work. A new (non-resume) Agent call starts a fresh agent with no memory of prior runs, so the prompt must be self-contained.
+- Use steer_subagent to send mid-run messages to a running background agent.
+- Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, etc.), since it is not aware of the user's intent.
+- If an agent's description says it should be used proactively, try to use it without the user having to ask for it first.
+- Use model to specify a different model (as "provider/modelId", or fuzzy e.g. "haiku", "sonnet").
+- Use thinking to control extended thinking level.
+- Use inherit_context if the agent needs the parent conversation history.
+- Use isolation: "worktree" to run the agent in an isolated git worktree (safe parallel file modifications). The worktree is automatically cleaned up if the agent makes no changes; otherwise the path and branch are returned in the result.{{scheduleGuideline}}
+
+## Writing the prompt
+
+Provide clear, detailed prompts so the agent can work autonomously. Brief it like a smart colleague who just walked into the room — it hasn't seen this conversation, doesn't know what you've tried, doesn't understand why this task matters.
+- Explain what you're trying to accomplish and why.
+- Describe what you've already learned or ruled out.
+- Give enough context about the surrounding problem that the agent can make judgment calls rather than just following a narrow instruction.
+- If you need a short response, say so ("report in under 200 words").
+- Lookups: hand over the exact command. Investigations: hand over the question — prescribed steps become dead weight when the premise is wrong.
+
+Terse command-style prompts produce shallow, generic work.
+
+**Never delegate understanding.** Don't write "based on your findings, fix the bug" or "based on the research, implement it." Those phrases push synthesis onto the agent instead of doing it yourself. Write prompts that prove you understood: include file paths, line numbers, what specifically to change.

--- a/packages/pi-subagents/package.json
+++ b/packages/pi-subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhcsyncer/pi-subagents",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Claude Code-style autonomous sub-agents for the Pi coding agent, with a step-summary conversation viewer.",
   "author": "tintinweb",
   "contributors": [

--- a/packages/pi-subagents/package.json
+++ b/packages/pi-subagents/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@zhcsyncer/pi-subagents",
+  "version": "0.1.0",
+  "description": "Claude Code-style autonomous sub-agents for the Pi coding agent, with a step-summary conversation viewer.",
+  "author": "tintinweb",
+  "contributors": [
+    "zhcsyncer (fork maintainer)"
+  ],
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zhcsyncer/pi-extensions.git",
+    "directory": "packages/pi-subagents"
+  },
+  "homepage": "https://github.com/zhcsyncer/pi-extensions/tree/main/packages/pi-subagents#readme",
+  "bugs": {
+    "url": "https://github.com/zhcsyncer/pi-extensions/issues"
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-extension",
+    "subagent",
+    "agent",
+    "autonomous"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "src/**/*.ts",
+    "examples/**/*",
+    "README.md",
+    "README.zh-CN.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    "UPSTREAM_LICENSE",
+    "UPSTREAM_README.md",
+    "UPSTREAM_CHANGELOG.md",
+    "UPSTREAM_SOURCE.md",
+    "!src/**/*.test.ts",
+    "!test/**"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "check": "pnpm typecheck && pnpm test"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": ">=0.80.0",
+    "@earendil-works/pi-coding-agent": ">=0.80.0",
+    "@earendil-works/pi-tui": ">=0.80.0"
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.49",
+    "croner": "^10.0.1",
+    "nanoid": "^5.0.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-ai": "0.81.1",
+    "@earendil-works/pi-coding-agent": "0.81.1",
+    "@earendil-works/pi-tui": "0.81.1",
+    "@types/node": "25.6.0",
+    "typescript": "6.0.3",
+    "vitest": "4.1.7"
+  }
+}

--- a/packages/pi-subagents/src/agent-manager.ts
+++ b/packages/pi-subagents/src/agent-manager.ts
@@ -1,0 +1,631 @@
+/**
+ * agent-manager.ts — Tracks agents, background execution, resume support.
+ *
+ * Background agents are subject to a configurable concurrency limit (default: 4).
+ * Excess agents are queued and auto-started as running agents complete.
+ * Foreground agents bypass the queue (they block the parent anyway).
+ */
+
+import { randomUUID } from "node:crypto";
+import { statSync } from "node:fs";
+import { isAbsolute } from "node:path";
+import type { Model } from "@earendil-works/pi-ai";
+import type { AgentSession, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { resumeAgent, runAgent, type ToolActivity } from "./agent-runner.js";
+import type { AgentInvocation, AgentRecord, IsolationMode, SubagentType, ThinkingLevel } from "./types.js";
+import { addUsage } from "./usage.js";
+import { cleanupWorktree, createWorktree, pruneWorktrees, } from "./worktree.js";
+
+export type OnAgentComplete = (record: AgentRecord) => void;
+export type OnAgentStart = (record: AgentRecord) => void;
+export type OnAgentCompact = (record: AgentRecord, info: CompactionInfo) => void;
+export type CompactionInfo = { reason: "manual" | "threshold" | "overflow"; tokensBefore: number };
+
+/** Default max concurrent background agents. */
+const DEFAULT_MAX_CONCURRENT = 4;
+
+/**
+ * Validate a caller-supplied SpawnOptions.cwd. `undefined`/`null` mean "unset"
+ * (parent cwd). Anything else must be an absolute path to an existing
+ * directory — curated errors instead of TypeErrors from path/fs internals
+ * (RPC callers send arbitrary JSON: null, numbers, file paths).
+ */
+function assertValidSpawnCwd(cwd: unknown): asserts cwd is string | undefined | null {
+  if (cwd == null) return;
+  if (typeof cwd !== "string" || !isAbsolute(cwd)) {
+    throw new Error(`SpawnOptions.cwd must be an absolute path: "${String(cwd)}"`);
+  }
+  let isDirectory = false;
+  try {
+    isDirectory = statSync(cwd).isDirectory();
+  } catch {
+    throw new Error(`SpawnOptions.cwd does not exist: "${cwd}"`);
+  }
+  if (!isDirectory) {
+    throw new Error(`SpawnOptions.cwd is not a directory: "${cwd}"`);
+  }
+}
+
+interface SpawnArgs {
+  pi: ExtensionAPI;
+  ctx: ExtensionContext;
+  type: SubagentType;
+  prompt: string;
+  options: SpawnOptions;
+}
+
+interface SpawnOptions {
+  description: string;
+  model?: Model<any>;
+  maxTurns?: number;
+  isolated?: boolean;
+  inheritContext?: boolean;
+  thinkingLevel?: ThinkingLevel;
+  isBackground?: boolean;
+  /**
+   * Skip the maxConcurrent queue check for this spawn — start immediately even
+   * if the configured concurrency limit would otherwise queue it. Used by the
+   * scheduler so a fired job can't be deferred past its trigger window.
+   */
+  bypassQueue?: boolean;
+  /** Isolation mode — "worktree" creates a temp git worktree for the agent. */
+  isolation?: IsolationMode;
+  /**
+   * Working directory for the agent (absolute path). Default: parent session
+   * cwd. The agent's tools operate here, but .pi config (extensions, skills,
+   * settings, memory) still loads from the parent session's project — the
+   * target directory's `.pi` extensions never execute. With isolation:
+   * "worktree", the worktree is created FROM this directory and the result
+   * branch lands in that repo.
+   */
+  cwd?: string;
+  /** Resolved invocation snapshot captured for UI display. */
+  invocation?: AgentInvocation;
+  /** Parent abort signal — when aborted, the subagent is also stopped. */
+  signal?: AbortSignal;
+  /** Called on tool start/end with activity info (for streaming progress to UI). */
+  onToolActivity?: (activity: ToolActivity) => void;
+  /** Called on streaming text deltas from the assistant response. */
+  onTextDelta?: (delta: string, fullText: string) => void;
+  /** Called when the agent session is created (for accessing session stats). */
+  onSessionCreated?: (session: AgentSession) => void;
+  /** Called at the end of each agentic turn with the cumulative count. */
+  onTurnEnd?: (turnCount: number) => void;
+  /** Called once per assistant message_end with that message's usage delta. */
+  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+  /** Called when the session successfully compacts. */
+  onCompaction?: (info: CompactionInfo) => void;
+}
+
+export class AgentManager {
+  private agents = new Map<string, AgentRecord>();
+  private cleanupInterval: ReturnType<typeof setInterval>;
+  private onComplete?: OnAgentComplete;
+  private onStart?: OnAgentStart;
+  private onCompact?: OnAgentCompact;
+  private maxConcurrent: number;
+  /** Base repos worktrees were created from — so dispose() can prune them all,
+   *  not just the parent repo (caller-supplied cwd can target other repos). */
+  private worktreeRepos = new Set<string>();
+
+  /** Queue of background agents waiting to start. */
+  private queue: { id: string; args: SpawnArgs }[] = [];
+  /** Number of currently running background agents. */
+  private runningBackground = 0;
+
+  constructor(
+    onComplete?: OnAgentComplete,
+    maxConcurrent = DEFAULT_MAX_CONCURRENT,
+    onStart?: OnAgentStart,
+    onCompact?: OnAgentCompact,
+  ) {
+    this.onComplete = onComplete;
+    this.onStart = onStart;
+    this.onCompact = onCompact;
+    this.maxConcurrent = maxConcurrent;
+    // Cleanup completed agents after 10 minutes (but keep sessions for resume)
+    this.cleanupInterval = setInterval(() => this.cleanup(), 60_000);
+    this.cleanupInterval.unref();
+  }
+
+  /** Update the max concurrent background agents limit. */
+  setMaxConcurrent(n: number) {
+    this.maxConcurrent = Math.max(1, n);
+    // Start queued agents if the new limit allows
+    this.drainQueue();
+  }
+
+  getMaxConcurrent(): number {
+    return this.maxConcurrent;
+  }
+
+  /**
+   * Spawn an agent and return its ID immediately (for background use).
+   * If the concurrency limit is reached, the agent is queued.
+   */
+  spawn(
+    pi: ExtensionAPI,
+    ctx: ExtensionContext,
+    type: SubagentType,
+    prompt: string,
+    options: SpawnOptions,
+  ): string {
+    // Validate before the queue branch — a queued spawn should fail at the
+    // call, not minutes later at drain. Throw (not warn): programmatic callers
+    // can fix and retry; the RPC layer converts throws into error envelopes.
+    assertValidSpawnCwd(options.cwd);
+
+    const id = randomUUID().slice(0, 17);
+    const abortController = new AbortController();
+    const record: AgentRecord = {
+      id,
+      type,
+      description: options.description,
+      status: options.isBackground ? "queued" : "running",
+      toolUses: 0,
+      startedAt: Date.now(),
+      abortController,
+      lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+      compactionCount: 0,
+      // Raw tri-state (not coerced to a boolean): true = background, false =
+      // foreground (has an inline tool-result surface), undefined = caller never
+      // declared it (e.g. a cross-extension RPC spawn). The widget's background-
+      // only filter excludes only explicit `false`, so undefined agents — which
+      // have no inline surface — stay visible instead of vanishing.
+      isBackground: options.isBackground,
+      invocation: options.invocation,
+    };
+    this.agents.set(id, record);
+
+    const args: SpawnArgs = { pi, ctx, type, prompt, options };
+
+    if (options.isBackground && !options.bypassQueue && this.runningBackground >= this.maxConcurrent) {
+      // Queue it — will be started when a running agent completes
+      this.queue.push({ id, args });
+      return id;
+    }
+
+    // startAgent can throw (e.g. strict worktree-isolation failure) — clean
+    // up the record so callers don't see an orphan in `listAgents()`.
+    try {
+      this.startAgent(id, record, args);
+    } catch (err) {
+      this.agents.delete(id);
+      throw err;
+    }
+    return id;
+  }
+
+  /** Actually start an agent (called immediately or from queue drain). */
+  private startAgent(id: string, record: AgentRecord, { pi, ctx, type, prompt, options }: SpawnArgs) {
+    // Re-validate a caller-supplied cwd: queued spawns can start minutes after
+    // spawn()'s check, and the directory may be gone by then (TOCTOU). Same
+    // curated errors; drainQueue parks a throw on the record as an error.
+    assertValidSpawnCwd(options.cwd);
+    // Single resolution point for the caller-supplied cwd — the worktree base
+    // repo and both cleanup calls below MUST agree on this value forever.
+    const customCwd = options.cwd ?? undefined; // null (RPC "unset") → undefined
+    const baseCwd = customCwd ?? ctx.cwd;
+
+    // Worktree isolation: try to create a temporary git worktree. Strict —
+    // fail loud if not possible (no silent fallback to main tree). Done
+    // BEFORE state mutation so a throw doesn't leave the record half-running.
+    let worktreeCwd: string | undefined;
+    if (options.isolation === "worktree") {
+      const wt = createWorktree(baseCwd, id);
+      if (!wt) {
+        throw new Error(
+          'Cannot run with isolation: "worktree" — not a git repo, no commits yet, or `git worktree add` failed. ' +
+          'Initialize git and commit at least once, or omit `isolation`.',
+        );
+      }
+      record.worktree = wt;
+      // workPath preserves subdirectory scoping for caller-supplied cwds: a
+      // cwd deep in a monorepo maps to the same subdir inside the copy, not
+      // the copied repo's root. Plain worktree spawns keep the historical
+      // behavior (agent at the copy's root) — moving them to workPath would
+      // also move .pi config discovery when the parent session sits in a repo
+      // subdirectory, silently dropping extensions/skills.
+      worktreeCwd = customCwd !== undefined ? wt.workPath : wt.path;
+      this.worktreeRepos.add(baseCwd);
+    }
+
+    record.status = "running";
+    record.startedAt = Date.now();
+    if (options.isBackground) this.runningBackground++;
+    this.onStart?.(record);
+
+    // Wire parent abort signal to stop the subagent when the parent is interrupted
+    let detachParentSignal: (() => void) | undefined;
+    if (options.signal) {
+      const onParentAbort = () => this.abort(id);
+      options.signal.addEventListener("abort", onParentAbort, { once: true });
+      detachParentSignal = () => options.signal!.removeEventListener("abort", onParentAbort);
+    }
+    const detach = () => { detachParentSignal?.(); detachParentSignal = undefined; };
+
+    const promise = runAgent(ctx, type, prompt, {
+      pi,
+      agentId: id,
+      model: options.model,
+      maxTurns: options.maxTurns,
+      isolated: options.isolated,
+      inheritContext: options.inheritContext,
+      thinkingLevel: options.thinkingLevel,
+      // Worktree wins for the working dir (the agent must run in the copy —
+      // which, with a custom cwd, was created from that target). Config stays
+      // with the parent project when a caller-supplied cwd is in play; it must
+      // stay undefined otherwise so plain worktree runs keep resolving config
+      // (incl. relative extension paths and memory) inside the worktree copy.
+      cwd: worktreeCwd ?? customCwd,
+      configCwd: customCwd !== undefined ? ctx.cwd : undefined,
+      signal: record.abortController!.signal,
+      onToolActivity: (activity) => {
+        if (activity.type === "end") record.toolUses++;
+        options.onToolActivity?.(activity);
+      },
+      onTurnEnd: options.onTurnEnd,
+      onTextDelta: options.onTextDelta,
+      onAssistantUsage: (usage) => {
+        addUsage(record.lifetimeUsage, usage);
+        options.onAssistantUsage?.(usage);
+      },
+      onCompaction: (info) => {
+        record.compactionCount++;
+        this.onCompact?.(record, info);
+        options.onCompaction?.(info);
+      },
+      onSessionCreated: (session) => {
+        record.session = session;
+        // Flush any steers that arrived before the session was ready
+        if (record.pendingSteers?.length) {
+          for (const msg of record.pendingSteers) {
+            session.steer(msg).catch(() => {});
+          }
+          record.pendingSteers = undefined;
+        }
+        options.onSessionCreated?.(session);
+      },
+    })
+      .then(({ responseText, session, aborted, steered, failure }) => {
+        // Don't overwrite status if externally stopped via abort()
+        if (record.status !== "stopped") {
+          // Precedence: a hard abort keeps "aborted"; then a failed final turn
+          // (provider error that pi resolved instead of rejecting, #144) is an
+          // honest "error" — not a completion with an empty or stale result.
+          if (aborted) {
+            record.status = "aborted";
+          } else if (failure) {
+            record.status = "error";
+            record.error = failure;
+          } else {
+            record.status = steered ? "steered" : "completed";
+          }
+        }
+        record.result = responseText;
+        record.session = session;
+        record.completedAt ??= Date.now();
+
+        detach();
+
+        // Final flush of streaming output file
+        if (record.outputCleanup) {
+          try { record.outputCleanup(); } catch { /* ignore */ }
+          record.outputCleanup = undefined;
+        }
+
+        // Clean up worktree if used
+        if (record.worktree) {
+          const wtResult = cleanupWorktree(baseCwd, record.worktree, options.description);
+          record.worktreeResult = wtResult;
+          if (wtResult.hasChanges && wtResult.branch) {
+            // With a caller-supplied cwd the branch lives in THAT repo, not the
+            // parent session's — say so, or the orchestrator merges in the wrong repo.
+            const repoNote = customCwd !== undefined ? ` in \`${baseCwd}\`` : "";
+            record.result = (record.result ?? "") +
+              `\n\n---\nChanges saved to branch \`${wtResult.branch}\`${repoNote}. Merge with: \`git merge ${wtResult.branch}\`${customCwd !== undefined ? ` (run in \`${baseCwd}\`)` : ""}`;
+          }
+        }
+
+        // Fire onComplete for foreground agents too — lifecycle symmetry.
+        // Mark resultConsumed so the callback skips notifications (result returned inline).
+        if (!options.isBackground) {
+          record.resultConsumed = true;
+          try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
+        } else {
+          this.runningBackground--;
+          try { this.onComplete?.(record); } catch { /* ignore completion side-effect errors */ }
+          this.drainQueue();
+        }
+        return responseText;
+      })
+      .catch((err) => {
+        // Don't overwrite status if externally stopped via abort()
+        if (record.status !== "stopped") {
+          record.status = "error";
+        }
+        record.error = err instanceof Error ? err.message : String(err);
+        record.completedAt ??= Date.now();
+
+        detach();
+
+        // Final flush of streaming output file on error
+        if (record.outputCleanup) {
+          try { record.outputCleanup(); } catch { /* ignore */ }
+          record.outputCleanup = undefined;
+        }
+
+        // Best-effort worktree cleanup on error
+        if (record.worktree) {
+          try {
+            const wtResult = cleanupWorktree(baseCwd, record.worktree, options.description);
+            record.worktreeResult = wtResult;
+          } catch { /* ignore cleanup errors */ }
+        }
+
+        // Fire onComplete for foreground agents too — lifecycle symmetry.
+        // Mark resultConsumed so the callback skips notifications (result returned inline).
+        if (!options.isBackground) {
+          record.resultConsumed = true;
+          this.onComplete?.(record);
+        } else {
+          this.runningBackground--;
+          this.onComplete?.(record);
+          this.drainQueue();
+        }
+        return "";
+      });
+
+    record.promise = promise;
+
+    // Notify caller that spawn is complete (record is in the map, promise is set).
+    // Called synchronously — onSessionCreated fires asynchronously inside runAgent.
+    // Used by spawnAndWait to let the caller set up output files before streaming starts.
+    this.onSpawned?.(id);
+  }
+
+  /** Start queued agents up to the concurrency limit. */
+  private drainQueue() {
+    while (this.queue.length > 0 && this.runningBackground < this.maxConcurrent) {
+      const next = this.queue.shift()!;
+      const record = this.agents.get(next.id);
+      if (!record || record.status !== "queued") continue;
+      try {
+        this.startAgent(next.id, record, next.args);
+      } catch (err) {
+        // Late failure (e.g. strict worktree-isolation) — surface on the record
+        // so the user/agent can see it via /agents, then keep draining.
+        record.status = "error";
+        record.error = err instanceof Error ? err.message : String(err);
+        record.completedAt = Date.now();
+        this.onComplete?.(record);
+      }
+    }
+  }
+
+  /**
+   * Called synchronously right after spawn, before onSessionCreated fires.
+   * Lets the caller set up the output file path on the record.
+   * The record is guaranteed to be in this.agents at this point.
+   */
+  private onSpawned?: (id: string) => void;
+
+  /**
+   * Spawn an agent and wait for completion (foreground use).
+   * Foreground agents bypass the concurrency queue.
+   * Returns { id, record } so callers can access the agent ID.
+   *
+   * @param onSpawned - Called synchronously after spawn(), before onSessionCreated fires.
+   *   Use this to set record.outputFile so streamToOutputFile can pick it up.
+   */
+  async spawnAndWait(
+    pi: ExtensionAPI,
+    ctx: ExtensionContext,
+    type: SubagentType,
+    prompt: string,
+    options: Omit<SpawnOptions, "isBackground">,
+    onSpawned?: (id: string) => void,
+  ): Promise<{ id: string; record: AgentRecord }> {
+    // Temporarily register the onSpawned hook so startAgent can call it.
+    const prevOnSpawned = this.onSpawned;
+    this.onSpawned = onSpawned;
+    try {
+      const id = this.spawn(pi, ctx, type, prompt, { ...options, isBackground: false });
+      const record = this.agents.get(id)!;
+      await record.promise;
+      return { id, record };
+    } finally {
+      this.onSpawned = prevOnSpawned;
+    }
+  }
+
+  /**
+   * Resume an existing agent session with a new prompt.
+   */
+  async resume(
+    id: string,
+    prompt: string,
+    signal?: AbortSignal,
+  ): Promise<AgentRecord | undefined> {
+    const record = this.agents.get(id);
+    if (!record?.session) return undefined;
+
+    record.status = "running";
+    record.startedAt = Date.now();
+    record.completedAt = undefined;
+    record.result = undefined;
+    record.error = undefined;
+
+    try {
+      const { text, failure } = await resumeAgent(record.session, prompt, {
+        onToolActivity: (activity) => {
+          if (activity.type === "end") record.toolUses++;
+        },
+        onAssistantUsage: (usage) => {
+          addUsage(record.lifetimeUsage, usage);
+        },
+        onCompaction: (info) => {
+          record.compactionCount++;
+          this.onCompact?.(record, info);
+        },
+        signal,
+      });
+      // Same contract as the spawn path (#144): a failed final turn is an
+      // error, not a completion — but the resumed text stays available.
+      record.status = failure ? "error" : "completed";
+      if (failure) record.error = failure;
+      record.result = text;
+      record.completedAt = Date.now();
+    } catch (err) {
+      record.status = "error";
+      record.error = err instanceof Error ? err.message : String(err);
+      record.completedAt = Date.now();
+    }
+
+    return record;
+  }
+
+  /**
+   * Send a steering message to an agent from the UI (mirrors the steer_subagent
+   * tool). A live session delivers it now — it interrupts the agent after its
+   * current tool execution and appears as a user message. If the session isn't
+   * ready yet, the message is queued on `pendingSteers` and flushed when the
+   * session is created. Returns false if the agent can't accept steering
+   * (unknown id, or no longer running/queued).
+   */
+  steer(id: string, message: string): boolean {
+    const record = this.agents.get(id);
+    if (!record) return false;
+    if (record.status !== "running" && record.status !== "queued") return false;
+    if (record.session) {
+      record.session.steer(message).catch(() => {});
+    } else {
+      if (!record.pendingSteers) record.pendingSteers = [];
+      record.pendingSteers.push(message);
+    }
+    return true;
+  }
+
+  getRecord(id: string): AgentRecord | undefined {
+    return this.agents.get(id);
+  }
+
+  listAgents(): AgentRecord[] {
+    return [...this.agents.values()].sort(
+      (a, b) => b.startedAt - a.startedAt,
+    );
+  }
+
+  abort(id: string): boolean {
+    const record = this.agents.get(id);
+    if (!record) return false;
+
+    // Remove from queue if queued
+    if (record.status === "queued") {
+      this.queue = this.queue.filter(q => q.id !== id);
+      record.status = "stopped";
+      record.completedAt = Date.now();
+      return true;
+    }
+
+    if (record.status !== "running") return false;
+    record.abortController?.abort();
+    record.status = "stopped";
+    record.completedAt = Date.now();
+    return true;
+  }
+
+  /** Dispose a record's session and remove it from the map. */
+  private removeRecord(id: string, record: AgentRecord): void {
+    record.session?.dispose?.();
+    record.session = undefined;
+    this.agents.delete(id);
+  }
+
+  private cleanup() {
+    const cutoff = Date.now() - 10 * 60_000;
+    for (const [id, record] of this.agents) {
+      if (record.status === "running" || record.status === "queued") continue;
+      if ((record.completedAt ?? 0) >= cutoff) continue;
+      this.removeRecord(id, record);
+    }
+  }
+
+  /**
+   * Remove all completed/stopped/errored records immediately.
+   * Called on session start/switch so tasks from a prior session don't persist.
+   * Pass skipUnconsumed=true to preserve records the LLM hasn't read yet
+   * (resultConsumed=false) — they will be evicted by the 10-minute cleanup timer instead.
+   */
+  clearCompleted(skipUnconsumed = false): void {
+    for (const [id, record] of this.agents) {
+      if (record.status === "running" || record.status === "queued") continue;
+      if (skipUnconsumed && !record.resultConsumed) continue;
+      this.removeRecord(id, record);
+    }
+  }
+
+  /** Whether any agents are still running or queued. */
+  hasRunning(): boolean {
+    return [...this.agents.values()].some(
+      r => r.status === "running" || r.status === "queued",
+    );
+  }
+
+  /** Abort all running and queued agents immediately. */
+  abortAll(): number {
+    let count = 0;
+    // Clear queued agents first
+    for (const queued of this.queue) {
+      const record = this.agents.get(queued.id);
+      if (record) {
+        record.status = "stopped";
+        record.completedAt = Date.now();
+        count++;
+      }
+    }
+    this.queue = [];
+    // Abort running agents
+    for (const record of this.agents.values()) {
+      if (record.status === "running") {
+        record.abortController?.abort();
+        record.status = "stopped";
+        record.completedAt = Date.now();
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** Wait for all running and queued agents to complete (including queued ones). */
+  async waitForAll(): Promise<void> {
+    // Loop because drainQueue respects the concurrency limit — as running
+    // agents finish they start queued ones, which need awaiting too.
+    while (true) {
+      this.drainQueue();
+      const pending = [...this.agents.values()]
+        .filter(r => r.status === "running" || r.status === "queued")
+        .map(r => r.promise)
+        .filter(Boolean);
+      if (pending.length === 0) break;
+      await Promise.allSettled(pending);
+    }
+  }
+
+  dispose() {
+    clearInterval(this.cleanupInterval);
+    // Clear queue
+    this.queue = [];
+    for (const record of this.agents.values()) {
+      record.session?.dispose();
+    }
+    this.agents.clear();
+    // Prune any orphaned git worktrees (crash recovery)
+    try { pruneWorktrees(process.cwd()); } catch { /* ignore */ }
+    // Also prune repos that caller-supplied cwds created worktrees in — a clean
+    // exit with in-flight agents would otherwise leave stale registrations there.
+    for (const repo of this.worktreeRepos) {
+      try { pruneWorktrees(repo); } catch { /* ignore */ }
+    }
+  }
+}

--- a/packages/pi-subagents/src/agent-runner.ts
+++ b/packages/pi-subagents/src/agent-runner.ts
@@ -345,6 +345,10 @@ function resolveDefaultModel(
 export interface ToolActivity {
   type: "start" | "end";
   toolName: string;
+  /** Stable id for pairing start/end (preferred over toolName). */
+  toolCallId?: string;
+  /** Tool-call arguments at start — used for widget step summaries. */
+  args?: unknown;
 }
 
 export interface RunOptions {
@@ -875,10 +879,19 @@ export async function runAgent(
       options.onTextDelta?.(event.assistantMessageEvent.delta, currentMessageText);
     }
     if (event.type === "tool_execution_start") {
-      options.onToolActivity?.({ type: "start", toolName: event.toolName });
+      options.onToolActivity?.({
+        type: "start",
+        toolName: event.toolName,
+        toolCallId: event.toolCallId,
+        args: event.args,
+      });
     }
     if (event.type === "tool_execution_end") {
-      options.onToolActivity?.({ type: "end", toolName: event.toolName });
+      options.onToolActivity?.({
+        type: "end",
+        toolName: event.toolName,
+        toolCallId: event.toolCallId,
+      });
     }
     if (event.type === "message_end" && event.message.role === "assistant") {
       const u = (event.message as any).usage;
@@ -942,8 +955,21 @@ export async function resumeAgent(
 
   const unsubEvents = (options.onToolActivity || options.onAssistantUsage || options.onCompaction)
     ? session.subscribe((event: AgentSessionEvent) => {
-        if (event.type === "tool_execution_start") options.onToolActivity?.({ type: "start", toolName: event.toolName });
-        if (event.type === "tool_execution_end") options.onToolActivity?.({ type: "end", toolName: event.toolName });
+        if (event.type === "tool_execution_start") {
+          options.onToolActivity?.({
+            type: "start",
+            toolName: event.toolName,
+            toolCallId: event.toolCallId,
+            args: event.args,
+          });
+        }
+        if (event.type === "tool_execution_end") {
+          options.onToolActivity?.({
+            type: "end",
+            toolName: event.toolName,
+            toolCallId: event.toolCallId,
+          });
+        }
         if (event.type === "message_end" && event.message.role === "assistant") {
           const u = (event.message as any).usage;
           if (u) options.onAssistantUsage?.({

--- a/packages/pi-subagents/src/agent-runner.ts
+++ b/packages/pi-subagents/src/agent-runner.ts
@@ -1,0 +1,1015 @@
+/**
+ * agent-runner.ts — Core execution engine: creates sessions, runs agents, collects results.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import type { Model } from "@earendil-works/pi-ai";
+import type { ExtensionContext, LoadExtensionsResult } from "@earendil-works/pi-coding-agent";
+import {
+  type AgentSession,
+  type AgentSessionEvent,
+  createAgentSession,
+  DefaultResourceLoader,
+  type ExtensionAPI,
+  getAgentDir,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { BUILTIN_TOOL_NAMES, getAgentConfig, getConfig, getMemoryToolNames, getReadOnlyMemoryToolNames, getToolNamesForType } from "./agent-types.js";
+import { buildParentContext, extractText } from "./context.js";
+import { DEFAULT_AGENTS } from "./default-agents.js";
+import { detectEnv } from "./env.js";
+import { buildMemoryBlock, buildReadOnlyMemoryBlock } from "./memory.js";
+import { buildAgentPrompt, type PromptExtras } from "./prompts.js";
+import { preloadSkills } from "./skill-loader.js";
+import type { SubagentType, ThinkingLevel } from "./types.js";
+
+/**
+ * Tool names registered by THIS extension. Single source of truth so the
+ * registration sites (index.ts) and the subagent exclusion list below can't
+ * drift apart. These are our own tools, not pi built-ins, so they can't be
+ * derived from pi — but they only need defining once.
+ */
+export const SUBAGENT_TOOL_NAMES = {
+  AGENT: "Agent",
+  GET_RESULT: "get_subagent_result",
+  STEER: "steer_subagent",
+} as const;
+
+/** Names of tools registered by this extension that subagents must NOT inherit. */
+const EXCLUDED_TOOL_NAMES: string[] = Object.values(SUBAGENT_TOOL_NAMES);
+
+/**
+ * Canonical name of an extension for `extensions: [...]` allowlist matching.
+ * Lowercased — extension names match case-insensitively so `extensions: [Mcp]`
+ * resolves the same as `[mcp]`. Tool names within `ext:foo/bar` are not affected.
+ * Directory extensions (`foo/index.ts`) resolve to the parent directory name;
+ * single-file extensions to the basename minus `.ts`/`.js`.
+ */
+export function extensionCanonicalName(extPath: string): string {
+  const base = basename(extPath);
+  const name = base === "index.ts" || base === "index.js"
+    ? basename(dirname(extPath))
+    : base.replace(/\.(ts|js)$/, "");
+  return name.toLowerCase();
+}
+
+/**
+ * The unscoped, lowercased npm short name of the pi package that DECLARES
+ * `extPath` as an extension entry — or undefined if the entry doesn't belong to
+ * such a package.
+ *
+ * Climbs from the entry's directory looking for the package that owns it, and
+ * stays strictly within that package's tree by stopping at two structural
+ * boundaries — no hardcoded depth:
+ *   - the FIRST `package.json` found (the package root); the entry's own
+ *     manifest always sits at the root, above the entry, below any node_modules.
+ *   - a `node_modules` directory: a package never spans one (it's where OTHER
+ *     packages live), so reaching it means we've climbed out of the package —
+ *     stop before reading a consumer's or parent package's manifest.
+ * The name is then taken only when that root's `pi.extensions` manifest actually
+ * lists this entry. That "declares this entry" check is deliberate: our own test
+ * fixtures live under this repo, whose root manifest declares `./src/index.ts`
+ * as `@tintinweb/pi-subagents`, so a looser rule would misattribute every
+ * co-located file to `pi-subagents`.
+ */
+function extensionPackageName(extPath: string): string | undefined {
+  const entry = resolve(extPath);
+  let dir = dirname(extPath);
+  for (;;) {
+    // Climbing into node_modules means we've left the owning package's tree.
+    if (basename(dir) === "node_modules") return undefined;
+    let pkg: { name?: unknown; pi?: { extensions?: unknown } };
+    try {
+      pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf-8"));
+    } catch {
+      const parent = dirname(dir);
+      if (parent === dir) return undefined; // walked to the filesystem root
+      dir = parent;
+      continue;
+    }
+    // First package.json wins — it's the package root; decide here.
+    const entries = pkg.pi?.extensions;
+    if (
+      typeof pkg.name === "string" &&
+      Array.isArray(entries) &&
+      entries.some((e) => typeof e === "string" && resolve(dir, e) === entry)
+    ) {
+      const short = pkg.name.startsWith("@") ? pkg.name.slice(pkg.name.indexOf("/") + 1) : pkg.name;
+      return short.toLowerCase();
+    }
+    return undefined;
+  }
+}
+
+/**
+ * All names an extension answers to for allowlist matching (lowercased): its
+ * path-derived {@link extensionCanonicalName} plus, when a pi package manifest
+ * declares this entry, that package's unscoped short name (`@scope/foo` → `foo`).
+ * #143: an extension installed via `pi.extensions: ["./src/index.ts"]` would
+ * otherwise only ever match as `src` (the source directory), never by its
+ * package name. The path-derived name is preserved, so it keeps matching too.
+ */
+export function extensionCanonicalNames(extPath: string): string[] {
+  const canonical = extensionCanonicalName(extPath);
+  const pkg = extensionPackageName(extPath);
+  return pkg && pkg !== canonical ? [canonical, pkg] : [canonical];
+}
+
+/**
+ * Classify `extensions: string[]` frontmatter entries for the loader-level filter.
+ *
+ * An entry is a PATH iff it contains a path separator or starts with `~`; otherwise
+ * it is a NAME. `"*"` sets the wildcard flag (keep all default-discovered extensions).
+ *
+ * Path entries are resolved (`~` expanded, made absolute against `cwd`) into `paths`
+ * — and their canonical name is also added to `names`. The loader override matches
+ * everything by canonical name, so path-loaded extensions are matched via their name
+ * rather than their post-staging `Extension.path`.
+ */
+export function parseExtensionsSpec(
+  entries: string[],
+  cwd: string,
+): { names: Set<string>; paths: string[]; wildcard: boolean } {
+  const names = new Set<string>();
+  const paths: string[] = [];
+  let wildcard = false;
+  for (const entry of entries) {
+    if (!entry) continue;
+    if (entry === "*") {
+      wildcard = true;
+      continue;
+    }
+    const isPathEntry = entry.includes("/") || entry.includes("\\") || entry.startsWith("~");
+    if (!isPathEntry) {
+      names.add(entry.toLowerCase());
+      continue;
+    }
+    let p = entry;
+    if (p === "~" || p.startsWith("~/") || p.startsWith("~\\")) {
+      p = homedir() + p.slice(1);
+    }
+    const abs = isAbsolute(p) ? p : resolve(cwd, p);
+    paths.push(abs);
+    names.add(extensionCanonicalName(abs));
+  }
+  return { names, paths, wildcard };
+}
+
+/**
+ * Parse raw `ext:` selector strings (from the `tools:` CSV) into the set of
+ * extension names to keep loaded and a per-extension tool-narrowing map.
+ *
+ * `ext:foo` → `extNames` has `foo`, no narrowing entry (all of foo's tools).
+ * `ext:foo/bar` → `extNames` has `foo`, `narrowing.foo` has `bar` (only `bar`).
+ * A name lands in `narrowing` only when a `/tool` form is seen, so a bare
+ * `ext:foo` alongside `ext:foo/bar` leaves narrowing in effect (narrowing wins).
+ * The split is on the first `/`; extension canonical names never contain `/`.
+ */
+export function parseExtSelectors(entries: string[]): {
+  extNames: Set<string>;
+  narrowing: Map<string, Set<string>>;
+} {
+  const extNames = new Set<string>();
+  const narrowing = new Map<string, Set<string>>();
+  for (const raw of entries) {
+    if (!raw) continue;
+    const body = raw.slice("ext:".length);
+    const slash = body.indexOf("/");
+    // Extension name matches case-insensitively (matches the loader-side canonical
+    // name). Tool names are case-preserved — they're matched against pi-mono's
+    // registered identifiers, which are case-sensitive.
+    const name = (slash === -1 ? body : body.slice(0, slash)).trim().toLowerCase();
+    if (!name) continue;
+    extNames.add(name);
+    if (slash === -1) continue;
+    const tool = body.slice(slash + 1).trim();
+    if (!tool) continue;
+    let set = narrowing.get(name);
+    if (!set) {
+      set = new Set();
+      narrowing.set(name, set);
+    }
+    set.add(tool);
+  }
+  return { extNames, narrowing };
+}
+
+/**
+ * Keep a subagent's tool scope correct as extensions register tools over time.
+ *
+ * Extensions may call `registerTool` long after load — pi-mcp from `session_start`,
+ * context-mode from `before_agent_start` — so scope has to be re-derived rather than
+ * snapshotted. `registerTool` writes into the very `extension.tools` maps this reads,
+ * so `inScope()` sees late arrivals on the next call.
+ *
+ * Two enforcement points, because neither covers the whole picture:
+ *
+ *   - `turn_end` re-narrows the ACTIVE set. pi emits `turn_end` immediately before
+ *     `prepareNextTurn` re-snapshots `agent.state.tools`, and session listeners run
+ *     synchronously, so the narrow lands in time for turns 2..N.
+ *   - `beforeToolCall` blocks out-of-scope calls. Turn 1 cannot be narrowed at all:
+ *     `before_agent_start` fires INSIDE `prompt()` and may widen the tool set, but
+ *     `createContextSnapshot()` freezes that turn's tools immediately after — there
+ *     is no hook in between. A call-time check is the only correct guard there.
+ *
+ * Both are installed on the session and deliberately NOT unsubscribed: they must
+ * outlive the `runAgent` call so resumed/steered turns stay scoped. pi's `dispose()`
+ * clears `_eventListeners`, so they die with the session rather than leaking.
+ *
+ * Only meaningful when extensions are loaded — under `noExtensions`/`isolated` the
+ * static `allowedToolNames` allowlist already gates the registry itself.
+ */
+export function installExtensionToolScope(
+  session: AgentSession,
+  ctx: {
+    loader: DefaultResourceLoader;
+    toolNames: string[];
+    disallowedSet: Set<string> | undefined;
+    extNames: Set<string>;
+    narrowing: Map<string, Set<string>>;
+  },
+): void {
+  const { loader, toolNames, disallowedSet, extNames, narrowing } = ctx;
+
+  // The names allowed right now. Mirrors the `ext:` opt-in flip: when any `ext:`
+  // selector is present, extension tools become an explicit allowlist — a loaded
+  // extension not named by a selector contributes nothing (its handlers still ran),
+  // and `ext:foo/bar` narrows `foo` to just `bar`.
+  const inScope = (): Set<string> => {
+    const keep = new Set(toolNames.filter((t) => !disallowedSet?.has(t)));
+    const optInActive = extNames.size > 0;
+    for (const extension of loader.getExtensions().extensions) {
+      const canons = extensionCanonicalNames(extension.path);
+      if (optInActive && !canons.some((c) => extNames.has(c))) continue;
+      // First alias that carries a narrowing set — a user won't narrow one
+      // extension under two different names, so first-match is correct.
+      const narrowed = canons.map((c) => narrowing.get(c)).find(Boolean);
+      for (const name of extension.tools.keys()) {
+        if (narrowed && !narrowed.has(name)) continue;
+        if (disallowedSet?.has(name)) continue;
+        keep.add(name);
+      }
+    }
+    for (const name of EXCLUDED_TOOL_NAMES) keep.delete(name);
+    return keep;
+  };
+
+  const renarrow = () => {
+    const allowed = inScope();
+    const next = session.getAllTools().map((t) => t.name).filter((n) => allowed.has(n));
+    const current = session.getActiveToolNames();
+    // setActiveToolsByName unconditionally rebuilds the system prompt, so skip
+    // the no-op that steady-state turns would otherwise pay for every turn.
+    if (next.length !== current.length || next.some((n, i) => n !== current[i])) {
+      session.setActiveToolsByName(next);
+    }
+  };
+
+  // Activate what registered during session_start (eager MCP servers); pi would
+  // otherwise leave only its four default built-ins active at turn 1.
+  renarrow();
+
+  session.subscribe((event: AgentSessionEvent) => {
+    if (event.type === "turn_end") renarrow();
+  });
+
+  const priorBeforeToolCall = session.agent.beforeToolCall;
+  session.agent.beforeToolCall = async (context, signal) => {
+    if (!inScope().has(context.toolCall.name)) {
+      return {
+        block: true,
+        reason: `Tool "${context.toolCall.name}" is not available to this subagent.`,
+      };
+    }
+    return priorBeforeToolCall?.(context, signal);
+  };
+}
+
+/** Default max turns. undefined = unlimited (no turn limit). */
+let defaultMaxTurns: number | undefined;
+
+/** Normalize max turns. undefined or 0 = unlimited, otherwise minimum 1. */
+export function normalizeMaxTurns(n: number | undefined): number | undefined {
+  if (n == null || n === 0) return undefined;
+  return Math.max(1, n);
+}
+
+/** Get the default max turns value. undefined = unlimited. */
+export function getDefaultMaxTurns(): number | undefined { return defaultMaxTurns; }
+/** Set the default max turns value. undefined or 0 = unlimited, otherwise minimum 1. */
+export function setDefaultMaxTurns(n: number | undefined): void { defaultMaxTurns = normalizeMaxTurns(n); }
+
+/** Additional turns allowed after the soft limit steer message. */
+let graceTurns = 5;
+
+/** Get the grace turns value. */
+export function getGraceTurns(): number { return graceTurns; }
+/** Set the grace turns value (minimum 1). */
+export function setGraceTurns(n: number): void { graceTurns = Math.max(1, n); }
+
+/**
+ * Try to find the right model for an agent type.
+ * Priority: explicit option > config.model > parent model.
+ */
+function resolveDefaultModel(
+  parentModel: Model<any> | undefined,
+  registry: { find(provider: string, modelId: string): Model<any> | undefined; getAvailable?(): Model<any>[] },
+  configModel?: string,
+): Model<any> | undefined {
+  if (configModel) {
+    const slashIdx = configModel.indexOf("/");
+    if (slashIdx !== -1) {
+      const provider = configModel.slice(0, slashIdx);
+      const modelId = configModel.slice(slashIdx + 1);
+
+      // Build a set of available model keys for fast lookup
+      const available = registry.getAvailable?.();
+      const availableKeys = available
+        ? new Set(available.map((m: any) => `${m.provider}/${m.id}`))
+        : undefined;
+      const isAvailable = (p: string, id: string) =>
+        !availableKeys || availableKeys.has(`${p}/${id}`);
+
+      const found = registry.find(provider, modelId);
+      if (found && isAvailable(provider, modelId)) return found;
+    }
+  }
+
+  return parentModel;
+}
+
+/** Info about a tool event in the subagent. */
+export interface ToolActivity {
+  type: "start" | "end";
+  toolName: string;
+}
+
+export interface RunOptions {
+  /** ExtensionAPI instance — used for pi.exec() instead of execSync. */
+  pi: ExtensionAPI;
+  /** Manager-assigned id; suffixes session name to disambiguate parallel spawns (e.g. `Explore#a1b2c3d4`). */
+  agentId?: string;
+  model?: Model<any>;
+  maxTurns?: number;
+  signal?: AbortSignal;
+  isolated?: boolean;
+  inheritContext?: boolean;
+  thinkingLevel?: ThinkingLevel;
+  /** Override working directory (e.g. for worktree isolation). */
+  cwd?: string;
+  /**
+   * Where .pi config is discovered (project extensions, skills, pi settings,
+   * agent memory). Default: same as the working directory. The manager sets
+   * this to the parent session's cwd when `SpawnOptions.cwd` points the
+   * working directory elsewhere — the agent works *there* but carries the
+   * parent project's config (the target's `.pi` extensions never execute).
+   *
+   * WARNING for future callers: if you pass `cwd` pointing at a directory the
+   * user didn't open, you almost certainly must pass `configCwd` too —
+   * omitting it makes the target's `.pi` extensions execute in this process.
+   * (Worktree isolation is the one intentional exception: its copy IS the
+   * parent's repo, so config resolving inside it is correct.)
+   */
+  configCwd?: string;
+  /** Called on tool start/end with activity info. */
+  onToolActivity?: (activity: ToolActivity) => void;
+  /** Called on streaming text deltas from the assistant response. */
+  onTextDelta?: (delta: string, fullText: string) => void;
+  onSessionCreated?: (session: AgentSession) => void;
+  /** Called at the end of each agentic turn with the cumulative count. */
+  onTurnEnd?: (turnCount: number) => void;
+  /**
+   * Called once per assistant message_end with that message's usage delta.
+   * Lets callers maintain a lifetime accumulator that survives compaction
+   * (which replaces session.state.messages and resets stats-derived sums).
+   */
+  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+  /**
+   * Called when the session successfully compacts. `tokensBefore` is upstream's
+   * pre-compaction context size estimate. Aborted compactions don't fire.
+   */
+  onCompaction?: (info: { reason: "manual" | "threshold" | "overflow"; tokensBefore: number }) => void;
+}
+
+export interface RunResult {
+  responseText: string;
+  session: AgentSession;
+  /** True if the agent was hard-aborted (max_turns + grace exceeded). */
+  aborted: boolean;
+  /** True if the agent was steered to wrap up (hit soft turn limit) but finished in time. */
+  steered: boolean;
+  /**
+   * A failure message for the run's FINAL assistant turn, when that turn failed:
+   * a provider error (stopReason "error"), or a "length" stop that produced no
+   * text (a silent max-token death). pi resolves an exhausted-retries failure
+   * normally instead of rejecting, so without this the manager would report such
+   * a run as completed — with an empty result, or worse, an earlier turn's text
+   * presented as the answer (#144). Undefined for a clean stop, or a "length"
+   * stop that produced text (a legitimate truncated answer).
+   */
+  failure?: string;
+}
+
+/**
+ * Subscribe to a session and collect the last assistant message text.
+ * Returns an object with a `getText()` getter and an `unsubscribe` function.
+ */
+function collectResponseText(session: AgentSession) {
+  let text = "";
+  const unsubscribe = session.subscribe((event: AgentSessionEvent) => {
+    // message_start also fires for user and toolResult messages — resetting on
+    // those would wipe assistant text already collected. Reset only when a new
+    // ASSISTANT message begins, so getText() is the last assistant message's text.
+    if (event.type === "message_start" && event.message.role === "assistant") {
+      text = "";
+    }
+    if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+      text += event.assistantMessageEvent.delta;
+    }
+  });
+  return { getText: () => text, unsubscribe };
+}
+
+/**
+ * Get the last non-empty assistant text produced during THIS invocation.
+ * `startIndex` is the message count captured before the prompt, so the walk-back
+ * never crosses into a previous turn: on a resume whose new turn failed empty,
+ * this returns "" instead of the prior turn's answer (#144). Defaults to 0 (a
+ * fresh spawn, where the whole history belongs to this run).
+ */
+function getLastAssistantText(session: AgentSession, startIndex = 0): string {
+  for (let i = session.messages.length - 1; i >= startIndex; i--) {
+    const msg = session.messages[i];
+    if (msg.role !== "assistant") continue;
+    const text = extractText(msg.content).trim();
+    if (text) return text;
+  }
+  return "";
+}
+
+/**
+ * Error message of THIS invocation's final assistant message, when that turn
+ * failed. Two failure shapes, both keyed off how the final turn STOPPED:
+ *   - stopReason "error": a provider failure pi resolved instead of rejecting
+ *     (any text; partial output is surfaced separately).
+ *   - stopReason "length" with NO text: a silent max-token death — the run hit
+ *     the output-token ceiling before writing anything, which would otherwise
+ *     land as a "completed" run with an empty result (the #144 symptom).
+ * Everything else completes: a clean "stop"/"toolUse" final, and — crucially — a
+ * "length" stop that DID produce text (a legitimate truncated-but-useful answer).
+ * "aborted" is handled by the manager's abort flag / "stopped" guard, not here.
+ * Bounded by `startIndex` (like the text fallback) so a resume that produced no
+ * assistant message of its own never inherits a PRIOR turn's stop reason.
+ */
+function finalTurnError(session: AgentSession, startIndex = 0): string | undefined {
+  for (let i = session.messages.length - 1; i >= startIndex; i--) {
+    const msg = session.messages[i];
+    if (msg.role !== "assistant") continue;
+    if (msg.stopReason === "error") {
+      return (msg as { errorMessage?: string }).errorMessage?.trim() || "provider error with no output";
+    }
+    if (msg.stopReason === "length" && !extractText(msg.content).trim()) {
+      return "run hit the output token limit before producing any text";
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Wire an AbortSignal to abort a session.
+ * Returns a cleanup function to remove the listener.
+ */
+function forwardAbortSignal(session: AgentSession, signal?: AbortSignal): () => void {
+  if (!signal) return () => {};
+  const onAbort = () => session.abort();
+  signal.addEventListener("abort", onAbort, { once: true });
+  return () => signal.removeEventListener("abort", onAbort);
+}
+
+function resolveConfiguredSessionDir(sessionDir: string | undefined, cwd: string): string | undefined {
+  if (!sessionDir) return undefined;
+  if (sessionDir === "~" || sessionDir.startsWith("~/")) return resolve(homedir(), sessionDir.slice(2));
+  if (isAbsolute(sessionDir)) return sessionDir;
+  return resolve(cwd, sessionDir);
+}
+
+export async function runAgent(
+  ctx: ExtensionContext,
+  type: SubagentType,
+  prompt: string,
+  options: RunOptions,
+): Promise<RunResult> {
+  const config = getConfig(type);
+  const agentConfig = getAgentConfig(type);
+
+  // Resolve working directory: worktree override > parent cwd
+  const effectiveCwd = options.cwd ?? ctx.cwd;
+  // Filesystem work happens in effectiveCwd; config discovery in configCwd.
+  // They differ only for SpawnOptions.cwd spawns (config stays with the parent).
+  const configCwd = options.configCwd ?? effectiveCwd;
+
+  const env = await detectEnv(options.pi, effectiveCwd);
+
+  // Get parent system prompt for append-mode agents
+  const parentSystemPrompt = ctx.getSystemPrompt();
+
+  // Build prompt extras (memory, skill preloading)
+  const extras: PromptExtras = {};
+
+  // Resolve extensions/skills: isolated overrides to false
+  const extensions = options.isolated ? false : config.extensions;
+  // Nulling excludes under isolated also suppresses the orphaned-exclude warning —
+  // isolation is an intentional override, not a misconfiguration.
+  const excludeExtensions = options.isolated ? undefined : config.excludeExtensions;
+  const skills = options.isolated ? false : config.skills;
+
+  // Skill preloading: when skills is string[], preload their content into prompt
+  if (Array.isArray(skills)) {
+    const loaded = preloadSkills(skills, configCwd);
+    if (loaded.length > 0) {
+      extras.skillBlocks = loaded;
+    }
+  }
+
+  let toolNames = getToolNamesForType(type);
+
+  // Persistent memory: detect write capability and branch accordingly.
+  // Account for disallowedTools — a tool in the base set but on the denylist is not truly available.
+  if (agentConfig?.memory) {
+    const existingNames = new Set(toolNames);
+    const denied = agentConfig.disallowedTools ? new Set(agentConfig.disallowedTools) : undefined;
+    const effectivelyHas = (name: string) => existingNames.has(name) && !denied?.has(name);
+    const hasWriteTools = effectivelyHas("write") || effectivelyHas("edit");
+
+    if (hasWriteTools) {
+      // Read-write memory: add any missing memory tool names (read/write/edit)
+      const extraNames = getMemoryToolNames(existingNames);
+      if (extraNames.length > 0) toolNames = [...toolNames, ...extraNames];
+      extras.memoryBlock = buildMemoryBlock(agentConfig.name, agentConfig.memory, configCwd);
+    } else {
+      // Read-only memory: only add read tool name, use read-only prompt
+      const extraNames = getReadOnlyMemoryToolNames(existingNames);
+      if (extraNames.length > 0) toolNames = [...toolNames, ...extraNames];
+      extras.memoryBlock = buildReadOnlyMemoryBlock(agentConfig.name, agentConfig.memory, configCwd);
+    }
+  }
+
+  // Build system prompt from agent config
+  let systemPrompt: string;
+  if (agentConfig) {
+    systemPrompt = buildAgentPrompt(agentConfig, effectiveCwd, env, parentSystemPrompt, extras);
+  } else {
+    // Unknown type fallback: spread the canonical general-purpose config (defensive —
+    // unreachable in practice since index.ts resolves unknown types before calling runAgent).
+    const fallback = DEFAULT_AGENTS.get("general-purpose");
+    if (!fallback) throw new Error(`No fallback config available for unknown type "${type}"`);
+    systemPrompt = buildAgentPrompt({ ...fallback, name: type }, effectiveCwd, env, parentSystemPrompt, extras);
+  }
+
+  // When skills is string[], we've already preloaded them into the prompt.
+  // Still pass noSkills: true since we don't need the skill loader to load them again.
+  const noSkills = skills === false || Array.isArray(skills);
+
+  const agentDir = getAgentDir();
+
+  // Extension loading:
+  // - true  → all default-discovered extensions
+  // - false → none (noExtensions)
+  // - string[] → loader-level allowlist. Bare names keep the matching
+  //   default-discovered extension; path entries load that extension fresh;
+  //   "*" keeps all default-discovered extensions. Excluded extensions never
+  //   bind handlers or register tools (their factory still runs once).
+  //
+  // Suppress AGENTS.md/CLAUDE.md and APPEND_SYSTEM.md — upstream's
+  // buildSystemPrompt() re-appends both AFTER systemPromptOverride, which
+  // would defeat prompt_mode: replace and isolated: true. Parent context, if
+  // wanted, reaches the subagent via prompt_mode: append (parentSystemPrompt
+  // is embedded in systemPromptOverride) or inherit_context (conversation).
+  // `ext:` selectors from the `tools:` CSV narrow which extension tools surface to
+  // the LLM. They do NOT control loading — `extensions:` is the sole authority for
+  // which extensions load. `ext:foo` against an extension that `extensions:` excluded
+  // is an orphan and warns after reload. `isolated` means no extension tools at all.
+  const { extNames, narrowing } = parseExtSelectors(
+    options.isolated ? [] : (agentConfig?.extSelectors ?? []),
+  );
+  const noExtensions = extensions === false;
+
+  const extensionsSpec = Array.isArray(extensions)
+    ? parseExtensionsSpec(extensions, configCwd)
+    : undefined;
+  const keepNames = extensionsSpec?.names ?? new Set<string>();
+  // `exclude_extensions:` is a denylist applied AFTER the include set — exclude wins.
+  // Plain canonical names only (case-insensitive). Note: excluded extensions'
+  // factories still run once during reload() (see comment above) — exclusion
+  // suppresses handler binding and tool registration; it is not a sandbox.
+  const excludeNames = new Set((excludeExtensions ?? []).map((n) => n.toLowerCase()));
+  const hasExcludes = excludeNames.size > 0;
+  // The override filters loaded extensions down to `keepNames` minus `excludeNames`.
+  // It's only needed when we're neither loading everything without excludes
+  // (`extensions: true` or a `"*"` wildcard) nor nothing (`noExtensions`).
+  const loadAll = extensions === true || extensionsSpec?.wildcard === true;
+  const additionalExtensionPaths = extensionsSpec?.paths.length ? extensionsSpec.paths : undefined;
+  // Pre-filter discovered set, captured by the override — the exclude-typo warning
+  // must compare against this, not the surviving set (absence from survivors is
+  // an exclude *succeeding*).
+  let discoveredNames: Set<string> | undefined;
+  const extensionsOverride: ((base: LoadExtensionsResult) => LoadExtensionsResult) | undefined =
+    noExtensions || (loadAll && !hasExcludes)
+      ? undefined
+      : (base) => {
+          discoveredNames = new Set(base.extensions.flatMap((e) => extensionCanonicalNames(e.path)));
+          return {
+            ...base,
+            extensions: base.extensions.filter((e) => {
+              const canons = extensionCanonicalNames(e.path);
+              if (canons.some((n) => excludeNames.has(n))) return false; // exclude wins
+              return loadAll || canons.some((n) => keepNames.has(n));
+            }),
+          };
+        };
+
+  const loader = new DefaultResourceLoader({
+    cwd: configCwd,
+    agentDir,
+    noExtensions,
+    additionalExtensionPaths,
+    extensionsOverride,
+    noSkills,
+    noPromptTemplates: true,
+    noThemes: true,
+    noContextFiles: true,
+    systemPromptOverride: () => systemPrompt,
+    appendSystemPromptOverride: () => [],
+  });
+  await loader.reload();
+
+  // Plain entries in `tools:` are expected to be built-in names (extension tools
+  // go through `ext:`), so an unknown name there is unambiguously a typo. Previously
+  // this produced a silently broken agent (#75) — pi-mono accepted the bogus name
+  // into the allowlist, then dropped it at registration with no signal back.
+  if (agentConfig?.builtinToolNames?.length) {
+    const knownBuiltins = new Set(BUILTIN_TOOL_NAMES);
+    for (const name of agentConfig.builtinToolNames) {
+      if (!knownBuiltins.has(name)) {
+        options.onToolActivity?.({
+          type: "end",
+          toolName: `tools-error:tool "${name}" requested by agent "${type}" is not a known built-in`,
+        });
+      }
+    }
+  }
+
+  // A subagent spawns mid-task, so a bad `extensions:`/`ext:` entry warns rather
+  // than aborts. Two distinct misconfigurations to catch:
+  //   - `extensions: [foo]` but no extension named foo was discovered (typo or
+  //     path that failed to load — path entries fold their canonical name into
+  //     `keepNames`, so this covers them too).
+  //   - `tools: ext:foo` but foo isn't in the loaded set (because `extensions:`
+  //     didn't include it). Since v0.9, `ext:` no longer pulls extensions in;
+  //     loading is `extensions:`-authoritative.
+  // An exclude_extensions: alongside extensions: false is contradictory — nothing
+  // loads, so there is nothing to exclude.
+  if (hasExcludes && noExtensions) {
+    options.onToolActivity?.({
+      type: "end",
+      toolName: `extension-error:exclude_extensions has no effect for agent "${type}" — extensions: false loads nothing`,
+    });
+  }
+  // Exclude typo check: compares against the PRE-filter discovered set (an excluded
+  // name absent from the surviving set is the exclude working as intended). Also
+  // flags path-like and "*" entries — excludes are plain names only.
+  if (hasExcludes && discoveredNames) {
+    for (const name of excludeNames) {
+      if (!discoveredNames.has(name)) {
+        options.onToolActivity?.({
+          type: "end",
+          toolName: `extension-error:exclude_extensions: "${name}" for agent "${type}" did not match any discovered extension`,
+        });
+      }
+    }
+  }
+  if (keepNames.size > 0 || extNames.size > 0) {
+    const survivingNames = new Set(
+      loader.getExtensions().extensions.flatMap((e) => extensionCanonicalNames(e.path)),
+    );
+    for (const name of keepNames) {
+      if (!survivingNames.has(name)) {
+        options.onToolActivity?.({
+          type: "end",
+          toolName: excludeNames.has(name)
+            ? `extension-error:extension "${name}" is in both extensions: and exclude_extensions: for agent "${type}" — exclude wins`
+            : `extension-error:extension "${name}" requested by agent "${type}" was not loaded`,
+        });
+      }
+    }
+    for (const name of extNames) {
+      if (!survivingNames.has(name)) {
+        options.onToolActivity?.({
+          type: "end",
+          toolName: `extension-error:ext:${name} referenced by agent "${type}" but extension "${name}" is not loaded (check extensions:/exclude_extensions:)`,
+        });
+      }
+    }
+  }
+
+  // Resolve model: explicit option > config.model > parent model
+  const model = options.model ?? resolveDefaultModel(
+    ctx.model, ctx.modelRegistry, agentConfig?.model,
+  );
+
+  // Resolve thinking level: explicit option > agent config > undefined (inherit)
+  const thinkingLevel = options.thinkingLevel ?? agentConfig?.thinking;
+
+  const disallowedSet = agentConfig?.disallowedTools
+    ? new Set(agentConfig.disallowedTools)
+    : undefined;
+
+  // ─── Tool scoping ───────────────────────────────────────────────────────
+  //
+  // Some extensions register their tools ASYNCHRONOUSLY, long after the
+  // `loader.reload()` above: pi-mcp calls registerTool from `session_start`
+  // (once its MCP servers connect), context-mode from `before_agent_start`.
+  // That is deliberate on their part — eagerly spawning an MCP bridge during
+  // extension discovery orphans child processes on pi's non-agent code paths
+  // (--help, config, trust probing).
+  //
+  // So the tool set cannot be snapshotted here. pi's `allowedToolNames` gates
+  // tool *registration* (`_refreshToolRegistry`'s `isAllowedTool`), not merely
+  // the active set, and is frozen at construction — a name absent from the
+  // snapshot is dropped forever, even once the tool actually registers (#125).
+  //
+  // Whenever extensions are in play we therefore:
+  //   - leave `allowedToolNames` unset, so pi's live gate admits tools whenever
+  //     they register;
+  //   - express the name-stable, permanent part of the scope (our own
+  //     orchestration tools, built-ins the agent didn't ask for, and
+  //     `disallowedTools`) as `excludeTools`, which pi re-applies on every
+  //     registry refresh;
+  //   - enforce `ext:` narrowing on the ACTIVE set via the live `inScope()`
+  //     predicate installed after bind — the active set is what the LLM sees,
+  //     so a registry tool that is never activated is invisible and uncallable.
+  //
+  // `noExtensions`/`isolated` keeps the historical static allowlist: nothing
+  // async can appear there, and a hard registry gate is the correct boundary.
+  const builtinToolNameSet = new Set(toolNames);
+
+  let sessionTools: string[] | undefined;
+  let sessionExcludeTools: string[] | undefined;
+  if (noExtensions) {
+    sessionTools = toolNames.filter(
+      (t) => !EXCLUDED_TOOL_NAMES.includes(t) && !disallowedSet?.has(t),
+    );
+  } else {
+    const denyTools = new Set<string>(EXCLUDED_TOOL_NAMES);
+    // Keep only the built-ins the agent asked for — deny the rest.
+    for (const name of BUILTIN_TOOL_NAMES) {
+      if (!builtinToolNameSet.has(name)) denyTools.add(name);
+    }
+    if (disallowedSet) {
+      for (const name of disallowedSet) denyTools.add(name);
+    }
+    sessionExcludeTools = [...denyTools];
+  }
+
+  const settingsManager = SettingsManager.create(configCwd, agentDir);
+  const configuredSessionDir = resolveConfiguredSessionDir(agentConfig?.sessionDir, effectiveCwd);
+  const defaultSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR ?? settingsManager.getSessionDir?.();
+  const sessionManager = agentConfig?.persistSession
+    ? SessionManager.create(effectiveCwd, configuredSessionDir ?? defaultSessionDir)
+    : SessionManager.inMemory(effectiveCwd);
+
+  // Pi 0.80.8 replaced createAgentSession's modelRegistry option with
+  // modelRuntime, but ExtensionContext still exposes only the registry facade.
+  // Pass both so the full supported Pi range retains the parent's providers.
+  const parentModelRuntime = (ctx.modelRegistry as unknown as { runtime?: unknown }).runtime;
+  // Prefer modelRuntime when the parent registry exposes one (Pi >=0.80.8). Skip null
+  // so the options object stays assignable under stricter ModelRuntime typings.
+  const sessionOpts: Parameters<typeof createAgentSession>[0] & {
+    modelRegistry: ExtensionContext["modelRegistry"];
+  } = {
+    cwd: effectiveCwd,
+    agentDir,
+    sessionManager,
+    settingsManager,
+    modelRegistry: ctx.modelRegistry,
+    ...(parentModelRuntime != null ? { modelRuntime: parentModelRuntime as never } : {}),
+    model,
+    tools: sessionTools,
+    resourceLoader: loader,
+  };
+  if (sessionExcludeTools) {
+    sessionOpts.excludeTools = sessionExcludeTools;
+  }
+  if (thinkingLevel) {
+    sessionOpts.thinkingLevel = thinkingLevel;
+  }
+
+  const { session } = await createAgentSession(sessionOpts);
+
+  const baseSessionName = agentConfig?.name ?? type;
+  session.setSessionName(
+    options.agentId ? `${baseSessionName}#${options.agentId.slice(0, 8)}` : baseSessionName,
+  );
+
+  // Bind extensions so that session_start fires and extensions can initialize
+  // (e.g. loading credentials, setting up state). Tool gating already happened
+  // at session construction via the `tools:` allowlist above — no separate
+  // post-bind filter is needed. All ExtensionBindings fields are optional.
+  await session.bindExtensions({
+    onError: (err) => {
+      options.onToolActivity?.({
+        type: "end",
+        toolName: `extension-error:${err.extensionPath}`,
+      });
+    },
+  });
+
+  // With `allowedToolNames` unset, the registry is scoped by `excludeTools` but
+  // the ACTIVE set still needs managing: pi activates only its four default
+  // built-ins at turn 1, and `ext:` narrowing has no registry-level expression
+  // (we can't deny the name of a tool that hasn't registered yet). Both are
+  // handled below by re-deriving scope from the loader's live extension maps —
+  // `registerTool` writes into those same maps, so late arrivals are judged too.
+  if (!noExtensions) {
+    installExtensionToolScope(session, {
+      loader,
+      toolNames,
+      disallowedSet,
+      extNames,
+      narrowing,
+    });
+  }
+
+  options.onSessionCreated?.(session);
+
+  // Track turns for graceful max_turns enforcement
+  let turnCount = 0;
+  const maxTurns = normalizeMaxTurns(options.maxTurns ?? agentConfig?.maxTurns ?? defaultMaxTurns);
+  let softLimitReached = false;
+  let aborted = false;
+
+  let currentMessageText = "";
+  const unsubTurns = session.subscribe((event: AgentSessionEvent) => {
+    if (event.type === "turn_end") {
+      turnCount++;
+      options.onTurnEnd?.(turnCount);
+      if (maxTurns != null) {
+        if (!softLimitReached && turnCount >= maxTurns) {
+          softLimitReached = true;
+          session.steer("You have reached your turn limit. Wrap up immediately — provide your final answer now.");
+        } else if (softLimitReached && turnCount >= maxTurns + graceTurns) {
+          aborted = true;
+          session.abort();
+        }
+      }
+    }
+    if (event.type === "message_start") {
+      currentMessageText = "";
+    }
+    if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+      currentMessageText += event.assistantMessageEvent.delta;
+      options.onTextDelta?.(event.assistantMessageEvent.delta, currentMessageText);
+    }
+    if (event.type === "tool_execution_start") {
+      options.onToolActivity?.({ type: "start", toolName: event.toolName });
+    }
+    if (event.type === "tool_execution_end") {
+      options.onToolActivity?.({ type: "end", toolName: event.toolName });
+    }
+    if (event.type === "message_end" && event.message.role === "assistant") {
+      const u = (event.message as any).usage;
+      if (u) options.onAssistantUsage?.({
+        input: u.input ?? 0,
+        output: u.output ?? 0,
+        cacheWrite: u.cacheWrite ?? 0,
+      });
+    }
+    if (event.type === "compaction_end" && !event.aborted && event.result) {
+      options.onCompaction?.({ reason: event.reason, tokensBefore: event.result.tokensBefore });
+    }
+  });
+
+  const collector = collectResponseText(session);
+  const cleanupAbort = forwardAbortSignal(session, options.signal);
+
+  // Build the effective prompt: optionally prepend parent context
+  let effectivePrompt = prompt;
+  if (options.inheritContext) {
+    const parentContext = buildParentContext(ctx);
+    if (parentContext) {
+      effectivePrompt = parentContext + prompt;
+    }
+  }
+
+  // Boundary for the history fallback: only assistant text produced from here
+  // on counts as this run's output (a fresh session, so usually 0).
+  const startLen = session.messages.length;
+  try {
+    await session.prompt(effectivePrompt);
+  } finally {
+    unsubTurns();
+    collector.unsubscribe();
+    cleanupAbort();
+  }
+
+  const responseText = collector.getText().trim() || getLastAssistantText(session, startLen);
+  return { responseText, session, aborted, steered: softLimitReached, failure: finalTurnError(session, startLen) };
+}
+
+/**
+ * Send a new prompt to an existing session (resume).
+ */
+export async function resumeAgent(
+  session: AgentSession,
+  prompt: string,
+  options: {
+    onToolActivity?: (activity: ToolActivity) => void;
+    onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+    onCompaction?: (info: { reason: "manual" | "threshold" | "overflow"; tokensBefore: number }) => void;
+    signal?: AbortSignal;
+  } = {},
+): Promise<{ text: string; failure?: string }> {
+  // Boundary for the history fallback: the session already holds prior turns,
+  // so only assistant text produced by THIS resume prompt counts as its output
+  // — a failed resume must not surface the previous turn's answer (#144).
+  const startLen = session.messages.length;
+  const collector = collectResponseText(session);
+  const cleanupAbort = forwardAbortSignal(session, options.signal);
+
+  const unsubEvents = (options.onToolActivity || options.onAssistantUsage || options.onCompaction)
+    ? session.subscribe((event: AgentSessionEvent) => {
+        if (event.type === "tool_execution_start") options.onToolActivity?.({ type: "start", toolName: event.toolName });
+        if (event.type === "tool_execution_end") options.onToolActivity?.({ type: "end", toolName: event.toolName });
+        if (event.type === "message_end" && event.message.role === "assistant") {
+          const u = (event.message as any).usage;
+          if (u) options.onAssistantUsage?.({
+            input: u.input ?? 0,
+            output: u.output ?? 0,
+            cacheWrite: u.cacheWrite ?? 0,
+          });
+        }
+        if (event.type === "compaction_end" && !event.aborted && event.result) {
+          options.onCompaction?.({ reason: event.reason, tokensBefore: event.result.tokensBefore });
+        }
+      })
+    : () => {};
+
+  try {
+    await session.prompt(prompt);
+  } finally {
+    collector.unsubscribe();
+    unsubEvents();
+    cleanupAbort();
+  }
+
+  return {
+    text: collector.getText().trim() || getLastAssistantText(session, startLen),
+    failure: finalTurnError(session, startLen),
+  };
+}
+
+/**
+ * Send a steering message to a running subagent.
+ * The message will interrupt the agent after its current tool execution.
+ */
+export async function steerAgent(
+  session: AgentSession,
+  message: string,
+): Promise<void> {
+  await session.steer(message);
+}
+
+/**
+ * Get the subagent's conversation messages as formatted text.
+ */
+export function getAgentConversation(session: AgentSession): string {
+  const parts: string[] = [];
+
+  for (const msg of session.messages) {
+    if (msg.role === "user") {
+      const text = typeof msg.content === "string"
+        ? msg.content
+        : extractText(msg.content);
+      if (text.trim()) parts.push(`[User]: ${text.trim()}`);
+    } else if (msg.role === "assistant") {
+      const textParts: string[] = [];
+      const toolCalls: string[] = [];
+      for (const c of msg.content) {
+        if (c.type === "text" && c.text) textParts.push(c.text);
+        else if (c.type === "toolCall") toolCalls.push(`  Tool: ${(c as any).name ?? (c as any).toolName ?? "unknown"}`);
+      }
+      if (textParts.length > 0) parts.push(`[Assistant]: ${textParts.join("\n")}`);
+      if (toolCalls.length > 0) parts.push(`[Tool Calls]:\n${toolCalls.join("\n")}`);
+    } else if (msg.role === "toolResult") {
+      const text = extractText(msg.content);
+      const truncated = text.length > 200 ? text.slice(0, 200) + "..." : text;
+      parts.push(`[Tool Result (${msg.toolName})]: ${truncated}`);
+    }
+  }
+
+  return parts.join("\n\n");
+}

--- a/packages/pi-subagents/src/agent-types.ts
+++ b/packages/pi-subagents/src/agent-types.ts
@@ -1,0 +1,189 @@
+/**
+ * agent-types.ts — Unified agent type registry.
+ *
+ * Merges embedded default agents with user-defined agents from .pi/agents/*.md, .agents/agents/*.md, and global agents.
+ * User agents override defaults with the same name. Disabled agents are kept but excluded from spawning.
+ */
+
+import { createCodingTools, createReadOnlyTools } from "@earendil-works/pi-coding-agent";
+import { DEFAULT_AGENTS } from "./default-agents.js";
+import type { AgentConfig } from "./types.js";
+
+/**
+ * All known built-in tool names, derived from pi's own tool factories rather
+ * than hardcoded so the set tracks pi-mono if it adds/renames a built-in.
+ * `createCodingTools` → read/bash/edit/write; `createReadOnlyTools` →
+ * read/grep/find/ls; their de-duplicated union is the 7 built-ins
+ * (read, bash, edit, write, grep, find, ls). The `cwd` only binds tool
+ * operations we never invoke here — we read each tool's `.name` and discard it.
+ */
+export const BUILTIN_TOOL_NAMES: string[] = [
+  ...new Set([...createCodingTools("."), ...createReadOnlyTools(".")].map((t) => t.name)),
+];
+
+/** Unified runtime registry of all agents (defaults + user-defined). */
+const agents = new Map<string, AgentConfig>();
+
+/** When true, DEFAULT_AGENTS are skipped during registration. */
+let disableDefaults = false;
+
+/** Check whether default agents are disabled. */
+export function isDefaultsDisabled(): boolean { return disableDefaults; }
+
+/** Set whether default agents are disabled. */
+export function setDefaultsDisabled(b: boolean): void { disableDefaults = b; }
+
+/**
+ * Register agents into the unified registry.
+ * Starts with DEFAULT_AGENTS, then overlays user agents (overrides defaults with same name).
+ * Disabled agents (enabled === false) are kept in the registry but excluded from spawning.
+ */
+export function registerAgents(userAgents: Map<string, AgentConfig>): void {
+  agents.clear();
+
+  // Start with defaults (unless disabled via settings)
+  if (!disableDefaults) {
+    for (const [name, config] of DEFAULT_AGENTS) {
+      agents.set(name, config);
+    }
+  }
+
+  // Overlay user agents (overrides defaults with same name)
+  for (const [name, config] of userAgents) {
+    agents.set(name, config);
+  }
+}
+
+/** Case-insensitive key resolution. */
+function resolveKey(name: string): string | undefined {
+  if (agents.has(name)) return name;
+  const lower = name.toLowerCase();
+  for (const key of agents.keys()) {
+    if (key.toLowerCase() === lower) return key;
+  }
+  return undefined;
+}
+
+/** Resolve a type name case-insensitively. Returns the canonical key or undefined. */
+export function resolveType(name: string): string | undefined {
+  return resolveKey(name);
+}
+
+/** Get the agent config for a type (case-insensitive). */
+export function getAgentConfig(name: string): AgentConfig | undefined {
+  const key = resolveKey(name);
+  return key ? agents.get(key) : undefined;
+}
+
+/** Get all enabled type names (for spawning and tool descriptions). */
+export function getAvailableTypes(): string[] {
+  return [...agents.entries()]
+    .filter(([_, config]) => config.enabled !== false)
+    .map(([name]) => name);
+}
+
+/** Get all type names including disabled (for UI listing). */
+export function getAllTypes(): string[] {
+  return [...agents.keys()];
+}
+
+/** Get names of default agents currently in the registry. */
+export function getDefaultAgentNames(): string[] {
+  return [...agents.entries()]
+    .filter(([_, config]) => config.isDefault === true)
+    .map(([name]) => name);
+}
+
+/** Get names of user-defined agents (non-defaults) currently in the registry. */
+export function getUserAgentNames(): string[] {
+  return [...agents.entries()]
+    .filter(([_, config]) => config.isDefault !== true)
+    .map(([name]) => name);
+}
+
+/** Check if a type is valid and enabled (case-insensitive). */
+export function isValidType(type: string): boolean {
+  const key = resolveKey(type);
+  if (!key) return false;
+  return agents.get(key)?.enabled !== false;
+}
+
+/** Tool names required for memory management. */
+const MEMORY_TOOL_NAMES = ["read", "write", "edit"];
+
+/**
+ * Get memory tool names (read/write/edit) not already in the provided set.
+ */
+export function getMemoryToolNames(existingToolNames: Set<string>): string[] {
+  return MEMORY_TOOL_NAMES.filter(n => !existingToolNames.has(n));
+}
+
+/** Tool names needed for read-only memory access. */
+const READONLY_MEMORY_TOOL_NAMES = ["read"];
+
+/**
+ * Get read-only memory tool names not already in the provided set.
+ */
+export function getReadOnlyMemoryToolNames(existingToolNames: Set<string>): string[] {
+  return READONLY_MEMORY_TOOL_NAMES.filter(n => !existingToolNames.has(n));
+}
+
+/** Get built-in tool names for a type (case-insensitive). */
+export function getToolNamesForType(type: string): string[] {
+  const key = resolveKey(type);
+  const raw = key ? agents.get(key) : undefined;
+  const config = raw?.enabled !== false ? raw : undefined;
+  // `undefined` (definition omitted the field) → all built-ins; an explicit `[]`
+  // (`tools: none` or a `tools:` with only `ext:` entries) → zero built-ins.
+  return config?.builtinToolNames ?? [...BUILTIN_TOOL_NAMES];
+}
+
+/** Get config for a type (case-insensitive, returns a SubagentTypeConfig-compatible object). Falls back to general-purpose. */
+export function getConfig(type: string): {
+  displayName: string;
+  description: string;
+  builtinToolNames: string[];
+  extensions: true | string[] | false;
+  excludeExtensions?: string[];
+  skills: true | string[] | false;
+  promptMode: "replace" | "append";
+} {
+  const key = resolveKey(type);
+  const config = key ? agents.get(key) : undefined;
+  if (config && config.enabled !== false) {
+    return {
+      displayName: config.displayName ?? config.name,
+      description: config.description,
+      builtinToolNames: config.builtinToolNames ?? BUILTIN_TOOL_NAMES,
+      extensions: config.extensions,
+      excludeExtensions: config.excludeExtensions,
+      skills: config.skills,
+      promptMode: config.promptMode,
+    };
+  }
+
+  // Fallback for unknown/disabled types — general-purpose config
+  const gp = agents.get("general-purpose");
+  if (gp && gp.enabled !== false) {
+    return {
+      displayName: gp.displayName ?? gp.name,
+      description: gp.description,
+      builtinToolNames: gp.builtinToolNames ?? BUILTIN_TOOL_NAMES,
+      extensions: gp.extensions,
+      excludeExtensions: gp.excludeExtensions,
+      skills: gp.skills,
+      promptMode: gp.promptMode,
+    };
+  }
+
+  // Absolute fallback (should never happen)
+  return {
+    displayName: "Agent",
+    description: "General-purpose agent for complex, multi-step tasks",
+    builtinToolNames: BUILTIN_TOOL_NAMES,
+    extensions: true,
+    skills: true,
+    promptMode: "append",
+  };
+}
+

--- a/packages/pi-subagents/src/context.ts
+++ b/packages/pi-subagents/src/context.ts
@@ -1,0 +1,58 @@
+/**
+ * context.ts — Extract parent conversation context for subagent inheritance.
+ */
+
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+/** Extract text from a message content block array. */
+export function extractText(content: unknown[]): string {
+  return content
+    .filter((c: any) => c.type === "text")
+    .map((c: any) => c.text ?? "")
+    .join("\n");
+}
+
+/**
+ * Build a text representation of the parent conversation context.
+ * Used when inherit_context is true to give the subagent visibility
+ * into what has been discussed/done so far.
+ */
+export function buildParentContext(ctx: ExtensionContext): string {
+  const entries = ctx.sessionManager.getBranch();
+  if (!entries || entries.length === 0) return "";
+
+  const parts: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.type === "message") {
+      const msg = entry.message;
+      if (msg.role === "user") {
+        const text = typeof msg.content === "string"
+          ? msg.content
+          : extractText(msg.content);
+        if (text.trim()) parts.push(`[User]: ${text.trim()}`);
+      } else if (msg.role === "assistant") {
+        const text = extractText(msg.content);
+        if (text.trim()) parts.push(`[Assistant]: ${text.trim()}`);
+      }
+      // Skip toolResult messages — too verbose for context
+    } else if (entry.type === "compaction") {
+      // Include compaction summaries — they're already condensed
+      if (entry.summary) {
+        parts.push(`[Summary]: ${entry.summary}`);
+      }
+    }
+  }
+
+  if (parts.length === 0) return "";
+
+  return `# Parent Conversation Context
+The following is the conversation history from the parent session that spawned you.
+Use this context to understand what has been discussed and decided so far.
+
+${parts.join("\n\n")}
+
+---
+# Your Task (below)
+`;
+}

--- a/packages/pi-subagents/src/cross-extension-rpc.ts
+++ b/packages/pi-subagents/src/cross-extension-rpc.ts
@@ -1,0 +1,122 @@
+/**
+ * Cross-extension RPC handlers for the subagents extension.
+ *
+ * Exposes ping, spawn, and stop RPCs over the pi.events event bus,
+ * using per-request scoped reply channels.
+ *
+ * Reply envelope follows pi-mono convention:
+ *   success → { success: true, data?: T }
+ *   error   → { success: false, error: string }
+ */
+
+import { type ModelRegistry, resolveModel } from "./model-resolver.js";
+
+/** Minimal event bus interface needed by the RPC handlers. */
+export interface EventBus {
+  on(event: string, handler: (data: unknown) => void): () => void;
+  emit(event: string, data: unknown): void;
+}
+
+/** RPC reply envelope — matches pi-mono's RpcResponse shape. */
+export type RpcReply<T = void> =
+  | { success: true; data?: T }
+  | { success: false; error: string };
+
+/** RPC protocol version — bumped when the envelope or method contracts change. */
+export const PROTOCOL_VERSION = 2;
+
+/** Minimal AgentManager interface needed by the spawn/stop RPCs. */
+export interface SpawnCapable {
+  spawn(pi: unknown, ctx: unknown, type: string, prompt: string, options: any): string;
+  abort(id: string): boolean;
+}
+
+export interface RpcDeps {
+  events: EventBus;
+  pi: unknown;                    // passed through to manager.spawn
+  getCtx: () => unknown | undefined;  // returns current ExtensionContext
+  manager: SpawnCapable;
+}
+
+export interface RpcHandle {
+  unsubPing: () => void;
+  unsubSpawn: () => void;
+  unsubStop: () => void;
+}
+
+/**
+ * Wire a single RPC handler: listen on `channel`, run `fn(params)`,
+ * emit the reply envelope on `channel:reply:${requestId}`.
+ */
+function handleRpc<P extends { requestId: string }>(
+  events: EventBus,
+  channel: string,
+  fn: (params: P) => unknown | Promise<unknown>,
+): () => void {
+  return events.on(channel, async (raw: unknown) => {
+    const params = raw as P;
+    try {
+      const data = await fn(params);
+      const reply: { success: true; data?: unknown } = { success: true };
+      if (data !== undefined) reply.data = data;
+      events.emit(`${channel}:reply:${params.requestId}`, reply);
+    } catch (err: any) {
+      events.emit(`${channel}:reply:${params.requestId}`, {
+        success: false, error: err?.message ?? String(err),
+      });
+    }
+  });
+}
+
+/**
+ * Register ping, spawn, and stop RPC handlers on the event bus.
+ * Returns unsub functions for cleanup.
+ */
+export function registerRpcHandlers(deps: RpcDeps): RpcHandle {
+  const { events, pi, getCtx, manager } = deps;
+
+  const unsubPing = handleRpc(events, "subagents:rpc:ping", () => {
+    return { version: PROTOCOL_VERSION };
+  });
+
+  const unsubSpawn = handleRpc<{ requestId: string; type: string; prompt: string; options?: any }>(
+    events, "subagents:rpc:spawn", ({ type, prompt, options }) => {
+      const ctx = getCtx();
+      if (!ctx) throw new Error("No active session");
+
+      // Cross-extension RPC callers (e.g. pi-tasks TaskExecute) naturally
+      // forward serializable values, so options.model can be a string like
+      // "openai-codex/gpt-5.5". Resolve it to a real Model instance here
+      // — same pattern the scheduler path already uses — so the spawned
+      // agent's auth lookup doesn't crash with "No API key found for
+      // undefined".
+      let normalizedOptions = options ?? {};
+      if (typeof normalizedOptions.model === "string") {
+        const registry = (ctx as { modelRegistry?: ModelRegistry }).modelRegistry;
+        if (!registry) {
+          throw new Error(
+            `Model override "${normalizedOptions.model}" provided but ctx.modelRegistry is unavailable`,
+          );
+        }
+        const resolved = resolveModel(normalizedOptions.model, registry);
+        if (typeof resolved === "string") {
+          // resolveModel returns a human-readable error string when the
+          // input doesn't match any available model. Surface it instead of
+          // silently falling back so the caller sees the auth/typo issue.
+          throw new Error(resolved);
+        }
+        normalizedOptions = { ...normalizedOptions, model: resolved };
+      }
+
+      return { id: manager.spawn(pi, ctx, type, prompt, normalizedOptions) };
+    },
+  );
+
+  const unsubStop = handleRpc<{ requestId: string; agentId: string }>(
+    events, "subagents:rpc:stop", ({ agentId }) => {
+      if (!manager.abort(agentId)) throw new Error("Agent not found");
+    },
+  );
+
+  return { unsubPing, unsubSpawn, unsubStop };
+}

--- a/packages/pi-subagents/src/custom-agents.ts
+++ b/packages/pi-subagents/src/custom-agents.ts
@@ -1,0 +1,167 @@
+/**
+ * custom-agents.ts — Load user-defined agents from project (.pi/agents/, plus the shared .agents/agents/ workspace) and global ($PI_CODING_AGENT_DIR/agents/, default ~/.pi/agent/agents/) locations.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
+import { BUILTIN_TOOL_NAMES } from "./agent-types.js";
+import type { AgentConfig, MemoryScope, ThinkingLevel } from "./types.js";
+
+/**
+ * Scan for custom agent .md files from multiple locations.
+ * Discovery hierarchy (higher priority wins):
+ *   1. Project:   <cwd>/.pi/agents/*.md (authoritative — also where /agents writes)
+ *   2. Workspace: <cwd>/.agents/agents/*.md (shared cross-tool .agents workspace, read-only)
+ *   3. Global:    $PI_CODING_AGENT_DIR/agents/*.md (default: ~/.pi/agent/agents/*.md)
+ *
+ * Project-level agents override global ones with the same name. On a name clash
+ * between the two project locations, .pi/agents wins — .pi stays the project
+ * authority; .agents/agents is an additional read location.
+ * Any name is allowed — names matching defaults (e.g. "Explore") override them.
+ */
+export function loadCustomAgents(cwd: string): Map<string, AgentConfig> {
+  const globalDir = join(getAgentDir(), "agents");
+  const workspaceProjectDir = join(cwd, ".agents", "agents");
+  const projectDir = join(cwd, ".pi", "agents");
+
+  const agents = new Map<string, AgentConfig>();
+  loadFromDir(globalDir, agents, "global");            // lowest priority
+  loadFromDir(workspaceProjectDir, agents, "project"); // shared workspace
+  loadFromDir(projectDir, agents, "project");          // highest priority (overwrites)
+  return agents;
+}
+
+/** Load agent configs from a directory into the map. */
+function loadFromDir(dir: string, agents: Map<string, AgentConfig>, source: "project" | "global"): void {
+  if (!existsSync(dir)) return;
+
+  let files: string[];
+  try {
+    files = readdirSync(dir).filter(f => f.endsWith(".md"));
+  } catch {
+    return;
+  }
+
+  for (const file of files) {
+    const name = basename(file, ".md");
+
+    let content: string;
+    try {
+      content = readFileSync(join(dir, file), "utf-8");
+    } catch {
+      continue;
+    }
+
+    const { frontmatter: fm, body } = parseFrontmatter<Record<string, unknown>>(content);
+
+    const { builtinToolNames, extSelectors } = parseToolsField(fm.tools);
+
+    agents.set(name, {
+      name,
+      displayName: str(fm.display_name),
+      description: str(fm.description) ?? name,
+      builtinToolNames,
+      extSelectors,
+      disallowedTools: csvListOptional(fm.disallowed_tools),
+      extensions: inheritField(fm.extensions ?? fm.inherit_extensions),
+      excludeExtensions: csvListOptional(fm.exclude_extensions),
+      skills: inheritField(fm.skills ?? fm.inherit_skills),
+      model: str(fm.model),
+      thinking: str(fm.thinking) as ThinkingLevel | undefined,
+      maxTurns: nonNegativeInt(fm.max_turns),
+      persistSession: fm.persist_session != null ? fm.persist_session === true : undefined,
+      outputTranscript: fm.output_transcript != null ? fm.output_transcript !== false : undefined,
+      sessionDir: str(fm.session_dir),
+      systemPrompt: body.trim(),
+      promptMode: fm.prompt_mode === "append" ? "append" : "replace",
+      inheritContext: fm.inherit_context != null ? fm.inherit_context === true : undefined,
+      runInBackground: fm.run_in_background != null ? fm.run_in_background === true : undefined,
+      isolated: fm.isolated != null ? fm.isolated === true : undefined,
+      memory: parseMemory(fm.memory),
+      isolation: fm.isolation === "worktree" ? "worktree" : undefined,
+      enabled: fm.enabled !== false,  // default true; explicitly false disables
+      source,
+    });
+  }
+}
+
+// ---- Field parsers ----
+// All follow the same convention: omitted → default, "none"/empty → nothing, value → exact.
+
+/** Extract a string or undefined. */
+function str(val: unknown): string | undefined {
+  return typeof val === "string" ? val : undefined;
+}
+
+/** Extract a non-negative integer or undefined. 0 means unlimited for max_turns. */
+function nonNegativeInt(val: unknown): number | undefined {
+  return typeof val === "number" && val >= 0 ? val : undefined;
+}
+
+/**
+ * Parse a raw CSV field value into items, or undefined if absent/empty/"none".
+ */
+function parseCsvField(val: unknown): string[] | undefined {
+  if (val === undefined || val === null) return undefined;
+  const s = String(val).trim();
+  if (!s || s === "none") return undefined;
+  const items = s.split(",").map(t => t.trim()).filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
+/**
+ * Parse a comma-separated list field with defaults.
+ * omitted → defaults; "none"/empty → []; csv → listed items.
+ */
+function csvList(val: unknown, defaults: string[]): string[] {
+  if (val === undefined || val === null) return defaults;
+  return parseCsvField(val) ?? [];
+}
+
+/**
+ * Partition the `tools:` CSV into the built-in tool allowlist and raw `ext:` selectors.
+ * `*` (and the case-insensitive alias `all`, for `tools: all`) expands to all
+ * built-ins; plain entries are built-in names; `ext:` entries are extension-tool
+ * selectors parsed later by the runner. omitted → all built-ins, no selectors.
+ * `tools:` present with only `ext:` entries → zero built-ins (use `*`).
+ */
+function parseToolsField(val: unknown): { builtinToolNames: string[]; extSelectors: string[] | undefined } {
+  const entries = csvList(val, BUILTIN_TOOL_NAMES);
+  const isWildcard = (e: string) => e === "*" || e.toLowerCase() === "all";
+  const hasWildcard = entries.some(isWildcard);
+  const plain = entries.filter(e => !isWildcard(e) && !e.startsWith("ext:"));
+  const extEntries = entries.filter(e => e.startsWith("ext:"));
+  return {
+    builtinToolNames: hasWildcard ? [...new Set([...BUILTIN_TOOL_NAMES, ...plain])] : plain,
+    extSelectors: extEntries.length > 0 ? extEntries : undefined,
+  };
+}
+
+/**
+ * Parse an optional comma-separated list field.
+ * omitted → undefined; "none"/empty → undefined; csv → listed items.
+ */
+function csvListOptional(val: unknown): string[] | undefined {
+  return parseCsvField(val);
+}
+
+/**
+ * Parse a memory scope field.
+ * omitted → undefined; "user"/"project"/"local" → MemoryScope.
+ */
+function parseMemory(val: unknown): MemoryScope | undefined {
+  if (val === "user" || val === "project" || val === "local") return val;
+  return undefined;
+}
+
+/**
+ * Parse an inherit field (extensions, skills).
+ * omitted/true → true (inherit all); false/"none"/empty → false; csv → listed names.
+ */
+function inheritField(val: unknown): true | string[] | false {
+  if (val === undefined || val === null || val === true) return true;
+  if (val === false || val === "none") return false;
+  const items = csvList(val, []);
+  return items.length > 0 ? items : false;
+}

--- a/packages/pi-subagents/src/default-agents.ts
+++ b/packages/pi-subagents/src/default-agents.ts
@@ -1,0 +1,126 @@
+/**
+ * default-agents.ts — Embedded default agent configurations.
+ *
+ * These are always available but can be overridden by user .md files with the same name.
+ */
+
+import type { AgentConfig } from "./types.js";
+
+const READ_ONLY_TOOLS = ["read", "bash", "grep", "find", "ls"];
+
+export const DEFAULT_AGENTS: Map<string, AgentConfig> = new Map([
+  [
+    "general-purpose",
+    {
+      name: "general-purpose",
+      displayName: "Agent",
+      description: "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you.",
+      // builtinToolNames omitted — means "all available tools" (resolved at lookup time)
+      // inheritContext / runInBackground / isolated omitted — strategy fields, callers decide per-call.
+      // Setting them to false would lock callsite intent (see resolveAgentInvocationConfig in invocation-config.ts).
+      extensions: true,
+      skills: true,
+      systemPrompt: "",
+      promptMode: "append",
+      isDefault: true,
+    },
+  ],
+  [
+    "Explore",
+    {
+      name: "Explore",
+      displayName: "Explore",
+      description: "Fast read-only search agent for locating code. Use it to find files by pattern (eg. \"src/components/**/*.tsx\"), grep for symbols or keywords (eg. \"API endpoints\"), or answer \"where is X defined / which files reference Y.\" Do NOT use it for code review, design-doc auditing, cross-file consistency checks, or open-ended analysis — it reads excerpts rather than whole files and will miss content past its read window. When calling, specify search breadth: \"quick\" for a single targeted lookup, \"medium\" for moderate exploration, or \"very thorough\" to search across multiple locations and naming conventions.",
+      builtinToolNames: READ_ONLY_TOOLS,
+      extensions: true,
+      skills: true,
+      // Fast/cheap model for read-only search. Provider-preferred but resilient:
+      // resolveModel matches this fuzzily (date-stamp optional) and falls back to
+      // the same model under another provider if anthropic doesn't expose it.
+      model: "anthropic/claude-haiku-4-5",
+      systemPrompt: `# CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS
+You are a file search specialist. You excel at thoroughly navigating and exploring codebases.
+Your role is EXCLUSIVELY to search and analyze existing code. You do NOT have access to file editing tools.
+
+You are STRICTLY PROHIBITED from:
+- Creating new files
+- Modifying existing files
+- Deleting files
+- Moving or copying files
+- Creating temporary files anywhere, including /tmp
+- Using redirect operators (>, >>, |) or heredocs to write to files
+- Running ANY commands that change system state
+
+Use Bash ONLY for read-only operations: ls, git status, git log, git diff, find, cat, head, tail.
+
+# Tool Usage
+- Use the find tool for file pattern matching (NOT the bash find command)
+- Use the grep tool for content search (NOT bash grep/rg command)
+- Use the read tool for reading files (NOT bash cat/head/tail)
+- Use Bash ONLY for read-only operations
+- Make independent tool calls in parallel for efficiency
+- Adapt search approach based on thoroughness level specified
+
+# Output
+- Use absolute file paths in all references
+- Report findings as regular messages
+- Do not use emojis
+- Be thorough and precise`,
+      promptMode: "replace",
+      isDefault: true,
+    },
+  ],
+  [
+    "Plan",
+    {
+      name: "Plan",
+      displayName: "Plan",
+      description: "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.",
+      builtinToolNames: READ_ONLY_TOOLS,
+      extensions: true,
+      skills: true,
+      systemPrompt: `# CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS
+You are a software architect and planning specialist.
+Your role is EXCLUSIVELY to explore the codebase and design implementation plans.
+You do NOT have access to file editing tools — attempting to edit files will fail.
+
+You are STRICTLY PROHIBITED from:
+- Creating new files
+- Modifying existing files
+- Deleting files
+- Moving or copying files
+- Creating temporary files anywhere, including /tmp
+- Using redirect operators (>, >>, |) or heredocs to write to files
+- Running ANY commands that change system state
+
+# Planning Process
+1. Understand requirements
+2. Explore thoroughly (read files, find patterns, understand architecture)
+3. Design solution based on your assigned perspective
+4. Detail the plan with step-by-step implementation strategy
+
+# Requirements
+- Consider trade-offs and architectural decisions
+- Identify dependencies and sequencing
+- Anticipate potential challenges
+- Follow existing patterns where appropriate
+
+# Tool Usage
+- Use the find tool for file pattern matching (NOT the bash find command)
+- Use the grep tool for content search (NOT bash grep/rg command)
+- Use the read tool for reading files (NOT bash cat/head/tail)
+- Use Bash ONLY for read-only operations
+
+# Output Format
+- Use absolute file paths
+- Do not use emojis
+- End your response with:
+
+### Critical Files for Implementation
+List 3-5 files most critical for implementing this plan:
+- /absolute/path/to/file.ts - [Brief reason]`,
+      promptMode: "replace",
+      isDefault: true,
+    },
+  ],
+]);

--- a/packages/pi-subagents/src/enabled-models.ts
+++ b/packages/pi-subagents/src/enabled-models.ts
@@ -1,0 +1,180 @@
+/**
+ * Reads `enabledModels` from pi's settings (global `<agentDir>/settings.json`
+ * + project-local `<cwd>/.pi/settings.json`, project wins) and resolves
+ * entries to concrete `provider/modelId` keys for scope validation.
+ *
+ * **Project overrides global**, mirroring pi's own `SettingsManager`
+ * deep-merge behavior and matching the precedence we use for our own
+ * `subagents.json` settings (see `src/settings.ts:loadSettings`). If
+ * project file has `enabledModels` set, it wholly replaces global's
+ * (array fields are replaced, not concatenated).
+ *
+ * **Limited subset of upstream's resolveModelScope.** We support exact
+ * `provider/modelId` matching only. Upstream (pi-coding-agent's
+ * `core/model-resolver.ts`) additionally supports glob patterns
+ * (`*sonnet*`, `anthropic/*`), bare model IDs without provider, and
+ * thinking-level suffixes (`provider/*:high`). Those forms are silently
+ * ignored here.
+ *
+ * In practice, pi's `/scoped-models` picker writes exact `provider/modelId`
+ * entries, so the limitation is invisible for users who configure scope
+ * through pi's UI. Hand-edited settings using globs or bare IDs will
+ * produce an empty allowed set (scope check becomes a no-op).
+ *
+ * Example:
+ *   enabledModels = ["anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-6"]
+ *   → resolves to { "anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-6" }
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { ModelEntry } from "./model-resolver.js";
+
+/** Minimal registry shape — only the methods resolveEnabledModels actually calls. */
+export interface ModelRegistryRef {
+  getAll(): unknown[];
+  getAvailable?(): unknown[];
+}
+
+/** Paths to pi's settings.json files: [project, global] (project takes precedence). */
+function settingsPaths(cwd: string): [project: string, global: string] {
+  return [
+    join(cwd, ".pi", "settings.json"),
+    join(getAgentDir(), "settings.json"),
+  ];
+}
+
+/** Read `enabledModels` from a single settings.json file. Undefined when missing or absent. */
+function readField(path: string): string[] | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf-8"));
+    if (Array.isArray(raw?.enabledModels)) return raw.enabledModels as string[];
+  } catch {
+    /* corrupt file — silent */
+  }
+  return undefined;
+}
+
+/**
+ * Read enabledModels from pi's settings — project-local overrides global.
+ * Mirrors pi's SettingsManager deep-merge for the `enabledModels` field
+ * (and matches our own loadSettings precedence in src/settings.ts).
+ * Returns undefined when neither file has the field.
+ */
+export function readEnabledModels(cwd: string): string[] | undefined {
+  const [project, global] = settingsPaths(cwd);
+  return readField(project) ?? readField(global);
+}
+
+/**
+ * Resolve enabledModels patterns → Set<"provider/modelId"> (lowercase keys).
+ *
+ * Only exact `provider/modelId` patterns are matched (case-insensitive).
+ * Patterns without a slash, with glob characters, or with a `:thinking`
+ * suffix are silently dropped. See module-level docstring for rationale.
+ *
+ * Cache: keyed on JSON.stringify(patterns) + mtime/size of *both*
+ * project and global settings.json files. Re-resolves when either file
+ * changes or the patterns argument differs.
+ *
+ * Returns undefined when no patterns are provided or no patterns match
+ * (scope check becomes a no-op at the call site).
+ */
+
+// Module-level cache — invalidated when either settings.json changes or patterns differ.
+let cachedAllowed: Set<string> | undefined;
+let cachedHash = "";
+let cachedPatternsKey = "";
+
+/** mtime+size hash of one file, or "missing" if absent. */
+function hashOf(path: string): string {
+  try {
+    const s = statSync(path);
+    return `${s.mtimeMs}-${s.size}`;
+  } catch {
+    return "missing";
+  }
+}
+
+export function resolveEnabledModels(
+  patterns: string[] | undefined,
+  registry: ModelRegistryRef,
+  cwd: string = process.cwd(),
+): Set<string> | undefined {
+  // Fast path: check cache (stat both project and global settings.json files)
+  const patternsKey = JSON.stringify(patterns);
+  const [project, global] = settingsPaths(cwd);
+  const fileHash = `${hashOf(project)};${hashOf(global)}`;
+
+  if (fileHash === cachedHash && patternsKey === cachedPatternsKey) {
+    return cachedAllowed;
+  }
+
+  // Cache miss — resolve
+  if (!patterns || patterns.length === 0) {
+    cachedHash = fileHash;
+    cachedPatternsKey = patternsKey;
+    cachedAllowed = undefined;
+    return undefined;
+  }
+
+  const available = (registry.getAvailable?.() ?? registry.getAll()) as ModelEntry[];
+  const allowed = new Set<string>();
+
+  for (const pattern of patterns) {
+    const trimmed = pattern.trim();
+    if (!trimmed) continue;  // skip empty/whitespace
+    resolveExact(trimmed, available, allowed);
+  }
+
+  const result = allowed.size > 0 ? allowed : undefined;
+  cachedHash = fileHash;
+  cachedPatternsKey = patternsKey;
+  cachedAllowed = result;
+  return result;
+}
+
+
+
+/**
+ * True when `model` is in the allowed set. Centralizes the key format
+ * (`provider/id` lowercase) so callers don't have to reproduce it —
+ * both set-building (resolveExact) and lookup go through `modelKey`.
+ */
+export function isModelInScope(
+  model: { provider: string; id: string },
+  allowed: Set<string>,
+): boolean {
+  return allowed.has(modelKey(model));
+}
+
+/** Canonical lowercase `provider/id` key for the allowed set. */
+function modelKey(model: { provider: string; id: string }): string {
+  return `${model.provider}/${model.id}`.toLowerCase();
+}
+
+/**
+ * Resolve exact model pattern. Example: "google/gemma-4-31b-it".
+ */
+function resolveExact(
+  pattern: string,
+  available: ModelEntry[],
+  allowed: Set<string>,
+): void {
+  // "provider/modelId" — exact (colon is part of id, not split)
+  const slashIdx = pattern.indexOf("/");
+  if (slashIdx === -1) return; // bare modelId not supported
+
+  const provider = pattern.slice(0, slashIdx).toLowerCase();
+  const modelId = pattern.slice(slashIdx + 1).toLowerCase();
+  const exact = available.find(
+    m => m.provider.toLowerCase() === provider && m.id.toLowerCase() === modelId,
+  );
+  if (exact) {
+    allowed.add(modelKey(exact));
+  }
+}
+
+

--- a/packages/pi-subagents/src/env.ts
+++ b/packages/pi-subagents/src/env.ts
@@ -1,0 +1,33 @@
+/**
+ * env.ts — Detect environment info (git, platform) for subagent system prompts.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { EnvInfo } from "./types.js";
+
+export async function detectEnv(pi: ExtensionAPI, cwd: string): Promise<EnvInfo> {
+  let isGitRepo = false;
+  let branch = "";
+
+  try {
+    const result = await pi.exec("git", ["rev-parse", "--is-inside-work-tree"], { cwd, timeout: 5000 });
+    isGitRepo = result.code === 0 && result.stdout.trim() === "true";
+  } catch {
+    // Not a git repo or git not installed
+  }
+
+  if (isGitRepo) {
+    try {
+      const result = await pi.exec("git", ["branch", "--show-current"], { cwd, timeout: 5000 });
+      branch = result.code === 0 ? result.stdout.trim() : "unknown";
+    } catch {
+      branch = "unknown";
+    }
+  }
+
+  return {
+    isGitRepo,
+    branch,
+    platform: process.platform,
+  };
+}

--- a/packages/pi-subagents/src/group-join.ts
+++ b/packages/pi-subagents/src/group-join.ts
@@ -1,0 +1,141 @@
+/**
+ * group-join.ts — Manages grouped background agent completion notifications.
+ *
+ * Instead of each agent individually nudging the main agent on completion,
+ * agents in a group are held until all complete (or a timeout fires),
+ * then a single consolidated notification is sent.
+ */
+
+import type { AgentRecord } from "./types.js";
+
+export type DeliveryCallback = (records: AgentRecord[], partial: boolean) => void;
+
+interface AgentGroup {
+  groupId: string;
+  agentIds: Set<string>;
+  completedRecords: Map<string, AgentRecord>;
+  timeoutHandle?: ReturnType<typeof setTimeout>;
+  delivered: boolean;
+  /** Shorter timeout for stragglers after a partial delivery. */
+  isStraggler: boolean;
+}
+
+/** Default timeout: 30s after first completion in a group. */
+const DEFAULT_TIMEOUT = 30_000;
+/** Straggler re-batch timeout: 15s. */
+const STRAGGLER_TIMEOUT = 15_000;
+
+export class GroupJoinManager {
+  private groups = new Map<string, AgentGroup>();
+  private agentToGroup = new Map<string, string>();
+
+  constructor(
+    private deliverCb: DeliveryCallback,
+    private groupTimeout = DEFAULT_TIMEOUT,
+  ) {}
+
+  /** Register a group of agent IDs that should be joined. */
+  registerGroup(groupId: string, agentIds: string[]): void {
+    const group: AgentGroup = {
+      groupId,
+      agentIds: new Set(agentIds),
+      completedRecords: new Map(),
+      delivered: false,
+      isStraggler: false,
+    };
+    this.groups.set(groupId, group);
+    for (const id of agentIds) {
+      this.agentToGroup.set(id, groupId);
+    }
+  }
+
+  /**
+   * Called when an agent completes.
+   * Returns:
+   * - 'pass'      — agent is not grouped, caller should send individual nudge
+   * - 'held'      — result held, waiting for group completion
+   * - 'delivered'  — this completion triggered the group notification
+   */
+  onAgentComplete(record: AgentRecord): 'delivered' | 'held' | 'pass' {
+    const groupId = this.agentToGroup.get(record.id);
+    if (!groupId) return 'pass';
+
+    const group = this.groups.get(groupId);
+    if (!group || group.delivered) return 'pass';
+
+    group.completedRecords.set(record.id, record);
+
+    // All done — deliver immediately
+    if (group.completedRecords.size >= group.agentIds.size) {
+      this.deliver(group, false);
+      return 'delivered';
+    }
+
+    // First completion in this batch — start timeout
+    if (!group.timeoutHandle) {
+      const timeout = group.isStraggler ? STRAGGLER_TIMEOUT : this.groupTimeout;
+      group.timeoutHandle = setTimeout(() => {
+        this.onTimeout(group);
+      }, timeout);
+    }
+
+    return 'held';
+  }
+
+  private onTimeout(group: AgentGroup): void {
+    if (group.delivered) return;
+    group.timeoutHandle = undefined;
+
+    // Partial delivery — some agents still running
+    const remaining = new Set<string>();
+    for (const id of group.agentIds) {
+      if (!group.completedRecords.has(id)) remaining.add(id);
+    }
+
+    // Clean up agentToGroup for delivered agents (they won't complete again)
+    for (const id of group.completedRecords.keys()) {
+      this.agentToGroup.delete(id);
+    }
+
+    // Deliver what we have
+    this.deliverCb([...group.completedRecords.values()], true);
+
+    // Set up straggler group for remaining agents
+    group.completedRecords.clear();
+    group.agentIds = remaining;
+    group.isStraggler = true;
+    // Timeout will be started when the next straggler completes
+  }
+
+  private deliver(group: AgentGroup, partial: boolean): void {
+    if (group.timeoutHandle) {
+      clearTimeout(group.timeoutHandle);
+      group.timeoutHandle = undefined;
+    }
+    group.delivered = true;
+    this.deliverCb([...group.completedRecords.values()], partial);
+    this.cleanupGroup(group.groupId);
+  }
+
+  private cleanupGroup(groupId: string): void {
+    const group = this.groups.get(groupId);
+    if (!group) return;
+    for (const id of group.agentIds) {
+      this.agentToGroup.delete(id);
+    }
+    this.groups.delete(groupId);
+  }
+
+  /** Check if an agent is in a group. */
+  isGrouped(agentId: string): boolean {
+    return this.agentToGroup.has(agentId);
+  }
+
+  dispose(): void {
+    for (const group of this.groups.values()) {
+      if (group.timeoutHandle) clearTimeout(group.timeoutHandle);
+    }
+    this.groups.clear();
+    this.agentToGroup.clear();
+  }
+}

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -36,6 +36,7 @@ import {
   AgentWidget,
   buildInvocationTags,
   describeActivity,
+  formatActiveToolSummary,
   formatDuration,
   formatMs,
   formatTokens,
@@ -154,12 +155,29 @@ function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
   };
 
   const callbacks = {
-    onToolActivity: (activity: { type: "start" | "end"; toolName: string }) => {
+    onToolActivity: (activity: {
+      type: "start" | "end";
+      toolName: string;
+      toolCallId?: string;
+      args?: unknown;
+    }) => {
       if (activity.type === "start") {
-        state.activeTools.set(activity.toolName + "_" + Date.now(), activity.toolName);
+        const id = activity.toolCallId ?? `${activity.toolName}_${Date.now()}`;
+        // Store a one-line step summary (not bare tool name) so the widget
+        // last line shows e.g. "reading src/a.ts" instead of only "thinking…".
+        state.activeTools.set(id, formatActiveToolSummary(activity.toolName, activity.args));
       } else {
-        for (const [key, name] of state.activeTools) {
-          if (name === activity.toolName) { state.activeTools.delete(key); break; }
+        if (activity.toolCallId && state.activeTools.has(activity.toolCallId)) {
+          state.activeTools.delete(activity.toolCallId);
+        } else {
+          // Fallback: drop one entry whose summary starts with this tool's action/name.
+          const action = formatActiveToolSummary(activity.toolName);
+          for (const [key, summary] of state.activeTools) {
+            if (summary === action || summary.startsWith(`${action} `) || summary.startsWith(activity.toolName)) {
+              state.activeTools.delete(key);
+              break;
+            }
+          }
         }
         state.toolUses++;
       }

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -42,6 +42,7 @@ import {
   formatTurns,
   getDisplayName,
   getPromptModeLabel,
+  shortModelLabel,
   SPINNER,
   type Theme,
   type UICtx,
@@ -50,6 +51,7 @@ import { FleetList, type FleetUICtx } from "./ui/fleet-list.js";
 import { showSchedulesMenu } from "./ui/schedule-menu.js";
 import {
   firstLinePreview,
+  formatAgentCallMeta,
   formatAgentDetailsStats,
   renderAgentLikeResult,
   renderExpandedMarkdown,
@@ -79,6 +81,8 @@ function errorTextResult(msg: string, partial?: Partial<AgentDetails>) {
     error: partial?.error ?? firstLinePreview(msg, 160),
     agentId: partial?.agentId,
     modelName: partial?.modelName,
+    modelInherited: partial?.modelInherited,
+    effort: partial?.effort,
     tags: partial?.tags,
   });
 }
@@ -246,7 +250,7 @@ function formatTaskNotification(record: AgentRecord, resultMaxLen: number): stri
 
 /** Build AgentDetails from a base + record-specific fields. */
 function buildDetails(
-  base: Pick<AgentDetails, "displayName" | "description" | "subagentType" | "modelName" | "tags">,
+  base: Pick<AgentDetails, "displayName" | "description" | "subagentType" | "modelName" | "modelInherited" | "effort" | "tags">,
   record: { toolUses: number; startedAt: number; completedAt?: number; status: string; error?: string; id?: string; session?: any; lifetimeUsage: LifetimeUsage },
   activity?: AgentActivity,
   overrides?: Partial<AgentDetails>,
@@ -1000,9 +1004,16 @@ Terse command-style prompts produce shallow, generic work.
     // ---- Custom rendering: Claude Code style ----
 
     renderCall(args, theme) {
-      const displayName = args.subagent_type ? getDisplayName(args.subagent_type) : "Agent";
+      const displayName = args.subagent_type ? getDisplayName(args.subagent_type as string) : "Agent";
       const desc = typeof args.description === "string" ? args.description : "";
-      return renderToolCallTitle(displayName, desc || undefined, theme);
+      // Call-time chips use tool args (may be fuzzy model / unset = inherit).
+      // Result stats use the resolved effective model from details.
+      const meta = formatAgentCallMeta({
+        model: typeof args.model === "string" ? args.model : undefined,
+        effort: typeof args.thinking === "string" ? args.thinking : undefined,
+        background: args.run_in_background === true,
+      });
+      return renderToolCallTitle(displayName, desc || undefined, theme, meta);
     },
 
     renderResult(result, { expanded, isPartial }, theme, context) {
@@ -1102,9 +1113,10 @@ Terse command-style prompts produce shallow, generic work.
 
       const parentModelId = ctx.model?.id;
       const effectiveModelId = model?.id;
-      const modelName = effectiveModelId && effectiveModelId !== parentModelId
-        ? (model?.name ?? effectiveModelId).replace(/^Claude\s+/i, "").toLowerCase()
-        : undefined;
+      // Always surface the effective model on the tool node (including inherit).
+      const modelName = shortModelLabel(model);
+      const modelInherited = !!(effectiveModelId && parentModelId && effectiveModelId === parentModelId);
+      const effort = thinking ? String(thinking) : undefined;
       const effectiveMaxTurns = normalizeMaxTurns(resolvedConfig.maxTurns ?? getDefaultMaxTurns());
       const agentInvocation: AgentInvocation = {
         modelName,
@@ -1121,11 +1133,16 @@ Terse command-style prompts produce shallow, generic work.
       const modeLabel = getPromptModeLabel(subagentType);
       const { tags: invocationTags } = buildInvocationTags(agentInvocation);
       const agentTags = modeLabel ? [modeLabel, ...invocationTags] : invocationTags;
-      const detailBase = {
+      const detailBase: Pick<
+        AgentDetails,
+        "displayName" | "description" | "subagentType" | "modelName" | "modelInherited" | "effort" | "tags"
+      > = {
         displayName,
         description: params.description,
         subagentType,
         modelName,
+        modelInherited: modelInherited || undefined,
+        effort,
         tags: agentTags.length > 0 ? agentTags : undefined,
       };
 
@@ -1424,8 +1441,16 @@ Terse command-style prompts produce shallow, generic work.
       const flags = [
         args.wait ? "wait" : undefined,
         args.verbose ? "verbose" : undefined,
-      ].filter((f): f is string => !!f).join(" · ");
-      return renderToolCallTitle("Get Result", id || undefined, theme, flags || undefined);
+      ].filter((f): f is string => !!f);
+      // Prefer live record meta when the id is still in the manager.
+      const rec = typeof args.agent_id === "string" ? manager.getRecord(args.agent_id) : undefined;
+      const meta = formatAgentCallMeta({
+        model: rec?.invocation?.modelName,
+        effort: rec?.invocation?.thinking ? String(rec.invocation.thinking) : undefined,
+        background: rec?.invocation?.runInBackground === true,
+        extra: flags,
+      });
+      return renderToolCallTitle("Get Result", id || undefined, theme, meta);
     },
 
     renderResult(result, { expanded, isPartial }, theme, context) {
@@ -1498,6 +1523,8 @@ Terse command-style prompts produce shallow, generic work.
       }
 
       const activity = agentActivity.get(record.id);
+      const inv = record.invocation;
+      const invTags = buildInvocationTags(inv).tags;
       const details: AgentDetails = {
         displayName,
         description: record.description,
@@ -1510,6 +1537,9 @@ Terse command-style prompts produce shallow, generic work.
         error: record.error,
         turnCount: activity?.turnCount,
         maxTurns: activity?.maxTurns,
+        modelName: inv?.modelName,
+        effort: inv?.thinking ? String(inv.thinking) : undefined,
+        tags: invTags.length > 0 ? invTags : undefined,
         activity: activity
           ? describeActivity(activity.activeTools, activity.responseText)
           : undefined,

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -36,7 +36,6 @@ import {
   AgentWidget,
   buildInvocationTags,
   describeActivity,
-  fgPreservingNestedStyles,
   formatDuration,
   formatMs,
   formatTokens,
@@ -49,6 +48,14 @@ import {
 } from "./ui/agent-widget.js";
 import { FleetList, type FleetUICtx } from "./ui/fleet-list.js";
 import { showSchedulesMenu } from "./ui/schedule-menu.js";
+import {
+  firstLinePreview,
+  formatAgentDetailsStats,
+  renderAgentLikeResult,
+  renderExpandedMarkdown,
+  renderToolCallTitle,
+  toolResultText,
+} from "./ui/tool-render.js";
 import { addUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsage } from "./usage.js";
 
 // ---- Shared helpers ----
@@ -976,88 +983,39 @@ Terse command-style prompts produce shallow, generic work.
 
     renderCall(args, theme) {
       const displayName = args.subagent_type ? getDisplayName(args.subagent_type) : "Agent";
-      const desc = args.description ?? "";
-      return new Text("▸ " + theme.fg("toolTitle", theme.bold(displayName)) + (desc ? "  " + theme.fg("muted", desc) : ""), 0, 0);
+      const desc = typeof args.description === "string" ? args.description : "";
+      return renderToolCallTitle(displayName, desc || undefined, theme);
     },
 
     renderResult(result, { expanded, isPartial }, theme) {
       const details = result.details as AgentDetails | undefined;
+      const text = toolResultText(result);
       if (!details) {
-        const text = result.content[0]?.type === "text" ? result.content[0].text : "";
-        return new Text(text, 0, 0);
+        // No structured details — still honor expand so we never dump walls by default.
+        return renderAgentLikeResult(
+          {
+            displayName: "Agent",
+            description: "",
+            subagentType: "general-purpose",
+            toolUses: 0,
+            tokens: "",
+            durationMs: 0,
+            status: "completed",
+          },
+          text,
+          { expanded, isPartial },
+          theme,
+        );
       }
 
-      // Helper: build "haiku · thinking: high · ↻5≤30 · 3 tool uses · 33.8k tokens" stats string
-      const stats = (d: AgentDetails) => {
-        const parts: string[] = [];
-        if (d.modelName) parts.push(d.modelName);
-        if (d.tags) parts.push(...d.tags);
-        if (d.turnCount != null && d.turnCount > 0) {
-          parts.push(formatTurns(d.turnCount, d.maxTurns));
-        }
-        if (d.toolUses > 0) parts.push(`${d.toolUses} tool use${d.toolUses === 1 ? "" : "s"}`);
-        if (d.tokens) parts.push(d.tokens);
-        return parts.map(p => fgPreservingNestedStyles(theme, "dim", p)).join(" " + theme.fg("dim", "·") + " ");
-      };
-
-      // ---- While running (streaming) ----
+      // Streaming partials keep the live spinner component (animated via onUpdate).
       if (isPartial || details.status === "running") {
         const frame = SPINNER[details.spinnerFrame ?? 0];
-        const s = stats(details);
+        const s = formatAgentDetailsStats(details, theme);
         return renderRunningAgentStatus(frame, s, details.activity ?? "thinking…", theme);
       }
 
-      // ---- Background agent launched ----
-      if (details.status === "background") {
-        return new Text(theme.fg("dim", `  ⎿  Running in background (ID: ${details.agentId})`), 0, 0);
-      }
-
-      // ---- Completed / Steered ----
-      if (details.status === "completed" || details.status === "steered") {
-        const duration = formatMs(details.durationMs);
-        const isSteered = details.status === "steered";
-        const icon = isSteered ? theme.fg("warning", "✓") : theme.fg("success", "✓");
-        const s = stats(details);
-        let line = icon + (s ? " " + s : "");
-        line += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
-
-        if (expanded) {
-          const resultText = result.content[0]?.type === "text" ? result.content[0].text : "";
-          if (resultText) {
-            const lines = resultText.split("\n").slice(0, 50);
-            for (const l of lines) {
-              line += "\n" + theme.fg("dim", `  ${l}`);
-            }
-            if (resultText.split("\n").length > 50) {
-              line += "\n" + theme.fg("muted", "  ... (use get_subagent_result with verbose for full output)");
-            }
-          }
-        } else {
-          const doneText = isSteered ? "Wrapped up (turn limit)" : "Done";
-          line += "\n" + theme.fg("dim", `  ⎿  ${doneText}`);
-        }
-        return new Text(line, 0, 0);
-      }
-
-      // ---- Stopped (user-initiated abort) ----
-      if (details.status === "stopped") {
-        const s = stats(details);
-        let line = theme.fg("dim", "■") + (s ? " " + s : "");
-        line += "\n" + theme.fg("dim", "  ⎿  Stopped");
-        return new Text(line, 0, 0);
-      }
-
-      // ---- Error / Aborted (hard max_turns) ----
-      const s = stats(details);
-      let line = theme.fg("error", "✗") + (s ? " " + s : "");
-
-      if (details.status === "error") {
-        line += "\n" + theme.fg("error", `  ⎿  Error: ${details.error ?? "unknown"}`);
-      } else {
-        line += "\n" + theme.fg("warning", "  ⎿  Aborted (max turns exceeded)");
-      }
-
-      return new Text(line, 0, 0);
+      return renderAgentLikeResult(details, text, { expanded, isPartial }, theme);
     },
 
     // ---- Execute ----
@@ -1459,6 +1417,40 @@ Terse command-style prompts produce shallow, generic work.
         }),
       ),
     }),
+
+    // Without renderResult Pi dumps the entire model-facing payload (often a full
+    // agent transcript) with no collapse — keep the TUI to a one-line preview.
+    renderCall(args, theme) {
+      const id = typeof args.agent_id === "string" ? args.agent_id : "";
+      const flags = [
+        args.wait ? "wait" : undefined,
+        args.verbose ? "verbose" : undefined,
+      ].filter((f): f is string => !!f).join(" · ");
+      return renderToolCallTitle("Get Result", id || undefined, theme, flags || undefined);
+    },
+
+    renderResult(result, { expanded, isPartial }, theme) {
+      const details = result.details as AgentDetails | undefined;
+      const text = toolResultText(result);
+      if (!details) {
+        return renderAgentLikeResult(
+          {
+            displayName: "Get Result",
+            description: "",
+            subagentType: "general-purpose",
+            toolUses: 0,
+            tokens: "",
+            durationMs: 0,
+            status: "completed",
+          },
+          text,
+          { expanded, isPartial },
+          theme,
+        );
+      }
+      return renderAgentLikeResult(details, text, { expanded, isPartial }, theme);
+    },
+
     execute: async (_toolCallId, params, signal, _onUpdate, _ctx) => {
       const record = manager.getRecord(params.agent_id);
       if (!record) {
@@ -1495,8 +1487,10 @@ Terse command-style prompts produce shallow, generic work.
         `Type: ${displayName} | Status: ${record.status}${getStatusNote(record.status)} | ${statsParts.join(" | ")}\n` +
         `Description: ${record.description}\n\n`;
 
-      if (record.status === "running") {
-        output += "Agent is still running. Use wait: true or check back later.";
+      if (record.status === "running" || record.status === "queued") {
+        output += record.status === "queued"
+          ? "Agent is queued. Use wait: true or check back later."
+          : "Agent is still running. Use wait: true or check back later.";
       } else if (record.status === "error") {
         output += `Error: ${record.error}${partialOutputSuffix(record)}`;
       } else {
@@ -1517,7 +1511,25 @@ Terse command-style prompts produce shallow, generic work.
         }
       }
 
-      return textResult(output);
+      const activity = agentActivity.get(record.id);
+      const details: AgentDetails = {
+        displayName,
+        description: record.description,
+        subagentType: record.type,
+        toolUses: record.toolUses,
+        tokens: tokens || "",
+        durationMs: record.completedAt ? record.completedAt - record.startedAt : 0,
+        status: record.status as AgentDetails["status"],
+        agentId: record.id,
+        error: record.error,
+        turnCount: activity?.turnCount,
+        maxTurns: activity?.maxTurns,
+        activity: activity
+          ? describeActivity(activity.activeTools, activity.responseText)
+          : undefined,
+      };
+
+      return textResult(output, details);
     },
   }));
 
@@ -1538,6 +1550,30 @@ Terse command-style prompts produce shallow, generic work.
         description: "The steering message to send. This will appear as a user message in the agent's conversation.",
       }),
     }),
+
+    renderCall(args, theme) {
+      const id = typeof args.agent_id === "string" ? args.agent_id : "";
+      const msg = typeof args.message === "string" ? firstLinePreview(args.message, 60) : "";
+      return renderToolCallTitle("Steer", id || undefined, theme, msg || undefined);
+    },
+
+    renderResult(result, { expanded }, theme) {
+      const text = toolResultText(result);
+      const failed =
+        /\bfailed\b/i.test(text) ||
+        /\bnot found\b/i.test(text) ||
+        /\bcannot steer\b/i.test(text) ||
+        /\bnot running\b/i.test(text);
+      const icon = failed ? theme.fg("error", "✗") : theme.fg("success", "✓");
+      if (expanded) {
+        const container = new Container();
+        container.addChild(new Text(icon, 0, 0));
+        container.addChild(renderExpandedMarkdown(text.trim() || "_(empty)_"));
+        return container;
+      }
+      return new Text(icon + " " + theme.fg("dim", firstLinePreview(text, 100) || "steered"), 0, 0);
+    },
+
     execute: async (_toolCallId, params, _signal, _onUpdate, _ctx) => {
       const record = manager.getRecord(params.agent_id);
       if (!record) {

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -1,0 +1,2399 @@
+/**
+ * pi-agents — A pi extension providing Claude Code-style autonomous sub-agents.
+ *
+ * Tools:
+ *   Agent             — LLM-callable: spawn a sub-agent
+ *   get_subagent_result  — LLM-callable: check background agent status/result
+ *   steer_subagent       — LLM-callable: send a steering message to a running agent
+ *
+ * Commands:
+ *   /agents                 — Interactive agent management menu
+ */
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { defineTool, type ExtensionAPI, type ExtensionCommandContext, type ExtensionContext, getAgentDir, getSettingsListTheme } from "@earendil-works/pi-coding-agent";
+import { Container, Key, matchesKey, type SettingItem, SettingsList, Spacer, Text } from "@earendil-works/pi-tui";
+import { Type } from "@sinclair/typebox";
+import { AgentManager } from "./agent-manager.js";
+import { getAgentConversation, getDefaultMaxTurns, getGraceTurns, normalizeMaxTurns, SUBAGENT_TOOL_NAMES, setDefaultMaxTurns, setGraceTurns, steerAgent } from "./agent-runner.js";
+import { BUILTIN_TOOL_NAMES, getAgentConfig, getAllTypes, getAvailableTypes, isDefaultsDisabled, registerAgents, resolveType, setDefaultsDisabled } from "./agent-types.js";
+import { type RpcHandle, registerRpcHandlers } from "./cross-extension-rpc.js";
+import { loadCustomAgents } from "./custom-agents.js";
+import { isModelInScope, readEnabledModels, resolveEnabledModels } from "./enabled-models.js";
+import { GroupJoinManager } from "./group-join.js";
+import { resolveAgentInvocationConfig, resolveJoinMode } from "./invocation-config.js";
+import { type ModelRegistry, resolveModel } from "./model-resolver.js";
+import { createOutputFilePath, streamToOutputFile, writeInitialEntry } from "./output-file.js";
+import { SubagentScheduler } from "./schedule.js";
+import { resolveStorePath, ScheduleStore } from "./schedule-store.js";
+import { applyAndEmitLoaded, type SubagentsSettings, saveAndEmitChanged, type ToolDescriptionMode } from "./settings.js";
+import { getStatusNote } from "./status-note.js";
+import { type AgentConfig, type AgentInvocation, type AgentRecord, type JoinMode, type NotificationDetails, type SubagentType, type WidgetMode } from "./types.js";
+import {
+  type AgentActivity,
+  type AgentDetails,
+  AgentWidget,
+  buildInvocationTags,
+  describeActivity,
+  fgPreservingNestedStyles,
+  formatDuration,
+  formatMs,
+  formatTokens,
+  formatTurns,
+  getDisplayName,
+  getPromptModeLabel,
+  SPINNER,
+  type Theme,
+  type UICtx,
+} from "./ui/agent-widget.js";
+import { FleetList, type FleetUICtx } from "./ui/fleet-list.js";
+import { showSchedulesMenu } from "./ui/schedule-menu.js";
+import { addUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsage } from "./usage.js";
+
+// ---- Shared helpers ----
+
+/** Tool execute return value for a text response. */
+function textResult(msg: string, details?: AgentDetails) {
+  return { content: [{ type: "text" as const, text: msg }], details: details as any };
+}
+
+/** Await a promise until it settles or the caller cancels, without aborting the underlying work. */
+function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(signal.reason);
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(signal.reason);
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+export function renderRunningAgentStatus(
+  frame: string,
+  statsText: string,
+  activity: string,
+  theme: Pick<Theme, "fg">,
+): Container {
+  const container = new Container();
+  container.addChild(new Text(theme.fg("accent", frame) + (statsText ? " " + statsText : ""), 0, 0));
+  container.addChild(new Text(theme.fg("dim", `  ⎿  ${activity}`), 0, 0));
+  return container;
+}
+
+/** Format an agent's lifetime token total, or "" when zero. */
+function formatLifetimeTokens(o: { lifetimeUsage: LifetimeUsage }): string {
+  const t = getLifetimeTotal(o.lifetimeUsage);
+  return t > 0 ? formatTokens(t) : "";
+}
+
+/**
+ * Create an AgentActivity state and spawn callbacks for tracking tool usage.
+ * Used by both foreground and background paths to avoid duplication.
+ */
+function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
+  const state: AgentActivity = {
+    activeTools: new Map(),
+    toolUses: 0,
+    turnCount: 1,
+    maxTurns,
+    responseText: "",
+    session: undefined,
+    lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+  };
+
+  const callbacks = {
+    onToolActivity: (activity: { type: "start" | "end"; toolName: string }) => {
+      if (activity.type === "start") {
+        state.activeTools.set(activity.toolName + "_" + Date.now(), activity.toolName);
+      } else {
+        for (const [key, name] of state.activeTools) {
+          if (name === activity.toolName) { state.activeTools.delete(key); break; }
+        }
+        state.toolUses++;
+      }
+      onStreamUpdate?.();
+    },
+    onTextDelta: (_delta: string, fullText: string) => {
+      state.responseText = fullText;
+      onStreamUpdate?.();
+    },
+    onTurnEnd: (turnCount: number) => {
+      state.turnCount = turnCount;
+      onStreamUpdate?.();
+    },
+    onSessionCreated: (session: any) => {
+      state.session = session;
+    },
+    onAssistantUsage: (usage: { input: number; output: number; cacheWrite: number }) => {
+      addUsage(state.lifetimeUsage, usage);
+      onStreamUpdate?.();
+    },
+  };
+
+  return { state, callbacks };
+}
+
+/**
+ * Advertised thinking levels, ordered to mirror pi-ai's EXTENDED_THINKING_LEVELS
+ * (`off` + every `ThinkingLevel`). Single source for the Agent tool description,
+ * the generated-agent template, and the `/agents` wizard so these lists can't
+ * drift behind pi again (#147). Availability of any level still depends on the
+ * host pi version and the selected model — pi clamps unsupported levels down.
+ */
+const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+/**
+ * Salvaged partial output of a failed run, as a labeled suffix for the error
+ * surfaces (or "" if the run produced nothing). `record.result` is bounded to
+ * the run's own turns, so this is never a stale earlier answer (#144).
+ */
+function partialOutputSuffix(record: AgentRecord): string {
+  const partial = record.result?.trim();
+  return partial ? `\n\nPartial output before the failure:\n${partial}` : "";
+}
+
+/** Human-readable status label for agent completion. */
+function getStatusLabel(status: string, error?: string): string {
+  switch (status) {
+    case "error": return `Error: ${error ?? "unknown"}`;
+    case "aborted": return "Aborted (max turns exceeded)";
+    case "steered": return "Wrapped up (turn limit)";
+    case "stopped": return "Stopped";
+    default: return "Done";
+  }
+}
+
+/** Escape XML special characters to prevent injection in structured notifications. */
+function escapeXml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Format a structured task notification matching Claude Code's <task-notification> XML. */
+function formatTaskNotification(record: AgentRecord, resultMaxLen: number): string {
+  const status = getStatusLabel(record.status, record.error);
+  const durationMs = record.completedAt ? record.completedAt - record.startedAt : 0;
+  const totalTokens = getLifetimeTotal(record.lifetimeUsage);
+  const contextPercent = getSessionContextPercent(record.session);
+  const ctxXml = contextPercent !== null ? `<context_percent>${Math.round(contextPercent)}</context_percent>` : "";
+  const compactXml = record.compactionCount ? `<compactions>${record.compactionCount}</compactions>` : "";
+
+  const resultPreview = record.result
+    ? record.result.length > resultMaxLen
+      ? record.result.slice(0, resultMaxLen) + "\n...(truncated, use get_subagent_result for full output)"
+      : record.result
+    : "No output.";
+
+  return [
+    `<task-notification>`,
+    `<task-id>${record.id}</task-id>`,
+    record.toolCallId ? `<tool-use-id>${escapeXml(record.toolCallId)}</tool-use-id>` : null,
+    record.outputFile ? `<output-file>${escapeXml(record.outputFile)}</output-file>` : null,
+    `<status>${escapeXml(status)}</status>`,
+    `<summary>Agent "${escapeXml(record.description)}" ${record.status}${getStatusNote(record.status)}</summary>`,
+    `<result>${escapeXml(resultPreview)}</result>`,
+    `<usage><total_tokens>${totalTokens}</total_tokens><tool_uses>${record.toolUses}</tool_uses>${ctxXml}${compactXml}<duration_ms>${durationMs}</duration_ms></usage>`,
+    `</task-notification>`,
+  ].filter(Boolean).join('\n');
+}
+
+/** Build AgentDetails from a base + record-specific fields. */
+function buildDetails(
+  base: Pick<AgentDetails, "displayName" | "description" | "subagentType" | "modelName" | "tags">,
+  record: { toolUses: number; startedAt: number; completedAt?: number; status: string; error?: string; id?: string; session?: any; lifetimeUsage: LifetimeUsage },
+  activity?: AgentActivity,
+  overrides?: Partial<AgentDetails>,
+): AgentDetails {
+  return {
+    ...base,
+    toolUses: record.toolUses,
+    tokens: formatLifetimeTokens(record),
+    turnCount: activity?.turnCount,
+    maxTurns: activity?.maxTurns,
+    durationMs: (record.completedAt ?? Date.now()) - record.startedAt,
+    status: record.status as AgentDetails["status"],
+    agentId: record.id,
+    error: record.error,
+    ...overrides,
+  };
+}
+
+/** Build notification details for the custom message renderer. */
+function buildNotificationDetails(record: AgentRecord, resultMaxLen: number, activity?: AgentActivity): NotificationDetails {
+  const totalTokens = getLifetimeTotal(record.lifetimeUsage);
+
+  return {
+    id: record.id,
+    description: record.description,
+    status: record.status,
+    toolUses: record.toolUses,
+    turnCount: activity?.turnCount ?? 0,
+    maxTurns: activity?.maxTurns,
+    totalTokens,
+    durationMs: record.completedAt ? record.completedAt - record.startedAt : 0,
+    outputFile: record.outputFile,
+    error: record.error,
+    resultPreview: record.result
+      ? record.result.length > resultMaxLen
+        ? record.result.slice(0, resultMaxLen) + "…"
+        : record.result
+      : "No output.",
+  };
+}
+
+export default function (pi: ExtensionAPI) {
+  // ---- Register custom notification renderer ----
+  pi.registerMessageRenderer<NotificationDetails>(
+    "subagent-notification",
+    (message, { expanded }, theme) => {
+      const d = message.details;
+      if (!d) return undefined;
+
+      function renderOne(d: NotificationDetails): string {
+        const isError = d.status === "error" || d.status === "stopped" || d.status === "aborted";
+        const icon = isError ? theme.fg("error", "✗") : theme.fg("success", "✓");
+        const statusText = isError ? d.status
+          : d.status === "steered" ? "completed (steered)"
+          : "completed";
+
+        // Line 1: icon + agent description + status
+        let line = `${icon} ${theme.bold(d.description)} ${theme.fg("dim", statusText)}`;
+
+        // Line 2: stats
+        const parts: string[] = [];
+        if (d.turnCount > 0) parts.push(formatTurns(d.turnCount, d.maxTurns));
+        if (d.toolUses > 0) parts.push(`${d.toolUses} tool use${d.toolUses === 1 ? "" : "s"}`);
+        if (d.totalTokens > 0) parts.push(formatTokens(d.totalTokens));
+        if (d.durationMs > 0) parts.push(formatMs(d.durationMs));
+        if (parts.length) {
+          line += "\n  " + parts.map(p => theme.fg("dim", p)).join(" " + theme.fg("dim", "·") + " ");
+        }
+
+        // Line 3: result preview (collapsed) or full (expanded)
+        if (expanded) {
+          const lines = d.resultPreview.split("\n").slice(0, 30);
+          for (const l of lines) line += "\n" + theme.fg("dim", `  ${l}`);
+        } else {
+          const preview = d.resultPreview.split("\n")[0]?.slice(0, 80) ?? "";
+          line += "\n  " + theme.fg("dim", `⎿  ${preview}`);
+        }
+
+        // Line 4: output file link (if present)
+        if (d.outputFile) {
+          line += "\n  " + theme.fg("muted", `transcript: ${d.outputFile}`);
+        }
+
+        return line;
+      }
+
+      const all = [d, ...(d.others ?? [])];
+      return new Text(all.map(renderOne).join("\n"), 0, 0);
+    }
+  );
+
+  /** Reload agents from project/global custom agent dirs and merge with defaults (called on init and each Agent invocation). */
+  const reloadCustomAgents = () => {
+    const userAgents = loadCustomAgents(process.cwd());
+    registerAgents(userAgents);
+  };
+
+  // Initial load
+  reloadCustomAgents();
+
+  // ---- Agent activity tracking + widget ----
+  const agentActivity = new Map<string, AgentActivity>();
+
+  // ---- Cancellable pending notifications ----
+  // Holds notifications briefly so get_subagent_result can cancel them
+  // before they reach pi.sendMessage (fire-and-forget).
+  const pendingNudges = new Map<string, ReturnType<typeof setTimeout>>();
+  const NUDGE_HOLD_MS = 200;
+  // A queued result wait must observe completion before its held notification
+  // can fire, so successful waits can still suppress that redundant nudge.
+  const QUEUE_WAIT_POLL_MS = Math.floor(NUDGE_HOLD_MS / 4);
+
+  function scheduleNudge(key: string, send: () => void, delay = NUDGE_HOLD_MS) {
+    cancelNudge(key);
+    pendingNudges.set(key, setTimeout(() => {
+      pendingNudges.delete(key);
+      try { send(); } catch { /* ignore stale completion side-effect errors */ }
+    }, delay));
+  }
+
+  function cancelNudge(key: string) {
+    const timer = pendingNudges.get(key);
+    if (timer != null) {
+      clearTimeout(timer);
+      pendingNudges.delete(key);
+    }
+  }
+
+  // ---- Individual nudge helper (async join mode) ----
+  function emitIndividualNudge(record: AgentRecord) {
+    if (record.resultConsumed) return;  // re-check at send time
+
+    const notification = formatTaskNotification(record, 500);
+    const footer = record.outputFile ? `\nFull transcript available at: ${record.outputFile}` : '';
+
+    pi.sendMessage<NotificationDetails>({
+      customType: "subagent-notification",
+      content: notification + footer,
+      display: true,
+      details: buildNotificationDetails(record, 500, agentActivity.get(record.id)),
+    }, { deliverAs: "followUp", triggerTurn: true });
+  }
+
+  function sendIndividualNudge(record: AgentRecord) {
+    agentActivity.delete(record.id);
+    widget.markFinished(record.id);
+    fleet.onAgentFinished(record.id);
+    scheduleNudge(record.id, () => emitIndividualNudge(record));
+    widget.update();
+  }
+
+  // ---- Group join manager ----
+  const groupJoin = new GroupJoinManager(
+    (records, partial) => {
+      for (const r of records) { agentActivity.delete(r.id); widget.markFinished(r.id); fleet.onAgentFinished(r.id); }
+
+      const groupKey = `group:${records.map(r => r.id).join(",")}`;
+      scheduleNudge(groupKey, () => {
+        // Re-check at send time
+        const unconsumed = records.filter(r => !r.resultConsumed);
+        if (unconsumed.length === 0) { widget.update(); return; }
+
+        const notifications = unconsumed.map(r => formatTaskNotification(r, 300)).join('\n\n');
+        const label = partial
+          ? `${unconsumed.length} agent(s) finished (partial — others still running)`
+          : `${unconsumed.length} agent(s) finished`;
+
+        const [first, ...rest] = unconsumed;
+        const details = buildNotificationDetails(first, 300, agentActivity.get(first.id));
+        if (rest.length > 0) {
+          details.others = rest.map(r => buildNotificationDetails(r, 300, agentActivity.get(r.id)));
+        }
+
+        pi.sendMessage<NotificationDetails>({
+          customType: "subagent-notification",
+          content: `Background agent group completed: ${label}\n\n${notifications}\n\nUse get_subagent_result for full output.`,
+          display: true,
+          details,
+        }, { deliverAs: "followUp", triggerTurn: true });
+      });
+      widget.update();
+    },
+    30_000,
+  );
+
+  /** Helper: build event data for lifecycle events from an AgentRecord. */
+  function buildEventData(record: AgentRecord) {
+    const durationMs = record.completedAt ? record.completedAt - record.startedAt : Date.now() - record.startedAt;
+    // All three fields are lifetime-accumulated (Σ over every assistant message_end),
+    // so they survive compaction together — input + output ≤ total always.
+    // tokens is omitted when nothing was ever produced (e.g. agent errored before
+    // any message_end fired), preserving prior payload shape.
+    const u = record.lifetimeUsage;
+    const total = getLifetimeTotal(u);
+    const tokens = total > 0
+      ? { input: u.input, output: u.output, total }
+      : undefined;
+    return {
+      id: record.id,
+      type: record.type,
+      description: record.description,
+      result: record.result,
+      error: record.error,
+      status: record.status,
+      toolUses: record.toolUses,
+      durationMs,
+      tokens,
+    };
+  }
+
+  // Background completion: route through group join or send individual nudge
+  const manager = new AgentManager((record) => {
+    // Emit lifecycle event based on terminal status
+    const isError = record.status === "error" || record.status === "stopped" || record.status === "aborted";
+    const eventData = buildEventData(record);
+    if (isError) {
+      pi.events.emit("subagents:failed", eventData);
+    } else {
+      pi.events.emit("subagents:completed", eventData);
+    }
+
+    // Persist final record for cross-extension history reconstruction
+    pi.appendEntry("subagents:record", {
+      id: record.id, type: record.type, description: record.description,
+      status: record.status, result: record.result, error: record.error,
+      startedAt: record.startedAt, completedAt: record.completedAt,
+    });
+
+    // Skip notification if result was already consumed via get_subagent_result
+    if (record.resultConsumed) {
+      agentActivity.delete(record.id);
+      widget.markFinished(record.id);
+      fleet.onAgentFinished(record.id);
+      widget.update();
+      return;
+    }
+
+    // If this agent is pending batch finalization (debounce window still open),
+    // don't send an individual nudge — finalizeBatch will pick it up retroactively.
+    if (currentBatchAgents.some(a => a.id === record.id)) {
+      widget.update();
+      return;
+    }
+
+    const result = groupJoin.onAgentComplete(record);
+    if (result === 'pass') {
+      sendIndividualNudge(record);
+    }
+    // 'held' → do nothing, group will fire later
+    // 'delivered' → group callback already fired
+    widget.update();
+  }, undefined, (record) => {
+    // Emit started event when agent transitions to running (including from queue)
+    pi.events.emit("subagents:started", {
+      id: record.id,
+      type: record.type,
+      description: record.description,
+    });
+  }, (record, info) => {
+    // Emit compacted event when agent's session compacts (preserves count on record).
+    pi.events.emit("subagents:compacted", {
+      id: record.id,
+      type: record.type,
+      description: record.description,
+      reason: info.reason,
+      tokensBefore: info.tokensBefore,
+      compactionCount: record.compactionCount,
+    });
+  });
+
+  // Expose manager via Symbol.for() global registry for cross-package access.
+  // Standard Node.js pattern for cross-package singletons (used by OpenTelemetry, etc.).
+  //
+  // Claim the slot only if it's free: subagent sessions re-activate this
+  // extension in the same process (session.bindExtensions in agent-runner.ts),
+  // and unconditionally overwriting would point the registry at a short-lived
+  // child manager — and the child's shutdown would then delete the root
+  // session's entry. The first activation (the root session) wins; child
+  // activations leave it alone.
+  const MANAGER_KEY = Symbol.for("pi-subagents:manager");
+  const registryEntry = {
+    waitForAll: () => manager.waitForAll(),
+    hasRunning: () => manager.hasRunning(),
+    spawn: (piRef: any, ctx: any, type: string, prompt: string, options: any) =>
+      manager.spawn(piRef, ctx, type, prompt, options),
+    getRecord: (id: string) => manager.getRecord(id),
+  };
+  const ownsManagerRegistry = (globalThis as any)[MANAGER_KEY] === undefined;
+  if (ownsManagerRegistry) {
+    (globalThis as any)[MANAGER_KEY] = registryEntry;
+  }
+
+  // --- Cross-extension RPC via pi.events ---
+  let currentCtx: ExtensionContext | undefined;
+  // RPC handlers + the `subagents:ready` broadcast are wired on `session_start`
+  // (a bound lifecycle event), not at factory time. pi runs every extension
+  // factory before the `extensions:` filter and only fires lifecycle events for
+  // survivors, so a child session that filtered pi-subagents out never reaches
+  // session_start — and must not advertise or answer RPC it can't service
+  // (currentCtx would stay undefined → spawn always "No active session"). Gating
+  // here makes a filtered session behave like an absent one (#142).
+  let rpcHandle: RpcHandle | undefined;
+
+  // ---- Subagent scheduler ----
+  // Session-scoped: store is constructed inside session_start once sessionId
+  // is available. Mirrors pi-chonky-tasks's session-scoped task store —
+  // schedules reset on /new, restore on /resume.
+  const scheduler = new SubagentScheduler();
+
+  function startScheduler(ctx: ExtensionContext) {
+    try {
+      const sessionId = ctx.sessionManager?.getSessionId?.();
+      if (!sessionId) return;  // sessionId not yet available — try again on next event
+      const path = resolveStorePath(ctx.cwd, sessionId);
+      const store = new ScheduleStore(path);
+      scheduler.start(pi, ctx, manager, store);
+      pi.events.emit("subagents:scheduler_ready", { sessionId, jobCount: store.list().length });
+    } catch (err) {
+      // Scheduling is non-essential — log and move on so the rest of the
+      // extension keeps working if e.g. .pi/ is unwritable.
+      console.warn("[pi-subagents] Failed to start scheduler:", err);
+    }
+  }
+
+  // Capture ctx from session_start for RPC spawn handler + start the scheduler.
+  // This also wires the RPC handlers and broadcasts readiness — on the first
+  // bound session_start, so a filtered-out activation never advertises (#142).
+  pi.on("session_start", async (_event, ctx) => {
+    currentCtx = ctx;
+    manager.clearCompleted(true);
+    // Guard mirrors the `!scheduler.isActive()` pattern below: session_start
+    // fires once per activation, but a double-bind must not leak listeners.
+    if (!rpcHandle) {
+      rpcHandle = registerRpcHandlers({
+        events: pi.events,
+        pi,
+        getCtx: () => currentCtx,
+        manager,
+      });
+      // Broadcast readiness so extensions loaded alongside us can discover us.
+      // Emitting after all factories have run (rather than at factory time)
+      // also avoids the race where a consumer loaded after us misses the event.
+      pi.events.emit("subagents:ready", {});
+    }
+    if (isSchedulingEnabled() && !scheduler.isActive()) startScheduler(ctx);
+  });
+
+  pi.on("session_before_switch", () => {
+    manager.clearCompleted(true);
+    scheduler.stop();
+  });
+
+  // On shutdown, abort all agents immediately and clean up.
+  // If the session is going down, there's nothing left to consume agent results.
+  pi.on("session_shutdown", async () => {
+    rpcHandle?.unsubSpawn();
+    rpcHandle?.unsubStop();
+    rpcHandle?.unsubPing();
+    rpcHandle = undefined;
+    currentCtx = undefined;
+    // Only release the global slot if this activation claimed it — a child
+    // session's shutdown must not delete the root session's registry entry.
+    if (ownsManagerRegistry && (globalThis as any)[MANAGER_KEY] === registryEntry) {
+      delete (globalThis as any)[MANAGER_KEY];
+    }
+    scheduler.stop();
+    manager.abortAll();
+    for (const timer of pendingNudges.values()) clearTimeout(timer);
+    pendingNudges.clear();
+    fleet.dispose();
+    manager.dispose();
+  });
+
+  // Live widget: show running agents above editor.
+  // widgetMode (default "background") selects what the widget shows: "all" =
+  // every agent; "background" = hide foreground (they already render inline as
+  // the Agent tool result, so showing them here too is a duplicate, #118), keep
+  // everything else; "off" = hide the widget entirely. Read live at render time.
+  let widgetMode: WidgetMode = "background";
+  function getWidgetMode(): WidgetMode { return widgetMode; }
+  const widget = new AgentWidget(manager, agentActivity, getWidgetMode);
+  function setWidgetMode(m: WidgetMode): void { widgetMode = m; widget.update(); }
+
+  // Claude Code-style FleetView: navigable list of main + subagents below the editor.
+  const fleet = new FleetList(manager, agentActivity);
+  let fleetViewEnabled = true;
+  function isFleetViewEnabled(): boolean { return fleetViewEnabled; }
+  function setFleetViewEnabled(b: boolean): void { fleetViewEnabled = b; fleet.setEnabled(b); }
+
+  // Project/global default for writing the subagent .output transcript. A custom
+  // agent's `output_transcript` frontmatter overrides this per spawn; when the
+  // frontmatter is silent, this default applies. Read live at spawn time.
+  let outputTranscriptDefault = true;
+  function getOutputTranscriptDefault(): boolean { return outputTranscriptDefault; }
+  function setOutputTranscript(b: boolean): void { outputTranscriptDefault = b; }
+
+  // ---- Join mode configuration ----
+  let defaultJoinMode: JoinMode = 'smart';
+  function getDefaultJoinMode(): JoinMode { return defaultJoinMode; }
+  function setDefaultJoinMode(mode: JoinMode) { defaultJoinMode = mode; }
+
+  // Master switch for the schedule subagent feature. Defaults to enabled.
+  // Read once at extension init (before tool registration) so the Agent tool's
+  // param schema reflects the persisted setting. Runtime toggles via /agents
+  // → Settings short-circuit the menu entry + the execute-time addJob path
+  // immediately, but the schema-level removal only takes effect on next
+  // extension load (next pi session). Documented in CHANGELOG/README.
+  let schedulingEnabled = true;
+  function isSchedulingEnabled(): boolean { return schedulingEnabled; }
+  function setSchedulingEnabled(b: boolean) { schedulingEnabled = b; }
+
+  // ---- Scope models configuration ----
+  // When enabled, subagent model choices are validated against `enabledModels`
+  // from pi's settings — both global `<agentDir>/settings.json` and
+  // project-local `<cwd>/.pi/settings.json` (project overrides global).
+  // Off by default; opt-in via `/agents → Settings`. See docstring on
+  // SubagentsSettings.scopeModels for the hard-error vs warn-and-proceed
+  // policy and its rationale.
+  let scopeModelsEnabled = false;
+  function isScopeModelsEnabled(): boolean { return scopeModelsEnabled; }
+  function setScopeModelsEnabled(enabled: boolean): void { scopeModelsEnabled = enabled; }
+
+  // ---- Disable default agents configuration ----
+  // When enabled, the three hardcoded default agents (general-purpose, Explore,
+  // Plan) are not registered. User-defined agents from project/global custom
+  // agent dirs are completely unaffected — only DEFAULT_AGENTS are suppressed.
+  // Defaults to false; opt-in via `/agents → Settings` or subagents.json.
+  // State lives in agent-types.ts (isDefaultsDisabled) because registerAgents
+  // needs it; this wrapper just re-registers after flipping it.
+  function setDisableDefaultAgents(b: boolean): void {
+    setDefaultsDisabled(b);
+    reloadCustomAgents(); // re-register with new setting
+  }
+
+  // ---- Agent tool description mode ----
+  // "full" (default) keeps the rich Claude Code-style description; "compact"
+  // swaps in a ~75% smaller one for small/local models (#91). Read once at
+  // tool registration — flipping it applies on the next pi session.
+  let toolDescriptionMode: ToolDescriptionMode = "full";
+  function getToolDescriptionMode(): ToolDescriptionMode { return toolDescriptionMode; }
+  function setToolDescriptionMode(mode: ToolDescriptionMode): void { toolDescriptionMode = mode; }
+
+  // ---- Batch tracking for smart join mode ----
+  // Collects background agent IDs spawned in the current turn for smart grouping.
+  // Uses a debounced timer: each new agent resets the 100ms window so that all
+  // parallel tool calls (which may be dispatched across multiple microtasks by the
+  // framework) are captured in the same batch.
+  let currentBatchAgents: { id: string; joinMode: JoinMode }[] = [];
+  let batchFinalizeTimer: ReturnType<typeof setTimeout> | undefined;
+  let batchCounter = 0;
+
+  /** Finalize the current batch: if 2+ smart-mode agents, register as a group. */
+  function finalizeBatch() {
+    batchFinalizeTimer = undefined;
+    const batchAgents = [...currentBatchAgents];
+    currentBatchAgents = [];
+
+    const smartAgents = batchAgents.filter(a => a.joinMode === 'smart' || a.joinMode === 'group');
+    if (smartAgents.length >= 2) {
+      const groupId = `batch-${++batchCounter}`;
+      const ids = smartAgents.map(a => a.id);
+      groupJoin.registerGroup(groupId, ids);
+      // Retroactively process agents that already completed during the debounce window.
+      // Their onComplete fired but was deferred (agent was in currentBatchAgents),
+      // so we feed them into the group now.
+      for (const id of ids) {
+        const record = manager.getRecord(id);
+        if (!record) continue;
+        record.groupId = groupId;
+        if (record.completedAt != null && !record.resultConsumed) {
+          groupJoin.onAgentComplete(record);
+        }
+      }
+    } else {
+      // No group formed — send individual nudges for any agents that completed
+      // during the debounce window and had their notification deferred.
+      for (const { id } of batchAgents) {
+        const record = manager.getRecord(id);
+        if (record?.completedAt != null && !record.resultConsumed) {
+          sendIndividualNudge(record);
+        }
+      }
+    }
+  }
+
+  // Grab UI context from first tool execution + clear lingering widget on new turn
+  pi.on("tool_execution_start", async (_event, ctx) => {
+    widget.setUICtx(ctx.ui as UICtx);
+    fleet.setUICtx(ctx.ui as unknown as FleetUICtx);
+    widget.onTurnStart();
+  });
+
+  /** Format an agent's tool scope: "*" when it has all built-ins, else a comma-separated list. */
+  const formatToolsSuffix = (cfg: AgentConfig | undefined): string => {
+    const tools = cfg?.builtinToolNames;
+    if (!tools || tools.length === 0) return "*";
+    const isFullSet =
+      tools.length === BUILTIN_TOOL_NAMES.length
+      && BUILTIN_TOOL_NAMES.every((t) => tools.includes(t));
+    return isFullSet ? "*" : tools.join(", ");
+  };
+
+  /** Build the full type list text dynamically from available agents only. */
+  const buildTypeListText = () => {
+    const available = getAvailableTypes();
+
+    return available.map((name) => {
+      const cfg = getAgentConfig(name);
+      const modelSuffix = cfg?.model ? ` (${getModelLabelFromConfig(cfg.model)})` : "";
+      const toolsSuffix = ` (Tools: ${formatToolsSuffix(cfg)})`;
+      return `- ${name}: ${cfg?.description ?? name}${modelSuffix}${toolsSuffix}`;
+    }).join("\n");
+  };
+
+  /** First sentence of an agent description — for the compact type list. */
+  const firstSentence = (text: string): string => {
+    const match = text.match(/^.*?[.!?](?=\s|$)/s);
+    return (match ? match[0] : text).replace(/\s+/g, " ").trim();
+  };
+
+  /** Compact type list: one line per agent, first sentence only. */
+  const buildCompactTypeListText = () =>
+    getAvailableTypes().map((name) => {
+      const cfg = getAgentConfig(name);
+      return `- ${name}: ${firstSentence(cfg?.description ?? name)} (Tools: ${formatToolsSuffix(cfg)})`;
+    }).join("\n");
+
+  /** Derive a short model label from a model string. */
+  function getModelLabelFromConfig(model: string): string {
+    // Strip provider prefix (e.g. "anthropic/claude-sonnet-4-6" → "claude-sonnet-4-6")
+    const name = model.includes("/") ? model.split("/").pop()! : model;
+    // Strip trailing date suffix (e.g. "claude-haiku-4-5-20251001" → "claude-haiku-4-5")
+    return name.replace(/-\d{8}$/, "");
+  }
+
+  // Apply persisted settings on startup and emit `subagents:settings_loaded`.
+  // Global + project merged; missing → defaults; corrupt file emits a warning
+  // to stderr and falls back to defaults.
+  applyAndEmitLoaded(
+    {
+      setMaxConcurrent: (n) => manager.setMaxConcurrent(n),
+      setDefaultMaxTurns,
+      setGraceTurns,
+      setDefaultJoinMode,
+      setSchedulingEnabled,
+      setScopeModels: setScopeModelsEnabled,
+      setDisableDefaultAgents: setDisableDefaultAgents,
+      setToolDescriptionMode: setToolDescriptionMode,
+      setFleetView: setFleetViewEnabled,
+      setWidgetMode: setWidgetMode,
+      setOutputTranscript: setOutputTranscript,
+    },
+    (event, payload) => pi.events.emit(event, payload),
+  );
+
+  // ---- Agent tool ----
+
+  // Schedule param + its guideline are gated on `schedulingEnabled` (read once
+  // at registration; flipping the setting later requires next pi session for
+  // the schema to update). Defining the shape once and spreading it via Partial
+  // preserves Type.Object's inference when present and produces a
+  // `schedule`-free schema when absent — zero LLM-context cost in disabled mode.
+  const scheduleParamShape = {
+    schedule: Type.Optional(
+      Type.String({
+        description:
+          'Opt-in only — fire later instead of now. Omit to run immediately (the default, almost always correct). ' +
+          'Formats: 6-field cron ("0 0 9 * * 1" = 9am Mon), interval ("5m"/"1h"), one-shot ("+10m" or ISO). ' +
+          'Forces run_in_background; incompatible with inherit_context and resume. Returns job ID.',
+      }),
+    ),
+  };
+  const scheduleParam: Partial<typeof scheduleParamShape> =
+    isSchedulingEnabled() ? scheduleParamShape : {};
+
+  const scheduleGuideline = isSchedulingEnabled()
+    ? `\n- Use \`schedule\` only when the user explicitly asked for scheduled / recurring / delayed execution (e.g. "every Monday", "in an hour"). Don't auto-schedule from vague intent like "monitor X" — run once now or ask.`
+    : "";
+
+  // Compact Agent tool description (#91, `toolDescriptionMode: "compact"`) —
+  // the same load-bearing facts as the full version at ~75% fewer tokens, for
+  // small/local models. Per-option details live in the param descriptions.
+  const compactAgentToolDescription = `Launch an autonomous agent for complex, multi-step tasks. Agent types:
+${buildCompactTypeListText()}
+
+Custom agents: .pi/agents/<name>.md (project) or ${getAgentDir()}/agents/<name>.md (global).
+
+Notes:
+- description: 3-5 words (shown in UI). Prompts must be self-contained — the agent has not seen this conversation.
+- Parallel work: one message, multiple Agent calls, run_in_background: true on each. You are notified when background agents finish — never poll or sleep.
+- The result is not shown to the user — summarize it for them. Verify an agent's claimed code changes before reporting work done.
+- resume continues a previous agent by ID; steer_subagent messages a running one.
+- isolation: "worktree" runs the agent in an isolated git worktree; changes land on a branch.`;
+
+  const fullAgentToolDescription = `Launch a new agent to handle complex, multi-step tasks autonomously. Each agent type has specific capabilities and tools available to it.
+
+Available agent types and the tools they have access to:
+${buildTypeListText()}
+
+Custom agents can be defined in .pi/agents/<name>.md (project) or ${getAgentDir()}/agents/<name>.md (global) — they are picked up automatically. Project-level agents override global ones. Creating a .md file with the same name as a default agent overrides it.
+
+When using the Agent tool, specify a subagent_type parameter to select which agent type to use.
+
+## When not to use
+
+If the target is already known, use a direct tool — \`read\` for a known path, \`grep\`/\`find\` for a specific symbol or string. Reserve this tool for open-ended questions that span the codebase, or tasks that match an available agent type.
+
+## Usage notes
+
+- Always include a short (3-5 word) description summarizing what the agent will do (shown in UI).
+- When you launch multiple agents for independent work, send them in a single message with multiple tool uses, with run_in_background: true on each, so they run concurrently. If the user specifies that they want agents run "in parallel", you MUST send a single message with multiple tool calls. Foreground calls run sequentially — only one executes at a time.
+- When the agent is done, it returns a single message back to you. The result is not visible to the user — to show the user, send a text message with a concise summary.
+- Trust but verify: an agent's summary describes what it intended to do, not necessarily what it did. When an agent writes or edits code, check the actual changes before reporting work as done.
+- Use run_in_background for work you don't need immediately. You will be notified when it completes — do NOT poll or sleep waiting for it. Continue with other work or respond to the user instead.
+- Foreground vs background: use foreground (default) when you need the agent's results before you can proceed. Use background when you have genuinely independent work to do in parallel.
+- Use resume with an agent ID to continue a previous agent's work. A new (non-resume) Agent call starts a fresh agent with no memory of prior runs, so the prompt must be self-contained.
+- Use steer_subagent to send mid-run messages to a running background agent.
+- Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, etc.), since it is not aware of the user's intent.
+- If an agent's description says it should be used proactively, try to use it without the user having to ask for it first.
+- Use model to specify a different model (as "provider/modelId", or fuzzy e.g. "haiku", "sonnet").
+- Use thinking to control extended thinking level.
+- Use inherit_context if the agent needs the parent conversation history.
+- Use isolation: "worktree" to run the agent in an isolated git worktree (safe parallel file modifications). The worktree is automatically cleaned up if the agent makes no changes; otherwise the path and branch are returned in the result.${scheduleGuideline}
+
+## Writing the prompt
+
+Provide clear, detailed prompts so the agent can work autonomously. Brief it like a smart colleague who just walked into the room — it hasn't seen this conversation, doesn't know what you've tried, doesn't understand why this task matters.
+- Explain what you're trying to accomplish and why.
+- Describe what you've already learned or ruled out.
+- Give enough context about the surrounding problem that the agent can make judgment calls rather than just following a narrow instruction.
+- If you need a short response, say so ("report in under 200 words").
+- Lookups: hand over the exact command. Investigations: hand over the question — prescribed steps become dead weight when the premise is wrong.
+
+Terse command-style prompts produce shallow, generic work.
+
+**Never delegate understanding.** Don't write "based on your findings, fix the bug" or "based on the research, implement it." Those phrases push synthesis onto the agent instead of doing it yourself. Write prompts that prove you understood: include file paths, line numbers, what specifically to change.`;
+
+  // `toolDescriptionMode: "custom"` — user-authored description with live
+  // dynamic parts. Project file wins over global; missing/empty falls back to
+  // "full" (a stale fallback beats a blank tool description). Only the prose
+  // is customizable — the parameter schema stays code-owned.
+  const renderToolDescriptionTemplate = (template: string): string => {
+    const vars: Record<string, () => string> = {
+      typeList: buildTypeListText,
+      compactTypeList: buildCompactTypeListText,
+      agentDir: getAgentDir,
+      scheduleGuideline: () => scheduleGuideline,
+    };
+    // Replacement callback (not a string) — agent descriptions may contain `$&` etc.
+    return template.replace(/\{\{(\w+)\}\}/g, (raw, name: string) => {
+      if (vars[name]) return vars[name]();
+      console.warn(`[pi-subagents] agent-tool-description.md: unknown placeholder ${raw} left as-is`);
+      return raw;
+    });
+  };
+
+  const loadCustomToolDescription = (): string | undefined => {
+    for (const path of [
+      join(process.cwd(), ".pi", "agent-tool-description.md"),
+      join(getAgentDir(), "agent-tool-description.md"),
+    ]) {
+      try {
+        if (!existsSync(path)) continue;
+        const text = readFileSync(path, "utf-8").trim();
+        if (text) return renderToolDescriptionTemplate(text);
+        console.warn(`[pi-subagents] ${path} is empty — ignoring`);
+      } catch (err) {
+        console.warn(`[pi-subagents] failed to read ${path}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    return undefined;
+  };
+
+  const agentToolDescription = (() => {
+    const mode = getToolDescriptionMode();
+    if (mode === "compact") return compactAgentToolDescription;
+    if (mode === "custom") {
+      const custom = loadCustomToolDescription();
+      if (custom) return custom;
+      console.warn('[pi-subagents] toolDescriptionMode is "custom" but no agent-tool-description.md found — using "full"');
+    }
+    return fullAgentToolDescription;
+  })();
+
+  pi.registerTool(defineTool({
+    name: SUBAGENT_TOOL_NAMES.AGENT,
+    label: "Agent",
+    description: agentToolDescription,
+    promptSnippet: "Launch autonomous sub-agents for complex multi-step tasks",
+    promptGuidelines: [
+      "Use Agent with specialized agents when the task matches an agent type's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing — if you delegate research to a subagent, do not also perform the same searches yourself.",
+      "For broad codebase exploration or research, spawn Agent with an appropriate subagent_type (e.g. Explore). Otherwise use direct tools (read, grep, find) when the target is already known.",
+      "When an agent runs in the background, you will be notified on completion — do not poll or sleep waiting for it. Continue with other work instead.",
+      "Trust but verify: an agent's summary describes intent, not outcome. When an agent writes or edits code, check the actual changes before reporting work as done.",
+    ],
+    parameters: Type.Object({
+      prompt: Type.String({
+        description: "The task for the agent to perform.",
+      }),
+      description: Type.String({
+        description: "A short (3-5 word) description of the task (shown in UI).",
+      }),
+      subagent_type: Type.String({
+        description: `The type of specialized agent to use. Available types: ${getAvailableTypes().join(", ")}. Custom agents from .pi/agents/*.md (project) or ${getAgentDir()}/agents/*.md (global) are also available.`,
+      }),
+      model: Type.Optional(
+        Type.String({
+          description:
+            'Optional model override. Accepts "provider/modelId" or fuzzy name (e.g. "haiku", "sonnet"). Omit to use the agent type\'s default.',
+        }),
+      ),
+      thinking: Type.Optional(
+        Type.String({
+          description: `Thinking level: ${THINKING_LEVELS.join(", ")}. Overrides agent default.`,
+        }),
+      ),
+      max_turns: Type.Optional(
+        Type.Number({
+          description: "Maximum number of agentic turns before stopping. Omit for unlimited (default).",
+          minimum: 1,
+        }),
+      ),
+      run_in_background: Type.Optional(
+        Type.Boolean({
+          description: "Set to true to run in background. Returns agent ID immediately. You will be notified on completion.",
+        }),
+      ),
+      resume: Type.Optional(
+        Type.String({
+          description: "Optional agent ID to resume from. Continues from previous context.",
+        }),
+      ),
+      isolated: Type.Optional(
+        Type.Boolean({
+          description: "If true, agent gets no extension/MCP tools — only built-in tools.",
+        }),
+      ),
+      inherit_context: Type.Optional(
+        Type.Boolean({
+          description: "If true, fork parent conversation into the agent. Default: false (fresh context).",
+        }),
+      ),
+      isolation: Type.Optional(
+        Type.Literal("worktree", {
+          description: 'Set to "worktree" to run the agent in a temporary git worktree (isolated copy of the repo). Changes are saved to a branch on completion.',
+        }),
+      ),
+      ...scheduleParam,
+    }),
+
+    // ---- Custom rendering: Claude Code style ----
+
+    renderCall(args, theme) {
+      const displayName = args.subagent_type ? getDisplayName(args.subagent_type) : "Agent";
+      const desc = args.description ?? "";
+      return new Text("▸ " + theme.fg("toolTitle", theme.bold(displayName)) + (desc ? "  " + theme.fg("muted", desc) : ""), 0, 0);
+    },
+
+    renderResult(result, { expanded, isPartial }, theme) {
+      const details = result.details as AgentDetails | undefined;
+      if (!details) {
+        const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+        return new Text(text, 0, 0);
+      }
+
+      // Helper: build "haiku · thinking: high · ↻5≤30 · 3 tool uses · 33.8k tokens" stats string
+      const stats = (d: AgentDetails) => {
+        const parts: string[] = [];
+        if (d.modelName) parts.push(d.modelName);
+        if (d.tags) parts.push(...d.tags);
+        if (d.turnCount != null && d.turnCount > 0) {
+          parts.push(formatTurns(d.turnCount, d.maxTurns));
+        }
+        if (d.toolUses > 0) parts.push(`${d.toolUses} tool use${d.toolUses === 1 ? "" : "s"}`);
+        if (d.tokens) parts.push(d.tokens);
+        return parts.map(p => fgPreservingNestedStyles(theme, "dim", p)).join(" " + theme.fg("dim", "·") + " ");
+      };
+
+      // ---- While running (streaming) ----
+      if (isPartial || details.status === "running") {
+        const frame = SPINNER[details.spinnerFrame ?? 0];
+        const s = stats(details);
+        return renderRunningAgentStatus(frame, s, details.activity ?? "thinking…", theme);
+      }
+
+      // ---- Background agent launched ----
+      if (details.status === "background") {
+        return new Text(theme.fg("dim", `  ⎿  Running in background (ID: ${details.agentId})`), 0, 0);
+      }
+
+      // ---- Completed / Steered ----
+      if (details.status === "completed" || details.status === "steered") {
+        const duration = formatMs(details.durationMs);
+        const isSteered = details.status === "steered";
+        const icon = isSteered ? theme.fg("warning", "✓") : theme.fg("success", "✓");
+        const s = stats(details);
+        let line = icon + (s ? " " + s : "");
+        line += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
+
+        if (expanded) {
+          const resultText = result.content[0]?.type === "text" ? result.content[0].text : "";
+          if (resultText) {
+            const lines = resultText.split("\n").slice(0, 50);
+            for (const l of lines) {
+              line += "\n" + theme.fg("dim", `  ${l}`);
+            }
+            if (resultText.split("\n").length > 50) {
+              line += "\n" + theme.fg("muted", "  ... (use get_subagent_result with verbose for full output)");
+            }
+          }
+        } else {
+          const doneText = isSteered ? "Wrapped up (turn limit)" : "Done";
+          line += "\n" + theme.fg("dim", `  ⎿  ${doneText}`);
+        }
+        return new Text(line, 0, 0);
+      }
+
+      // ---- Stopped (user-initiated abort) ----
+      if (details.status === "stopped") {
+        const s = stats(details);
+        let line = theme.fg("dim", "■") + (s ? " " + s : "");
+        line += "\n" + theme.fg("dim", "  ⎿  Stopped");
+        return new Text(line, 0, 0);
+      }
+
+      // ---- Error / Aborted (hard max_turns) ----
+      const s = stats(details);
+      let line = theme.fg("error", "✗") + (s ? " " + s : "");
+
+      if (details.status === "error") {
+        line += "\n" + theme.fg("error", `  ⎿  Error: ${details.error ?? "unknown"}`);
+      } else {
+        line += "\n" + theme.fg("warning", "  ⎿  Aborted (max turns exceeded)");
+      }
+
+      return new Text(line, 0, 0);
+    },
+
+    // ---- Execute ----
+
+    execute: async (toolCallId, params, signal, onUpdate, ctx) => {
+      // Ensure we have UI context for widget rendering
+      widget.setUICtx(ctx.ui as UICtx);
+
+      // Reload custom agents so new project/global .md files are picked up without restart
+      reloadCustomAgents();
+
+      const rawType = params.subagent_type as SubagentType;
+      const resolved = resolveType(rawType);
+      const subagentType = resolved ?? "general-purpose";
+      const fellBack = resolved === undefined;
+
+      const displayName = getDisplayName(subagentType);
+
+      // Get agent config (if any)
+      const customConfig = getAgentConfig(subagentType);
+
+      const resolvedConfig = resolveAgentInvocationConfig(customConfig, params);
+
+      // Resolve model from agent config first; tool-call params only fill gaps.
+      let model = ctx.model;
+      if (resolvedConfig.modelInput) {
+        const resolved = resolveModel(resolvedConfig.modelInput, ctx.modelRegistry);
+        if (typeof resolved === "string") {
+          if (resolvedConfig.modelFromParams) return textResult(resolved);
+          // config-specified: silent fallback to parent
+        } else {
+          model = resolved;
+        }
+      }
+
+      // Scope validation: the effective resolved model is checked against the
+      // user's enabledModels list (read in `enabled-models.ts`).
+      //
+      // Design: scopeModels guards against *runtime* LLM choices, not user-level config.
+      //   - Caller-supplied out-of-scope → hard error (the orchestrator made an explicit
+      //     out-of-scope choice; surface it so it picks differently).
+      //   - Frontmatter-pinned or parent-inherited out-of-scope → warn but proceed (the
+      //     user authored/installed this agent or chose the parent's model; trust it).
+      // See SubagentsSettings.scopeModels docstring for the full policy.
+      if (isScopeModelsEnabled() && model) {
+        const allowed = resolveEnabledModels(readEnabledModels(ctx.cwd), ctx.modelRegistry, ctx.cwd);
+        if (allowed && !isModelInScope(model, allowed)) {
+          if (resolvedConfig.modelFromParams) {
+            const list = [...allowed].sort().map(m => `  ${m}`).join("\n");
+            return textResult(
+              `Model not in scope: "${resolvedConfig.modelInput}".\n\n` +
+              `Allowed models (from enabledModels):\n${list}`,
+            );
+          }
+          // Frontmatter-pinned or parent-inherited: warn + proceed.
+          const agentLabel = customConfig?.displayName ?? subagentType;
+          const modelLabel = resolvedConfig.modelInput ?? `${model.provider}/${model.id}`;
+          ctx.ui.notify(
+            `Agent "${agentLabel}" using out-of-scope model "${modelLabel}"`,
+            "warning",
+          );
+        }
+      }
+
+      const thinking = resolvedConfig.thinking;
+      const inheritContext = resolvedConfig.inheritContext;
+      const runInBackground = resolvedConfig.runInBackground;
+      const isolated = resolvedConfig.isolated;
+      const isolation = resolvedConfig.isolation;
+      // Whether this spawn writes its .output transcript. Per-agent
+      // frontmatter (`output_transcript`) wins; otherwise the project/global
+      // default applies. `attachTranscript` below is the SOLE gate — every
+      // downstream consumer keys off record.outputFile being set, so no spawn
+      // path can re-enable the transcript by accident.
+      const outputTranscript = customConfig?.outputTranscript ?? getOutputTranscriptDefault();
+      const attachTranscript = (rec: AgentRecord | undefined, agentId: string): void => {
+        if (!rec || !outputTranscript) return;
+        rec.outputFile = createOutputFilePath(ctx.cwd, agentId, ctx.sessionManager.getSessionId());
+        writeInitialEntry(rec.outputFile, agentId, params.prompt, ctx.cwd);
+      };
+
+      const parentModelId = ctx.model?.id;
+      const effectiveModelId = model?.id;
+      const modelName = effectiveModelId && effectiveModelId !== parentModelId
+        ? (model?.name ?? effectiveModelId).replace(/^Claude\s+/i, "").toLowerCase()
+        : undefined;
+      const effectiveMaxTurns = normalizeMaxTurns(resolvedConfig.maxTurns ?? getDefaultMaxTurns());
+      const agentInvocation: AgentInvocation = {
+        modelName,
+        thinking,
+        // Explicit value only — the default fallback would just add noise.
+        // Normalize so `0` (unlimited) doesn't surface as a misleading "max turns: 0".
+        maxTurns: normalizeMaxTurns(resolvedConfig.maxTurns),
+        isolated,
+        inheritContext,
+        runInBackground,
+        isolation,
+      };
+      // Tool-result render shows the mode label too; viewer's header already does.
+      const modeLabel = getPromptModeLabel(subagentType);
+      const { tags: invocationTags } = buildInvocationTags(agentInvocation);
+      const agentTags = modeLabel ? [modeLabel, ...invocationTags] : invocationTags;
+      const detailBase = {
+        displayName,
+        description: params.description,
+        subagentType,
+        modelName,
+        tags: agentTags.length > 0 ? agentTags : undefined,
+      };
+
+      // ---- Schedule: register a job, don't spawn now ----
+      if (params.schedule) {
+        if (!isSchedulingEnabled()) {
+          return textResult("Scheduling is disabled in this project. Enable via /agents → Settings → Scheduling.");
+        }
+        if (params.resume) {
+          return textResult("Cannot combine `schedule` with `resume` — schedules create fresh agents.");
+        }
+        if (params.inherit_context) {
+          return textResult("Cannot combine `schedule` with `inherit_context` — there is no parent conversation at fire time.");
+        }
+        if (params.run_in_background === false) {
+          return textResult("Cannot combine `schedule` with `run_in_background: false` — scheduled jobs always run in background.");
+        }
+        if (!scheduler.isActive()) {
+          return textResult("Scheduler is not active in this session yet. Try again after the session has fully started.");
+        }
+        try {
+          const job = scheduler.addJob({
+            name: params.description as string,
+            description: params.description as string,
+            schedule: params.schedule as string,
+            subagent_type: subagentType,
+            prompt: params.prompt as string,
+            model: params.model as string | undefined,
+            thinking: thinking,
+            max_turns: effectiveMaxTurns,
+            isolated: isolated,
+            isolation: isolation,
+          });
+          const next = scheduler.getNextRun(job.id);
+          return textResult(
+            `Scheduled "${job.name}" (id: ${job.id}, type: ${job.scheduleType}). ` +
+            `Next run: ${next ?? "(unknown)"}. ` +
+            `Manage via /agents → Scheduled jobs.`,
+          );
+        } catch (err) {
+          return textResult(err instanceof Error ? err.message : String(err));
+        }
+      }
+
+      // Resume existing agent
+      if (params.resume) {
+        const existing = manager.getRecord(params.resume);
+        if (!existing) {
+          return textResult(`Agent not found: "${params.resume}". It may have been cleaned up.`);
+        }
+        if (!existing.session) {
+          return textResult(`Agent "${params.resume}" has no active session to resume.`);
+        }
+        const record = await manager.resume(params.resume, params.prompt, signal);
+        if (!record) {
+          return textResult(`Failed to resume agent "${params.resume}".`);
+        }
+        // A failed resume surfaces the error, plus any partial output THIS
+        // resume produced (never the previous turn's answer, #144).
+        if (record.status === "error") {
+          return textResult(`Agent failed: ${record.error}${partialOutputSuffix(record)}`, buildDetails(detailBase, record));
+        }
+        return textResult(
+          record.result?.trim() || "No output.",
+          buildDetails(detailBase, record),
+        );
+      }
+
+      // Background execution
+      if (runInBackground) {
+        const { state: bgState, callbacks: bgCallbacks } = createActivityTracker(effectiveMaxTurns);
+
+        // Wrap onSessionCreated to wire output file streaming.
+        // The callback lazily reads record.outputFile (set right after spawn)
+        // rather than closing over a value that doesn't exist yet.
+        let id: string;
+        const origBgOnSession = bgCallbacks.onSessionCreated;
+        bgCallbacks.onSessionCreated = (session: any) => {
+          origBgOnSession(session);
+          const rec = manager.getRecord(id);
+          if (rec?.outputFile) {
+            rec.outputCleanup = streamToOutputFile(session, rec.outputFile, id, ctx.cwd);
+          }
+        };
+
+        try {
+          id = manager.spawn(pi, ctx, subagentType, params.prompt, {
+            description: params.description,
+            model,
+            maxTurns: effectiveMaxTurns,
+            isolated,
+            inheritContext,
+            thinkingLevel: thinking,
+            isBackground: true,
+            isolation,
+            invocation: agentInvocation,
+            ...bgCallbacks,
+          });
+        } catch (err) {
+          return textResult(err instanceof Error ? err.message : String(err));
+        }
+
+        // Set output file + join mode synchronously after spawn, before the
+        // event loop yields — onSessionCreated is async so this is safe.
+        const joinMode = resolveJoinMode(defaultJoinMode, true);
+        const record = manager.getRecord(id);
+        if (record && joinMode) {
+          record.joinMode = joinMode;
+          record.toolCallId = toolCallId;
+          attachTranscript(record, id);
+        }
+
+        if (joinMode == null || joinMode === 'async') {
+          // Foreground/no join mode or explicit async — not part of any batch
+        } else {
+          // smart or group — add to current batch
+          currentBatchAgents.push({ id, joinMode });
+          // Debounce: reset timer on each new agent so parallel tool calls
+          // dispatched across multiple event loop ticks are captured together
+          if (batchFinalizeTimer) clearTimeout(batchFinalizeTimer);
+          batchFinalizeTimer = setTimeout(finalizeBatch, 100);
+        }
+
+        agentActivity.set(id, bgState);
+        widget.ensureTimer();
+        widget.update();
+        fleet.ensureTimer();
+        fleet.update();
+
+        // Emit created event
+        pi.events.emit("subagents:created", {
+          id,
+          type: subagentType,
+          description: params.description,
+          isBackground: true,
+        });
+
+        const isQueued = record?.status === "queued";
+        return textResult(
+          `Agent ${isQueued ? "queued" : "started"} in background.\n` +
+          `Agent ID: ${id}\n` +
+          `Type: ${displayName}\n` +
+          `Description: ${params.description}\n` +
+          (record?.outputFile ? `Output file: ${record.outputFile}\n` : "") +
+          (isQueued ? `Position: queued (max ${manager.getMaxConcurrent()} concurrent)\n` : "") +
+          `\nYou will be notified when this agent completes.\n` +
+          `Use get_subagent_result to retrieve full results, or steer_subagent to send it messages.\n` +
+          `Do not duplicate this agent's work.`,
+          { ...detailBase, toolUses: 0, tokens: "", durationMs: 0, status: "background" as const, agentId: id },
+        );
+      }
+
+      // Foreground (synchronous) execution — stream progress via onUpdate
+      let spinnerFrame = 0;
+      const startedAt = Date.now();
+      let fgId: string | undefined;
+
+      const streamUpdate = () => {
+        const details: AgentDetails = {
+          ...detailBase,
+          toolUses: fgState.toolUses,
+          tokens: formatLifetimeTokens(fgState),
+          turnCount: fgState.turnCount,
+          maxTurns: fgState.maxTurns,
+          durationMs: Date.now() - startedAt,
+          status: "running",
+          activity: describeActivity(fgState.activeTools, fgState.responseText),
+          spinnerFrame: spinnerFrame % SPINNER.length,
+        };
+        onUpdate?.({
+          content: [{ type: "text", text: `${fgState.toolUses} tool uses...` }],
+          details: details as any,
+        });
+      };
+
+      const { state: fgState, callbacks: fgCallbacks } = createActivityTracker(effectiveMaxTurns, streamUpdate);
+
+      // Wire session creation: register in widget + stream to output file.
+      // The output file path is set synchronously after spawn (below),
+      // before onSessionCreated fires — same pattern as background agents.
+      const origOnSession = fgCallbacks.onSessionCreated;
+      fgCallbacks.onSessionCreated = (session: any) => {
+        origOnSession(session);
+        for (const a of manager.listAgents()) {
+          if (a.session === session) {
+            fgId = a.id;
+            agentActivity.set(a.id, fgState);
+            widget.ensureTimer();
+            fleet.ensureTimer();
+            fleet.update();
+            break;
+          }
+        }
+        // Stream conversation to output file (foreground agent logging)
+        if (fgId) {
+          const rec = manager.getRecord(fgId);
+          if (rec?.outputFile) {
+            rec.outputCleanup = streamToOutputFile(session, rec.outputFile, fgId, ctx.cwd);
+          }
+        }
+      };
+
+      // Animate spinner at ~80ms (smooth rotation through 10 braille frames)
+      const spinnerInterval = setInterval(() => {
+        spinnerFrame++;
+        streamUpdate();
+      }, 80);
+
+      streamUpdate();
+
+      let record: AgentRecord;
+      try {
+        const fgResult = await manager.spawnAndWait(pi, ctx, subagentType, params.prompt, {
+          description: params.description,
+          model,
+          maxTurns: effectiveMaxTurns,
+          isolated,
+          inheritContext,
+          thinkingLevel: thinking,
+          isolation,
+          invocation: agentInvocation,
+          signal,
+          ...fgCallbacks,
+        }, (fgAgentId) => {
+          // onSpawned: called synchronously after spawn, before onSessionCreated fires.
+          // Set up the output file so streamToOutputFile can pick it up.
+          const fgRec = manager.getRecord(fgAgentId);
+          attachTranscript(fgRec, fgAgentId);
+        });
+        record = fgResult.record;
+      } catch (err) {
+        clearInterval(spinnerInterval);
+        return textResult(err instanceof Error ? err.message : String(err));
+      }
+
+      clearInterval(spinnerInterval);
+
+      // Clean up foreground agent from widget
+      if (fgId) {
+        agentActivity.delete(fgId);
+        widget.markFinished(fgId);
+        fleet.onAgentFinished(fgId);
+      }
+
+      // Get final token count
+      const tokenText = formatLifetimeTokens(fgState);
+
+      const details = buildDetails(detailBase, record, fgState, { tokens: tokenText });
+
+      // "general-purpose" may itself be unregistered (defaults disabled, no
+      // user override) — getConfig then uses the hardcoded fallback config.
+      const fallbackNote = fellBack
+        ? `Note: Unknown agent type "${rawType}" — using ${resolveType("general-purpose") ? "general-purpose" : "the fallback agent config"}.\n\n`
+        : "";
+
+      if (record.status === "error") {
+        // Error headline + any partial output the run produced before failing.
+        return textResult(`${fallbackNote}Agent failed: ${record.error}${partialOutputSuffix(record)}`, details);
+      }
+
+      const durationMs = (record.completedAt ?? Date.now()) - record.startedAt;
+      const statsParts = [`${record.toolUses} tool uses`];
+      if (tokenText) statsParts.push(tokenText);
+      return textResult(
+        `${fallbackNote}Agent completed in ${formatMs(durationMs)} (${statsParts.join(", ")})${getStatusNote(record.status)}.\n\n` +
+        (record.result?.trim() || "No output."),
+        details,
+      );
+    },
+  }));
+
+  // ---- get_subagent_result tool ----
+
+  pi.registerTool(defineTool({
+    name: SUBAGENT_TOOL_NAMES.GET_RESULT,
+    label: "Get Agent Result",
+    description:
+      "Check status and retrieve results from a background agent. Use the agent ID returned by Agent with run_in_background.",
+    promptSnippet: "Check status and retrieve results from a background agent",
+    parameters: Type.Object({
+      agent_id: Type.String({
+        description: "The agent ID to check.",
+      }),
+      wait: Type.Optional(
+        Type.Boolean({
+          description: "If true, wait for the agent to complete before returning. Default: false.",
+        }),
+      ),
+      verbose: Type.Optional(
+        Type.Boolean({
+          description: "If true, include the agent's full conversation (messages + tool calls). Default: false.",
+        }),
+      ),
+    }),
+    execute: async (_toolCallId, params, signal, _onUpdate, _ctx) => {
+      const record = manager.getRecord(params.agent_id);
+      if (!record) {
+        return textResult(`Agent not found: "${params.agent_id}". It may have been cleaned up.`);
+      }
+
+      // Wait for completion if requested. Cancellation stops only this tool
+      // call; the background agent keeps running and remains unconsumed so its
+      // completion notification can still be delivered.
+      // Queued agents have no promise yet (it's created when the queue starts
+      // them), so poll until they leave the queue, then await like a running one.
+      if (params.wait && (record.status === "running" || record.status === "queued")) {
+        while (record.status === "queued") {
+          await abortable(
+            new Promise<void>((resolve) => setTimeout(resolve, QUEUE_WAIT_POLL_MS)),
+            signal,
+          );
+        }
+        if (record.promise) await abortable(record.promise, signal);
+      }
+
+      const displayName = getDisplayName(record.type);
+      const duration = formatDuration(record.startedAt, record.completedAt);
+      const tokens = formatLifetimeTokens(record);
+      const contextPercent = getSessionContextPercent(record.session);
+      const statsParts = [`Tool uses: ${record.toolUses}`];
+      if (tokens) statsParts.push(tokens);
+      if (contextPercent !== null) statsParts.push(`Context: ${Math.round(contextPercent)}%`);
+      if (record.compactionCount) statsParts.push(`Compactions: ${record.compactionCount}`);
+      statsParts.push(`Duration: ${duration}`);
+
+      let output =
+        `Agent: ${record.id}\n` +
+        `Type: ${displayName} | Status: ${record.status}${getStatusNote(record.status)} | ${statsParts.join(" | ")}\n` +
+        `Description: ${record.description}\n\n`;
+
+      if (record.status === "running") {
+        output += "Agent is still running. Use wait: true or check back later.";
+      } else if (record.status === "error") {
+        output += `Error: ${record.error}${partialOutputSuffix(record)}`;
+      } else {
+        output += record.result?.trim() || "No output.";
+      }
+
+      // Mark result as consumed — suppresses the completion notification
+      if (record.status !== "running" && record.status !== "queued") {
+        record.resultConsumed = true;
+        cancelNudge(params.agent_id);
+      }
+
+      // Verbose: include full conversation
+      if (params.verbose && record.session) {
+        const conversation = getAgentConversation(record.session);
+        if (conversation) {
+          output += `\n\n--- Agent Conversation ---\n${conversation}`;
+        }
+      }
+
+      return textResult(output);
+    },
+  }));
+
+  // ---- steer_subagent tool ----
+
+  pi.registerTool(defineTool({
+    name: SUBAGENT_TOOL_NAMES.STEER,
+    label: "Steer Agent",
+    description:
+      "Send a steering message to a running agent. The message will interrupt the agent after its current tool execution " +
+      "and be injected into its conversation, allowing you to redirect its work mid-run. Only works on running agents.",
+    promptSnippet: "Send a steering message to redirect a running background agent",
+    parameters: Type.Object({
+      agent_id: Type.String({
+        description: "The agent ID to steer (must be currently running).",
+      }),
+      message: Type.String({
+        description: "The steering message to send. This will appear as a user message in the agent's conversation.",
+      }),
+    }),
+    execute: async (_toolCallId, params, _signal, _onUpdate, _ctx) => {
+      const record = manager.getRecord(params.agent_id);
+      if (!record) {
+        return textResult(`Agent not found: "${params.agent_id}". It may have been cleaned up.`);
+      }
+      if (record.status !== "running") {
+        return textResult(`Agent "${params.agent_id}" is not running (status: ${record.status}). Cannot steer a non-running agent.`);
+      }
+      if (!record.session) {
+        // Session not ready yet — queue the steer for delivery once initialized
+        if (!record.pendingSteers) record.pendingSteers = [];
+        record.pendingSteers.push(params.message);
+        pi.events.emit("subagents:steered", { id: record.id, message: params.message });
+        return textResult(`Steering message queued for agent ${record.id}. It will be delivered once the session initializes.`);
+      }
+
+      try {
+        await steerAgent(record.session, params.message);
+        pi.events.emit("subagents:steered", { id: record.id, message: params.message });
+        const tokens = formatLifetimeTokens(record);
+        const contextPercent = getSessionContextPercent(record.session);
+        const stateParts: string[] = [];
+        if (tokens) stateParts.push(tokens);
+        stateParts.push(`${record.toolUses} tool ${record.toolUses === 1 ? "use" : "uses"}`);
+        if (contextPercent !== null) stateParts.push(`context ${Math.round(contextPercent)}% full`);
+        if (record.compactionCount) stateParts.push(`${record.compactionCount} compaction${record.compactionCount === 1 ? "" : "s"}`);
+        return textResult(
+          `Steering message sent to agent ${record.id}. The agent will process it after its current tool execution.\n` +
+          `Current state: ${stateParts.join(" · ")}`,
+        );
+      } catch (err) {
+        return textResult(`Failed to steer agent: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
+  }));
+
+  // ---- /agents interactive menu ----
+
+  const projectAgentsDir = () => join(process.cwd(), ".pi", "agents");
+  const workspaceAgentsDir = () => join(process.cwd(), ".agents", "agents");
+  const personalAgentsDir = () => join(getAgentDir(), "agents");
+
+  /** Find the file path of a custom agent by name, in discovery-precedence order (project, workspace, then global). */
+  function findAgentFile(name: string): { path: string; location: "project" | "workspace" | "personal" } | undefined {
+    const projectPath = join(projectAgentsDir(), `${name}.md`);
+    if (existsSync(projectPath)) return { path: projectPath, location: "project" };
+    const workspacePath = join(workspaceAgentsDir(), `${name}.md`);
+    if (existsSync(workspacePath)) return { path: workspacePath, location: "workspace" };
+    const personalPath = join(personalAgentsDir(), `${name}.md`);
+    if (existsSync(personalPath)) return { path: personalPath, location: "personal" };
+    return undefined;
+  }
+
+  function getModelLabel(type: string, registry?: ModelRegistry): string {
+    const cfg = getAgentConfig(type);
+    if (!cfg?.model) return "inherit"; // no model configured → really inherits parent
+    const label = getModelLabelFromConfig(cfg.model);
+    if (!registry) return label;
+    const resolved = resolveModel(cfg.model, registry);
+    // Configured but unresolvable: the runtime silently falls back to the parent
+    // model, so flag it (and the fallback) rather than hiding the config.
+    if (typeof resolved === "string") return `${label} (unavailable, fallback: inherit)`;
+    // Surface what it actually resolved to when that differs from the config —
+    // e.g. a provider fallback or a looser version pin. Cosmetic separator/date
+    // differences are normalized away so an effectively-identical match stays quiet.
+    const resolvedFull = `${resolved.provider}/${resolved.id}`;
+    const norm = (s: string) => s.toLowerCase().replace(/\./g, "-").replace(/-\d{8}$/, "");
+    if (norm(cfg.model) === norm(resolvedFull)) return label;
+    return `${label} (→ ${resolvedFull.replace(/-\d{8}$/, "")})`;
+  }
+
+  async function showAgentsMenu(ctx: ExtensionCommandContext) {
+    reloadCustomAgents();
+    const allNames = getAllTypes();
+
+    // Build select options
+    const options: string[] = [];
+
+    // Running agents entry (only if there are active agents)
+    const agents = manager.listAgents();
+    if (agents.length > 0) {
+      const running = agents.filter(a => a.status === "running" || a.status === "queued").length;
+      const done = agents.filter(a => a.status === "completed" || a.status === "steered").length;
+      options.push(`Running agents (${agents.length}) — ${running} running, ${done} done`);
+    }
+
+    // Agent types list
+    if (allNames.length > 0) {
+      options.push(`Agent types (${allNames.length})`);
+    }
+
+    // Scheduled jobs entry (always present when scheduler is active)
+    if (scheduler.isActive()) {
+      const jobCount = scheduler.list().length;
+      options.push(`Scheduled jobs (${jobCount})`);
+    }
+
+    // Actions
+    options.push("Create new agent");
+    options.push("Settings");
+
+    const noAgentsMsg = allNames.length === 0 && agents.length === 0
+      ? "No agents found. Create specialized subagents that can be delegated to.\n\n" +
+        "Each subagent has its own context window, custom system prompt, and specific tools.\n\n" +
+        "Try creating: Code Reviewer, Security Auditor, Test Writer, or Documentation Writer.\n\n"
+      : "";
+
+    if (noAgentsMsg) {
+      ctx.ui.notify(noAgentsMsg, "info");
+    }
+
+    const choice = await ctx.ui.select("Agents", options);
+    if (!choice) return;
+
+    if (choice.startsWith("Running agents (")) {
+      await showRunningAgents(ctx);
+      await showAgentsMenu(ctx);
+    } else if (choice.startsWith("Agent types (")) {
+      await showAllAgentsList(ctx);
+      await showAgentsMenu(ctx);
+    } else if (choice.startsWith("Scheduled jobs (")) {
+      await showSchedulesMenu(ctx, scheduler);
+      await showAgentsMenu(ctx);
+    } else if (choice === "Create new agent") {
+      await showCreateWizard(ctx);
+    } else if (choice === "Settings") {
+      await showSettings(ctx);
+      await showAgentsMenu(ctx);
+    }
+  }
+
+  async function showAllAgentsList(ctx: ExtensionCommandContext) {
+    const allNames = getAllTypes();
+    if (allNames.length === 0) {
+      ctx.ui.notify("No agents.", "info");
+      return;
+    }
+
+    // Source indicators: defaults unmarked, custom agents get • (project) or ◦ (global)
+    // Disabled agents get ✕ prefix
+    const sourceIndicator = (cfg: AgentConfig | undefined) => {
+      const disabled = cfg?.enabled === false;
+      if (cfg?.source === "project") return disabled ? "✕• " : "•  ";
+      if (cfg?.source === "global") return disabled ? "✕◦ " : "◦  ";
+      if (disabled) return "✕  ";
+      return "   ";
+    };
+
+    // One row per agent (name in the left column, model on the right); the
+    // full description renders below the highlighted row via SettingsList,
+    // exactly like the Settings menu — so long descriptions never wrap the list.
+    const items: SettingItem[] = allNames.map(name => {
+      const cfg = getAgentConfig(name);
+      const disabled = cfg?.enabled === false;
+      const model = getModelLabel(name, ctx.modelRegistry);
+      return {
+        id: name,
+        label: `${sourceIndicator(cfg)}${name}`,
+        currentValue: model,
+        description: disabled ? "(disabled)" : (cfg?.description ?? name),
+        // Single-value list so Enter "activates" the row (fires onChange with the
+        // agent's id) without offering anything to actually cycle.
+        values: [model],
+      };
+    });
+
+    const hasCustom = allNames.some(n => { const c = getAgentConfig(n); return c && !c.isDefault && c.enabled !== false; });
+    const hasDisabled = allNames.some(n => getAgentConfig(n)?.enabled === false);
+    const legendParts: string[] = [];
+    if (hasCustom) legendParts.push("• = project  ◦ = global");
+    if (hasDisabled) legendParts.push("✕ = disabled");
+
+    const selected = await ctx.ui.custom<string | undefined>((_tui, _theme, _kb, done) => {
+      const slTheme = getSettingsListTheme();
+      const list = new SettingsList(
+        items,
+        Math.min(items.length, 12),
+        slTheme,
+        id => done(id), // Enter/Space on a row → return that agent's name
+        () => done(undefined), // Esc → cancel
+      );
+      const container = new Container();
+      container.addChild(new Text("Agent types", 0, 0));
+      if (legendParts.length) container.addChild(new Text(slTheme.hint(legendParts.join("  ")), 0, 0));
+      container.addChild(new Spacer(1));
+      container.addChild(list);
+      return {
+        render: (w: number) => container.render(w),
+        invalidate: () => container.invalidate(),
+        handleInput: (data: string) => list.handleInput?.(data),
+      };
+    });
+
+    if (selected && getAgentConfig(selected)) {
+      await showAgentDetail(ctx, selected);
+      await showAllAgentsList(ctx);
+    }
+  }
+
+  async function showRunningAgents(ctx: ExtensionCommandContext) {
+    const agents = manager.listAgents();
+    if (agents.length === 0) {
+      ctx.ui.notify("No agents.", "info");
+      return;
+    }
+
+    const options = agents.map(a => {
+      const dn = getDisplayName(a.type);
+      const dur = formatDuration(a.startedAt, a.completedAt);
+      return `${dn} (${a.description}) · ${a.toolUses} tools · ${a.status} · ${dur}`;
+    });
+
+    const choice = await ctx.ui.select("Running agents", options);
+    if (!choice) return;
+
+    // Find the selected agent by matching the option index
+    const idx = options.indexOf(choice);
+    if (idx < 0) return;
+    const record = agents[idx];
+
+    await viewAgentConversation(ctx, record);
+    // Back-navigation: re-show the list
+    await showRunningAgents(ctx);
+  }
+
+  async function viewAgentConversation(ctx: ExtensionCommandContext, record: AgentRecord) {
+    if (!record.session) {
+      ctx.ui.notify(`Agent is ${record.status === "queued" ? "queued" : "expired"} — no session available.`, "info");
+      return;
+    }
+
+    const { ConversationViewer, VIEWPORT_HEIGHT_PCT } = await import("./ui/conversation-viewer.js");
+    const session = record.session;
+    const activity = agentActivity.get(record.id);
+
+    await ctx.ui.custom<undefined>(
+      (tui, theme, keybindings, done) => {
+        return new ConversationViewer(tui, session, record, activity, theme, done, () => {
+          if (manager.abort(record.id)) {
+            ctx.ui.notify(`Stopped "${record.description}".`, "info");
+          }
+        }, keybindings, (message: string) => manager.steer(record.id, message));
+      },
+      {
+        overlay: true,
+        overlayOptions: { anchor: "center", width: "90%", maxHeight: `${VIEWPORT_HEIGHT_PCT}%` },
+      },
+    );
+  }
+
+  async function showAgentDetail(ctx: ExtensionCommandContext, name: string) {
+    const cfg = getAgentConfig(name);
+    if (!cfg) {
+      ctx.ui.notify(`Agent config not found for "${name}".`, "warning");
+      return;
+    }
+
+    const file = findAgentFile(name);
+    const isDefault = cfg.isDefault === true;
+    const disabled = cfg.enabled === false;
+
+    let menuOptions: string[];
+    if (disabled && file) {
+      // Disabled agent with a file — offer Enable
+      menuOptions = isDefault
+        ? ["Enable", "Edit", "Reset to default", "Delete", "Back"]
+        : ["Enable", "Edit", "Delete", "Back"];
+    } else if (isDefault && !file) {
+      // Default agent with no .md override
+      menuOptions = ["Eject (export as .md)", "Disable", "Back"];
+    } else if (isDefault && file) {
+      // Default agent with .md override (ejected)
+      menuOptions = ["Edit", "Disable", "Reset to default", "Delete", "Back"];
+    } else {
+      // User-defined agent
+      menuOptions = ["Edit", "Disable", "Delete", "Back"];
+    }
+
+    const choice = await ctx.ui.select(name, menuOptions);
+    if (!choice || choice === "Back") return;
+
+    if (choice === "Edit" && file) {
+      const content = readFileSync(file.path, "utf-8");
+      const edited = await ctx.ui.editor(`Edit ${name}`, content);
+      if (edited !== undefined && edited !== content) {
+        const { writeFileSync } = await import("node:fs");
+        writeFileSync(file.path, edited, "utf-8");
+        reloadCustomAgents();
+        ctx.ui.notify(`Updated ${file.path}`, "info");
+      }
+    } else if (choice === "Delete") {
+      if (file) {
+        const confirmed = await ctx.ui.confirm("Delete agent", `Delete ${name} from ${file.location} (${file.path})?`);
+        if (confirmed) {
+          unlinkSync(file.path);
+          reloadCustomAgents();
+          ctx.ui.notify(`Deleted ${file.path}`, "info");
+        }
+      }
+    } else if (choice === "Reset to default" && file) {
+      const confirmed = await ctx.ui.confirm("Reset to default", `Delete override ${file.path} and restore embedded default?`);
+      if (confirmed) {
+        unlinkSync(file.path);
+        reloadCustomAgents();
+        ctx.ui.notify(`Restored default ${name}`, "info");
+      }
+    } else if (choice.startsWith("Eject")) {
+      await ejectAgent(ctx, name, cfg);
+    } else if (choice === "Disable") {
+      await disableAgent(ctx, name);
+    } else if (choice === "Enable") {
+      await enableAgent(ctx, name);
+    }
+  }
+
+  /** Eject a default agent: write its embedded config as a .md file. */
+  async function ejectAgent(ctx: ExtensionCommandContext, name: string, cfg: AgentConfig) {
+    const location = await ctx.ui.select("Choose location", [
+      "Project (.pi/agents/)",
+      `Personal (${personalAgentsDir()})`,
+    ]);
+    if (!location) return;
+
+    const targetDir = location.startsWith("Project") ? projectAgentsDir() : personalAgentsDir();
+    mkdirSync(targetDir, { recursive: true });
+
+    const targetPath = join(targetDir, `${name}.md`);
+    if (existsSync(targetPath)) {
+      const overwrite = await ctx.ui.confirm("Overwrite", `${targetPath} already exists. Overwrite?`);
+      if (!overwrite) return;
+    }
+
+    // Build the .md file content
+    const fmFields: string[] = [];
+    fmFields.push(`description: ${JSON.stringify(cfg.description)}`);
+    if (cfg.displayName) fmFields.push(`display_name: ${cfg.displayName}`);
+    fmFields.push(`tools: ${cfg.builtinToolNames?.join(", ") || "all"}`);
+    if (cfg.model) fmFields.push(`model: ${cfg.model}`);
+    if (cfg.thinking) fmFields.push(`thinking: ${cfg.thinking}`);
+    if (cfg.maxTurns) fmFields.push(`max_turns: ${cfg.maxTurns}`);
+    fmFields.push(`prompt_mode: ${cfg.promptMode}`);
+    if (cfg.extensions === false) fmFields.push("extensions: false");
+    else if (Array.isArray(cfg.extensions)) fmFields.push(`extensions: ${cfg.extensions.join(", ")}`);
+    if (cfg.excludeExtensions?.length) fmFields.push(`exclude_extensions: ${cfg.excludeExtensions.join(", ")}`);
+    if (cfg.skills === false) fmFields.push("skills: false");
+    else if (Array.isArray(cfg.skills)) fmFields.push(`skills: ${cfg.skills.join(", ")}`);
+    if (cfg.disallowedTools?.length) fmFields.push(`disallowed_tools: ${cfg.disallowedTools.join(", ")}`);
+    if (cfg.inheritContext) fmFields.push("inherit_context: true");
+    if (cfg.runInBackground) fmFields.push("run_in_background: true");
+    if (cfg.outputTranscript === false) fmFields.push("output_transcript: false");
+    if (cfg.isolated) fmFields.push("isolated: true");
+    if (cfg.memory) fmFields.push(`memory: ${cfg.memory}`);
+    if (cfg.isolation) fmFields.push(`isolation: ${cfg.isolation}`);
+
+    const content = `---\n${fmFields.join("\n")}\n---\n\n${cfg.systemPrompt}\n`;
+
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(targetPath, content, "utf-8");
+    reloadCustomAgents();
+    ctx.ui.notify(`Ejected ${name} to ${targetPath}`, "info");
+  }
+
+  /** Disable an agent: set enabled: false in its .md file, or create a stub for built-in defaults. */
+  async function disableAgent(ctx: ExtensionCommandContext, name: string) {
+    const file = findAgentFile(name);
+    if (file) {
+      // Existing file — set enabled: false in frontmatter (idempotent)
+      const content = readFileSync(file.path, "utf-8");
+      if (content.includes("\nenabled: false\n")) {
+        ctx.ui.notify(`${name} is already disabled.`, "info");
+        return;
+      }
+      const updated = content.replace(/^---\n/, "---\nenabled: false\n");
+      const { writeFileSync } = await import("node:fs");
+      writeFileSync(file.path, updated, "utf-8");
+      reloadCustomAgents();
+      ctx.ui.notify(`Disabled ${name} (${file.path})`, "info");
+      return;
+    }
+
+    // No file (built-in default) — create a stub
+    const location = await ctx.ui.select("Choose location", [
+      "Project (.pi/agents/)",
+      `Personal (${personalAgentsDir()})`,
+    ]);
+    if (!location) return;
+
+    const targetDir = location.startsWith("Project") ? projectAgentsDir() : personalAgentsDir();
+    mkdirSync(targetDir, { recursive: true });
+
+    const targetPath = join(targetDir, `${name}.md`);
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(targetPath, "---\nenabled: false\n---\n", "utf-8");
+    reloadCustomAgents();
+    ctx.ui.notify(`Disabled ${name} (${targetPath})`, "info");
+  }
+
+  /** Enable a disabled agent by removing enabled: false from its frontmatter. */
+  async function enableAgent(ctx: ExtensionCommandContext, name: string) {
+    const file = findAgentFile(name);
+    if (!file) return;
+
+    const content = readFileSync(file.path, "utf-8");
+    const updated = content.replace(/^(---\n)enabled: false\n/, "$1");
+    const { writeFileSync } = await import("node:fs");
+
+    // If the file was just a stub ("---\n---\n"), delete it to restore the built-in default
+    if (updated.trim() === "---\n---" || updated.trim() === "---\n---\n") {
+      unlinkSync(file.path);
+      reloadCustomAgents();
+      ctx.ui.notify(`Enabled ${name} (removed ${file.path})`, "info");
+    } else {
+      writeFileSync(file.path, updated, "utf-8");
+      reloadCustomAgents();
+      ctx.ui.notify(`Enabled ${name} (${file.path})`, "info");
+    }
+  }
+
+  async function showCreateWizard(ctx: ExtensionCommandContext) {
+    const location = await ctx.ui.select("Choose location", [
+      "Project (.pi/agents/)",
+      `Personal (${personalAgentsDir()})`,
+    ]);
+    if (!location) return;
+
+    const targetDir = location.startsWith("Project") ? projectAgentsDir() : personalAgentsDir();
+
+    const method = await ctx.ui.select("Creation method", [
+      "Generate with Claude (recommended)",
+      "Manual configuration",
+    ]);
+    if (!method) return;
+
+    if (method.startsWith("Generate")) {
+      await showGenerateWizard(ctx, targetDir);
+    } else {
+      await showManualWizard(ctx, targetDir);
+    }
+  }
+
+  async function showGenerateWizard(ctx: ExtensionCommandContext, targetDir: string) {
+    const description = await ctx.ui.input("Describe what this agent should do");
+    if (!description) return;
+
+    const name = await ctx.ui.input("Agent name (filename, no spaces)");
+    if (!name) return;
+
+    mkdirSync(targetDir, { recursive: true });
+
+    const targetPath = join(targetDir, `${name}.md`);
+    if (existsSync(targetPath)) {
+      const overwrite = await ctx.ui.confirm("Overwrite", `${targetPath} already exists. Overwrite?`);
+      if (!overwrite) return;
+    }
+
+    ctx.ui.notify("Generating agent definition...", "info");
+
+    const generatePrompt = `Create a custom pi sub-agent definition file based on this description: "${description}"
+
+Write a markdown file to: ${targetPath}
+
+The file format is a markdown file with YAML frontmatter and a system prompt body:
+
+\`\`\`markdown
+---
+description: <one-line description shown in UI>
+tools: <comma-separated built-in tools: read, bash, edit, write, grep, find, ls. Use "none" for no tools. Omit for all tools>
+model: <optional model as "provider/modelId", e.g. "anthropic/claude-haiku-4-5". Omit to inherit parent model>
+thinking: <optional thinking level: ${THINKING_LEVELS.join(", ")}. Omit to inherit>
+max_turns: <optional max agentic turns. 0 or omit for unlimited (default)>
+prompt_mode: <"replace" (body IS the full system prompt) or "append" (body is appended to default prompt). Default: replace>
+extensions: <true (inherit all MCP/extension tools), false (none), or comma-separated names. Default: true>
+skills: <true (inherit all), false (none), or comma-separated skill names to preload into prompt. Default: true>
+disallowed_tools: <comma-separated tool names to block, even if otherwise available. Omit for none>
+inherit_context: <true to fork parent conversation into agent so it sees chat history. Default: false>
+run_in_background: <true to run in background by default. Default: false>
+output_transcript: <false to write no transcript file or path for this agent. Independent of persist_session. Default: true>
+isolated: <true for no extension/MCP tools, only built-in tools. Default: false>
+memory: <"user" (global), "project" (per-project), or "local" (gitignored per-project) for persistent memory. Omit for none>
+isolation: <"worktree" to run in isolated git worktree. Omit for normal>
+---
+
+<system prompt body — instructions for the agent>
+\`\`\`
+
+Guidelines for choosing settings:
+- For read-only tasks (review, analysis): tools: read, bash, grep, find, ls
+- For code modification tasks: include edit, write
+- Use prompt_mode: append if the agent should keep the default system prompt and add specialization on top
+- Use prompt_mode: replace for fully custom agents with their own personality/instructions
+- Set inherit_context: true if the agent needs to know what was discussed in the parent conversation
+- Set isolated: true if the agent should NOT have access to MCP servers or other extensions
+- Set output_transcript: false to skip writing this agent's transcript; this alone doesn't keep the run off disk (persist_session, isolation: worktree commits, and memory still write) — set those too if that's the goal
+- Only include frontmatter fields that differ from defaults — omit fields where the default is fine
+
+Write the file using the write tool. Only write the file, nothing else.`;
+
+    const { record } = await manager.spawnAndWait(pi, ctx, "general-purpose", generatePrompt, {
+      description: `Generate ${name} agent`,
+      maxTurns: 5,
+    });
+
+    if (record.status === "error") {
+      ctx.ui.notify(`Generation failed: ${record.error}`, "warning");
+      return;
+    }
+
+    reloadCustomAgents();
+
+    if (existsSync(targetPath)) {
+      ctx.ui.notify(`Created ${targetPath}`, "info");
+    } else {
+      ctx.ui.notify("Agent generation completed but file was not created. Check the agent output.", "warning");
+    }
+  }
+
+  async function showManualWizard(ctx: ExtensionCommandContext, targetDir: string) {
+    // 1. Name
+    const name = await ctx.ui.input("Agent name (filename, no spaces)");
+    if (!name) return;
+
+    // 2. Description
+    const description = await ctx.ui.input("Description (one line)");
+    if (!description) return;
+
+    // 3. Tools
+    const toolChoice = await ctx.ui.select("Tools", ["all", "none", "read-only (read, bash, grep, find, ls)", "custom..."]);
+    if (!toolChoice) return;
+
+    let tools: string;
+    if (toolChoice === "all") {
+      tools = BUILTIN_TOOL_NAMES.join(", ");
+    } else if (toolChoice === "none") {
+      tools = "none";
+    } else if (toolChoice.startsWith("read-only")) {
+      tools = "read, bash, grep, find, ls";
+    } else {
+      const customTools = await ctx.ui.input("Tools (comma-separated)", BUILTIN_TOOL_NAMES.join(", "));
+      if (!customTools) return;
+      tools = customTools;
+    }
+
+    // 4. Model
+    const modelChoice = await ctx.ui.select("Model", [
+      "inherit (parent model)",
+      "haiku",
+      "sonnet",
+      "opus",
+      "custom...",
+    ]);
+    if (!modelChoice) return;
+
+    let modelLine = "";
+    if (modelChoice === "haiku") modelLine = "\nmodel: anthropic/claude-haiku-4-5";
+    else if (modelChoice === "sonnet") modelLine = "\nmodel: anthropic/claude-sonnet-4-6";
+    else if (modelChoice === "opus") modelLine = "\nmodel: anthropic/claude-opus-4-6";
+    else if (modelChoice === "custom...") {
+      const customModel = await ctx.ui.input("Model (provider/modelId)");
+      if (customModel) modelLine = `\nmodel: ${customModel}`;
+    }
+
+    // 5. Thinking
+    // "inherit" is a UI-only pseudo-choice (omit the field); the rest mirror pi.
+    const thinkingChoice = await ctx.ui.select("Thinking level", ["inherit", ...THINKING_LEVELS]);
+    if (!thinkingChoice) return;
+
+    let thinkingLine = "";
+    if (thinkingChoice !== "inherit") thinkingLine = `\nthinking: ${thinkingChoice}`;
+
+    // 6. System prompt
+    const systemPrompt = await ctx.ui.editor("System prompt", "");
+    if (systemPrompt === undefined) return;
+
+    // Build the file
+    const content = `---
+description: ${description}
+tools: ${tools}${modelLine}${thinkingLine}
+prompt_mode: replace
+---
+
+${systemPrompt}
+`;
+
+    mkdirSync(targetDir, { recursive: true });
+    const targetPath = join(targetDir, `${name}.md`);
+
+    if (existsSync(targetPath)) {
+      const overwrite = await ctx.ui.confirm("Overwrite", `${targetPath} already exists. Overwrite?`);
+      if (!overwrite) return;
+    }
+
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(targetPath, content, "utf-8");
+    reloadCustomAgents();
+    ctx.ui.notify(`Created ${targetPath}`, "info");
+  }
+
+  function snapshotSettings(): SubagentsSettings {
+    return {
+      maxConcurrent: manager.getMaxConcurrent(),
+      // 0 = unlimited — per SubagentsSettings.defaultMaxTurns docstring and
+      // normalizeMaxTurns() in agent-runner.ts (which maps 0 → undefined).
+      defaultMaxTurns: getDefaultMaxTurns() ?? 0,
+      graceTurns: getGraceTurns(),
+      defaultJoinMode: getDefaultJoinMode(),
+      schedulingEnabled: isSchedulingEnabled(),
+      scopeModels: isScopeModelsEnabled(),
+      disableDefaultAgents: isDefaultsDisabled(),
+      toolDescriptionMode: getToolDescriptionMode(),
+      fleetView: isFleetViewEnabled(),
+      widgetMode: getWidgetMode(),
+      outputTranscript: getOutputTranscriptDefault(),
+    };
+  }
+
+  const NUMERIC_IDS = new Set(["maxConcurrent", "defaultMaxTurns", "graceTurns"]);
+
+  async function showSettings(ctx: ExtensionCommandContext) {
+    function buildItems(): SettingItem[] {
+      const mc = manager.getMaxConcurrent();
+      const dmt = getDefaultMaxTurns() ?? 0;
+      const gt = getGraceTurns();
+
+      return [
+        {
+          id: "maxConcurrent",
+          label: "Max concurrency",
+          description: "Max concurrent background agents (Enter to type)",
+          currentValue: String(mc),
+          values: [String(mc)],
+        },
+        {
+          id: "defaultMaxTurns",
+          label: "Default max turns",
+          description: "Default max turns before wrap-up (0 = unlimited, Enter to type)",
+          currentValue: String(dmt),
+          values: [String(dmt)],
+        },
+        {
+          id: "graceTurns",
+          label: "Grace turns",
+          description: "Grace turns after wrap-up steer (Enter to type)",
+          currentValue: String(gt),
+          values: [String(gt)],
+        },
+        {
+          id: "joinMode",
+          label: "Join mode",
+          description: "Default join mode for background agents",
+          currentValue: getDefaultJoinMode(),
+          values: ["smart", "async", "group"],
+        },
+        {
+          id: "schedulingEnabled",
+          label: "Scheduling",
+          description: "Schedule subagent feature (off removes `schedule` param from Agent tool spec on next pi session)",
+          currentValue: isSchedulingEnabled() ? "on" : "off",
+          values: ["on", "off"],
+        },
+        {
+          id: "scopeModels",
+          label: "Scope models",
+          description: "Validate subagent models against scoped models (/scoped-models)",
+          currentValue: isScopeModelsEnabled() ? "on" : "off",
+          values: ["on", "off"],
+        },
+        {
+          id: "disableDefaultAgents",
+          label: "Disable defaults",
+          description: "Hide built-in agents (general-purpose, Explore, Plan) — custom agents are unaffected",
+          currentValue: isDefaultsDisabled() ? "on" : "off",
+          values: ["on", "off"],
+        },
+        {
+          id: "outputTranscript",
+          label: "Output transcript",
+          description: "Write each subagent's .output transcript by default. A custom agent's output_transcript frontmatter overrides this.",
+          currentValue: getOutputTranscriptDefault() ? "on" : "off",
+          values: ["on", "off"],
+        },
+        {
+          id: "fleetView",
+          label: "Fleet view",
+          description: "Claude Code-style main+subagents list below the editor (↓/← to navigate, Enter to view)",
+          currentValue: isFleetViewEnabled() ? "on" : "off",
+          values: ["on", "off"],
+        },
+        {
+          id: "widgetMode",
+          label: "Widget",
+          description: "Above-editor agent widget: all = every agent; background = hide foreground (they already render inline); off = hide the widget.",
+          currentValue: getWidgetMode(),
+          values: ["all", "background", "off"],
+        },
+        {
+          id: "toolDescriptionMode",
+          label: "Tool description",
+          description: "Agent tool description sent to the LLM: full (rich, default), compact (~75% fewer tokens, for small/local models), or custom (.pi/agent-tool-description.md with {{placeholders}})",
+          currentValue: getToolDescriptionMode(),
+          values: ["full", "compact", "custom"],
+        },
+      ];
+    }
+
+    function applyValue(id: string, value: string) {
+      if (id === "maxConcurrent") {
+        const n = parseInt(value, 10);
+        if (n >= 1) {
+          manager.setMaxConcurrent(n);
+          notifyApplied(ctx, `Max concurrency set to ${n}`);
+        }
+      } else if (id === "defaultMaxTurns") {
+        const n = parseInt(value, 10);
+        if (n === 0) {
+          setDefaultMaxTurns(undefined);
+          notifyApplied(ctx, "Default max turns set to unlimited");
+        } else if (n >= 1) {
+          setDefaultMaxTurns(n);
+          notifyApplied(ctx, `Default max turns set to ${n}`);
+        }
+      } else if (id === "graceTurns") {
+        const n = parseInt(value, 10);
+        if (n >= 1) {
+          setGraceTurns(n);
+          notifyApplied(ctx, `Grace turns set to ${n}`);
+        }
+      } else if (id === "joinMode") {
+        setDefaultJoinMode(value as JoinMode);
+        notifyApplied(ctx, `Default join mode set to ${value}`);
+      } else if (id === "schedulingEnabled") {
+        const enabled = value === "on";
+        if (enabled === isSchedulingEnabled()) {
+          ctx.ui.notify(`Scheduling already ${enabled ? "enabled" : "disabled"}.`, "info");
+        } else {
+          setSchedulingEnabled(enabled);
+          if (!enabled) scheduler.stop();  // immediate kill — outstanding fires stop ticking
+          notifyApplied(
+            ctx,
+            `Scheduling ${enabled ? "enabled" : "disabled"}. Tool spec change takes effect on next pi session.`,
+          );
+        }
+      } else if (id === "scopeModels") {
+        const enabled = value === "on";
+        setScopeModelsEnabled(enabled);
+        notifyApplied(ctx, `Scope models ${enabled ? "enabled" : "disabled"}`);
+      } else if (id === "disableDefaultAgents") {
+        const enabled = value === "on";
+        setDisableDefaultAgents(enabled);
+        notifyApplied(ctx, `Default agents ${enabled ? "disabled" : "enabled"}. Tool spec change takes effect on next pi session.`);
+      } else if (id === "outputTranscript") {
+        const enabled = value === "on";
+        setOutputTranscript(enabled);
+        notifyApplied(ctx, `Output transcript ${enabled ? "enabled" : "disabled"} by default`);
+      } else if (id === "toolDescriptionMode") {
+        setToolDescriptionMode(value as ToolDescriptionMode);
+        notifyApplied(ctx, `Tool description set to ${value}. Takes effect on next pi session.`);
+      } else if (id === "fleetView") {
+        const enabled = value === "on";
+        setFleetViewEnabled(enabled);
+        notifyApplied(ctx, `Fleet view ${enabled ? "enabled" : "disabled"}`);
+      } else if (id === "widgetMode") {
+        setWidgetMode(value as WidgetMode);
+        notifyApplied(ctx, `Widget set to ${value}`);
+      }
+    }
+
+    let list: SettingsList;
+    // Track current selection index directly (SettingsList doesn't expose it).
+    // Updated on arrow keys so Enter knows which field is selected immediately.
+    let currentIndex = 0;
+
+    const result = await ctx.ui.custom<string | undefined>((_tui, _theme, _kb, done) => {
+      const items = buildItems();
+
+      list = new SettingsList(
+        items,
+        items.length + 2,
+        getSettingsListTheme(),
+        (id, newValue) => {
+          applyValue(id, newValue);
+        },
+        () => done(undefined as undefined),
+      );
+
+      const container = new Container();
+      container.addChild(new Text("⚙  Subagent Settings", 0, 0));
+      container.addChild(new Spacer(1));
+      container.addChild(list);
+
+      return {
+        render: (w: number) => container.render(w),
+        invalidate: () => container.invalidate(),
+        handleInput: (data: string) => {
+          // Track navigation so Enter knows the current field
+          if (matchesKey(data, "up")) {
+            currentIndex = Math.max(0, currentIndex - 1);
+          } else if (matchesKey(data, "down")) {
+            currentIndex = Math.min(items.length - 1, currentIndex + 1);
+          }
+
+          // Enter on numeric field → close and prompt for typed input
+          if (matchesKey(data, Key.enter) && NUMERIC_IDS.has(items[currentIndex].id)) {
+            done(items[currentIndex].id);
+            return;
+          }
+          list.handleInput?.(data);
+        },
+      };
+    });
+
+    // If a numeric field ID was returned, prompt for typed input
+    if (result && NUMERIC_IDS.has(result)) {
+      const current = result === "maxConcurrent"
+        ? String(manager.getMaxConcurrent())
+        : result === "defaultMaxTurns"
+          ? String(getDefaultMaxTurns() ?? 0)
+          : String(getGraceTurns());
+
+      const label = result === "maxConcurrent"
+        ? "Max concurrency (1+)"
+        : result === "defaultMaxTurns"
+          ? "Default max turns (0 = unlimited)"
+          : "Grace turns (1+)";
+
+      // Loop until user enters a valid integer or cancels (Esc / null).
+      // Silently trims whitespace; rejects non-numeric input by re-prompting.
+      let input: string | undefined = await ctx.ui.input(label, current);
+      while (input != null) {
+        const trimmed = input.trim();
+        const n = Number(trimmed);
+        if (trimmed !== "" && Number.isInteger(n)) {
+          applyValue(result, String(n));
+          await showSettings(ctx);
+          return;
+        }
+        // Invalid — re-prompt with the user's last entry so they can edit it
+        input = await ctx.ui.input(label, trimmed);
+      }
+    }
+  }
+
+  // Persist the current snapshot, emit `subagents:settings_changed`, and surface
+  // the right toast. Successful saves show info; persistence failures downgrade
+  // to warning so users aren't silently reverted on restart. Event fires regardless
+  // of outcome so listeners see the in-memory change.
+  function notifyApplied(ctx: ExtensionCommandContext, successMsg: string) {
+    const { message, level } = saveAndEmitChanged(
+      snapshotSettings(),
+      successMsg,
+      (event, payload) => pi.events.emit(event, payload),
+    );
+    ctx.ui.notify(message, level);
+  }
+
+  pi.registerCommand("agents", {
+    description: "Manage agents",
+    handler: async (_args, ctx) => { await showAgentsMenu(ctx); },
+  });
+}

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -55,8 +55,8 @@ import {
   firstLinePreview,
   formatAgentCallMeta,
   formatAgentDetailsStats,
+  isFailureDetailsStatus,
   renderAgentLikeResult,
-  renderExpandedMarkdown,
   renderToolCallTitle,
   renderUndetailedResult,
   toolResultText,
@@ -87,6 +87,31 @@ function errorTextResult(msg: string, partial?: Partial<AgentDetails>) {
     effort: partial?.effort,
     tags: partial?.tags,
   });
+}
+
+/** Rebuild display base from a stored invocation (resume / get_result) — never invent current-parent model. */
+function detailBaseFromRecord(record: {
+  type: string;
+  description: string;
+  invocation?: AgentInvocation;
+}): Pick<
+  AgentDetails,
+  "displayName" | "description" | "subagentType" | "modelName" | "modelInherited" | "effort" | "tags"
+> {
+  const displayName = getDisplayName(record.type);
+  const invMeta = detailsFromInvocation(record.invocation);
+  const modeLabel = getPromptModeLabel(record.type);
+  const tags = invMeta.tags ? [...invMeta.tags] : [];
+  if (modeLabel) tags.unshift(modeLabel);
+  return {
+    displayName,
+    description: record.description,
+    subagentType: record.type,
+    modelName: invMeta.modelName,
+    modelInherited: invMeta.modelInherited,
+    effort: invMeta.effort,
+    tags: tags.length > 0 ? tags : undefined,
+  };
 }
 
 /** Await a promise until it settles or the caller cancels, without aborting the underlying work. */
@@ -312,6 +337,23 @@ function buildNotificationDetails(record: AgentRecord, resultMaxLen: number, act
 }
 
 export default function (pi: ExtensionAPI) {
+  // Map structured failure details → Pi tool-result isError so the default shell
+  // uses toolErrorBg (inner chrome already paints ✗). Keeps model-facing text.
+  pi.on("tool_result", async (event) => {
+    if (
+      event.toolName !== SUBAGENT_TOOL_NAMES.AGENT &&
+      event.toolName !== SUBAGENT_TOOL_NAMES.GET_RESULT &&
+      event.toolName !== SUBAGENT_TOOL_NAMES.STEER
+    ) {
+      return;
+    }
+    const details = event.details as AgentDetails | undefined;
+    if (!details || typeof details !== "object") return;
+    if (isFailureDetailsStatus(details.status)) {
+      return { isError: true };
+    }
+  });
+
   // ---- Register custom notification renderer ----
   pi.registerMessageRenderer<NotificationDetails>(
     "subagent-notification",
@@ -1130,11 +1172,14 @@ Terse command-style prompts produce shallow, generic work.
         writeInitialEntry(rec.outputFile, agentId, params.prompt, ctx.cwd);
       };
 
-      const parentModelId = ctx.model?.id;
-      const effectiveModelId = model?.id;
+      const parentModelKey =
+        ctx.model?.provider && ctx.model?.id ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+      const effectiveModelKey =
+        model?.provider && model?.id ? `${model.provider}/${model.id}` : undefined;
       // Always surface the effective model on the tool node (including inherit).
+      // Compare provider+id so cross-provider same-id models are not marked inherit.
       const modelName = shortModelLabel(model);
-      const modelInherited = !!(effectiveModelId && parentModelId && effectiveModelId === parentModelId);
+      const modelInherited = !!(effectiveModelKey && parentModelKey && effectiveModelKey === parentModelKey);
       const effort = thinking ? String(thinking) : undefined;
       const effectiveMaxTurns = normalizeMaxTurns(resolvedConfig.maxTurns ?? getDefaultMaxTurns());
       const agentInvocation: AgentInvocation = {
@@ -1199,9 +1244,12 @@ Terse command-style prompts produce shallow, generic work.
             isolation: isolation,
           });
           const next = scheduler.getNextRun(job.id);
-          return textResult(`Scheduled "${job.name}" (id: ${job.id}, type: ${job.scheduleType}). ` +
-            `Next run: ${next ?? "(unknown)"}. ` +
-            `Manage via /agents → Scheduled jobs.`,);
+          // No AgentDetails: undetailed path with context.isError=false (never heuristic-red).
+          return textResult(
+            `Scheduled "${job.name}" (id: ${job.id}, type: ${job.scheduleType}). ` +
+              `Next run: ${next ?? "(unknown)"}. ` +
+              `Manage via /agents → Scheduled jobs.`,
+          );
         } catch (err) {
           return errorTextResult(err instanceof Error ? err.message : String(err));
         }
@@ -1216,18 +1264,22 @@ Terse command-style prompts produce shallow, generic work.
         if (!existing.session) {
           return errorTextResult(`Agent "${params.resume}" has no active session to resume.`);
         }
+        // Resume continues the old session model/effort — current parent params and
+        // tool-call model/thinking do not apply. Details must come from the stored
+        // invocation so chips match get_subagent_result.
         const record = await manager.resume(params.resume, params.prompt, signal);
         if (!record) {
           return errorTextResult(`Failed to resume agent "${params.resume}".`);
         }
+        const resumeBase = detailBaseFromRecord(record);
         // A failed resume surfaces the error, plus any partial output THIS
         // resume produced (never the previous turn's answer, #144).
         if (record.status === "error") {
-          return textResult(`Agent failed: ${record.error}${partialOutputSuffix(record)}`, buildDetails(detailBase, record));
+          return textResult(`Agent failed: ${record.error}${partialOutputSuffix(record)}`, buildDetails(resumeBase, record));
         }
         return textResult(
           record.result?.trim() || "No output.",
-          buildDetails(detailBase, record),
+          buildDetails(resumeBase, record),
         );
       }
 
@@ -1310,7 +1362,16 @@ Terse command-style prompts produce shallow, generic work.
           `\nYou will be notified when this agent completes.\n` +
           `Use get_subagent_result to retrieve full results, or steer_subagent to send it messages.\n` +
           `Do not duplicate this agent's work.`,
-          { ...detailBase, toolUses: 0, tokens: "", durationMs: 0, status: "background" as const, agentId: id },);
+          {
+            ...detailBase,
+            toolUses: 0,
+            tokens: "",
+            durationMs: 0,
+            // Tell the truth: queued agents are not "running in background" yet.
+            status: isQueued ? ("queued" as const) : ("background" as const),
+            activity: isQueued ? "queued…" : undefined,
+            agentId: id,
+          },);
       }
 
       // Foreground (synchronous) execution — stream progress via onUpdate
@@ -1550,6 +1611,13 @@ Terse command-style prompts produce shallow, generic work.
 
       const activity = agentActivity.get(record.id);
       const invMeta = detailsFromInvocation(record.invocation);
+      // Queued must force "queued…" — never let an empty activity map become thinking…
+      const activityText =
+        record.status === "queued"
+          ? "queued…"
+          : activity
+            ? describeActivity(activity.activeTools, activity.responseText)
+            : undefined;
       const details: AgentDetails = {
         displayName,
         description: record.description,
@@ -1563,9 +1631,7 @@ Terse command-style prompts produce shallow, generic work.
         turnCount: activity?.turnCount,
         maxTurns: activity?.maxTurns,
         ...invMeta,
-        activity: activity
-          ? describeActivity(activity.activeTools, activity.responseText)
-          : undefined,
+        activity: activityText,
       };
 
       return textResult(output, details);
@@ -1622,7 +1688,9 @@ Terse command-style prompts produce shallow, generic work.
         if (!record.pendingSteers) record.pendingSteers = [];
         record.pendingSteers.push(params.message);
         pi.events.emit("subagents:steered", { id: record.id, message: params.message });
-        return textResult(`Steering message queued for agent ${record.id}. It will be delivered once the session initializes.`);
+        return textResult(
+          `Steering message queued for agent ${record.id}. It will be delivered once the session initializes.`,
+        );
       }
 
       try {
@@ -1637,7 +1705,7 @@ Terse command-style prompts produce shallow, generic work.
         if (record.compactionCount) stateParts.push(`${record.compactionCount} compaction${record.compactionCount === 1 ? "" : "s"}`);
         return textResult(
           `Steering message sent to agent ${record.id}. The agent will process it after its current tool execution.\n` +
-          `Current state: ${stateParts.join(" · ")}`,
+            `Current state: ${stateParts.join(" · ")}`,
         );
       } catch (err) {
         return errorTextResult(`Failed to steer agent: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -54,6 +54,7 @@ import {
   renderAgentLikeResult,
   renderExpandedMarkdown,
   renderToolCallTitle,
+  renderUndetailedResult,
   toolResultText,
 } from "./ui/tool-render.js";
 import { addUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsage } from "./usage.js";
@@ -63,6 +64,23 @@ import { addUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsag
 /** Tool execute return value for a text response. */
 function textResult(msg: string, details?: AgentDetails) {
   return { content: [{ type: "text" as const, text: msg }], details: details as any };
+}
+
+/** Validation / not-found / misconfig failures — always carry error details for TUI. */
+function errorTextResult(msg: string, partial?: Partial<AgentDetails>) {
+  return textResult(msg, {
+    displayName: partial?.displayName ?? "Agent",
+    description: partial?.description ?? "",
+    subagentType: partial?.subagentType ?? "general-purpose",
+    toolUses: partial?.toolUses ?? 0,
+    tokens: partial?.tokens ?? "",
+    durationMs: partial?.durationMs ?? 0,
+    status: "error",
+    error: partial?.error ?? firstLinePreview(msg, 160),
+    agentId: partial?.agentId,
+    modelName: partial?.modelName,
+    tags: partial?.tags,
+  });
 }
 
 /** Await a promise until it settles or the caller cancels, without aborting the underlying work. */
@@ -987,25 +1005,12 @@ Terse command-style prompts produce shallow, generic work.
       return renderToolCallTitle(displayName, desc || undefined, theme);
     },
 
-    renderResult(result, { expanded, isPartial }, theme) {
+    renderResult(result, { expanded, isPartial }, theme, context) {
       const details = result.details as AgentDetails | undefined;
       const text = toolResultText(result);
       if (!details) {
-        // No structured details — still honor expand so we never dump walls by default.
-        return renderAgentLikeResult(
-          {
-            displayName: "Agent",
-            description: "",
-            subagentType: "general-purpose",
-            toolUses: 0,
-            tokens: "",
-            durationMs: 0,
-            status: "completed",
-          },
-          text,
-          { expanded, isPartial },
-          theme,
-        );
+        // Never default to completed/✓ — validation failures often omit details.
+        return renderUndetailedResult(text, { expanded, isError: context?.isError === true }, theme);
       }
 
       // Streaming partials keep the live spinner component (animated via onUpdate).
@@ -1044,7 +1049,7 @@ Terse command-style prompts produce shallow, generic work.
       if (resolvedConfig.modelInput) {
         const resolved = resolveModel(resolvedConfig.modelInput, ctx.modelRegistry);
         if (typeof resolved === "string") {
-          if (resolvedConfig.modelFromParams) return textResult(resolved);
+          if (resolvedConfig.modelFromParams) return errorTextResult(resolved);
           // config-specified: silent fallback to parent
         } else {
           model = resolved;
@@ -1065,10 +1070,8 @@ Terse command-style prompts produce shallow, generic work.
         if (allowed && !isModelInScope(model, allowed)) {
           if (resolvedConfig.modelFromParams) {
             const list = [...allowed].sort().map(m => `  ${m}`).join("\n");
-            return textResult(
-              `Model not in scope: "${resolvedConfig.modelInput}".\n\n` +
-              `Allowed models (from enabledModels):\n${list}`,
-            );
+            return errorTextResult(`Model not in scope: "${resolvedConfig.modelInput}".\n\n` +
+              `Allowed models (from enabledModels):\n${list}`,);
           }
           // Frontmatter-pinned or parent-inherited: warn + proceed.
           const agentLabel = customConfig?.displayName ?? subagentType;
@@ -1129,19 +1132,19 @@ Terse command-style prompts produce shallow, generic work.
       // ---- Schedule: register a job, don't spawn now ----
       if (params.schedule) {
         if (!isSchedulingEnabled()) {
-          return textResult("Scheduling is disabled in this project. Enable via /agents → Settings → Scheduling.");
+          return errorTextResult("Scheduling is disabled in this project. Enable via /agents → Settings → Scheduling.");
         }
         if (params.resume) {
-          return textResult("Cannot combine `schedule` with `resume` — schedules create fresh agents.");
+          return errorTextResult("Cannot combine `schedule` with `resume` — schedules create fresh agents.");
         }
         if (params.inherit_context) {
-          return textResult("Cannot combine `schedule` with `inherit_context` — there is no parent conversation at fire time.");
+          return errorTextResult("Cannot combine `schedule` with `inherit_context` — there is no parent conversation at fire time.");
         }
         if (params.run_in_background === false) {
-          return textResult("Cannot combine `schedule` with `run_in_background: false` — scheduled jobs always run in background.");
+          return errorTextResult("Cannot combine `schedule` with `run_in_background: false` — scheduled jobs always run in background.");
         }
         if (!scheduler.isActive()) {
-          return textResult("Scheduler is not active in this session yet. Try again after the session has fully started.");
+          return errorTextResult("Scheduler is not active in this session yet. Try again after the session has fully started.");
         }
         try {
           const job = scheduler.addJob({
@@ -1157,13 +1160,11 @@ Terse command-style prompts produce shallow, generic work.
             isolation: isolation,
           });
           const next = scheduler.getNextRun(job.id);
-          return textResult(
-            `Scheduled "${job.name}" (id: ${job.id}, type: ${job.scheduleType}). ` +
+          return textResult(`Scheduled "${job.name}" (id: ${job.id}, type: ${job.scheduleType}). ` +
             `Next run: ${next ?? "(unknown)"}. ` +
-            `Manage via /agents → Scheduled jobs.`,
-          );
+            `Manage via /agents → Scheduled jobs.`,);
         } catch (err) {
-          return textResult(err instanceof Error ? err.message : String(err));
+          return errorTextResult(err instanceof Error ? err.message : String(err));
         }
       }
 
@@ -1171,14 +1172,14 @@ Terse command-style prompts produce shallow, generic work.
       if (params.resume) {
         const existing = manager.getRecord(params.resume);
         if (!existing) {
-          return textResult(`Agent not found: "${params.resume}". It may have been cleaned up.`);
+          return errorTextResult(`Agent not found: "${params.resume}". It may have been cleaned up.`);
         }
         if (!existing.session) {
-          return textResult(`Agent "${params.resume}" has no active session to resume.`);
+          return errorTextResult(`Agent "${params.resume}" has no active session to resume.`);
         }
         const record = await manager.resume(params.resume, params.prompt, signal);
         if (!record) {
-          return textResult(`Failed to resume agent "${params.resume}".`);
+          return errorTextResult(`Failed to resume agent "${params.resume}".`);
         }
         // A failed resume surfaces the error, plus any partial output THIS
         // resume produced (never the previous turn's answer, #144).
@@ -1222,7 +1223,7 @@ Terse command-style prompts produce shallow, generic work.
             ...bgCallbacks,
           });
         } catch (err) {
-          return textResult(err instanceof Error ? err.message : String(err));
+          return errorTextResult(err instanceof Error ? err.message : String(err));
         }
 
         // Set output file + join mode synchronously after spawn, before the
@@ -1261,8 +1262,7 @@ Terse command-style prompts produce shallow, generic work.
         });
 
         const isQueued = record?.status === "queued";
-        return textResult(
-          `Agent ${isQueued ? "queued" : "started"} in background.\n` +
+        return textResult(`Agent ${isQueued ? "queued" : "started"} in background.\n` +
           `Agent ID: ${id}\n` +
           `Type: ${displayName}\n` +
           `Description: ${params.description}\n` +
@@ -1271,8 +1271,7 @@ Terse command-style prompts produce shallow, generic work.
           `\nYou will be notified when this agent completes.\n` +
           `Use get_subagent_result to retrieve full results, or steer_subagent to send it messages.\n` +
           `Do not duplicate this agent's work.`,
-          { ...detailBase, toolUses: 0, tokens: "", durationMs: 0, status: "background" as const, agentId: id },
-        );
+          { ...detailBase, toolUses: 0, tokens: "", durationMs: 0, status: "background" as const, agentId: id },);
       }
 
       // Foreground (synchronous) execution — stream progress via onUpdate
@@ -1355,7 +1354,7 @@ Terse command-style prompts produce shallow, generic work.
         record = fgResult.record;
       } catch (err) {
         clearInterval(spinnerInterval);
-        return textResult(err instanceof Error ? err.message : String(err));
+        return errorTextResult(err instanceof Error ? err.message : String(err));
       }
 
       clearInterval(spinnerInterval);
@@ -1429,24 +1428,11 @@ Terse command-style prompts produce shallow, generic work.
       return renderToolCallTitle("Get Result", id || undefined, theme, flags || undefined);
     },
 
-    renderResult(result, { expanded, isPartial }, theme) {
+    renderResult(result, { expanded, isPartial }, theme, context) {
       const details = result.details as AgentDetails | undefined;
       const text = toolResultText(result);
       if (!details) {
-        return renderAgentLikeResult(
-          {
-            displayName: "Get Result",
-            description: "",
-            subagentType: "general-purpose",
-            toolUses: 0,
-            tokens: "",
-            durationMs: 0,
-            status: "completed",
-          },
-          text,
-          { expanded, isPartial },
-          theme,
-        );
+        return renderUndetailedResult(text, { expanded, isError: context?.isError === true }, theme);
       }
       return renderAgentLikeResult(details, text, { expanded, isPartial }, theme);
     },
@@ -1454,7 +1440,7 @@ Terse command-style prompts produce shallow, generic work.
     execute: async (_toolCallId, params, signal, _onUpdate, _ctx) => {
       const record = manager.getRecord(params.agent_id);
       if (!record) {
-        return textResult(`Agent not found: "${params.agent_id}". It may have been cleaned up.`);
+        return errorTextResult(`Agent not found: "${params.agent_id}". It may have been cleaned up.`);
       }
 
       // Wait for completion if requested. Cancellation stops only this tool
@@ -1557,30 +1543,26 @@ Terse command-style prompts produce shallow, generic work.
       return renderToolCallTitle("Steer", id || undefined, theme, msg || undefined);
     },
 
-    renderResult(result, { expanded }, theme) {
+    renderResult(result, { expanded }, theme, context) {
       const text = toolResultText(result);
-      const failed =
-        /\bfailed\b/i.test(text) ||
-        /\bnot found\b/i.test(text) ||
-        /\bcannot steer\b/i.test(text) ||
-        /\bnot running\b/i.test(text);
-      const icon = failed ? theme.fg("error", "✗") : theme.fg("success", "✓");
-      if (expanded) {
-        const container = new Container();
-        container.addChild(new Text(icon, 0, 0));
-        container.addChild(renderExpandedMarkdown(text.trim() || "_(empty)_"));
-        return container;
+      const details = result.details as AgentDetails | undefined;
+      if (details) {
+        return renderAgentLikeResult(details, text, { expanded }, theme);
       }
-      return new Text(icon + " " + theme.fg("dim", firstLinePreview(text, 100) || "steered"), 0, 0);
+      return renderUndetailedResult(
+        text,
+        { expanded, isError: context?.isError === true },
+        theme,
+      );
     },
 
     execute: async (_toolCallId, params, _signal, _onUpdate, _ctx) => {
       const record = manager.getRecord(params.agent_id);
       if (!record) {
-        return textResult(`Agent not found: "${params.agent_id}". It may have been cleaned up.`);
+        return errorTextResult(`Agent not found: "${params.agent_id}". It may have been cleaned up.`);
       }
       if (record.status !== "running") {
-        return textResult(`Agent "${params.agent_id}" is not running (status: ${record.status}). Cannot steer a non-running agent.`);
+        return errorTextResult(`Agent "${params.agent_id}" is not running (status: ${record.status}). Cannot steer a non-running agent.`);
       }
       if (!record.session) {
         // Session not ready yet — queue the steer for delivery once initialized
@@ -1605,7 +1587,7 @@ Terse command-style prompts produce shallow, generic work.
           `Current state: ${stateParts.join(" · ")}`,
         );
       } catch (err) {
-        return textResult(`Failed to steer agent: ${err instanceof Error ? err.message : String(err)}`);
+        return errorTextResult(`Failed to steer agent: ${err instanceof Error ? err.message : String(err)}`);
       }
     },
   }));

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -36,6 +36,7 @@ import {
   AgentWidget,
   buildInvocationTags,
   describeActivity,
+  detailsFromInvocation,
   formatActiveToolSummary,
   formatDuration,
   formatMs,
@@ -1138,6 +1139,9 @@ Terse command-style prompts produce shallow, generic work.
       const effectiveMaxTurns = normalizeMaxTurns(resolvedConfig.maxTurns ?? getDefaultMaxTurns());
       const agentInvocation: AgentInvocation = {
         modelName,
+        // Persist inherit flag on the record so get_subagent_result can restore
+        // the same "model (inherit)" chip as the original Agent tool row.
+        modelInherited: modelInherited || undefined,
         thinking,
         // Explicit value only — the default fallback would just add noise.
         // Normalize so `0` (unlimited) doesn't surface as a misleading "max turns: 0".
@@ -1462,13 +1466,17 @@ Terse command-style prompts produce shallow, generic work.
       ].filter((f): f is string => !!f);
       // Prefer live record meta when the id is still in the manager.
       const rec = typeof args.agent_id === "string" ? manager.getRecord(args.agent_id) : undefined;
+      // Only attach model/effort chips when the live record still has an invocation
+      // snapshot — never invent "inherit" for unknown/expired ids.
+      const inv = rec?.invocation;
       const meta = formatAgentCallMeta({
-        model: rec?.invocation?.modelName,
-        effort: rec?.invocation?.thinking ? String(rec.invocation.thinking) : undefined,
-        background: rec?.invocation?.runInBackground === true,
+        model: inv?.modelName,
+        modelInherited: inv?.modelInherited,
+        effort: inv?.thinking ? String(inv.thinking) : undefined,
+        background: inv?.runInBackground === true,
         extra: flags,
       });
-      return renderToolCallTitle("Get Result", id || undefined, theme, meta);
+      return renderToolCallTitle("Get Result", id || undefined, theme, meta || undefined);
     },
 
     renderResult(result, { expanded, isPartial }, theme, context) {
@@ -1541,8 +1549,7 @@ Terse command-style prompts produce shallow, generic work.
       }
 
       const activity = agentActivity.get(record.id);
-      const inv = record.invocation;
-      const invTags = buildInvocationTags(inv).tags;
+      const invMeta = detailsFromInvocation(record.invocation);
       const details: AgentDetails = {
         displayName,
         description: record.description,
@@ -1555,9 +1562,7 @@ Terse command-style prompts produce shallow, generic work.
         error: record.error,
         turnCount: activity?.turnCount,
         maxTurns: activity?.maxTurns,
-        modelName: inv?.modelName,
-        effort: inv?.thinking ? String(inv.thinking) : undefined,
-        tags: invTags.length > 0 ? invTags : undefined,
+        ...invMeta,
         activity: activity
           ? describeActivity(activity.activeTools, activity.responseText)
           : undefined,

--- a/packages/pi-subagents/src/invocation-config.ts
+++ b/packages/pi-subagents/src/invocation-config.ts
@@ -1,0 +1,40 @@
+import type { AgentConfig, IsolationMode, JoinMode, ThinkingLevel } from "./types.js";
+
+interface AgentInvocationParams {
+  model?: string;
+  thinking?: string;
+  max_turns?: number;
+  run_in_background?: boolean;
+  inherit_context?: boolean;
+  isolated?: boolean;
+  isolation?: IsolationMode;
+}
+
+export function resolveAgentInvocationConfig(
+  agentConfig: AgentConfig | undefined,
+  params: AgentInvocationParams,
+): {
+  modelInput?: string;
+  modelFromParams: boolean;
+  thinking?: ThinkingLevel;
+  maxTurns?: number;
+  inheritContext: boolean;
+  runInBackground: boolean;
+  isolated: boolean;
+  isolation?: IsolationMode;
+} {
+  return {
+    modelInput: agentConfig?.model ?? params.model,
+    modelFromParams: agentConfig?.model == null && params.model != null,
+    thinking: (agentConfig?.thinking ?? params.thinking) as ThinkingLevel | undefined,
+    maxTurns: agentConfig?.maxTurns ?? params.max_turns,
+    inheritContext: agentConfig?.inheritContext ?? params.inherit_context ?? false,
+    runInBackground: agentConfig?.runInBackground ?? params.run_in_background ?? false,
+    isolated: agentConfig?.isolated ?? params.isolated ?? false,
+    isolation: agentConfig?.isolation ?? params.isolation,
+  };
+}
+
+export function resolveJoinMode(defaultJoinMode: JoinMode, runInBackground: boolean): JoinMode | undefined {
+  return runInBackground ? defaultJoinMode : undefined;
+}

--- a/packages/pi-subagents/src/memory.ts
+++ b/packages/pi-subagents/src/memory.ts
@@ -1,0 +1,179 @@
+/**
+ * memory.ts — Persistent agent memory: per-agent memory directories that persist across sessions.
+ *
+ * Memory scopes:
+ *   - "user"    → getAgentDir()/agent-memory/{agent-name}/ (default ~/.pi/agent/agent-memory/, honors $PI_CODING_AGENT_DIR)
+ *   - "project" → .pi/agent-memory/{agent-name}/
+ *   - "local"   → .pi/agent-memory-local/{agent-name}/
+ *
+ * The user scope previously hardcoded ~/.pi/agent-memory/. That legacy location
+ * is still honored (read + write) when it exists and the new location doesn't,
+ * so existing memories aren't orphaned.
+ */
+
+import { existsSync, lstatSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { MemoryScope } from "./types.js";
+
+/** Maximum lines to read from MEMORY.md */
+const MAX_MEMORY_LINES = 200;
+
+/**
+ * Returns true if a name contains characters not allowed in agent/skill names.
+ * Uses a whitelist: only alphanumeric, hyphens, underscores, and dots (no leading dot).
+ */
+export function isUnsafeName(name: string): boolean {
+  if (!name || name.length > 128) return true;
+  return !/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(name);
+}
+
+/**
+ * Returns true if the given path is a symlink (defense against symlink attacks).
+ */
+export function isSymlink(filePath: string): boolean {
+  try {
+    return lstatSync(filePath).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Safely read a file, rejecting symlinks.
+ * Returns undefined if the file doesn't exist, is a symlink, or can't be read.
+ */
+export function safeReadFile(filePath: string): string | undefined {
+  if (!existsSync(filePath)) return undefined;
+  if (isSymlink(filePath)) return undefined;
+  try {
+    return readFileSync(filePath, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the memory directory path for a given agent + scope + cwd.
+ * Throws if agentName contains path traversal characters.
+ */
+export function resolveMemoryDir(agentName: string, scope: MemoryScope, cwd: string): string {
+  if (isUnsafeName(agentName)) {
+    throw new Error(`Unsafe agent name for memory directory: "${agentName}"`);
+  }
+  switch (scope) {
+    case "user": {
+      const current = join(getAgentDir(), "agent-memory", agentName);
+      // Legacy location from when this path was hardcoded. Keep using it if it
+      // already holds this agent's memory and the new location hasn't been
+      // created yet — otherwise existing memories would be silently orphaned.
+      const legacy = join(homedir(), ".pi", "agent-memory", agentName);
+      if (!existsSync(current) && existsSync(legacy) && !isSymlink(legacy)) {
+        return legacy;
+      }
+      return current;
+    }
+    case "project":
+      return join(cwd, ".pi", "agent-memory", agentName);
+    case "local":
+      return join(cwd, ".pi", "agent-memory-local", agentName);
+  }
+}
+
+/**
+ * Ensure the memory directory exists, creating it if needed.
+ * Refuses to create directories if any component in the path is a symlink
+ * to prevent symlink-based directory traversal attacks.
+ */
+export function ensureMemoryDir(memoryDir: string): void {
+  // If the directory already exists, verify it's not a symlink
+  if (existsSync(memoryDir)) {
+    if (isSymlink(memoryDir)) {
+      throw new Error(`Refusing to use symlinked memory directory: ${memoryDir}`);
+    }
+    return;
+  }
+  mkdirSync(memoryDir, { recursive: true });
+}
+
+/**
+ * Read the first N lines of MEMORY.md from the memory directory, if it exists.
+ * Returns undefined if no MEMORY.md exists or if the path is a symlink.
+ */
+export function readMemoryIndex(memoryDir: string): string | undefined {
+  // Reject symlinked memory directories
+  if (isSymlink(memoryDir)) return undefined;
+
+  const memoryFile = join(memoryDir, "MEMORY.md");
+  const content = safeReadFile(memoryFile);
+  if (content === undefined) return undefined;
+
+  const lines = content.split("\n");
+  if (lines.length > MAX_MEMORY_LINES) {
+    return lines.slice(0, MAX_MEMORY_LINES).join("\n") + "\n... (truncated at 200 lines)";
+  }
+  return content;
+}
+
+/**
+ * Build the memory block to inject into the agent's system prompt.
+ * Also ensures the memory directory exists (creates it if needed).
+ */
+export function buildMemoryBlock(agentName: string, scope: MemoryScope, cwd: string): string {
+  const memoryDir = resolveMemoryDir(agentName, scope, cwd);
+  // Create the memory directory so the agent can immediately write to it
+  ensureMemoryDir(memoryDir);
+
+  const existingMemory = readMemoryIndex(memoryDir);
+
+  const header = `# Agent Memory
+
+You have a persistent memory directory at: ${memoryDir}/
+Memory scope: ${scope}
+
+This memory persists across sessions. Use it to build up knowledge over time.`;
+
+  const memoryContent = existingMemory
+    ? `\n\n## Current MEMORY.md\n${existingMemory}`
+    : `\n\nNo MEMORY.md exists yet. Create one at ${join(memoryDir, "MEMORY.md")} to start building persistent memory.`;
+
+  const instructions = `
+
+## Memory Instructions
+- MEMORY.md is an index file — keep it concise (under 200 lines). Lines after 200 are truncated.
+- Store detailed memories in separate files within ${memoryDir}/ and link to them from MEMORY.md.
+- Each memory file should use this frontmatter format:
+  \`\`\`markdown
+  ---
+  name: <memory name>
+  description: <one-line description>
+  type: <user|feedback|project|reference>
+  ---
+  <memory content>
+  \`\`\`
+- Update or remove memories that become outdated. Check for existing memories before creating duplicates.
+- You have Read, Write, and Edit tools available for managing memory files.`;
+
+  return header + memoryContent + instructions;
+}
+
+/**
+ * Build a read-only memory block for agents that lack write/edit tools.
+ * Does NOT create the memory directory — agents can only consume existing memory.
+ */
+export function buildReadOnlyMemoryBlock(agentName: string, scope: MemoryScope, cwd: string): string {
+  const memoryDir = resolveMemoryDir(agentName, scope, cwd);
+  const existingMemory = readMemoryIndex(memoryDir);
+
+  const header = `# Agent Memory (read-only)
+
+Memory scope: ${scope}
+You have read-only access to memory. You can reference existing memories but cannot create or modify them.`;
+
+  const memoryContent = existingMemory
+    ? `\n\n## Current MEMORY.md\n${existingMemory}`
+    : `\n\nNo memory is available yet. Other agents or sessions with write access can create memories for you to consume.`;
+
+  return header + memoryContent;
+}

--- a/packages/pi-subagents/src/model-resolver.ts
+++ b/packages/pi-subagents/src/model-resolver.ts
@@ -1,0 +1,100 @@
+/**
+ * Model resolution: exact match ("provider/modelId") with fuzzy fallback.
+ */
+
+export interface ModelEntry {
+  id: string;
+  name: string;
+  provider: string;
+}
+
+export interface ModelRegistry {
+  find(provider: string, modelId: string): any;
+  getAll(): any[];
+  getAvailable?(): any[];
+}
+
+/**
+ * Resolve a model string to a Model instance.
+ * Tries exact match first ("provider/modelId"), then fuzzy match against all available models.
+ * Returns the Model on success, or an error message string on failure.
+ */
+export function resolveModel(
+  input: string,
+  registry: ModelRegistry,
+): any | string {
+  // Available models (those with auth configured)
+  const all = (registry.getAvailable?.() ?? registry.getAll()) as ModelEntry[];
+  const availableSet = new Set(all.map(m => `${m.provider}/${m.id}`.toLowerCase()));
+
+  // 1. Exact match: "provider/modelId" — only if available (has auth)
+  const slashIdx = input.indexOf("/");
+  if (slashIdx !== -1) {
+    const provider = input.slice(0, slashIdx);
+    const modelId = input.slice(slashIdx + 1);
+    if (availableSet.has(input.toLowerCase())) {
+      const found = registry.find(provider, modelId);
+      if (found) return found;
+    }
+  }
+
+  // 2. Fuzzy match against available models. Normalize separators so cosmetic
+  // punctuation differences still match — e.g. "claude-haiku-4.5" and
+  // "claude-haiku-4-5" (dot vs dash in the version) resolve to the same model.
+  const normalize = (s: string) => s.toLowerCase().replace(/\./g, "-");
+  const query = normalize(input);
+
+  // Score each model: prefer exact id match > id contains > name contains > provider+id contains
+  let bestMatch: ModelEntry | undefined;
+  let bestScore = 0;
+
+  for (const m of all) {
+    const id = normalize(m.id);
+    const name = normalize(m.name);
+    const full = normalize(`${m.provider}/${m.id}`);
+
+    let score = 0;
+    if (id === query || full === query) {
+      score = 100; // exact
+    } else if (id.includes(query) || full.includes(query)) {
+      score = 60 + (query.length / id.length) * 30; // substring, prefer tighter matches
+    } else if (name.includes(query)) {
+      score = 40 + (query.length / name.length) * 20;
+    } else if (
+      // A trailing date-stamp token (e.g. "20251001") is optional, so a
+      // date-pinned config like "claude-haiku-4-5-20251001" still matches an
+      // undated registry id like "claude-haiku-4-5".
+      query
+        .split(/[\s\-/]+/)
+        .every(part => /^\d{8}$/.test(part) || id.includes(part) || name.includes(part) || m.provider.toLowerCase().includes(part))
+    ) {
+      score = 20; // all parts present somewhere
+    }
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestMatch = m;
+    }
+  }
+
+  if (bestMatch && bestScore >= 20) {
+    const found = registry.find(bestMatch.provider, bestMatch.id);
+    if (found) return found;
+  }
+
+  // 3. Provider fallback: a "provider/modelId" query that didn't match under the
+  // named provider (exact or fuzzy above) retries against all providers. The
+  // named provider is preferred when present; this only kicks in when it isn't,
+  // so the same model from another provider beats falling back to "inherit".
+  if (slashIdx !== -1) {
+    const bare = resolveModel(input.slice(slashIdx + 1), registry);
+    if (typeof bare !== "string") return bare;
+  }
+
+  // 4. No match — list available models
+  const modelList = all
+    .map(m => `  ${m.provider}/${m.id}`)
+    .sort()
+    .join("\n");
+  return `Model not found: "${input}".\n\nAvailable models:\n${modelList}`;
+}

--- a/packages/pi-subagents/src/output-file.ts
+++ b/packages/pi-subagents/src/output-file.ts
@@ -1,0 +1,110 @@
+/**
+ * output-file.ts — Streaming JSONL output file for agent transcripts.
+ *
+ * Creates a per-agent output file that streams conversation turns as JSONL,
+ * matching Claude Code's task output file format.
+ */
+
+import { appendFileSync, chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentSession, AgentSessionEvent } from "@earendil-works/pi-coding-agent";
+
+/**
+ * Encode a cwd path as a filesystem-safe directory name. Handles:
+ *   - POSIX:   "/home/user/project"        → "home-user-project"
+ *   - Windows: "C:\Users\foo\project"      → "Users-foo-project"
+ *   - UNC:     "\\\\server\\share\\project"  → "server-share-project"
+ */
+export function encodeCwd(cwd: string): string {
+  return cwd
+    .replace(/[/\\]/g, "-")        // both separators → dash
+    .replace(/^[A-Za-z]:-/, "")    // strip Windows drive prefix ("C:-")
+    .replace(/^-+/, "");           // strip leading dashes (POSIX root, UNC)
+}
+
+/** Create the output file path, ensuring the directory exists.
+ *  Mirrors Claude Code's layout: /tmp/{prefix}-{uid}/{encoded-cwd}/{sessionId}/tasks/{agentId}.output */
+export function createOutputFilePath(cwd: string, agentId: string, sessionId: string): string {
+  const encoded = encodeCwd(cwd);
+  const root = join(tmpdir(), `pi-subagents-${process.getuid?.() ?? 0}`);
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  // chmod is a no-op on Windows and throws on some Windows filesystems.
+  // On Unix we still want to enforce 0o700 past umask, so only swallow on Windows.
+  try {
+    chmodSync(root, 0o700);
+  } catch (err) {
+    if (process.platform !== "win32") throw err;
+  }
+  const dir = join(root, encoded, sessionId, "tasks");
+  mkdirSync(dir, { recursive: true });
+  return join(dir, `${agentId}.output`);
+}
+
+/** Write the initial user prompt entry. */
+export function writeInitialEntry(path: string, agentId: string, prompt: string, cwd: string): void {
+  const entry = {
+    isSidechain: true,
+    agentId,
+    type: "user",
+    message: { role: "user", content: prompt },
+    timestamp: new Date().toISOString(),
+    cwd,
+  };
+  writeFileSync(path, JSON.stringify(entry) + "\n", "utf-8");
+}
+
+/**
+ * Subscribe to session events and flush new messages to the output file on each turn_end.
+ * Returns a cleanup function that does a final flush and unsubscribes.
+ */
+export function streamToOutputFile(
+  session: AgentSession,
+  path: string,
+  agentId: string,
+  cwd: string,
+): () => void {
+  let writtenCount = 1; // initial user prompt already written
+
+  const flush = () => {
+    const messages = session.messages;
+    while (writtenCount < messages.length) {
+      const msg = messages[writtenCount];
+      const entry = {
+        isSidechain: true,
+        agentId,
+        type: msg.role === "assistant" ? "assistant" : msg.role === "user" ? "user" : "toolResult",
+        message: msg,
+        timestamp: new Date().toISOString(),
+        cwd,
+      };
+      try {
+        appendFileSync(path, JSON.stringify(entry) + "\n", "utf-8");
+      } catch { /* ignore write errors */ }
+      writtenCount++;
+    }
+  };
+
+  const unsubscribe = session.subscribe((event: AgentSessionEvent) => {
+    if (event.type === "turn_end") flush();
+    // Compaction replaces session.messages with a shorter, summarized array,
+    // leaving writtenCount past the new end — without re-anchoring, the flush
+    // loop would never match again and streaming would halt for good (#145).
+    // Flush before it runs so any not-yet-flushed tail still reaches the file,
+    // then re-anchor to the rebuilt array once it lands. The re-anchor is
+    // deferred a microtask because on the overflow-retry path pi trims the
+    // trailing error assistant message AFTER emitting compaction_end —
+    // anchoring synchronously would sit one past the trimmed array and skip
+    // the first post-compaction message. Aborted/failed compactions leave
+    // session.messages untouched, so only successful ones re-anchor.
+    if (event.type === "compaction_start") flush();
+    if (event.type === "compaction_end" && !event.aborted && event.result) {
+      queueMicrotask(() => { writtenCount = session.messages.length; });
+    }
+  });
+
+  return () => {
+    flush();
+    unsubscribe();
+  };
+}

--- a/packages/pi-subagents/src/prompts.ts
+++ b/packages/pi-subagents/src/prompts.ts
@@ -1,0 +1,99 @@
+/**
+ * prompts.ts — System prompt builder for agents.
+ */
+
+import type { AgentConfig, EnvInfo } from "./types.js";
+
+/** Extra sections to inject into the system prompt (memory, skills, etc.). */
+export interface PromptExtras {
+  /** Persistent memory content to inject (first 200 lines of MEMORY.md + instructions). */
+  memoryBlock?: string;
+  /** Preloaded skill contents to inject. */
+  skillBlocks?: { name: string; content: string }[];
+}
+
+/**
+ * Build the system prompt for an agent from its config.
+ *
+ * - "replace" mode: env header + config.systemPrompt (full control, no parent identity)
+ * - "append" mode: parent system prompt + sub-agent context + env header + config.systemPrompt
+ * - "append" with empty systemPrompt: pure parent clone
+ *
+ * Both modes include an `<active_agent name="${config.name}"/>` tag so downstream
+ * extensions (e.g. permission/policy systems) can resolve per-agent policy
+ * inside the child session by parsing the system prompt. In replace mode the tag
+ * is prepended; in append mode it follows the shared inherited content so the
+ * parent prompt forms an identical, cacheable byte prefix with the parent
+ * session (the LLM's KV cache can then reuse those tokens across every spawn).
+ *
+ * @param parentSystemPrompt  The parent agent's effective system prompt (for append mode).
+ * @param extras  Optional extra sections to inject (memory, preloaded skills).
+ */
+export function buildAgentPrompt(
+  config: AgentConfig,
+  cwd: string,
+  env: EnvInfo,
+  parentSystemPrompt?: string,
+  extras?: PromptExtras,
+): string {
+  const activeAgentTag = `<active_agent name="${config.name}"/>\n\n`;
+
+  const envBlock = `# Environment
+Working directory: ${cwd}
+${env.isGitRepo ? `Git repository: yes\nBranch: ${env.branch}` : "Not a git repository"}
+Platform: ${env.platform}`;
+
+  // Build optional extras suffix
+  const extraSections: string[] = [];
+  if (extras?.memoryBlock) {
+    extraSections.push(extras.memoryBlock);
+  }
+  if (extras?.skillBlocks?.length) {
+    for (const skill of extras.skillBlocks) {
+      extraSections.push(`\n# Preloaded Skill: ${skill.name}\n${skill.content}`);
+    }
+  }
+  const extrasSuffix = extraSections.length > 0 ? "\n\n" + extraSections.join("\n") : "";
+
+  if (config.promptMode === "append") {
+    const identity = parentSystemPrompt || genericBase;
+
+    const bridge = `<sub_agent_context>
+You are operating as a sub-agent invoked to handle a specific task.
+- Use the read tool instead of cat/head/tail
+- Use the edit tool instead of sed/awk
+- Use the write tool instead of echo/heredoc
+- Use the find tool instead of bash find/ls for file search
+- Use the grep tool instead of bash grep/rg for content search
+- Make independent tool calls in parallel
+- Use absolute file paths
+- Do not use emojis
+- Be concise but complete
+</sub_agent_context>`;
+
+    const customSection = config.systemPrompt?.trim()
+      ? `\n\n<agent_instructions>\n${config.systemPrompt}\n</agent_instructions>`
+      : "";
+
+    // Place shared/stable content first so the LLM's KV cache can reuse the
+    // inherited prefix across all subagent invocations. The parent prompt is
+    // placed verbatim (no wrapper tag) so it forms an identical byte prefix
+    // with the parent session, maximising KV cache hits. The <active_agent>
+    // tag and env block vary per call and are placed after the cached prefix.
+    return identity + "\n\n" + bridge + "\n\n" + activeAgentTag + envBlock + customSection + extrasSuffix;
+  }
+
+  // "replace" mode — env header + the config's full system prompt
+  const replaceHeader = `You are a pi coding agent sub-agent.
+You have been invoked to handle a specific task autonomously.
+
+${envBlock}`;
+
+  return activeAgentTag + replaceHeader + "\n\n" + config.systemPrompt + extrasSuffix;
+}
+
+/** Fallback base prompt when parent system prompt is unavailable in append mode. */
+const genericBase = `# Role
+You are a general-purpose coding agent for complex, multi-step tasks.
+You have full access to read, write, edit files, and execute commands.
+Do what has been asked; nothing more, nothing less.`;

--- a/packages/pi-subagents/src/schedule-store.ts
+++ b/packages/pi-subagents/src/schedule-store.ts
@@ -1,0 +1,153 @@
+/**
+ * schedule-store.ts — File-backed store for scheduled subagents.
+ *
+ * Session-scoped: each pi session owns its own schedules at
+ * `<cwd>/.pi/subagent-schedules/<sessionId>.json`. `/new` starts a fresh
+ * empty store; `/resume` reloads.
+ *
+ * Concurrency model lifted from pi-chonky-tasks/src/task-store.ts: every
+ * mutation acquires a PID-based exclusion lock, re-reads the latest state
+ * from disk, applies the change, atomic-writes via temp+rename, releases.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { ScheduledSubagent, ScheduleStoreData } from "./types.js";
+
+const LOCK_RETRY_MS = 50;
+const LOCK_MAX_RETRIES = 100;
+
+function isProcessRunning(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+function acquireLock(lockPath: string): void {
+  for (let i = 0; i < LOCK_MAX_RETRIES; i++) {
+    try {
+      writeFileSync(lockPath, `${process.pid}`, { flag: "wx" });
+      return;
+    } catch (e: any) {
+      if (e.code === "EEXIST") {
+        try {
+          const pid = parseInt(readFileSync(lockPath, "utf-8"), 10);
+          if (pid && !isProcessRunning(pid)) {
+            unlinkSync(lockPath);
+            continue;
+          }
+        } catch { /* ignore — try again */ }
+        const start = Date.now();
+        while (Date.now() - start < LOCK_RETRY_MS) { /* busy wait */ }
+        continue;
+      }
+      throw e;
+    }
+  }
+  throw new Error(`Failed to acquire schedule lock: ${lockPath}`);
+}
+
+function releaseLock(lockPath: string): void {
+  try { unlinkSync(lockPath); } catch { /* ignore */ }
+}
+
+/** Resolve the storage path for a session-scoped store. */
+export function resolveStorePath(cwd: string, sessionId: string): string {
+  return join(cwd, ".pi", "subagent-schedules", `${sessionId}.json`);
+}
+
+export class ScheduleStore {
+  private filePath: string;
+  private lockPath: string;
+  private jobs = new Map<string, ScheduledSubagent>();
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+    this.lockPath = filePath + ".lock";
+    this.load();
+  }
+
+  /** Create the backing directory lazily — only when we're about to persist. */
+  private ensureDir(): void {
+    mkdirSync(dirname(this.filePath), { recursive: true });
+  }
+
+  /** Load from disk into the in-memory cache. Silent on parse errors. */
+  private load(): void {
+    if (!existsSync(this.filePath)) return;
+    try {
+      const data: ScheduleStoreData = JSON.parse(readFileSync(this.filePath, "utf-8"));
+      this.jobs.clear();
+      for (const j of data.jobs ?? []) this.jobs.set(j.id, j);
+    } catch { /* corrupt — start fresh, next save rewrites */ }
+  }
+
+  /** Atomic write via temp file + rename (POSIX-atomic). */
+  private save(): void {
+    const data: ScheduleStoreData = { version: 1, jobs: [...this.jobs.values()] };
+    const tmp = this.filePath + ".tmp";
+    writeFileSync(tmp, JSON.stringify(data, null, 2));
+    renameSync(tmp, this.filePath);
+  }
+
+  /** Acquire lock → reload → mutate → save → release. */
+  private withLock<T>(fn: () => T): T {
+    this.ensureDir();
+    acquireLock(this.lockPath);
+    try {
+      this.load();
+      const result = fn();
+      this.save();
+      return result;
+    } finally {
+      releaseLock(this.lockPath);
+    }
+  }
+
+  /** Read-only — returns a snapshot of the in-memory cache. */
+  list(): ScheduledSubagent[] {
+    return [...this.jobs.values()];
+  }
+
+  /** Read-only check — uses the cache. */
+  hasName(name: string, exceptId?: string): boolean {
+    for (const j of this.jobs.values()) {
+      if (j.id !== exceptId && j.name === name) return true;
+    }
+    return false;
+  }
+
+  get(id: string): ScheduledSubagent | undefined {
+    return this.jobs.get(id);
+  }
+
+  add(job: ScheduledSubagent): void {
+    this.withLock(() => {
+      this.jobs.set(job.id, job);
+    });
+  }
+
+  update(id: string, patch: Partial<ScheduledSubagent>): ScheduledSubagent | undefined {
+    // No-op fast path — an unknown id changes nothing, so don't lock or touch
+    // disk (which would otherwise lazily create the backing directory).
+    if (!this.jobs.has(id)) return undefined;
+    return this.withLock(() => {
+      const existing = this.jobs.get(id);
+      if (!existing) return undefined;
+      const updated = { ...existing, ...patch };
+      this.jobs.set(id, updated);
+      return updated;
+    });
+  }
+
+  remove(id: string): boolean {
+    // No-op fast path — see update().
+    if (!this.jobs.has(id)) return false;
+    return this.withLock(() => this.jobs.delete(id));
+  }
+
+  /** Delete the backing file (used when no jobs remain, optional cleanup). */
+  deleteFileIfEmpty(): void {
+    if (this.jobs.size === 0 && existsSync(this.filePath)) {
+      try { unlinkSync(this.filePath); } catch { /* ignore */ }
+    }
+  }
+}

--- a/packages/pi-subagents/src/schedule.ts
+++ b/packages/pi-subagents/src/schedule.ts
@@ -1,0 +1,365 @@
+/**
+ * schedule.ts — `SubagentScheduler`: timer-driven dispatcher of scheduled subagents.
+ *
+ * Mirrors the engine shape of pi-cron-schedule/src/scheduler.ts:
+ *   - two-Map split (jobs = croner Cron, intervals = setInterval/setTimeout)
+ *   - addJob/removeJob/updateJob/scheduleJob/unscheduleJob/executeJob
+ *   - static parsers for cron / "+10m" / "5m" / ISO formats
+ *
+ * Differences vs pi-cron-schedule:
+ *   - Persistence is via ScheduleStore (PID-locked, session-scoped, atomic).
+ *   - `executeJob` calls `manager.spawn(..., { bypassQueue: true })` instead
+ *     of dispatching a user message — schedule fires bypass maxConcurrent so
+ *     a 5-minute interval can't be deferred behind 4 long-running agents.
+ *   - Result delivery is implicit: spawn → background completion → existing
+ *     `subagent-notification` followUp path. No new delivery code.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Cron } from "croner";
+import { nanoid } from "nanoid";
+import type { AgentManager } from "./agent-manager.js";
+import { resolveModel } from "./model-resolver.js";
+import type { ScheduleStore } from "./schedule-store.js";
+import type { IsolationMode, ScheduledSubagent, SubagentType, ThinkingLevel } from "./types.js";
+
+/** Event emitted on `pi.events` for cross-extension consumers. */
+export type ScheduleChangeEvent =
+  | { type: "added"; job: ScheduledSubagent }
+  | { type: "removed"; jobId: string }
+  | { type: "updated"; job: ScheduledSubagent }
+  | { type: "fired"; jobId: string; agentId: string; name: string }
+  | { type: "error"; jobId: string; error: string };
+
+/** Params accepted at job creation — ID, timestamps, and state are derived. */
+export interface NewJobInput {
+  name: string;
+  description: string;
+  schedule: string;
+  subagent_type: SubagentType;
+  prompt: string;
+  model?: string;
+  thinking?: ThinkingLevel;
+  max_turns?: number;
+  isolated?: boolean;
+  isolation?: IsolationMode;
+}
+
+export class SubagentScheduler {
+  private jobs = new Map<string, Cron>();
+  private intervals = new Map<string, NodeJS.Timeout>();
+  private store: ScheduleStore | undefined;
+  private pi: ExtensionAPI | undefined;
+  private ctx: ExtensionContext | undefined;
+  private manager: AgentManager | undefined;
+
+  /** Start the scheduler: bind to a session's store and arm enabled jobs. */
+  start(pi: ExtensionAPI, ctx: ExtensionContext, manager: AgentManager, store: ScheduleStore): void {
+    this.pi = pi;
+    this.ctx = ctx;
+    this.manager = manager;
+    this.store = store;
+
+    for (const job of store.list()) {
+      if (job.enabled) this.scheduleJob(job);
+    }
+  }
+
+  /** Stop all timers; drop refs. Safe to call repeatedly. */
+  stop(): void {
+    for (const cron of this.jobs.values()) cron.stop();
+    this.jobs.clear();
+    for (const t of this.intervals.values()) clearTimeout(t);
+    this.intervals.clear();
+    this.store = undefined;
+    this.pi = undefined;
+    this.ctx = undefined;
+    this.manager = undefined;
+  }
+
+  /** True if start() has bound a store and the scheduler is active. */
+  isActive(): boolean {
+    return this.store !== undefined;
+  }
+
+  list(): ScheduledSubagent[] {
+    return this.store?.list() ?? [];
+  }
+
+  /**
+   * Build a `ScheduledSubagent` from user input. Validates the schedule
+   * format and tags `scheduleType`. Throws on invalid input.
+   */
+  buildJob(input: NewJobInput): ScheduledSubagent {
+    const detected = SubagentScheduler.detectSchedule(input.schedule);
+    return {
+      id: nanoid(10),
+      name: input.name,
+      description: input.description,
+      schedule: detected.normalized,
+      scheduleType: detected.type,
+      intervalMs: detected.intervalMs,
+      subagent_type: input.subagent_type,
+      prompt: input.prompt,
+      model: input.model,
+      thinking: input.thinking,
+      max_turns: input.max_turns,
+      isolated: input.isolated,
+      isolation: input.isolation,
+      enabled: true,
+      createdAt: new Date().toISOString(),
+      runCount: 0,
+    };
+  }
+
+  /** Add a job, persist, and arm if enabled. Returns the stored job. */
+  addJob(input: NewJobInput): ScheduledSubagent {
+    const store = this.requireStore();
+    if (store.hasName(input.name)) {
+      throw new Error(`A scheduled job named "${input.name}" already exists.`);
+    }
+    const job = this.buildJob(input);
+    store.add(job);
+    if (job.enabled) this.scheduleJob(job);
+    this.emit({ type: "added", job });
+    return job;
+  }
+
+  removeJob(id: string): boolean {
+    const store = this.requireStore();
+    if (!store.get(id)) return false;
+    this.unscheduleJob(id);
+    const ok = store.remove(id);
+    if (ok) this.emit({ type: "removed", jobId: id });
+    return ok;
+  }
+
+  /** Toggle / mutate a job. Re-arms based on the new `enabled` state. */
+  updateJob(id: string, patch: Partial<ScheduledSubagent>): ScheduledSubagent | undefined {
+    const store = this.requireStore();
+    const updated = store.update(id, patch);
+    if (!updated) return undefined;
+    this.unscheduleJob(id);
+    if (updated.enabled) this.scheduleJob(updated);
+    this.emit({ type: "updated", job: updated });
+    return updated;
+  }
+
+  /** Next-run time as ISO, or undefined if not currently armed. */
+  getNextRun(jobId: string): string | undefined {
+    const cron = this.jobs.get(jobId);
+    if (cron) return cron.nextRun()?.toISOString();
+    const job = this.store?.get(jobId);
+    if (!job?.enabled) return undefined;
+    if (job.scheduleType === "once") return job.schedule;
+    if (job.scheduleType === "interval" && job.intervalMs) {
+      // Before the first fire there's no `lastRun`, so fall back to "now" —
+      // accurate at create time (setInterval was just armed) and within
+      // intervalMs of correct in any pre-first-fire view.
+      const base = job.lastRun ? new Date(job.lastRun).getTime() : Date.now();
+      return new Date(base + job.intervalMs).toISOString();
+    }
+    return undefined;
+  }
+
+  // ── Scheduling primitives ────────────────────────────────────────────
+
+  private scheduleJob(job: ScheduledSubagent): void {
+    const store = this.store;
+    if (!store) return;
+    try {
+      if (job.scheduleType === "interval" && job.intervalMs) {
+        const t = setInterval(() => this.executeJob(job.id), job.intervalMs);
+        this.intervals.set(job.id, t);
+      } else if (job.scheduleType === "once") {
+        const target = new Date(job.schedule).getTime();
+        const delay = target - Date.now();
+        if (delay > 0) {
+          const t = setTimeout(() => {
+            this.executeJob(job.id);
+            // Auto-disable one-shots after they fire (mirrors pi-cron-schedule)
+            store.update(job.id, { enabled: false });
+            const updated = store.get(job.id);
+            if (updated) this.emit({ type: "updated", job: updated });
+          }, delay);
+          this.intervals.set(job.id, t);
+        } else {
+          // Past timestamp — disable, mark error, never fire
+          store.update(job.id, { enabled: false, lastStatus: "error" });
+          this.emit({ type: "error", jobId: job.id, error: `Scheduled time ${job.schedule} is in the past` });
+        }
+      } else {
+        const cron = new Cron(job.schedule, () => this.executeJob(job.id));
+        this.jobs.set(job.id, cron);
+      }
+    } catch (err) {
+      this.emit({ type: "error", jobId: job.id, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  private unscheduleJob(id: string): void {
+    const cron = this.jobs.get(id);
+    if (cron) {
+      cron.stop();
+      this.jobs.delete(id);
+    }
+    const t = this.intervals.get(id);
+    if (t) {
+      clearTimeout(t);
+      clearInterval(t);
+      this.intervals.delete(id);
+    }
+  }
+
+  /**
+   * Fire a job: persist running state, spawn (bypassing the concurrency
+   * queue), persist completion. Fire-and-forget: the timer tick returns
+   * immediately so other jobs keep firing.
+   */
+  private executeJob(id: string): void {
+    const store = this.store;
+    const pi = this.pi;
+    const ctx = this.ctx;
+    const manager = this.manager;
+    if (!store || !pi || !ctx || !manager) return;
+    const job = store.get(id);
+    if (!job?.enabled) return;
+
+    store.update(id, { lastStatus: "running" });
+
+    // Resolve model at fire time — registry contents may have changed since the
+    // job was created (auth added/removed). Fall back silently to spawn-default
+    // if resolution fails; the spawn path handles undefined model gracefully.
+    let resolvedModel: any | undefined;
+    if (job.model) {
+      const r = resolveModel(job.model, ctx.modelRegistry);
+      if (typeof r !== "string") resolvedModel = r;
+    }
+
+    let agentId: string;
+    try {
+      agentId = manager.spawn(pi, ctx, job.subagent_type, job.prompt, {
+        description: job.description,
+        isBackground: true,
+        bypassQueue: true,
+        model: resolvedModel,
+        maxTurns: job.max_turns,
+        isolated: job.isolated,
+        thinkingLevel: job.thinking,
+        isolation: job.isolation,
+      });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      store.update(id, { lastRun: new Date().toISOString(), lastStatus: "error" });
+      this.emit({ type: "error", jobId: id, error });
+      return;
+    }
+
+    this.emit({ type: "fired", jobId: id, agentId, name: job.name });
+
+    const record = manager.getRecord(agentId);
+    const finalize = (status: "success" | "error") => {
+      const next = this.getNextRun(id);
+      const current = store.get(id);
+      store.update(id, {
+        lastRun: new Date().toISOString(),
+        lastStatus: status,
+        runCount: (current?.runCount ?? 0) + 1,
+        nextRun: next,
+      });
+    };
+
+    // AgentManager's promise resolves either way (its .catch returns ""), so we
+    // can't infer success/failure from the promise — read record.status instead.
+    // Terminal states: completed/steered = success; error/aborted/stopped = error.
+    if (record?.promise) {
+      record.promise
+        .then(() => {
+          const r = manager.getRecord(agentId);
+          const failed = r?.status === "error" || r?.status === "aborted" || r?.status === "stopped";
+          finalize(failed ? "error" : "success");
+        })
+        .catch(() => finalize("error"));
+    } else {
+      // Spawn returned without a promise (defensive — bypassQueue path always sets one).
+      finalize("success");
+    }
+  }
+
+  private emit(event: ScheduleChangeEvent): void {
+    if (this.pi) this.pi.events.emit("subagents:scheduled", event);
+  }
+
+  private requireStore(): ScheduleStore {
+    if (!this.store) throw new Error("Scheduler not started — no active session.");
+    return this.store;
+  }
+
+  // ── Format detection / parsers (statics — pure) ──────────────────────
+
+  /**
+   * Sniff a schedule string and tag its type. Throws on invalid input.
+   * Order matters: relative ("+10m") and interval ("5m") both match digit+unit;
+   * relative requires the leading "+" to disambiguate.
+   */
+  static detectSchedule(s: string): { type: "cron" | "once" | "interval"; intervalMs?: number; normalized: string } {
+    const trimmed = s.trim();
+    // "+10m" — relative one-shot
+    const rel = SubagentScheduler.parseRelativeTime(trimmed);
+    if (rel !== null) return { type: "once", normalized: rel };
+    // "5m" — interval
+    const ivl = SubagentScheduler.parseInterval(trimmed);
+    if (ivl !== null) return { type: "interval", intervalMs: ivl, normalized: trimmed };
+    // ISO timestamp — one-shot. Reject past timestamps upfront so we never
+    // create a dead-on-arrival record (scheduleJob's safety net still catches
+    // micro-races from `+0s`-style relatives).
+    if (/^\d{4}-\d{2}-\d{2}T/.test(trimmed)) {
+      const d = new Date(trimmed);
+      if (!Number.isNaN(d.getTime())) {
+        if (d.getTime() <= Date.now()) {
+          throw new Error(`Scheduled time ${d.toISOString()} is in the past.`);
+        }
+        return { type: "once", normalized: d.toISOString() };
+      }
+    }
+    // Cron — 6-field
+    const cronCheck = SubagentScheduler.validateCronExpression(trimmed);
+    if (cronCheck.valid) return { type: "cron", normalized: trimmed };
+    throw new Error(
+      `Invalid schedule "${s}". Use 6-field cron (e.g. "0 0 9 * * 1" — 9am every Monday), interval ("5m"/"1h"), or one-shot ("+10m" / ISO).`
+    );
+  }
+
+  /** 6-field cron — 'second minute hour dom month dow'. */
+  static validateCronExpression(expr: string): { valid: boolean; error?: string } {
+    const fields = expr.trim().split(/\s+/);
+    if (fields.length !== 6) {
+      return {
+        valid: false,
+        error: `Cron must have 6 fields (second minute hour dom month dow), got ${fields.length}. Example: "0 0 9 * * 1" for 9am every Monday.`,
+      };
+    }
+    try {
+      // Croner validates by construction.
+      new Cron(expr, () => {});
+      return { valid: true };
+    } catch (e) {
+      return { valid: false, error: e instanceof Error ? e.message : "Invalid cron expression" };
+    }
+  }
+
+  /** "+10s"/"+5m"/"+1h"/"+2d" → ISO timestamp. */
+  static parseRelativeTime(s: string): string | null {
+    const m = s.match(/^\+(\d+)(s|m|h|d)$/);
+    if (!m) return null;
+    const ms = parseInt(m[1], 10) * { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 }[m[2] as "s" | "m" | "h" | "d"];
+    return new Date(Date.now() + ms).toISOString();
+  }
+
+  /** "10s"/"5m"/"1h"/"2d" → milliseconds. */
+  static parseInterval(s: string): number | null {
+    const m = s.match(/^(\d+)(s|m|h|d)$/);
+    if (!m) return null;
+    return parseInt(m[1], 10) * { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 }[m[2] as "s" | "m" | "h" | "d"];
+  }
+}

--- a/packages/pi-subagents/src/settings.ts
+++ b/packages/pi-subagents/src/settings.ts
@@ -1,0 +1,288 @@
+// Persistence for pi-subagents operational settings.
+// - Global:  ~/.pi/agent/subagents.json (via getAgentDir()) — manual defaults, never written here
+// - Project: <cwd>/.pi/subagents.json — written by /agents → Settings; overrides global on load
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { JoinMode, WidgetMode } from "./types.js";
+
+export interface SubagentsSettings {
+  maxConcurrent?: number;
+  /**
+   * 0 = unlimited — the extension's single source of truth for that convention:
+   * `normalizeMaxTurns()` in agent-runner.ts treats 0 → `undefined`, and the
+   * `/agents` → Settings input prompt explicitly says "0 = unlimited".
+   */
+  defaultMaxTurns?: number;
+  graceTurns?: number;
+  defaultJoinMode?: JoinMode;
+  /**
+   * Master switch for the schedule subagent feature. Defaults to `true`.
+   * When `false`: the `Agent` tool's `schedule` param + its guideline are
+   * stripped from the tool spec at registration (zero LLM-context cost), the
+   * scheduler doesn't bind to the session, and the `/agents → Scheduled jobs`
+   * menu entry is hidden. Schema-level removal applies at extension load
+   * (next pi session); runtime menu/runtime-fire short-circuit is immediate.
+   */
+  schedulingEnabled?: boolean;
+  /**
+   * When true, the effective model of each subagent spawn is validated
+   * against `enabledModels` from pi's settings — both global
+   * (`<agentDir>/settings.json`) and project-local (`<cwd>/.pi/settings.json`),
+   * with project overriding global (mirrors pi's SettingsManager deep-merge).
+   *
+   * scopeModels guards against runtime LLM choices, not user-level config.
+   * Out-of-scope handling reflects this:
+   *   - Caller-supplied via `Agent({ model: "..." })` (only when frontmatter
+   *     has no `model:`, since frontmatter is authoritative): hard error
+   *     returned to the orchestrator, listing the allowed models. The LLM
+   *     made an explicit out-of-scope choice and gets explicit feedback.
+   *   - Frontmatter-pinned: warning toast + the pinned model runs. The
+   *     agent's author/installer chose this; trust it.
+   *   - Parent-inherited (neither caller nor frontmatter sets a model):
+   *     warning toast + parent's model runs. The user chose the parent's
+   *     model when starting the session; trust it.
+   *
+   * No-op when pi's `enabledModels` is empty or absent — nothing to validate
+   * against. Defaults to false: subagents may use any model.
+   */
+  scopeModels?: boolean;
+  /**
+   * When true, the three built-in default agents (general-purpose, Explore, Plan)
+   * are not registered at startup. User-defined agents from project/global custom
+   * agent dirs are completely unaffected — only the hardcoded DEFAULT_AGENTS are suppressed.
+   * Defaults to false.
+   */
+  disableDefaultAgents?: boolean;
+  /**
+   * Which Agent tool description the LLM sees. "full" (default) is the rich
+   * Claude Code-style prompt; "compact" is a ~75% smaller version (one-line
+   * agent type list, terse usage notes) for small/local models where tool-spec
+   * tokens are expensive; "custom" reads `.pi/agent-tool-description.md`
+   * (project, falling back to `<agentDir>/agent-tool-description.md`) with
+   * `{{placeholder}}` substitution — a missing/empty file falls back to "full".
+   * The mode is read once at tool registration — changing it applies on the
+   * next pi session.
+   */
+  toolDescriptionMode?: ToolDescriptionMode;
+  /**
+   * Whether the Claude Code-style FleetView (the navigable main+subagents list
+   * rendered below the editor) is shown. Defaults to `true`. Pure-UI: when off,
+   * the list never registers and the global key handler never captures input.
+   */
+  fleetView?: boolean;
+  /**
+   * Display mode for the persistent above-editor agent widget:
+   *   - `all`: show every agent (foreground + background).
+   *   - `background`: hide foreground agents — they already render inline as the
+   *     Agent tool result, so the widget would otherwise double-render them
+   *     (#118); everything else (background, queued, scheduled, RPC) stays.
+   *   - `off`: hide the widget entirely.
+   * Defaults to `background`. Pure-UI and applied live (toggling refreshes the
+   * widget).
+   */
+  widgetMode?: WidgetMode;
+  /**
+   * Project/global default for writing each subagent's `.output` transcript
+   * (a JSON-lines copy of the run, stored under the OS temp dir).
+   * Defaults to `true`. Set `false` to make transcripts opt-in for the whole
+   * project (e.g. a repo that shouldn't leave run transcripts on disk for backup
+   * or DLP tooling to ingest). A custom agent's `output_transcript` frontmatter
+   * overrides this per agent. This governs only the transcript — it does NOT
+   * affect the persisted pi session (`persist_session`), worktree commits
+   * (`isolation: worktree`), or memory files.
+   */
+  outputTranscript?: boolean;
+}
+
+export type ToolDescriptionMode = "full" | "compact" | "custom";
+
+/** Setter hooks used by applySettings to wire persisted values into in-memory state. */
+export interface SettingsAppliers {
+  setMaxConcurrent: (n: number) => void;
+  setDefaultMaxTurns: (n: number) => void;
+  setGraceTurns: (n: number) => void;
+  setDefaultJoinMode: (mode: JoinMode) => void;
+  setSchedulingEnabled: (b: boolean) => void;
+  setScopeModels: (enabled: boolean) => void;
+  setDisableDefaultAgents: (b: boolean) => void;
+  setToolDescriptionMode: (mode: ToolDescriptionMode) => void;
+  setFleetView: (b: boolean) => void;
+  setWidgetMode: (mode: WidgetMode) => void;
+  setOutputTranscript: (b: boolean) => void;
+}
+
+/** Emit callback — a subset of `pi.events.emit` to keep helpers testable. */
+export type SettingsEmit = (event: string, payload: unknown) => void;
+
+const VALID_JOIN_MODES: ReadonlySet<string> = new Set<JoinMode>(["async", "group", "smart"]);
+const VALID_TOOL_DESCRIPTION_MODES: ReadonlySet<string> = new Set<ToolDescriptionMode>(["full", "compact", "custom"]);
+const VALID_WIDGET_MODES: ReadonlySet<string> = new Set<WidgetMode>(["all", "background", "off"]);
+
+// Sanity ceilings — prevent hand-edited configs from asking for values that
+// make no operational sense (e.g. 1e6 concurrent subagents). Permissive enough
+// that any realistic power-user setting passes through.
+const MAX_CONCURRENT_CEILING = 1024;
+const MAX_TURNS_CEILING = 10_000;
+const GRACE_TURNS_CEILING = 1_000;
+
+/** Drop fields that don't match the expected shape. Silent — garbage becomes absent. */
+function sanitize(raw: unknown): SubagentsSettings {
+  if (!raw || typeof raw !== "object") return {};
+  const r = raw as Record<string, unknown>;
+  const out: SubagentsSettings = {};
+  if (
+    Number.isInteger(r.maxConcurrent) &&
+    (r.maxConcurrent as number) >= 1 &&
+    (r.maxConcurrent as number) <= MAX_CONCURRENT_CEILING
+  ) {
+    out.maxConcurrent = r.maxConcurrent as number;
+  }
+  if (
+    Number.isInteger(r.defaultMaxTurns) &&
+    (r.defaultMaxTurns as number) >= 0 &&
+    (r.defaultMaxTurns as number) <= MAX_TURNS_CEILING
+  ) {
+    out.defaultMaxTurns = r.defaultMaxTurns as number;
+  }
+  if (
+    Number.isInteger(r.graceTurns) &&
+    (r.graceTurns as number) >= 1 &&
+    (r.graceTurns as number) <= GRACE_TURNS_CEILING
+  ) {
+    out.graceTurns = r.graceTurns as number;
+  }
+  if (typeof r.defaultJoinMode === "string" && VALID_JOIN_MODES.has(r.defaultJoinMode)) {
+    out.defaultJoinMode = r.defaultJoinMode as JoinMode;
+  }
+  if (typeof r.schedulingEnabled === "boolean") {
+    out.schedulingEnabled = r.schedulingEnabled;
+  }
+  if (typeof r.scopeModels === "boolean") {
+    out.scopeModels = r.scopeModels;
+  }
+  if (typeof r.disableDefaultAgents === "boolean") {
+    out.disableDefaultAgents = r.disableDefaultAgents;
+  }
+  if (typeof r.toolDescriptionMode === "string" && VALID_TOOL_DESCRIPTION_MODES.has(r.toolDescriptionMode)) {
+    out.toolDescriptionMode = r.toolDescriptionMode as ToolDescriptionMode;
+  }
+  if (typeof r.fleetView === "boolean") {
+    out.fleetView = r.fleetView;
+  }
+  if (typeof r.widgetMode === "string" && VALID_WIDGET_MODES.has(r.widgetMode)) {
+    out.widgetMode = r.widgetMode as WidgetMode;
+  }
+  if (typeof r.outputTranscript === "boolean") {
+    out.outputTranscript = r.outputTranscript;
+  }
+  return out;
+}
+
+function globalPath(): string {
+  return join(getAgentDir(), "subagents.json");
+}
+
+function projectPath(cwd: string): string {
+  return join(cwd, ".pi", "subagents.json");
+}
+
+/**
+ * Read a settings file. Missing file is silent (returns `{}`). A file that
+ * exists but can't be parsed emits a warning to stderr so users aren't
+ * silently reverted to defaults — and still returns `{}` so startup proceeds.
+ */
+function readSettingsFile(path: string): SubagentsSettings {
+  if (!existsSync(path)) return {};
+  try {
+    return sanitize(JSON.parse(readFileSync(path, "utf-8")));
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(`[pi-subagents] Ignoring malformed settings at ${path}: ${reason}`);
+    return {};
+  }
+}
+
+/** Load merged settings: global provides defaults, project overrides. */
+export function loadSettings(cwd: string = process.cwd()): SubagentsSettings {
+  return { ...readSettingsFile(globalPath()), ...readSettingsFile(projectPath(cwd)) };
+}
+
+/**
+ * Write project-local settings. Global is never touched from code.
+ * Returns `true` on success, `false` if the write (or mkdir) failed so the
+ * caller can surface a warning — persistence isn't fatal but isn't silent.
+ */
+export function saveSettings(s: SubagentsSettings, cwd: string = process.cwd()): boolean {
+  const path = projectPath(cwd);
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(s, null, 2), "utf-8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Apply persisted settings to the in-memory state via caller-supplied setters. */
+export function applySettings(s: SubagentsSettings, appliers: SettingsAppliers): void {
+  if (typeof s.maxConcurrent === "number") appliers.setMaxConcurrent(s.maxConcurrent);
+  if (typeof s.defaultMaxTurns === "number") appliers.setDefaultMaxTurns(s.defaultMaxTurns);
+  if (typeof s.graceTurns === "number") appliers.setGraceTurns(s.graceTurns);
+  if (s.defaultJoinMode) appliers.setDefaultJoinMode(s.defaultJoinMode);
+  if (typeof s.schedulingEnabled === "boolean") appliers.setSchedulingEnabled(s.schedulingEnabled);
+  if (typeof s.scopeModels === "boolean") appliers.setScopeModels(s.scopeModels);
+  if (typeof s.disableDefaultAgents === "boolean") appliers.setDisableDefaultAgents(s.disableDefaultAgents);
+  if (s.toolDescriptionMode) appliers.setToolDescriptionMode(s.toolDescriptionMode);
+  if (typeof s.fleetView === "boolean") appliers.setFleetView(s.fleetView);
+  if (s.widgetMode) appliers.setWidgetMode(s.widgetMode);
+  if (typeof s.outputTranscript === "boolean") appliers.setOutputTranscript(s.outputTranscript);
+}
+
+/**
+ * Format the user-facing toast for a settings mutation. Pure function —
+ * routes the success/failure of `saveSettings` into the right message + level
+ * so the UI layer (index.ts) stays a thin wire between input and notification.
+ */
+export function persistToastFor(
+  successMsg: string,
+  persisted: boolean,
+): { message: string; level: "info" | "warning" } {
+  return persisted
+    ? { message: successMsg, level: "info" }
+    : { message: `${successMsg} (session only; failed to persist)`, level: "warning" };
+}
+
+/**
+ * Load merged settings, apply them to in-memory state, and emit the
+ * `subagents:settings_loaded` lifecycle event. Returns the loaded settings so
+ * callers can log/inspect. Extension init wires this once.
+ */
+export function applyAndEmitLoaded(
+  appliers: SettingsAppliers,
+  emit: SettingsEmit,
+  cwd: string = process.cwd(),
+): SubagentsSettings {
+  const settings = loadSettings(cwd);
+  applySettings(settings, appliers);
+  emit("subagents:settings_loaded", { settings });
+  return settings;
+}
+
+/**
+ * Persist a settings snapshot, emit the `subagents:settings_changed` event
+ * (regardless of persist outcome so listeners see the in-memory change), and
+ * return the toast the UI should display. Event payload carries the `persisted`
+ * flag so listeners can react to write failures.
+ */
+export function saveAndEmitChanged(
+  snapshot: SubagentsSettings,
+  successMsg: string,
+  emit: SettingsEmit,
+  cwd: string = process.cwd(),
+): { message: string; level: "info" | "warning" } {
+  const persisted = saveSettings(snapshot, cwd);
+  emit("subagents:settings_changed", { settings: snapshot, persisted });
+  return persistToastFor(successMsg, persisted);
+}

--- a/packages/pi-subagents/src/skill-loader.ts
+++ b/packages/pi-subagents/src/skill-loader.ts
@@ -1,0 +1,102 @@
+/**
+ * skill-loader.ts — Preload named skills.
+ *
+ * Roots, in precedence order:
+ *   - <cwd>/.pi/skills           (project, Pi's standard)
+ *   - <cwd>/.agents/skills       (project, cross-tool Agent Skills spec — https://agentskills.io)
+ *   - getAgentDir()/skills       (user, default ~/.pi/agent/skills — Pi's standard)
+ *   - ~/.agents/skills           (user, cross-tool Agent Skills spec)
+ *   - ~/.pi/skills               (legacy global, pre-Pi)
+ *
+ * Layout per root:
+ *   - <root>/<name>.md            (flat file at the top level)
+ *   - <root>/.../<name>/SKILL.md  (directory skill, may be nested — Pi's standard)
+ *
+ * Recursion skips dotfile entries and node_modules. A directory that itself contains
+ * SKILL.md is a skill — we don't descend into it (Pi: skills don't nest).
+ *
+ * Symlinks are rejected for security (deviation from Pi, which follows them).
+ */
+
+import type { Dirent } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { isSymlink, isUnsafeName, safeReadFile } from "./memory.js";
+
+export interface PreloadedSkill {
+  name: string;
+  content: string;
+}
+
+export function preloadSkills(skillNames: string[], cwd: string): PreloadedSkill[] {
+  return skillNames.map((name) => ({ name, content: loadSkillContent(name, cwd) }));
+}
+
+function loadSkillContent(name: string, cwd: string): string {
+  if (isUnsafeName(name)) {
+    return `(Skill "${name}" skipped: name contains path traversal characters)`;
+  }
+  const roots = [
+    join(cwd, ".pi", "skills"), // project — Pi standard
+    join(cwd, ".agents", "skills"), // project — Agent Skills spec
+    join(getAgentDir(), "skills"), // user — Pi standard
+    join(homedir(), ".agents", "skills"), // user — Agent Skills spec
+    join(homedir(), ".pi", "skills"), // legacy global, pre-Pi
+  ];
+  for (const root of roots) {
+    const content = findInRoot(root, name);
+    if (content !== undefined) return content;
+  }
+  return `(Skill "${name}" not found in .pi/skills/, .agents/skills/, or global skill locations)`;
+}
+
+function findInRoot(root: string, name: string): string | undefined {
+  if (isSymlink(root)) return undefined; // reject symlinked roots entirely
+  const flat = safeReadFile(join(root, `${name}.md`))?.trim();
+  if (flat !== undefined) return flat;
+  return findSkillDirectory(root, name);
+}
+
+/** BFS under `root` for a directory named `name` containing `SKILL.md`. Pi-conforming filters. */
+function findSkillDirectory(root: string, name: string): string | undefined {
+  if (!existsSync(root)) return undefined;
+  const queue: string[] = [root];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined) continue;
+
+    let entries: Dirent<string>[];
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    // Deterministic byte-order traversal — locale-independent.
+    entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+
+      // Symlinked dirs already filtered by entry.isDirectory() — Dirent uses lstat semantics.
+      const path = join(current, entry.name);
+      const skillMd = join(path, "SKILL.md");
+      const isSkillDir = existsSync(skillMd);
+
+      if (isSkillDir) {
+        if (entry.name === name) {
+          const content = safeReadFile(skillMd)?.trim();
+          if (content !== undefined) return content;
+        }
+        continue; // Pi rule: skills don't nest — don't descend into a skill dir
+      }
+
+      queue.push(path);
+    }
+  }
+  return undefined;
+}

--- a/packages/pi-subagents/src/status-note.ts
+++ b/packages/pi-subagents/src/status-note.ts
@@ -1,0 +1,25 @@
+/**
+ * status-note.ts — Parenthetical status note appended to agent result text.
+ */
+
+/**
+ * Explicit parenthetical note for a non-normal terminal outcome, so the parent
+ * agent can't mistake partial output for a completed result. Empty string for a
+ * clean completion (and any unknown/non-terminal status).
+ *
+ * `stopped` (a human aborted it) is deliberately distinct from `aborted` (the
+ * turn limit was hit) — the parent should treat human intervention differently
+ * from a budget cutoff.
+ */
+export function getStatusNote(status: string): string {
+  switch (status) {
+    case "stopped":
+      return " (STOPPED BY THE USER before completion — output is partial; the task was NOT finished)";
+    case "aborted":
+      return " (aborted — hit the turn limit before completion; output may be incomplete)";
+    case "steered":
+      return " (wrapped up at the turn limit — output may be partial)";
+    default:
+      return "";
+  }
+}

--- a/packages/pi-subagents/src/types.ts
+++ b/packages/pi-subagents/src/types.ts
@@ -1,0 +1,208 @@
+/**
+ * types.ts — Type definitions for the subagent system.
+ */
+
+import type { ThinkingLevel } from "@earendil-works/pi-ai";
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import type { LifetimeUsage } from "./usage.js";
+
+export type { ThinkingLevel };
+
+/** Agent type: any string name (built-in defaults or user-defined). */
+export type SubagentType = string;
+
+/** Names of the three embedded default agents. */
+export const DEFAULT_AGENT_NAMES = ["general-purpose", "Explore", "Plan"] as const;
+
+/** Memory scope for persistent agent memory. */
+export type MemoryScope = "user" | "project" | "local";
+
+/** Isolation mode for agent execution. */
+export type IsolationMode = "worktree";
+
+/** Unified agent configuration — used for both default and user-defined agents. */
+export interface AgentConfig {
+  name: string;
+  displayName?: string;
+  description: string;
+  builtinToolNames?: string[];
+  /** Raw `ext:` selector entries from the `tools:` CSV, e.g. ["ext:foo", "ext:bar/x"].
+   * Presence of any entry flips extension tools to an explicit allowlist. */
+  extSelectors?: string[];
+  /** Tool denylist — these tools are removed even if `builtinToolNames` or extensions include them. */
+  disallowedTools?: string[];
+  /** true = inherit all, string[] = only listed, false = none */
+  extensions: true | string[] | false;
+  /** Extension-name denylist applied after the `extensions:` include set. Exclude wins.
+   * Plain canonical names only (case-insensitive); no paths, no wildcard. */
+  excludeExtensions?: string[];
+  /** true = inherit all, string[] = only listed, false = none */
+  skills: true | string[] | false;
+  model?: string;
+  thinking?: ThinkingLevel;
+  maxTurns?: number;
+  /** Persist this subagent as a normal pi session instead of keeping it in memory only. */
+  persistSession?: boolean;
+  /** Write the subagent's .output transcript. Defaults to true; false suppresses only that transcript. */
+  outputTranscript?: boolean;
+  /** Optional session directory used when persistSession is true. Omitted = pi's normal session location. */
+  sessionDir?: string;
+  systemPrompt: string;
+  promptMode: "replace" | "append";
+  /** Default for spawn: fork parent conversation. undefined = caller decides. */
+  inheritContext?: boolean;
+  /** Default for spawn: run in background. undefined = caller decides. */
+  runInBackground?: boolean;
+  /** Default for spawn: no extension tools. undefined = caller decides. */
+  isolated?: boolean;
+  /** Persistent memory scope — agents with memory get a persistent directory and MEMORY.md */
+  memory?: MemoryScope;
+  /** Isolation mode — "worktree" runs the agent in a temporary git worktree */
+  isolation?: IsolationMode;
+  /** true = this is an embedded default agent (informational) */
+  isDefault?: boolean;
+  /** false = agent is hidden from the registry */
+  enabled?: boolean;
+  /** Where this agent was loaded from */
+  source?: "default" | "project" | "global";
+}
+
+export type JoinMode = 'async' | 'group' | 'smart';
+
+/**
+ * Display mode for the persistent above-editor agent widget.
+ * - `all`: show every agent (foreground + background).
+ * - `background`: hide foreground agents (they already render inline as the
+ *   Agent tool result, #118); show background/queued/scheduled/RPC.
+ * - `off`: hide the widget entirely.
+ */
+export type WidgetMode = 'all' | 'background' | 'off';
+
+export interface AgentRecord {
+  id: string;
+  type: SubagentType;
+  description: string;
+  status: "queued" | "running" | "completed" | "steered" | "aborted" | "stopped" | "error";
+  result?: string;
+  error?: string;
+  toolUses: number;
+  startedAt: number;
+  completedAt?: number;
+  session?: AgentSession;
+  abortController?: AbortController;
+  promise?: Promise<string>;
+  groupId?: string;
+  joinMode?: JoinMode;
+  /** Set when result was already consumed via get_subagent_result — suppresses completion notification. */
+  resultConsumed?: boolean;
+  /** Steering messages queued before the session was ready. */
+  pendingSteers?: string[];
+  /** Worktree info if the agent is running in an isolated worktree. */
+  worktree?: { path: string; branch: string; baseSha: string; workPath: string };
+  /** Worktree cleanup result after agent completion. */
+  worktreeResult?: { hasChanges: boolean; branch?: string };
+  /** The tool_use_id from the original Agent tool call. */
+  toolCallId?: string;
+  /** Path to the streaming output transcript file. */
+  outputFile?: string;
+  /** Cleanup function for the output file stream subscription. */
+  outputCleanup?: () => void;
+  /**
+   * Lifetime usage breakdown, accumulated via `message_end` events. Survives
+   * compaction. Total = input + output + cacheWrite (cacheRead deliberately
+   * excluded — see issue #38). Initialized to zeros at spawn.
+   */
+  lifetimeUsage: LifetimeUsage;
+  /** Number of times this agent's session has compacted. Initialized to 0 at spawn. */
+  compactionCount: number;
+  /**
+   * Whether this agent was spawned to run in the background. Tri-state, set at
+   * spawn from `SpawnOptions.isBackground`: `true` = background, `false` =
+   * foreground (has an inline Agent tool-result surface), `undefined` = the
+   * caller never declared it (e.g. a cross-extension RPC spawn, which is detached
+   * and has no inline surface). The widget's background-only filter keys off this
+   * — and excludes only explicit `false`, so `undefined` agents stay visible.
+   * Reliable across ALL spawn paths, unlike the UI-only `invocation` snapshot,
+   * which only the Agent-tool path populates.
+   */
+  isBackground?: boolean;
+  /** Resolved spawn params, captured for UI display. Fixed at spawn time. */
+  invocation?: AgentInvocation;
+}
+
+export interface AgentInvocation {
+  /** Short display name, e.g. "haiku" — only set when different from parent. */
+  modelName?: string;
+  thinking?: ThinkingLevel;
+  maxTurns?: number;
+  isolated?: boolean;
+  inheritContext?: boolean;
+  runInBackground?: boolean;
+  isolation?: IsolationMode;
+}
+
+/** Details attached to custom notification messages for visual rendering. */
+export interface NotificationDetails {
+  id: string;
+  description: string;
+  status: string;
+  toolUses: number;
+  turnCount: number;
+  maxTurns?: number;
+  totalTokens: number;
+  durationMs: number;
+  outputFile?: string;
+  error?: string;
+  resultPreview: string;
+  /** Additional agents in a group notification. */
+  others?: NotificationDetails[];
+}
+
+export interface EnvInfo {
+  isGitRepo: boolean;
+  branch: string;
+  platform: string;
+}
+
+/**
+ * A subagent spawn registered to fire on a schedule.
+ *
+ * Stored at `<cwd>/.pi/subagent-schedules/<sessionId>.json`. Session-scoped:
+ * survives `/resume` but resets on `/new`, mirroring pi-chonky-tasks.
+ */
+export interface ScheduledSubagent {
+  id: string;
+  /** Unique within store. Defaults to `description`. */
+  name: string;
+  description: string;
+  /** Raw user input — cron expr | "+10m" | ISO | "5m". */
+  schedule: string;
+  scheduleType: "cron" | "once" | "interval";
+  /** Computed at create time for interval/once. */
+  intervalMs?: number;
+
+  // spawn params (subset of Agent tool params; no inherit_context, no resume)
+  subagent_type: SubagentType;
+  prompt: string;
+  model?: string;
+  thinking?: ThinkingLevel;
+  max_turns?: number;
+  isolated?: boolean;
+  isolation?: IsolationMode;
+
+  // state
+  enabled: boolean;
+  /** ISO timestamp. */
+  createdAt: string;
+  lastRun?: string;
+  lastStatus?: "success" | "error" | "running";
+  /** Refreshed on every fire and on store load. */
+  nextRun?: string;
+  runCount: number;
+}
+
+export interface ScheduleStoreData {
+  /** For future migrations. */
+  version: 1;
+  jobs: ScheduledSubagent[];
+}

--- a/packages/pi-subagents/src/types.ts
+++ b/packages/pi-subagents/src/types.ts
@@ -131,8 +131,10 @@ export interface AgentRecord {
 }
 
 export interface AgentInvocation {
-  /** Short display name, e.g. "haiku" — only set when different from parent. */
+  /** Effective short model label when known (e.g. "haiku"), including parent-inherited. */
   modelName?: string;
+  /** True when the effective model is the parent session model (for TUI "(inherit)" chips). */
+  modelInherited?: boolean;
   thinking?: ThinkingLevel;
   maxTurns?: number;
   isolated?: boolean;

--- a/packages/pi-subagents/src/ui/agent-widget.ts
+++ b/packages/pi-subagents/src/ui/agent-widget.ts
@@ -1,0 +1,566 @@
+/**
+ * agent-widget.ts — Persistent widget showing running/completed agents above the editor.
+ *
+ * Displays a tree of agents with animated spinners, live stats, and activity descriptions.
+ * Uses the callback form of setWidget for themed rendering.
+ */
+
+import { truncateToWidth } from "@earendil-works/pi-tui";
+import type { AgentManager } from "../agent-manager.js";
+import { getConfig } from "../agent-types.js";
+import type { AgentInvocation, SubagentType, WidgetMode } from "../types.js";
+import { getLifetimeTotal, getSessionContextPercent, type LifetimeUsage, type SessionLike } from "../usage.js";
+
+// ---- Constants ----
+
+/** Maximum number of rendered lines before overflow collapse kicks in. */
+const MAX_WIDGET_LINES = 12;
+
+/** Braille spinner frames for animated running indicator. */
+export const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/** Statuses that indicate an error/non-success outcome (used for linger behavior and icon rendering). */
+export const ERROR_STATUSES = new Set(["error", "aborted", "steered", "stopped"]);
+
+/** Tool name → human-readable action for activity descriptions. */
+const TOOL_DISPLAY: Record<string, string> = {
+  read: "reading",
+  bash: "running command",
+  edit: "editing",
+  write: "writing",
+  grep: "searching",
+  find: "finding files",
+  ls: "listing",
+};
+
+// ---- Types ----
+
+export type Theme = {
+  fg(color: string, text: string): string;
+  bold(text: string): string;
+};
+
+export type UICtx = {
+  setStatus(key: string, text: string | undefined): void;
+  setWidget(
+    key: string,
+    content: undefined | ((tui: any, theme: Theme) => { render(): string[]; invalidate(): void }),
+    options?: { placement?: "aboveEditor" | "belowEditor" },
+  ): void;
+};
+
+/** Per-agent live activity state. */
+export interface AgentActivity {
+  activeTools: Map<string, string>;
+  toolUses: number;
+  responseText: string;
+  session?: SessionLike;
+  /** Current turn count. */
+  turnCount: number;
+  /** Effective max turns for this agent (undefined = unlimited). */
+  maxTurns?: number;
+  /** Lifetime usage breakdown — see LifetimeUsage docs. */
+  lifetimeUsage: LifetimeUsage;
+}
+
+/** Metadata attached to Agent tool results for custom rendering. */
+export interface AgentDetails {
+  displayName: string;
+  description: string;
+  subagentType: string;
+  toolUses: number;
+  tokens: string;
+  durationMs: number;
+  status: "queued" | "running" | "completed" | "steered" | "aborted" | "stopped" | "error" | "background";
+  /** Human-readable description of what the agent is currently doing. */
+  activity?: string;
+  /** Current spinner frame index (for animated running indicator). */
+  spinnerFrame?: number;
+  /** Short model name if different from parent (e.g. "haiku", "sonnet"). */
+  modelName?: string;
+  /** Notable config tags (e.g. ["thinking: high", "isolated"]). */
+  tags?: string[];
+  /** Current turn count. */
+  turnCount?: number;
+  /** Effective max turns (undefined = unlimited). */
+  maxTurns?: number;
+  agentId?: string;
+  error?: string;
+}
+
+// ---- Formatting helpers ----
+
+/** Apply foreground styling while restoring it after nested foreground/full ANSI resets. */
+export function fgPreservingNestedStyles(theme: Theme, color: string, text: string): string {
+  const styledEmpty = theme.fg(color, "");
+  const styleStart = styledEmpty.replace(/\u001b\[(?:0|39)m/g, "");
+  return theme.fg(color, text.replace(/\u001b\[(?:0|39)m/g, reset => `${reset}${styleStart}`));
+}
+
+/** Format a token count compactly: "33.8k token", "1.2M token". */
+export function formatTokens(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M token`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k token`;
+  return `${count} token`;
+}
+
+/**
+ * Token count with optional context-fill % and compaction-count annotations.
+ * Thresholds for percent: <70% dim, 70–85% warning, ≥85% error.
+ * Compaction count rendered as `⇊N` in dim.
+ *
+ *   "12.3k token"               — no annotations
+ *   "12.3k token (45%)"         — percent only
+ *   "12.3k token (⇊2)"          — compactions only (e.g. right after compact)
+ *   "12.3k token (45% · ⇊2)"    — both
+ */
+export function formatSessionTokens(
+  tokens: number,
+  percent: number | null,
+  theme: Theme,
+  compactions = 0,
+): string {
+  const tokenStr = formatTokens(tokens);
+  const annot: string[] = [];
+  if (percent !== null) {
+    const color = percent >= 85 ? "error" : percent >= 70 ? "warning" : "dim";
+    annot.push(theme.fg(color, `${Math.round(percent)}%`));
+  }
+  if (compactions > 0) {
+    annot.push(theme.fg("dim", `⇊${compactions}`));
+  }
+  if (annot.length === 0) return tokenStr;
+  return `${tokenStr} (${annot.join(" · ")})`;
+}
+
+/** Format turn count with optional max limit: "↻5≤30" or "↻5". */
+export function formatTurns(turnCount: number, maxTurns?: number | null): string {
+  return maxTurns != null ? `↻${turnCount}≤${maxTurns}` : `↻${turnCount}`;
+}
+
+/** Format milliseconds as human-readable duration. */
+export function formatMs(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/** Format duration from start/completed timestamps. */
+export function formatDuration(startedAt: number, completedAt?: number): string {
+  if (completedAt) return formatMs(completedAt - startedAt);
+  return `${formatMs(Date.now() - startedAt)} (running)`;
+}
+
+/** Get display name for any agent type (built-in or custom). */
+export function getDisplayName(type: SubagentType): string {
+  return getConfig(type).displayName;
+}
+
+/** Short label for prompt mode: "twin" for append, nothing for replace (the default). */
+export function getPromptModeLabel(type: SubagentType): string | undefined {
+  const config = getConfig(type);
+  return config.promptMode === "append" ? "twin" : undefined;
+}
+
+/** Mode label is not included — callers add it where they want it. */
+export function buildInvocationTags(
+  invocation: AgentInvocation | undefined,
+): { modelName?: string; tags: string[] } {
+  const tags: string[] = [];
+  if (!invocation) return { tags };
+  if (invocation.thinking) tags.push(`thinking: ${invocation.thinking}`);
+  if (invocation.isolated) tags.push("isolated");
+  if (invocation.isolation === "worktree") tags.push("worktree");
+  if (invocation.inheritContext) tags.push("inherit context");
+  if (invocation.runInBackground) tags.push("background");
+  if (invocation.maxTurns != null) tags.push(`max turns: ${invocation.maxTurns}`);
+  return { modelName: invocation.modelName, tags };
+}
+
+/** Truncate text to a single line, max `len` chars. */
+function truncateLine(text: string, len = 60): string {
+  const line = text.split("\n").find(l => l.trim())?.trim() ?? "";
+  if (line.length <= len) return line;
+  return line.slice(0, len) + "…";
+}
+
+/** Build a human-readable activity string from currently-running tools or response text. */
+export function describeActivity(activeTools: Map<string, string>, responseText?: string): string {
+  if (activeTools.size > 0) {
+    const groups = new Map<string, number>();
+    for (const toolName of activeTools.values()) {
+      const action = TOOL_DISPLAY[toolName] ?? toolName;
+      groups.set(action, (groups.get(action) ?? 0) + 1);
+    }
+
+    const parts: string[] = [];
+    for (const [action, count] of groups) {
+      if (count > 1) {
+        parts.push(`${action} ${count} ${action === "searching" ? "patterns" : "files"}`);
+      } else {
+        parts.push(action);
+      }
+    }
+    return parts.join(", ") + "…";
+  }
+
+  // No tools active — show truncated response text if available
+  if (responseText && responseText.trim().length > 0) {
+    return truncateLine(responseText);
+  }
+
+  return "thinking…";
+}
+
+// ---- Widget manager ----
+
+export class AgentWidget {
+  private uiCtx: UICtx | undefined;
+  private widgetFrame = 0;
+  private widgetInterval: ReturnType<typeof setInterval> | undefined;
+  /** Tracks how many turns each finished agent has survived. Key: agent ID, Value: turns since finished. */
+  private finishedTurnAge = new Map<string, number>();
+  /** How many extra turns errors/aborted agents linger (completed agents clear after 1 turn). */
+  private static readonly ERROR_LINGER_TURNS = 2;
+
+  /** Whether the widget callback is currently registered with the TUI. */
+  private widgetRegistered = false;
+  /** Cached TUI reference from widget factory callback, used for requestRender(). */
+  private tui: any | undefined;
+  /** Last status bar text, used to avoid redundant setStatus calls. */
+  private lastStatusText: string | undefined;
+
+  constructor(
+    private manager: AgentManager,
+    private agentActivity: Map<string, AgentActivity>,
+    /**
+     * Read live at render time. Selects which agents the widget shows — see
+     * `WidgetMode`. Defaults to `"all"` when a caller supplies no policy; the
+     * extension supplies one defaulting to `"background"`.
+     */
+    private mode: () => WidgetMode = () => "all",
+  ) {}
+
+  /**
+   * Agents eligible for the widget, per the current `WidgetMode`:
+   *   - `off`: none (the widget's existing empty-state path hides it entirely).
+   *   - `background`: drop only agents *known* to be foreground
+   *     (`isBackground === false`); keep everything else — background, queued,
+   *     scheduled, or RPC-spawned (`undefined`). Keying off the `isBackground`
+   *     record flag rather than the UI-only `invocation` snapshot (which only the
+   *     Agent-tool path sets), and excluding rather than allow-listing, means
+   *     only proven-foreground runs drop out — nothing else silently vanishes.
+   *   - `all`: every agent.
+   */
+  private widgetAgents() {
+    const all = this.manager.listAgents();
+    switch (this.mode()) {
+      case "off": return [];
+      case "background": return all.filter(a => a.isBackground !== false);
+      default: return all;
+    }
+  }
+
+  /** Set the UI context (grabbed from first tool execution). */
+  setUICtx(ctx: UICtx) {
+    if (ctx !== this.uiCtx) {
+      // UICtx changed — the widget registered on the old context is gone.
+      // Force re-registration on next update().
+      this.uiCtx = ctx;
+      this.widgetRegistered = false;
+      this.tui = undefined;
+      this.lastStatusText = undefined;
+    }
+  }
+
+  /**
+   * Called on each new turn (tool_execution_start).
+   * Ages finished agents and clears those that have lingered long enough.
+   */
+  onTurnStart() {
+    // Age all finished agents
+    for (const [id, age] of this.finishedTurnAge) {
+      this.finishedTurnAge.set(id, age + 1);
+    }
+    // Trigger a widget refresh (will filter out expired agents)
+    this.update();
+  }
+
+  /** Ensure the widget update timer is running. */
+  ensureTimer() {
+    if (!this.widgetInterval) {
+      this.widgetInterval = setInterval(() => this.update(), 80);
+    }
+  }
+
+  /** Check if a finished agent should still be shown in the widget. */
+  private shouldShowFinished(agentId: string, status: string): boolean {
+    const age = this.finishedTurnAge.get(agentId) ?? 0;
+    const maxAge = ERROR_STATUSES.has(status) ? AgentWidget.ERROR_LINGER_TURNS : 1;
+    return age < maxAge;
+  }
+
+  /** Record an agent as finished (call when agent completes). */
+  markFinished(agentId: string) {
+    if (!this.finishedTurnAge.has(agentId)) {
+      this.finishedTurnAge.set(agentId, 0);
+    }
+  }
+
+  /** Render a finished agent line. */
+  private renderFinishedLine(a: { id: string; type: SubagentType; status: string; description: string; toolUses: number; startedAt: number; completedAt?: number; error?: string }, theme: Theme): string {
+    const name = getDisplayName(a.type);
+    const modeLabel = getPromptModeLabel(a.type);
+    const duration = formatMs((a.completedAt ?? Date.now()) - a.startedAt);
+
+    let icon: string;
+    let statusText: string;
+    if (a.status === "completed") {
+      icon = theme.fg("success", "✓");
+      statusText = "";
+    } else if (a.status === "steered") {
+      icon = theme.fg("warning", "✓");
+      statusText = theme.fg("warning", " (turn limit)");
+    } else if (a.status === "stopped") {
+      icon = theme.fg("dim", "■");
+      statusText = theme.fg("dim", " stopped");
+    } else if (a.status === "error") {
+      icon = theme.fg("error", "✗");
+      const errMsg = a.error ? `: ${a.error.slice(0, 60)}` : "";
+      statusText = theme.fg("error", ` error${errMsg}`);
+    } else {
+      // aborted
+      icon = theme.fg("error", "✗");
+      statusText = theme.fg("warning", " aborted");
+    }
+
+    const parts: string[] = [];
+    const activity = this.agentActivity.get(a.id);
+    if (activity) parts.push(formatTurns(activity.turnCount, activity.maxTurns));
+    if (a.toolUses > 0) parts.push(`${a.toolUses} tool use${a.toolUses === 1 ? "" : "s"}`);
+    parts.push(duration);
+
+    const modeTag = modeLabel ? ` ${theme.fg("dim", `(${modeLabel})`)}` : "";
+    return `${icon} ${theme.fg("dim", name)}${modeTag}  ${theme.fg("dim", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", parts.join(" · "))}${statusText}`;
+  }
+
+  /**
+   * Render the widget content. Called from the registered widget's render() callback,
+   * reading live state each time instead of capturing it in a closure.
+   */
+  private renderWidget(tui: any, theme: Theme): string[] {
+    const allAgents = this.widgetAgents();
+    const running = allAgents.filter(a => a.status === "running");
+    const queued = allAgents.filter(a => a.status === "queued");
+    const finished = allAgents.filter(a =>
+      a.status !== "running" && a.status !== "queued" && a.completedAt
+      && this.shouldShowFinished(a.id, a.status),
+    );
+
+    const hasActive = running.length > 0 || queued.length > 0;
+    const hasFinished = finished.length > 0;
+
+    // Nothing to show — return empty (widget will be unregistered by update())
+    if (!hasActive && !hasFinished) return [];
+
+    const w = tui.terminal.columns;
+    const truncate = (line: string) => truncateToWidth(line, w);
+    const headingColor = hasActive ? "accent" : "dim";
+    const headingIcon = hasActive ? "●" : "○";
+    const frame = SPINNER[this.widgetFrame % SPINNER.length];
+
+    // Build sections separately for overflow-aware assembly.
+    // Each running agent = 2 lines (header + activity), finished = 1 line, queued = 1 line.
+
+    const finishedLines: string[] = [];
+    for (const a of finished) {
+      finishedLines.push(truncate(theme.fg("dim", "├─") + " " + this.renderFinishedLine(a, theme)));
+    }
+
+    const runningLines: string[][] = []; // each entry is [header, activity]
+    for (const a of running) {
+      const name = getDisplayName(a.type);
+      const modeLabel = getPromptModeLabel(a.type);
+      const modeTag = modeLabel ? ` ${theme.fg("dim", `(${modeLabel})`)}` : "";
+      const elapsed = formatMs(Date.now() - a.startedAt);
+
+      const bg = this.agentActivity.get(a.id);
+      const toolUses = bg?.toolUses ?? a.toolUses;
+      const tokens = getLifetimeTotal(bg?.lifetimeUsage);
+      const contextPercent = getSessionContextPercent(bg?.session);
+      const tokenText = tokens > 0 ? formatSessionTokens(tokens, contextPercent, theme, a.compactionCount) : "";
+
+      const parts: string[] = [];
+      if (bg) parts.push(formatTurns(bg.turnCount, bg.maxTurns));
+      if (toolUses > 0) parts.push(`${toolUses} tool use${toolUses === 1 ? "" : "s"}`);
+      if (tokenText) parts.push(tokenText);
+      parts.push(elapsed);
+      const statsText = parts.join(" · ");
+
+      const activity = bg ? describeActivity(bg.activeTools, bg.responseText) : "thinking…";
+
+      runningLines.push([
+        truncate(theme.fg("dim", "├─") + ` ${theme.fg("accent", frame)} ${theme.bold(name)}${modeTag}  ${theme.fg("muted", a.description)} ${theme.fg("dim", "·")} ${fgPreservingNestedStyles(theme, "dim", statsText)}`),
+        truncate(theme.fg("dim", "│  ") + theme.fg("dim", `  ⎿  ${activity}`)),
+      ]);
+    }
+
+    const queuedLine = queued.length > 0
+      ? truncate(theme.fg("dim", "├─") + ` ${theme.fg("muted", "◦")} ${theme.fg("dim", `${queued.length} queued`)}`)
+      : undefined;
+
+    // Assemble with overflow cap (heading + overflow indicator = 2 reserved lines).
+    const maxBody = MAX_WIDGET_LINES - 1; // heading takes 1 line
+    const totalBody = finishedLines.length + runningLines.length * 2 + (queuedLine ? 1 : 0);
+
+    const lines: string[] = [truncate(theme.fg(headingColor, headingIcon) + " " + theme.fg(headingColor, "Agents"))];
+
+    if (totalBody <= maxBody) {
+      // Everything fits — add all lines and fix up connectors for the last item.
+      lines.push(...finishedLines);
+      for (const pair of runningLines) lines.push(...pair);
+      if (queuedLine) lines.push(queuedLine);
+
+      // Fix last connector: swap ├─ → └─ and │ → space for activity lines.
+      if (lines.length > 1) {
+        const last = lines.length - 1;
+        lines[last] = lines[last].replace("├─", "└─");
+        // If last item is a running agent activity line, fix indent of that line
+        // and fix the header line above it.
+        if (runningLines.length > 0 && !queuedLine) {
+          // The last two lines are the last running agent's header + activity.
+          if (last >= 2) {
+            lines[last - 1] = lines[last - 1].replace("├─", "└─");
+            lines[last] = lines[last].replace("│  ", "   ");
+          }
+        }
+      }
+    } else {
+      // Overflow — prioritize: running > queued > finished.
+      // Reserve 1 line for overflow indicator.
+      let budget = maxBody - 1;
+      let hiddenRunning = 0;
+      let hiddenFinished = 0;
+
+      // 1. Running agents (2 lines each)
+      for (const pair of runningLines) {
+        if (budget >= 2) {
+          lines.push(...pair);
+          budget -= 2;
+        } else {
+          hiddenRunning++;
+        }
+      }
+
+      // 2. Queued line
+      if (queuedLine && budget >= 1) {
+        lines.push(queuedLine);
+        budget--;
+      }
+
+      // 3. Finished agents
+      for (const fl of finishedLines) {
+        if (budget >= 1) {
+          lines.push(fl);
+          budget--;
+        } else {
+          hiddenFinished++;
+        }
+      }
+
+      // Overflow summary
+      const overflowParts: string[] = [];
+      if (hiddenRunning > 0) overflowParts.push(`${hiddenRunning} running`);
+      if (hiddenFinished > 0) overflowParts.push(`${hiddenFinished} finished`);
+      const overflowText = overflowParts.join(", ");
+      lines.push(truncate(theme.fg("dim", "└─") + ` ${theme.fg("dim", `+${hiddenRunning + hiddenFinished} more (${overflowText})`)}`)
+      );
+    }
+
+    return lines;
+  }
+
+  /** Force an immediate widget update. */
+  update() {
+    if (!this.uiCtx) return;
+    const allAgents = this.widgetAgents();
+
+    // Lightweight existence checks — full categorization happens in renderWidget()
+    let runningCount = 0;
+    let queuedCount = 0;
+    let hasFinished = false;
+    for (const a of allAgents) {
+      if (a.status === "running") { runningCount++; }
+      else if (a.status === "queued") { queuedCount++; }
+      else if (a.completedAt && this.shouldShowFinished(a.id, a.status)) { hasFinished = true; }
+    }
+    const hasActive = runningCount > 0 || queuedCount > 0;
+
+    // Nothing to show — clear widget
+    if (!hasActive && !hasFinished) {
+      if (this.widgetRegistered) {
+        this.uiCtx.setWidget("agents", undefined);
+        this.widgetRegistered = false;
+        this.tui = undefined;
+      }
+      if (this.lastStatusText !== undefined) {
+        this.uiCtx.setStatus("subagents", undefined);
+        this.lastStatusText = undefined;
+      }
+      if (this.widgetInterval) { clearInterval(this.widgetInterval); this.widgetInterval = undefined; }
+      // Clean up stale entries
+      for (const [id] of this.finishedTurnAge) {
+        if (!allAgents.some(a => a.id === id)) this.finishedTurnAge.delete(id);
+      }
+      return;
+    }
+
+    // Status bar — only call setStatus when the text actually changes
+    let newStatusText: string | undefined;
+    if (hasActive) {
+      const statusParts: string[] = [];
+      if (runningCount > 0) statusParts.push(`${runningCount} running`);
+      if (queuedCount > 0) statusParts.push(`${queuedCount} queued`);
+      const total = runningCount + queuedCount;
+      newStatusText = `${statusParts.join(", ")} agent${total === 1 ? "" : "s"}`;
+    }
+    if (newStatusText !== this.lastStatusText) {
+      this.uiCtx.setStatus("subagents", newStatusText);
+      this.lastStatusText = newStatusText;
+    }
+
+    this.widgetFrame++;
+
+    // Register widget callback once; subsequent updates use requestRender()
+    // which re-invokes render() without replacing the component (avoids layout thrashing).
+    if (!this.widgetRegistered) {
+      this.uiCtx.setWidget("agents", (tui, theme) => {
+        this.tui = tui;
+        return {
+          render: () => this.renderWidget(tui, theme),
+          invalidate: () => {
+            // Theme changed — force re-registration so factory captures fresh theme.
+            this.widgetRegistered = false;
+            this.tui = undefined;
+          },
+        };
+      }, { placement: "aboveEditor" });
+      this.widgetRegistered = true;
+    } else {
+      // Widget already registered — just request a re-render of existing components.
+      this.tui?.requestRender();
+    }
+  }
+
+  dispose() {
+    if (this.widgetInterval) {
+      clearInterval(this.widgetInterval);
+      this.widgetInterval = undefined;
+    }
+    if (this.uiCtx) {
+      this.uiCtx.setWidget("agents", undefined);
+      this.uiCtx.setStatus("subagents", undefined);
+    }
+    this.widgetRegistered = false;
+    this.tui = undefined;
+    this.lastStatusText = undefined;
+  }
+}

--- a/packages/pi-subagents/src/ui/agent-widget.ts
+++ b/packages/pi-subagents/src/ui/agent-widget.ts
@@ -76,9 +76,16 @@ export interface AgentDetails {
   activity?: string;
   /** Current spinner frame index (for animated running indicator). */
   spinnerFrame?: number;
-  /** Short model name if different from parent (e.g. "haiku", "sonnet"). */
+  /** Effective short model label when known (e.g. "haiku", "sonnet") — including parent-inherited. */
   modelName?: string;
-  /** Notable config tags (e.g. ["thinking: high", "isolated"]). */
+  /** True when the effective model is the parent session model. */
+  modelInherited?: boolean;
+  /**
+   * Thinking / effort level for TUI (maps from tool/frontmatter `thinking`).
+   * Shown as `effort: <level>` for Claude Code-adjacent wording.
+   */
+  effort?: string;
+  /** Notable config tags (e.g. ["effort: high", "isolated", "background"]). */
   tags?: string[];
   /** Current turn count. */
   turnCount?: number;
@@ -160,13 +167,22 @@ export function getPromptModeLabel(type: SubagentType): string | undefined {
   return config.promptMode === "append" ? "twin" : undefined;
 }
 
+/** Short model label for TUI (strips leading "Claude ", lowercases). */
+export function shortModelLabel(model: { id?: string; name?: string } | null | undefined): string | undefined {
+  if (!model) return undefined;
+  const raw = (model.name ?? model.id ?? "").trim();
+  if (!raw) return undefined;
+  return raw.replace(/^Claude\s+/i, "").toLowerCase();
+}
+
 /** Mode label is not included — callers add it where they want it. */
 export function buildInvocationTags(
   invocation: AgentInvocation | undefined,
 ): { modelName?: string; tags: string[] } {
   const tags: string[] = [];
   if (!invocation) return { tags };
-  if (invocation.thinking) tags.push(`thinking: ${invocation.thinking}`);
+  // TUI wording: effort (Claude Code-adjacent); source field remains `thinking`.
+  if (invocation.thinking) tags.push(`effort: ${invocation.thinking}`);
   if (invocation.isolated) tags.push("isolated");
   if (invocation.isolation === "worktree") tags.push("worktree");
   if (invocation.inheritContext) tags.push("inherit context");

--- a/packages/pi-subagents/src/ui/agent-widget.ts
+++ b/packages/pi-subagents/src/ui/agent-widget.ts
@@ -25,12 +25,15 @@ export const ERROR_STATUSES = new Set(["error", "aborted", "steered", "stopped"]
 /** Tool name → human-readable action for activity descriptions. */
 const TOOL_DISPLAY: Record<string, string> = {
   read: "reading",
-  bash: "running command",
+  bash: "running",
   edit: "editing",
   write: "writing",
   grep: "searching",
-  find: "finding files",
+  find: "finding",
   ls: "listing",
+  Agent: "spawning",
+  get_subagent_result: "awaiting",
+  steer_subagent: "steering",
 };
 
 // ---- Types ----
@@ -51,6 +54,10 @@ export type UICtx = {
 
 /** Per-agent live activity state. */
 export interface AgentActivity {
+  /**
+   * In-flight tools: key = toolCallId (or synthetic), value = one-line step summary
+   * e.g. "reading src/a.ts", "running rg auth".
+   */
   activeTools: Map<string, string>;
   toolUses: number;
   responseText: string;
@@ -198,24 +205,62 @@ function truncateLine(text: string, len = 60): string {
   return line.slice(0, len) + "…";
 }
 
-/** Build a human-readable activity string from currently-running tools or response text. */
+/**
+ * One-line summary for an in-flight tool (widget / tool-result activity row).
+ * Prefers path/command/pattern from args when present.
+ */
+export function formatActiveToolSummary(toolName: string, args?: unknown): string {
+  if (toolName.startsWith("tools-error:") || toolName.startsWith("extension-error:")) {
+    return truncateLine(toolName.replace(/^(tools|extension)-error:/, "⚠ "), 70);
+  }
+  const action = TOOL_DISPLAY[toolName] ?? toolName;
+  const record =
+    args && typeof args === "object" && !Array.isArray(args)
+      ? (args as Record<string, unknown>)
+      : {};
+  // Inline lightweight detail extraction (mirrors conversation-brief summarizeToolArgs keys).
+  const firstString = (...keys: string[]): string | undefined => {
+    for (const k of keys) {
+      const v = record[k];
+      if (typeof v === "string" && v.trim()) return v.trim();
+    }
+    return undefined;
+  };
+  const path = firstString("path", "file_path", "filePath", "filename", "file", "target");
+  const command = firstString("command", "cmd");
+  const pattern = firstString("pattern", "query", "regex", "search");
+  const glob = firstString("glob", "include", "glob_pattern", "globPattern");
+  let detail: string | undefined;
+  if (command) detail = command;
+  else if (path) detail = path;
+  else if (pattern && (path || glob)) detail = `${JSON.stringify(pattern)} ${path ?? glob}`;
+  else if (pattern) detail = JSON.stringify(pattern);
+  else if (glob) detail = glob;
+  else if (typeof record.url === "string" && record.url.trim()) detail = record.url.trim();
+  if (detail) {
+    const one = detail.replace(/\s+/g, " ");
+    const clipped = one.length > 48 ? `${one.slice(0, 47)}…` : one;
+    return `${action} ${clipped}`;
+  }
+  return action;
+}
+
+/**
+ * Build the widget's last-line activity string.
+ * Prefer in-flight tool step summaries; else streaming assistant text; else "thinking…".
+ */
 export function describeActivity(activeTools: Map<string, string>, responseText?: string): string {
   if (activeTools.size > 0) {
-    const groups = new Map<string, number>();
-    for (const toolName of activeTools.values()) {
-      const action = TOOL_DISPLAY[toolName] ?? toolName;
-      groups.set(action, (groups.get(action) ?? 0) + 1);
+    const parts = [...activeTools.values()].filter((p) => p.trim().length > 0);
+    if (parts.length === 1) {
+      const p = parts[0]!;
+      return p.endsWith("…") ? p : `${p}…`;
     }
-
-    const parts: string[] = [];
-    for (const [action, count] of groups) {
-      if (count > 1) {
-        parts.push(`${action} ${count} ${action === "searching" ? "patterns" : "files"}`);
-      } else {
-        parts.push(action);
-      }
+    if (parts.length > 1) {
+      const head = parts.slice(0, 2).join(", ");
+      const more = parts.length > 2 ? ` +${parts.length - 2}` : "";
+      return `${head}${more}…`;
     }
-    return parts.join(", ") + "…";
   }
 
   // No tools active — show truncated response text if available

--- a/packages/pi-subagents/src/ui/agent-widget.ts
+++ b/packages/pi-subagents/src/ui/agent-widget.ts
@@ -227,6 +227,19 @@ function truncateLine(text: string, len = 60): string {
 }
 
 /**
+ * Compact status-bar copy used only when the above-editor widget is off.
+ * Returns undefined when there is nothing to report.
+ */
+export function formatSubagentsStatusText(runningCount: number, queuedCount: number): string | undefined {
+  if (runningCount <= 0 && queuedCount <= 0) return undefined;
+  const parts: string[] = [];
+  if (runningCount > 0) parts.push(`${runningCount} running`);
+  if (queuedCount > 0) parts.push(`${queuedCount} queued`);
+  const total = runningCount + queuedCount;
+  return `${parts.join(", ")} agent${total === 1 ? "" : "s"}`;
+}
+
+/**
  * One-line summary for an in-flight tool (widget / tool-result activity row).
  * Prefers path/command/pattern from args when present.
  */
@@ -563,7 +576,9 @@ export class AgentWidget {
   /** Force an immediate widget update. */
   update() {
     if (!this.uiCtx) return;
+    const mode = this.mode();
     const allAgents = this.widgetAgents();
+    const listed = this.manager.listAgents();
 
     // Lightweight existence checks — full categorization happens in renderWidget()
     let runningCount = 0;
@@ -575,38 +590,46 @@ export class AgentWidget {
       else if (a.completedAt && this.shouldShowFinished(a.id, a.status)) { hasFinished = true; }
     }
     const hasActive = runningCount > 0 || queuedCount > 0;
+    const widgetWantsShow = hasActive || hasFinished;
 
-    // Nothing to show — clear widget
-    if (!hasActive && !hasFinished) {
+    // Status bar policy (auto):
+    //   - Widget mode all/background and the tree is (or will be) visible → clear status
+    //     (plain "1 running agent" fights the rich widget chrome).
+    //   - Widget mode off → compact count is the sole bottom-bar indicator.
+    //   - Nothing active → clear.
+    let newStatusText: string | undefined;
+    if (mode === "off") {
+      let statusRunning = 0;
+      let statusQueued = 0;
+      for (const a of listed) {
+        if (a.status === "running") statusRunning++;
+        else if (a.status === "queued") statusQueued++;
+      }
+      newStatusText = formatSubagentsStatusText(statusRunning, statusQueued);
+    } else {
+      newStatusText = undefined;
+    }
+    if (newStatusText !== this.lastStatusText) {
+      this.uiCtx.setStatus("subagents", newStatusText);
+      this.lastStatusText = newStatusText;
+    }
+
+    // Nothing for the above-editor tree — drop the widget (status may still be live when mode=off).
+    if (!widgetWantsShow) {
       if (this.widgetRegistered) {
         this.uiCtx.setWidget("agents", undefined);
         this.widgetRegistered = false;
         this.tui = undefined;
       }
-      if (this.lastStatusText !== undefined) {
-        this.uiCtx.setStatus("subagents", undefined);
-        this.lastStatusText = undefined;
+      // Keep the timer while status fallback must refresh; stop otherwise.
+      if (!(mode === "off" && newStatusText)) {
+        if (this.widgetInterval) { clearInterval(this.widgetInterval); this.widgetInterval = undefined; }
       }
-      if (this.widgetInterval) { clearInterval(this.widgetInterval); this.widgetInterval = undefined; }
-      // Clean up stale entries
+      // Clean up stale finished-age entries against the full list.
       for (const [id] of this.finishedTurnAge) {
-        if (!allAgents.some(a => a.id === id)) this.finishedTurnAge.delete(id);
+        if (!listed.some(a => a.id === id)) this.finishedTurnAge.delete(id);
       }
       return;
-    }
-
-    // Status bar — only call setStatus when the text actually changes
-    let newStatusText: string | undefined;
-    if (hasActive) {
-      const statusParts: string[] = [];
-      if (runningCount > 0) statusParts.push(`${runningCount} running`);
-      if (queuedCount > 0) statusParts.push(`${queuedCount} queued`);
-      const total = runningCount + queuedCount;
-      newStatusText = `${statusParts.join(", ")} agent${total === 1 ? "" : "s"}`;
-    }
-    if (newStatusText !== this.lastStatusText) {
-      this.uiCtx.setStatus("subagents", newStatusText);
-      this.lastStatusText = newStatusText;
     }
 
     this.widgetFrame++;

--- a/packages/pi-subagents/src/ui/agent-widget.ts
+++ b/packages/pi-subagents/src/ui/agent-widget.ts
@@ -195,7 +195,28 @@ export function buildInvocationTags(
   if (invocation.inheritContext) tags.push("inherit context");
   if (invocation.runInBackground) tags.push("background");
   if (invocation.maxTurns != null) tags.push(`max turns: ${invocation.maxTurns}`);
-  return { modelName: invocation.modelName, tags };
+  const modelName = invocation.modelName
+    ? (invocation.modelInherited ? `${invocation.modelName} (inherit)` : invocation.modelName)
+    : undefined;
+  return { modelName, tags };
+}
+
+/**
+ * Rebuild Agent tool-result details fields from a stored invocation snapshot.
+ * Keeps Agent row and get_subagent_result row chips aligned (model/inherit/effort).
+ */
+export function detailsFromInvocation(invocation: AgentInvocation | undefined): Pick<
+  AgentDetails,
+  "modelName" | "modelInherited" | "effort" | "tags"
+> {
+  if (!invocation) return {};
+  const { tags } = buildInvocationTags(invocation);
+  return {
+    modelName: invocation.modelName,
+    modelInherited: invocation.modelInherited,
+    effort: invocation.thinking ? String(invocation.thinking) : undefined,
+    tags: tags.length > 0 ? tags : undefined,
+  };
 }
 
 /** Truncate text to a single line, max `len` chars. */

--- a/packages/pi-subagents/src/ui/conversation-brief.ts
+++ b/packages/pi-subagents/src/ui/conversation-brief.ts
@@ -1,0 +1,322 @@
+/**
+ * conversation-brief.ts — Pure messages → brief progress view-model for ConversationViewer.
+ *
+ * Default overlay layout (scheme A):
+ *   Prompt (dispatch) · Steps (one-line tool summaries) · Result (final assistant text)
+ */
+
+import { extractText } from "../context.js";
+
+/** Max lines of the dispatch prompt shown before truncation note. */
+export const PROMPT_MAX_LINES = 30;
+/** Max characters for a single-line tool-result side note. */
+export const RESULT_PREVIEW_MAX_CHARS = 80;
+/** Max characters when collapsing arbitrary JSON/string args. */
+export const ARGS_FALLBACK_MAX_CHARS = 120;
+
+export type StepStatus = "running" | "completed" | "error";
+
+export interface BriefStep {
+  /** Tool-call id when known; synthetic ids for bashExecution / unmatched results. */
+  id: string;
+  toolName: string;
+  /** One-line argument summary (no status icon). */
+  summary: string;
+  status: StepStatus;
+  /** Short folded result note, e.g. "ok · 12 lines" or first-line preview. */
+  resultNote?: string;
+  isError: boolean;
+  /** Full args text for optional expand mode. */
+  argsText?: string;
+  /** Full tool-result text for optional expand mode. */
+  resultText?: string;
+}
+
+export interface ConversationBrief {
+  /** First meaningful user message text (untruncated). */
+  prompt: string | undefined;
+  /** Later user messages (e.g. steers), in order. */
+  steers: string[];
+  steps: BriefStep[];
+  /** Last non-empty assistant text content. */
+  result: string | undefined;
+}
+
+export type LooseMessage = {
+  role?: string;
+  content?: unknown;
+  toolCallId?: string;
+  toolUseId?: string;
+  toolName?: string;
+  isError?: boolean;
+  command?: string;
+  output?: string;
+  [key: string]: unknown;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return value as Record<string, unknown>;
+}
+
+function firstString(args: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const v = args[key];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return undefined;
+}
+
+function compactInline(text: string, maxChars: number): string {
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  if (oneLine.length <= maxChars) return oneLine;
+  if (maxChars <= 1) return "…";
+  return `${oneLine.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+/** Extract tool-call arguments from either `arguments` (pi-ai) or legacy `input`. */
+export function getToolCallArgs(block: Record<string, unknown>): Record<string, unknown> {
+  return asRecord(block.arguments) ?? asRecord(block.input) ?? asRecord(block.args) ?? {};
+}
+
+/** Extract tool-call id from `id` / `toolCallId` / `toolUseId`. */
+export function getToolCallId(block: Record<string, unknown>): string | undefined {
+  for (const key of ["id", "toolCallId", "toolUseId"] as const) {
+    const v = block[key];
+    if (typeof v === "string" && v) return v;
+  }
+  return undefined;
+}
+
+/** Human-readable one-line summary of tool arguments. */
+export function summarizeToolArgs(toolName: string, args: Record<string, unknown>, maxChars = ARGS_FALLBACK_MAX_CHARS): string {
+  const name = toolName.toLowerCase();
+  const path = firstString(args, ["path", "file_path", "filePath", "filename", "file", "target"]);
+  const command = firstString(args, ["command", "cmd"]);
+  const pattern = firstString(args, ["pattern", "query", "regex", "search"]);
+  const glob = firstString(args, ["glob", "include", "glob_pattern", "globPattern"]);
+  const url = firstString(args, ["url", "uri", "href"]);
+
+  let detail: string | undefined;
+
+  if (command && (name === "bash" || name.includes("bash") || name === "shell")) {
+    detail = command;
+  } else if (path && (name === "read" || name === "write" || name === "edit" || name.includes("read") || name.includes("write") || name.includes("edit"))) {
+    detail = path;
+  } else if (pattern && (name === "grep" || name === "rg" || name.includes("grep") || name.includes("search"))) {
+    const bits = [`${JSON.stringify(pattern)}`];
+    if (path) bits.push(path);
+    else if (glob) bits.push(glob);
+    detail = bits.join(" ");
+  } else if (pattern && path) {
+    detail = `${JSON.stringify(pattern)} ${path}`;
+  } else if (path) {
+    detail = path;
+  } else if (command) {
+    detail = command;
+  } else if (url) {
+    detail = url;
+  } else if (pattern) {
+    detail = JSON.stringify(pattern);
+  } else if (glob) {
+    detail = glob;
+  } else {
+    const keys = Object.keys(args);
+    if (keys.length === 0) {
+      detail = undefined;
+    } else {
+      try {
+        detail = JSON.stringify(args);
+      } catch {
+        detail = String(args);
+      }
+    }
+  }
+
+  if (!detail) return "";
+  return compactInline(detail, maxChars);
+}
+
+/** Build a folded one-line note for a tool result body. */
+export function summarizeToolResult(text: string, isError: boolean, maxChars = RESULT_PREVIEW_MAX_CHARS): string {
+  const trimmed = text.replace(/\r\n/g, "\n").trim();
+  if (!trimmed) return isError ? "error" : "ok";
+
+  const lines = trimmed.split("\n");
+  const lineCount = lines.length;
+  const first = compactInline(lines[0] ?? "", maxChars);
+
+  if (isError) {
+    return first ? `error · ${first}` : "error";
+  }
+
+  if (lineCount <= 1) {
+    return first ? `ok · ${first}` : "ok";
+  }
+  // Prefer compact stats; include a short first-line peek when it still fits.
+  const stats = `ok · ${lineCount} lines`;
+  if (!first || first.length > Math.max(12, maxChars - stats.length - 3)) {
+    return stats;
+  }
+  return `${stats} · ${first}`;
+}
+
+function messageText(msg: LooseMessage): string {
+  if (typeof msg.content === "string") return msg.content;
+  if (Array.isArray(msg.content)) return extractText(msg.content);
+  return "";
+}
+
+/**
+ * Build the scheme-A brief view model from a session message list.
+ * Pure: no theme, no TUI, no I/O.
+ */
+export function buildConversationBrief(messages: readonly LooseMessage[]): ConversationBrief {
+  let prompt: string | undefined;
+  const steers: string[] = [];
+  const steps: BriefStep[] = [];
+  const byId = new Map<string, BriefStep>();
+  let result: string | undefined;
+  let syntheticSeq = 0;
+
+  const pushStep = (step: BriefStep): BriefStep => {
+    steps.push(step);
+    if (step.id) byId.set(step.id, step);
+    return step;
+  };
+
+  for (const msg of messages) {
+    const role = msg.role;
+    if (role === "user") {
+      const text = messageText(msg).trim();
+      if (!text) continue;
+      if (prompt === undefined) prompt = text;
+      else steers.push(text);
+      continue;
+    }
+
+    if (role === "assistant") {
+      const content = Array.isArray(msg.content) ? msg.content : [];
+      const textParts: string[] = [];
+      for (const raw of content) {
+        const block = asRecord(raw);
+        if (!block) continue;
+        if (block.type === "text" && typeof block.text === "string" && block.text.trim()) {
+          textParts.push(block.text);
+        } else if (block.type === "toolCall") {
+          const toolName =
+            (typeof block.name === "string" && block.name) ||
+            (typeof block.toolName === "string" && block.toolName) ||
+            "unknown";
+          const id = getToolCallId(block) ?? `anon-${++syntheticSeq}`;
+          const args = getToolCallArgs(block);
+          let argsText: string | undefined;
+          try {
+            argsText = Object.keys(args).length > 0 ? JSON.stringify(args, null, 2) : undefined;
+          } catch {
+            argsText = undefined;
+          }
+          const existing = byId.get(id);
+          if (existing) {
+            existing.toolName = toolName;
+            existing.summary = summarizeToolArgs(toolName, args);
+            existing.argsText = argsText;
+          } else {
+            pushStep({
+              id,
+              toolName,
+              summary: summarizeToolArgs(toolName, args),
+              status: "running",
+              isError: false,
+              argsText,
+            });
+          }
+        }
+      }
+      const joined = textParts.join("\n").trim();
+      if (joined) result = joined;
+      continue;
+    }
+
+    if (role === "toolResult") {
+      const id =
+        (typeof msg.toolCallId === "string" && msg.toolCallId) ||
+        (typeof msg.toolUseId === "string" && msg.toolUseId) ||
+        `result-${++syntheticSeq}`;
+      const toolName =
+        (typeof msg.toolName === "string" && msg.toolName) ||
+        byId.get(id)?.toolName ||
+        "tool";
+      const text = messageText(msg);
+      const isError = msg.isError === true;
+      const note = summarizeToolResult(text, isError);
+      const existing = byId.get(id);
+      if (existing) {
+        existing.status = isError ? "error" : "completed";
+        existing.isError = isError;
+        existing.resultNote = note;
+        existing.resultText = text.trim() || undefined;
+        if (!existing.toolName || existing.toolName === "unknown") existing.toolName = toolName;
+      } else {
+        pushStep({
+          id,
+          toolName,
+          summary: "",
+          status: isError ? "error" : "completed",
+          isError,
+          resultNote: note,
+          resultText: text.trim() || undefined,
+        });
+      }
+      continue;
+    }
+
+    if (role === "bashExecution") {
+      const command = typeof msg.command === "string" ? msg.command : "";
+      const output = typeof msg.output === "string" ? msg.output : "";
+      const id = `bash-${++syntheticSeq}`;
+      pushStep({
+        id,
+        toolName: "bash",
+        summary: summarizeToolArgs("bash", { command }),
+        status: "completed",
+        isError: false,
+        argsText: command || undefined,
+        resultNote: output.trim() ? summarizeToolResult(output, false) : undefined,
+        resultText: output.trim() || undefined,
+      });
+    }
+  }
+
+  return { prompt, steers, steps, result };
+}
+
+/** Split prompt text into display lines with an optional truncation marker. */
+export function truncatePromptLines(prompt: string, maxLines = PROMPT_MAX_LINES): { lines: string[]; truncated: boolean } {
+  const lines = prompt.replace(/\r\n/g, "\n").split("\n");
+  if (lines.length <= maxLines) return { lines, truncated: false };
+  const kept = lines.slice(0, maxLines);
+  const hidden = lines.length - maxLines;
+  kept.push(`… (${hidden} more line${hidden === 1 ? "" : "s"} truncated — scroll source session for full prompt)`);
+  return { lines: kept, truncated: true };
+}
+
+export function stepStatusIcon(status: StepStatus): string {
+  if (status === "completed") return "✓";
+  if (status === "error") return "✗";
+  return "⠹";
+}
+
+/** Format one step row without theme colors: `✓ read   path/to/file.ts`. */
+export function formatStepLine(step: BriefStep, opts?: { includeResultNote?: boolean }): string {
+  const icon = stepStatusIcon(step.status);
+  const name = step.toolName || "tool";
+  const padName = name.length < 6 ? name.padEnd(6) : name;
+  const parts = [icon, padName];
+  if (step.summary) parts.push(step.summary);
+  let line = parts.join(" ");
+  if (opts?.includeResultNote !== false && step.resultNote) {
+    line += `  · ${step.resultNote}`;
+  }
+  return line;
+}

--- a/packages/pi-subagents/src/ui/conversation-brief.ts
+++ b/packages/pi-subagents/src/ui/conversation-brief.ts
@@ -299,14 +299,72 @@ export function buildConversationBrief(messages: readonly LooseMessage[]): Conve
   return { prompt, steers, steps, result };
 }
 
-/** Split prompt text into display lines with an optional truncation marker. */
+/** Detect inherit_context parent dump (see `buildParentContext`). */
+export function promptLooksLikeInheritedContext(prompt: string): boolean {
+  return /#\s*Parent Conversation Context/i.test(prompt);
+}
+
+/**
+ * Split prompt text into display lines with an optional truncation marker.
+ *
+ * Default keeps the **head** (normal dispatch). When the prompt embeds parent
+ * conversation context (inherit_context), keeps the **tail** so the actual
+ * dispatch task is not eaten by the parent history wall.
+ */
 export function truncatePromptLines(prompt: string, maxLines = PROMPT_MAX_LINES): { lines: string[]; truncated: boolean } {
   const lines = prompt.replace(/\r\n/g, "\n").split("\n");
   if (lines.length <= maxLines) return { lines, truncated: false };
-  const kept = lines.slice(0, maxLines);
   const hidden = lines.length - maxLines;
+  if (promptLooksLikeInheritedContext(prompt)) {
+    const kept = lines.slice(-maxLines);
+    kept.unshift(
+      `… (${hidden} earlier line${hidden === 1 ? "" : "s"} truncated — parent context folded; dispatch task below)`,
+    );
+    return { lines: kept, truncated: true };
+  }
+  const kept = lines.slice(0, maxLines);
   kept.push(`… (${hidden} more line${hidden === 1 ? "" : "s"} truncated — scroll source session for full prompt)`);
   return { lines: kept, truncated: true };
+}
+
+export type TerminalRecordStatus = "completed" | "steered" | "error" | "aborted" | "stopped";
+
+/** True when the agent record is no longer running/queued. */
+export function isTerminalRecordStatus(status: string | undefined): status is TerminalRecordStatus {
+  return (
+    status === "completed" ||
+    status === "steered" ||
+    status === "error" ||
+    status === "aborted" ||
+    status === "stopped"
+  );
+}
+
+/**
+ * After the agent has left running/queued, any step still marked `running`
+ * (toolCall without a matching toolResult) is a lie — settle it.
+ */
+export function settleDanglingBriefSteps(
+  steps: BriefStep[],
+  recordStatus: string | undefined,
+): BriefStep[] {
+  if (!isTerminalRecordStatus(recordStatus)) return steps;
+  const asError = recordStatus === "error" || recordStatus === "aborted" || recordStatus === "stopped";
+  const note =
+    recordStatus === "stopped"
+      ? "interrupted"
+      : recordStatus === "aborted"
+        ? "aborted"
+        : recordStatus === "error"
+          ? "interrupted"
+          : "ended";
+  for (const step of steps) {
+    if (step.status !== "running") continue;
+    step.status = asError ? "error" : "completed";
+    step.isError = asError;
+    if (!step.resultNote) step.resultNote = note;
+  }
+  return steps;
 }
 
 export function stepStatusIcon(status: StepStatus): string {

--- a/packages/pi-subagents/src/ui/conversation-brief.ts
+++ b/packages/pi-subagents/src/ui/conversation-brief.ts
@@ -274,15 +274,23 @@ export function buildConversationBrief(messages: readonly LooseMessage[]): Conve
     if (role === "bashExecution") {
       const command = typeof msg.command === "string" ? msg.command : "";
       const output = typeof msg.output === "string" ? msg.output : "";
+      // Pi records exitCode/cancelled on bashExecution (see recordBashResult).
+      const exitCode = typeof msg.exitCode === "number" ? msg.exitCode : undefined;
+      const cancelled = msg.cancelled === true;
+      const isError = cancelled || (exitCode !== undefined && exitCode !== 0);
       const id = `bash-${++syntheticSeq}`;
       pushStep({
         id,
         toolName: "bash",
         summary: summarizeToolArgs("bash", { command }),
-        status: "completed",
-        isError: false,
+        status: isError ? "error" : "completed",
+        isError,
         argsText: command || undefined,
-        resultNote: output.trim() ? summarizeToolResult(output, false) : undefined,
+        resultNote: output.trim()
+          ? summarizeToolResult(output, isError)
+          : isError
+            ? (cancelled ? "error · cancelled" : `error · exit ${exitCode}`)
+            : undefined,
         resultText: output.trim() || undefined,
       });
     }

--- a/packages/pi-subagents/src/ui/conversation-viewer.ts
+++ b/packages/pi-subagents/src/ui/conversation-viewer.ts
@@ -352,19 +352,38 @@ export class ConversationViewer implements Component {
     // ── Result ──────────────────────────────────────────────────────────
     lines.push("");
     section("Result");
-    if (brief.result) {
+    const failedTerminal =
+      this.record.status === "error" ||
+      this.record.status === "aborted" ||
+      this.record.status === "stopped";
+    if (failedTerminal) {
+      // Prefer record.error over intermediate assistant chatter so a mid-run
+      // "I'll check…" is never mistaken for the final outcome.
+      const errText =
+        (typeof this.record.error === "string" && this.record.error.trim()) ||
+        (this.record.status === "stopped"
+          ? "Stopped by user"
+          : this.record.status === "aborted"
+            ? "Aborted (max turns exceeded)"
+            : "failed");
+      lines.push(th.fg("error", errText));
+      if (brief.result?.trim()) {
+        lines.push(th.fg("dim", "── last assistant text before failure ──"));
+        for (const line of wrapTextWithAnsi(brief.result.trim(), width)) {
+          lines.push(th.fg("dim", line));
+        }
+      }
+    } else if (brief.result) {
       for (const line of wrapTextWithAnsi(brief.result.trim(), width)) {
         lines.push(line);
       }
-    } else if (this.record.status === "running") {
+    } else if (this.record.status === "running" || this.record.status === "queued") {
       if (this.activity) {
         const act = describeActivity(this.activity.activeTools, this.activity.responseText);
         lines.push(truncateToWidth(th.fg("accent", "⠹ ") + th.fg("dim", act || "running…"), width));
       } else {
         lines.push(th.fg("dim", "(running…)"));
       }
-    } else if (this.record.status === "error") {
-      lines.push(th.fg("error", "(failed — no final assistant text)"));
     } else {
       lines.push(th.fg("dim", "(no final result text)"));
     }

--- a/packages/pi-subagents/src/ui/conversation-viewer.ts
+++ b/packages/pi-subagents/src/ui/conversation-viewer.ts
@@ -14,9 +14,13 @@ import { type AgentActivity, buildInvocationTags, describeActivity, fgPreserving
 import {
   buildConversationBrief,
   formatStepLine,
+  settleDanglingBriefSteps,
   truncatePromptLines,
   type BriefStep,
 } from "./conversation-brief.js";
+
+/** Expanded step args/results hard cap (avoid write/edit dumping whole files). */
+const EXPAND_TEXT_MAX_CHARS = 1000;
 import { createViewerKeys, type ViewerKeybindings, type ViewerKeys } from "./viewer-keys.js";
 
 /** Base lines consumed by chrome: top border + header + header sep + footer sep + footer + bottom border. */
@@ -155,13 +159,7 @@ export class ConversationViewer implements Component {
     const name = getDisplayName(this.record.type);
     const modeLabel = getPromptModeLabel(this.record.type);
     const modeTag = modeLabel ? ` ${th.fg("dim", `(${modeLabel})`)}` : "";
-    const statusIcon = this.record.status === "running"
-      ? th.fg("accent", "●")
-      : this.record.status === "completed"
-        ? th.fg("success", "✓")
-        : this.record.status === "error"
-          ? th.fg("error", "✗")
-          : th.fg("dim", "○");
+    const statusIcon = headerStatusIcon(this.record.status, th);
     const duration = formatDuration(this.record.startedAt, this.record.completedAt);
 
     const headerParts: string[] = [duration];
@@ -309,6 +307,8 @@ export class ConversationViewer implements Component {
     }
 
     const brief = buildConversationBrief(messages);
+    // Terminal records must not keep spinner steps for unmatched toolCalls.
+    settleDanglingBriefSteps(brief.steps, this.record.status);
     const section = (title: string) => {
       lines.push(th.bold(title));
     };
@@ -373,6 +373,14 @@ export class ConversationViewer implements Component {
           lines.push(th.fg("dim", line));
         }
       }
+    } else if (this.record.status === "steered") {
+      // Turn-limit wrap-up is not a hard failure, but must not look like normal Done.
+      lines.push(th.fg("warning", "Wrapped up (turn limit)"));
+      if (brief.result?.trim()) {
+        for (const line of wrapTextWithAnsi(brief.result.trim(), width)) {
+          lines.push(line);
+        }
+      }
     } else if (brief.result) {
       for (const line of wrapTextWithAnsi(brief.result.trim(), width)) {
         lines.push(line);
@@ -426,13 +434,13 @@ export class ConversationViewer implements Component {
     if (!this.expandDetails) return;
 
     if (step.argsText?.trim()) {
-      for (const line of wrapTextWithAnsi(step.argsText.trim(), Math.max(1, width - 2))) {
+      const body = clipExpandText(step.argsText.trim());
+      for (const line of wrapTextWithAnsi(body, Math.max(1, width - 2))) {
         lines.push(truncateToWidth(th.fg("dim", `  ${line}`), width));
       }
     }
     if (step.resultText?.trim()) {
-      const body = step.resultText.trim();
-      const shown = body.length > 500 ? `${body.slice(0, 500)}... (truncated)` : body;
+      const shown = clipExpandText(step.resultText.trim());
       const color = step.isError ? "error" : "dim";
       for (const line of wrapTextWithAnsi(shown, Math.max(1, width - 2))) {
         lines.push(truncateToWidth(th.fg(color, `  ${line}`), width));
@@ -441,4 +449,30 @@ export class ConversationViewer implements Component {
       lines.push(truncateToWidth(th.fg(step.isError ? "error" : "dim", `  ${step.resultNote}`), width));
     }
   }
+}
+
+/** Header status icon aligned with tool-render chrome. */
+export function headerStatusIcon(status: string | undefined, th: Theme): string {
+  switch (status) {
+    case "running":
+      return th.fg("accent", "●");
+    case "queued":
+      return th.fg("accent", "○");
+    case "completed":
+      return th.fg("success", "✓");
+    case "steered":
+      return th.fg("warning", "✓");
+    case "error":
+    case "aborted":
+      return th.fg("error", "✗");
+    case "stopped":
+      return th.fg("dim", "■");
+    default:
+      return th.fg("dim", "○");
+  }
+}
+
+function clipExpandText(text: string, max = EXPAND_TEXT_MAX_CHARS): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}... (truncated)`;
 }

--- a/packages/pi-subagents/src/ui/conversation-viewer.ts
+++ b/packages/pi-subagents/src/ui/conversation-viewer.ts
@@ -1,0 +1,425 @@
+/**
+ * conversation-viewer.ts — Live conversation overlay for viewing agent sessions.
+ *
+ * Default view (scheme A): dispatch prompt · one-line tool step summaries · final result.
+ * Subscribes to session events for real-time streaming updates.
+ */
+
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import { type Component, Input, matchesKey, type TUI, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import type { AgentRecord } from "../types.js";
+import { getLifetimeTotal, getSessionContextPercent } from "../usage.js";
+import type { Theme } from "./agent-widget.js";
+import { type AgentActivity, buildInvocationTags, describeActivity, fgPreservingNestedStyles, formatDuration, formatSessionTokens, getDisplayName, getPromptModeLabel } from "./agent-widget.js";
+import {
+  buildConversationBrief,
+  formatStepLine,
+  truncatePromptLines,
+  type BriefStep,
+} from "./conversation-brief.js";
+import { createViewerKeys, type ViewerKeybindings, type ViewerKeys } from "./viewer-keys.js";
+
+/** Base lines consumed by chrome: top border + header + header sep + footer sep + footer + bottom border. */
+const CHROME_LINES_BASE = 6;
+const MIN_VIEWPORT = 3;
+/** Height ceiling shared by the overlay's `maxHeight` and the viewer's internal viewport cap. */
+export const VIEWPORT_HEIGHT_PCT = 70;
+
+export class ConversationViewer implements Component {
+  private scrollOffset = 0;
+  private autoScroll = true;
+  private unsubscribe: (() => void) | undefined;
+  private lastInnerW = 0;
+  private closed = false;
+  /** Two-press confirm guard for the stop key, so a stray key can't kill the agent. */
+  private stopArmed = false;
+  private keys: ViewerKeys;
+  /** Steering composer — present while the user is typing a message to the agent. */
+  private composer: Input | undefined;
+  /** When true, step args/results expand beyond the one-line summary. Default off. */
+  private expandDetails = false;
+
+  constructor(
+    private tui: TUI,
+    private session: AgentSession,
+    private record: AgentRecord,
+    private activity: AgentActivity | undefined,
+    private theme: Theme,
+    private done: (result: undefined) => void,
+    /** Abort the agent shown here. Omitted → no stop affordance (e.g. read-only history). */
+    private onStop?: () => void,
+    /** User keybindings from `ctx.ui.custom()`. Omitted → hardcoded defaults. */
+    keybindings?: ViewerKeybindings,
+    /** Send a steering message to the agent. Omitted → no compose affordance. */
+    private onSteer?: (message: string) => void,
+  ) {
+    this.keys = createViewerKeys(keybindings);
+    this.unsubscribe = session.subscribe(() => {
+      if (this.closed) return;
+      this.tui.requestRender();
+    });
+  }
+
+  handleInput(data: string): void {
+    // While composing a steer message, the input owns all keys (Enter sends,
+    // Esc cancels — both wired in openComposer()). Editing keys flow through.
+    if (this.composer) {
+      this.composer.handleInput(data);
+      this.tui.requestRender();
+      return;
+    }
+
+    if (matchesKey(data, "escape") || matchesKey(data, "q")) {
+      this.closed = true;
+      this.done(undefined);
+      return;
+    }
+
+    // Enter opens the steering composer (only while the agent can still be
+    // steered) — then type + Enter sends, Esc or an empty submit returns. When
+    // not steerable, fall through so the key still disarms a pending stop.
+    if (matchesKey(data, "enter") && this.canSteer()) {
+      this.stopArmed = false;
+      this.openComposer();
+      return;
+    }
+
+    // Toggle expanded tool detail (args + folded-away result bodies).
+    if (data === "o" || data === "O") {
+      this.expandDetails = !this.expandDetails;
+      this.stopArmed = false;
+      this.tui.requestRender();
+      return;
+    }
+
+    // Stop/abort the agent (only while it can still be stopped). Two-press:
+    // first "x" arms, second confirms — any other key disarms.
+    if (matchesKey(data, "x")) {
+      if (this.isStoppable()) {
+        if (this.stopArmed) {
+          this.stopArmed = false;
+          this.onStop?.();
+        } else {
+          this.stopArmed = true;
+        }
+        this.tui.requestRender();
+      }
+      return;
+    }
+    if (this.stopArmed) this.stopArmed = false;
+
+    const totalLines = this.buildContentLines(this.lastInnerW).length;
+    const viewportHeight = this.viewportHeight();
+    const maxScroll = Math.max(0, totalLines - viewportHeight);
+
+    if (this.keys.scrollUp(data)) {
+      this.scrollOffset = Math.max(0, this.scrollOffset - 1);
+      this.autoScroll = this.scrollOffset >= maxScroll;
+    } else if (this.keys.scrollDown(data)) {
+      this.scrollOffset = Math.min(maxScroll, this.scrollOffset + 1);
+      this.autoScroll = this.scrollOffset >= maxScroll;
+    } else if (this.keys.pageUp(data)) {
+      this.scrollOffset = Math.max(0, this.scrollOffset - viewportHeight);
+      this.autoScroll = false;
+    } else if (this.keys.pageDown(data)) {
+      this.scrollOffset = Math.min(maxScroll, this.scrollOffset + viewportHeight);
+      this.autoScroll = this.scrollOffset >= maxScroll;
+    } else if (matchesKey(data, "home")) {
+      this.scrollOffset = 0;
+      this.autoScroll = false;
+    } else if (matchesKey(data, "end")) {
+      this.scrollOffset = maxScroll;
+      this.autoScroll = true;
+    }
+  }
+
+  render(width: number): string[] {
+    if (width < 6) return []; // too narrow for any meaningful rendering
+    const th = this.theme;
+    const innerW = width - 4; // border + padding
+    this.lastInnerW = innerW;
+    const lines: string[] = [];
+
+    const pad = (s: string, len: number) => {
+      const vis = visibleWidth(s);
+      return s + " ".repeat(Math.max(0, len - vis));
+    };
+    const row = (content: string) =>
+      th.fg("border", "│") + " " + truncateToWidth(pad(content, innerW), innerW, "...", true) + " " + th.fg("border", "│");
+    const hrTop = th.fg("border", `╭${"─".repeat(width - 2)}╮`);
+    const hrBot = th.fg("border", `╰${"─".repeat(width - 2)}╯`);
+    const hrMid = row(th.fg("dim", "─".repeat(innerW)));
+
+    // Header
+    lines.push(hrTop);
+    const name = getDisplayName(this.record.type);
+    const modeLabel = getPromptModeLabel(this.record.type);
+    const modeTag = modeLabel ? ` ${th.fg("dim", `(${modeLabel})`)}` : "";
+    const statusIcon = this.record.status === "running"
+      ? th.fg("accent", "●")
+      : this.record.status === "completed"
+        ? th.fg("success", "✓")
+        : this.record.status === "error"
+          ? th.fg("error", "✗")
+          : th.fg("dim", "○");
+    const duration = formatDuration(this.record.startedAt, this.record.completedAt);
+
+    const headerParts: string[] = [duration];
+    const toolUses = this.activity?.toolUses ?? this.record.toolUses;
+    if (toolUses > 0) headerParts.unshift(`${toolUses} tool${toolUses === 1 ? "" : "s"}`);
+    const tokens = getLifetimeTotal(this.activity?.lifetimeUsage);
+    if (tokens > 0) {
+      const percent = getSessionContextPercent(this.activity?.session);
+      headerParts.push(formatSessionTokens(tokens, percent, th, this.record.compactionCount));
+    }
+
+    lines.push(row(
+      `${statusIcon} ${th.bold(name)}${modeTag}  ${th.fg("muted", this.record.description)} ${th.fg("dim", "·")} ${fgPreservingNestedStyles(th, "dim", headerParts.join(" · "))}`,
+    ));
+    const invocationLine = this.invocationLine();
+    if (invocationLine) lines.push(row(invocationLine));
+    lines.push(hrMid);
+
+    // Content area — rebuild every render (live data, no cache needed)
+    const contentLines = this.buildContentLines(innerW);
+    const viewportHeight = this.viewportHeight();
+    const maxScroll = Math.max(0, contentLines.length - viewportHeight);
+
+    if (this.autoScroll) {
+      this.scrollOffset = maxScroll;
+    }
+
+    const visibleStart = Math.min(this.scrollOffset, maxScroll);
+    const visible = contentLines.slice(visibleStart, visibleStart + viewportHeight);
+
+    for (let i = 0; i < viewportHeight; i++) {
+      lines.push(row(visible[i] ?? ""));
+    }
+
+    // Footer
+    lines.push(hrMid);
+    if (this.composer) {
+      // Composer row: the Input renders its own `> ` prompt and cursor.
+      lines.push(row(this.composer.render(innerW)[0] ?? ""));
+      const composeHint = th.fg("dim", "Enter send · Esc cancel");
+      const composeLeft = th.fg("accent", "✎ steer");
+      const composeGap = Math.max(1, innerW - visibleWidth(composeLeft) - visibleWidth(composeHint));
+      lines.push(row(composeLeft + " ".repeat(composeGap) + composeHint));
+    } else {
+      // Actions on the left, navigation on the right. The scroll hint keeps its
+      // full key list so the less-obvious bindings stay discoverable; it leads
+      // the right group so "Esc close" is the only part that truncates first.
+      const sep = th.fg("dim", " · ");
+      const actions: string[] = [];
+      if (this.canSteer()) actions.push(th.fg("dim", "Enter steer"));
+      if (this.isStoppable()) {
+        actions.push(this.stopArmed ? th.fg("error", "x again to STOP") : th.fg("dim", "x stop"));
+      }
+      actions.push(th.fg("dim", this.expandDetails ? "o fold" : "o detail"));
+      const footerRight = th.fg("dim", "↑↓ scroll · PgUp/PgDn or Shift+↑↓ · Esc close");
+
+      // Prepend the line-count/scroll-% readout only when there's spare width —
+      // it's the first thing dropped so it never crowds out the hints.
+      const scrollPct = contentLines.length <= viewportHeight
+        ? "100%"
+        : `${Math.round(((visibleStart + viewportHeight) / contentLines.length) * 100)}%`;
+      const count = th.fg("dim", `${contentLines.length} lines · ${scrollPct}`);
+      const withCount = [count, ...actions].join(sep);
+      const footerLeft = visibleWidth(withCount) + visibleWidth(footerRight) + 1 <= innerW
+        ? withCount
+        : actions.join(sep);
+
+      const footerGap = Math.max(1, innerW - visibleWidth(footerLeft) - visibleWidth(footerRight));
+      lines.push(row(footerLeft + " ".repeat(footerGap) + footerRight));
+    }
+    lines.push(hrBot);
+
+    return lines;
+  }
+
+  /** Stoppable only when a stop handler exists and the agent is still active. */
+  private isStoppable(): boolean {
+    return !!this.onStop && (this.record.status === "running" || this.record.status === "queued");
+  }
+
+  /** Steerable only when a steer handler exists and the agent is still active. */
+  private canSteer(): boolean {
+    return !!this.onSteer && (this.record.status === "running" || this.record.status === "queued");
+  }
+
+  /** Open the inline steering composer and route subsequent input to it. */
+  private openComposer(): void {
+    const input = new Input();
+    input.focused = true;
+    input.onSubmit = (value: string) => {
+      const message = value.trim();
+      this.composer = undefined;
+      if (message) this.onSteer?.(message);
+      this.tui.requestRender();
+    };
+    input.onEscape = () => {
+      this.composer = undefined;
+      this.tui.requestRender();
+    };
+    this.composer = input;
+    this.tui.requestRender();
+  }
+
+  invalidate(): void { /* no cached state to clear */ }
+
+  dispose(): void {
+    this.closed = true;
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = undefined;
+    }
+  }
+
+  // ---- Private ----
+
+  private viewportHeight(): number {
+    // Cap mirrors the overlay's maxHeight — otherwise the viewer would render
+    // more lines than the overlay shows and clip the footer.
+    const maxRows = Math.floor((this.tui.terminal.rows * VIEWPORT_HEIGHT_PCT) / 100);
+    return Math.max(MIN_VIEWPORT, maxRows - this.chromeLines());
+  }
+
+  private chromeLines(): number {
+    // The composer adds one row above the footer hint while it's open.
+    return CHROME_LINES_BASE + (this.invocationLine() ? 1 : 0) + (this.composer ? 1 : 0);
+  }
+
+  private invocationLine(): string | undefined {
+    const { modelName, tags } = buildInvocationTags(this.record.invocation);
+    const parts = modelName ? [modelName, ...tags] : tags;
+    if (parts.length === 0) return undefined;
+    return this.theme.fg("dim", `  ↳ ${parts.join(" · ")}`);
+  }
+
+  private buildContentLines(width: number): string[] {
+    if (width <= 0) return [];
+
+    const th = this.theme;
+    const messages = this.session.messages as unknown as Parameters<typeof buildConversationBrief>[0];
+    const lines: string[] = [];
+
+    if (!messages || messages.length === 0) {
+      lines.push(th.fg("dim", "(waiting for first message...)"));
+      return lines.map((l) => truncateToWidth(l, width));
+    }
+
+    const brief = buildConversationBrief(messages);
+    const section = (title: string) => {
+      lines.push(th.bold(title));
+    };
+
+    // ── Prompt ──────────────────────────────────────────────────────────
+    section("Prompt");
+    if (brief.prompt) {
+      const { lines: promptLines } = truncatePromptLines(brief.prompt);
+      for (const raw of promptLines) {
+        for (const line of wrapTextWithAnsi(raw, width)) {
+          lines.push(line);
+        }
+      }
+    } else {
+      lines.push(th.fg("dim", "(no dispatch prompt yet)"));
+    }
+
+    for (const steer of brief.steers) {
+      lines.push(th.fg("dim", "───"));
+      lines.push(th.fg("accent", "Steer"));
+      for (const line of wrapTextWithAnsi(steer.trim(), width)) {
+        lines.push(line);
+      }
+    }
+
+    // ── Steps ───────────────────────────────────────────────────────────
+    lines.push("");
+    section("Steps");
+    if (brief.steps.length === 0) {
+      if (this.record.status === "running") {
+        lines.push(th.fg("dim", "(no tool calls yet)"));
+      } else {
+        lines.push(th.fg("dim", "(no tool steps)"));
+      }
+    } else {
+      for (const step of brief.steps) {
+        this.pushStepLines(lines, step, width, th);
+      }
+    }
+
+    // ── Result ──────────────────────────────────────────────────────────
+    lines.push("");
+    section("Result");
+    if (brief.result) {
+      for (const line of wrapTextWithAnsi(brief.result.trim(), width)) {
+        lines.push(line);
+      }
+    } else if (this.record.status === "running") {
+      if (this.activity) {
+        const act = describeActivity(this.activity.activeTools, this.activity.responseText);
+        lines.push(truncateToWidth(th.fg("accent", "⠹ ") + th.fg("dim", act || "running…"), width));
+      } else {
+        lines.push(th.fg("dim", "(running…)"));
+      }
+    } else if (this.record.status === "error") {
+      lines.push(th.fg("error", "(failed — no final assistant text)"));
+    } else {
+      lines.push(th.fg("dim", "(no final result text)"));
+    }
+
+    // Live activity footer while tools are mid-flight (even if a prior result text exists).
+    if (this.record.status === "running" && this.activity && brief.result) {
+      const act = describeActivity(this.activity.activeTools, this.activity.responseText);
+      if (act) {
+        lines.push("");
+        lines.push(truncateToWidth(th.fg("accent", "⠹ ") + th.fg("dim", act), width));
+      }
+    }
+
+    return lines.map((l) => truncateToWidth(l, width));
+  }
+
+  private pushStepLines(lines: string[], step: BriefStep, width: number, th: Theme): void {
+    const plain = formatStepLine(step, { includeResultNote: !this.expandDetails });
+    const icon = plain.slice(0, 1);
+    const rest = plain.slice(1);
+    const coloredIcon =
+      step.status === "completed"
+        ? th.fg("success", icon)
+        : step.status === "error"
+          ? th.fg("error", icon)
+          : th.fg("accent", icon);
+    let main = coloredIcon + rest;
+    if (!this.expandDetails && step.resultNote) {
+      // Re-color the trailing note when present (formatStepLine already appended it).
+      const noteIdx = main.lastIndexOf("  · ");
+      if (noteIdx >= 0) {
+        const head = main.slice(0, noteIdx);
+        const note = main.slice(noteIdx + 4);
+        const noteColor = step.isError ? "error" : "dim";
+        main = head + th.fg("dim", "  · ") + th.fg(noteColor, note);
+      }
+    }
+    lines.push(truncateToWidth(main, width));
+
+    if (!this.expandDetails) return;
+
+    if (step.argsText?.trim()) {
+      for (const line of wrapTextWithAnsi(step.argsText.trim(), Math.max(1, width - 2))) {
+        lines.push(truncateToWidth(th.fg("dim", `  ${line}`), width));
+      }
+    }
+    if (step.resultText?.trim()) {
+      const body = step.resultText.trim();
+      const shown = body.length > 500 ? `${body.slice(0, 500)}... (truncated)` : body;
+      const color = step.isError ? "error" : "dim";
+      for (const line of wrapTextWithAnsi(shown, Math.max(1, width - 2))) {
+        lines.push(truncateToWidth(th.fg(color, `  ${line}`), width));
+      }
+    } else if (step.resultNote) {
+      lines.push(truncateToWidth(th.fg(step.isError ? "error" : "dim", `  ${step.resultNote}`), width));
+    }
+  }
+}

--- a/packages/pi-subagents/src/ui/fleet-list.ts
+++ b/packages/pi-subagents/src/ui/fleet-list.ts
@@ -1,0 +1,380 @@
+/**
+ * fleet-list.ts — Claude Code-style "FleetView" list rendered below the editor.
+ *
+ * Shows `main` + each running/queued subagent as a navigable list. Pressing ↓ (or
+ * ←) at an empty prompt activates the list; ↑/↓ move the selection (filled ● marker),
+ * Enter opens the selected agent's live conversation overlay, Esc returns to the prompt.
+ * A viewer stays open when its agent finishes; finished agents linger briefly in the list.
+ *
+ * Mechanics (see plan): the list is a `belowEditor` widget (render-only), and ALL key
+ * handling goes through `onTerminalInput` — which fires before the focused editor and
+ * can `consume` keys — gated on `getEditorText() === ""` so normal typing is untouched.
+ */
+
+import { Editor, isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { AgentManager } from "../agent-manager.js";
+import type { AgentRecord } from "../types.js";
+import { getLifetimeTotal } from "../usage.js";
+import { type AgentActivity, getDisplayName, type Theme } from "./agent-widget.js";
+import { ConversationViewer, VIEWPORT_HEIGHT_PCT } from "./conversation-viewer.js";
+
+/** Widget key for the below-editor fleet list. */
+const FLEET_KEY = "fleet";
+/** Max agent rows shown at once; extras collapse into a "↓ N more" indicator. */
+const MAX_AGENT_ROWS = 5;
+/** Re-render cadence so elapsed/token stats tick while agents run. */
+const TICK_MS = 200;
+/** How long a finished agent lingers in the list before it drops out. */
+const FINISHED_LINGER_MS = 4000;
+
+/** Minimal UI surface the FleetView needs from `ctx.ui` (structural subset). */
+export type FleetUICtx = {
+  setWidget(
+    key: string,
+    content: undefined | ((tui: any, theme: Theme) => { render(width: number): string[]; invalidate(): void; dispose?(): void }),
+    options?: { placement?: "aboveEditor" | "belowEditor" },
+  ): void;
+  onTerminalInput(handler: (data: string) => { consume?: boolean; data?: string } | undefined): () => void;
+  getEditorText(): string;
+  notify(message: string, type?: "info" | "warning" | "error"): void;
+  custom<T>(
+    factory: (tui: any, theme: Theme, keybindings: any, done: (result: T) => void) => { render(width: number): string[]; invalidate(): void; dispose?(): void },
+    options?: { overlay?: boolean; overlayOptions?: unknown; onHandle?: (handle: unknown) => void },
+  ): Promise<T>;
+};
+
+type MainEntry = { kind: "main" };
+type AgentEntry = { kind: "agent"; record: AgentRecord };
+type FleetEntry = MainEntry | AgentEntry;
+
+/** `11s` — integer seconds, no decimal/suffix (matches Claude Code, unlike formatMs). */
+export function formatFleetElapsed(ms: number): string {
+  return `${Math.max(0, Math.round(ms / 1000))}s`;
+}
+
+/** `↓ 13.1k tokens` — down-arrow prefix, compact magnitude, plural "tokens". */
+export function formatFleetTokens(count: number): string {
+  let compact: string;
+  if (count >= 1_000_000) compact = `${(count / 1_000_000).toFixed(1)}M`;
+  else if (count >= 1_000) compact = `${(count / 1_000).toFixed(1)}k`;
+  else compact = `${count}`;
+  return `↓ ${compact} tokens`;
+}
+
+/**
+ * Place `right` flush to `width`, truncating `left` first so the stats survive.
+ * The final clamp guarantees the line never exceeds `width` (which would wrap and
+ * desync pi's line-diff → flicker) even on a terminal too narrow for the stats.
+ */
+function rightAlign(left: string, right: string, width: number): string {
+  const rightW = visibleWidth(right);
+  const maxLeft = Math.max(0, width - rightW - 1);
+  const leftClamped = truncateToWidth(left, maxLeft);
+  const gap = Math.max(1, width - visibleWidth(leftClamped) - rightW);
+  return truncateToWidth(leftClamped + " ".repeat(gap) + right, width);
+}
+
+export class FleetList {
+  private ui: FleetUICtx | undefined;
+  private tui: any | undefined;
+  private inputUnsub: (() => void) | undefined;
+  private widgetRegistered = false;
+  private timer: ReturnType<typeof setInterval> | undefined;
+
+  private enabled = true;
+  /** Whether arrow keys currently navigate the list (vs. flow to the editor). */
+  private active = false;
+  /** 0 = `main`, 1..N = subagents. */
+  private selectedIndex = 0;
+  /** Set while a conversation overlay is open; calling it closes the overlay. */
+  private viewerClose: (() => void) | undefined;
+  private viewingAgentId: string | undefined;
+
+  constructor(
+    private manager: AgentManager,
+    private agentActivity: Map<string, AgentActivity>,
+  ) {}
+
+  // ---- Lifecycle ----
+
+  setEnabled(enabled: boolean): void {
+    if (enabled === this.enabled) return;
+    this.enabled = enabled;
+    if (!enabled) this.active = false;
+    this.update();
+  }
+
+  /** Capture the UI context and (re)register the global input handler. */
+  setUICtx(ui: FleetUICtx): void {
+    if (ui === this.ui) return;
+    this.inputUnsub?.();
+    this.ui = ui;
+    this.widgetRegistered = false;
+    this.tui = undefined;
+    this.inputUnsub = ui.onTerminalInput(data => this.handleKey(data));
+  }
+
+  /** Ensure the re-render timer is running (called when an agent spawns). */
+  ensureTimer(): void {
+    if (!this.timer) this.timer = setInterval(() => this.update(), TICK_MS);
+  }
+
+  /**
+   * Called when an agent finishes. The viewer (if open on it) stays open so the
+   * final output remains readable, and the row lingers in the list — just refresh.
+   */
+  onAgentFinished(_id: string): void {
+    this.update();
+  }
+
+  dispose(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = undefined; }
+    this.inputUnsub?.();
+    this.inputUnsub = undefined;
+    if (this.viewerClose) { this.viewerClose(); this.viewerClose = undefined; }
+    this.viewingAgentId = undefined;
+    if (this.ui && this.widgetRegistered) this.ui.setWidget(FLEET_KEY, undefined);
+    this.widgetRegistered = false;
+    this.tui = undefined;
+    this.active = false;
+    // Null last so a `viewerClose()` microtask above can't re-register the widget.
+    this.ui = undefined;
+  }
+
+  /** Re-register/refresh the below-editor widget; clears it when no agents remain. */
+  update(): void {
+    if (!this.ui) return;
+    const hasAgents = this.enabled && this.agentRecords().length > 0;
+
+    if (!hasAgents) {
+      if (this.widgetRegistered) {
+        this.ui.setWidget(FLEET_KEY, undefined);
+        this.widgetRegistered = false;
+        this.tui = undefined;
+      }
+      if (this.timer) { clearInterval(this.timer); this.timer = undefined; }
+      this.active = false;
+      this.selectedIndex = 0;
+      return;
+    }
+
+    this.clampSelection();
+    this.ensureTimer(); // keep stats ticking whenever the list is shown (e.g. after a re-enable)
+
+    if (!this.widgetRegistered) {
+      this.ui.setWidget(FLEET_KEY, (tui, theme) => {
+        this.tui = tui;
+        return {
+          render: (w: number) => this.renderBar(w, theme),
+          invalidate: () => { this.widgetRegistered = false; this.tui = undefined; },
+        };
+      }, { placement: "belowEditor" });
+      this.widgetRegistered = true;
+    } else {
+      this.tui?.requestRender();
+    }
+  }
+
+  // ---- Roster ----
+
+  /**
+   * Agents shown in the list, ordered earliest-launched first so the ones you
+   * started sooner sit at the top. Every row is openable (has a session), so Enter
+   * never dead-ends. Included: running/queued, plus the agent currently being
+   * viewed, plus recently-finished ones (they linger briefly before dropping out).
+   * Pending agents with no session yet are hidden until they start.
+   * (`listAgents()` is newest-first, so we re-sort.)
+   */
+  private agentRecords(): AgentRecord[] {
+    const now = Date.now();
+    return this.manager.listAgents()
+      .filter(a => a.session && (
+        a.status === "running" || a.status === "queued"
+        || a.id === this.viewingAgentId
+        || (a.completedAt != null && now - a.completedAt < FINISHED_LINGER_MS)
+      ))
+      .sort((a, b) => a.startedAt - b.startedAt);
+  }
+
+  private roster(): FleetEntry[] {
+    return [{ kind: "main" }, ...this.agentRecords().map(record => ({ kind: "agent" as const, record }))];
+  }
+
+  private clampSelection(): void {
+    const max = this.roster().length - 1;
+    if (this.selectedIndex > max) this.selectedIndex = Math.max(0, max);
+    if (this.selectedIndex < 0) this.selectedIndex = 0;
+  }
+
+  // ---- Key handling ----
+
+  /** Returns `{consume:true}` to swallow a key, or undefined to let it through. */
+  handleKey(data: string): { consume?: boolean; data?: string } | undefined {
+    if (!this.enabled || !this.ui) return undefined;
+    // Input listeners receive BOTH key-press and key-release (the kitty protocol
+    // emits both, and matchesKey matches either) — act on press only, or every
+    // tap would move/fire twice. Repeats still pass through for held-key nav.
+    if (isKeyRelease(data)) return undefined;
+    // While an overlay is open, let it own all input.
+    if (this.viewerClose) return undefined;
+    // Input listeners fire BEFORE the focused component, and dialogs
+    // (ctx.ui.select/confirm/input, pi's own menus) swap the prompt editor out
+    // while getEditorText() still reads the detached — empty — editor. So when
+    // anything but the editor owns the keyboard, stay out of its keys (#123).
+    if (!this.editorHasFocus()) {
+      if (this.active) this.deactivate();
+      return undefined;
+    }
+
+    if (!this.active) {
+      // Activate: ↓ or ← at an empty prompt moves focus into the list.
+      const isActivator = matchesKey(data, "down") || matchesKey(data, "left");
+      if (isActivator && this.agentRecords().length > 0 && this.ui.getEditorText() === "") {
+        this.active = true;
+        this.selectedIndex = 0;
+        this.update();
+        return { consume: true };
+      }
+      return undefined;
+    }
+
+    // Active — arrows navigate, Enter opens, Esc / Up-past-top exits.
+    if (matchesKey(data, "down")) {
+      const max = this.roster().length - 1;
+      this.selectedIndex = Math.min(max, this.selectedIndex + 1);
+      this.update();
+      return { consume: true };
+    }
+    if (matchesKey(data, "up")) {
+      if (this.selectedIndex === 0) { this.deactivate(); return { consume: true }; }
+      this.selectedIndex -= 1;
+      this.update();
+      return { consume: true };
+    }
+    if (matchesKey(data, "escape")) { this.deactivate(); return { consume: true }; }
+    if (matchesKey(data, Key.enter)) { this.openSelected(); return { consume: true }; }
+
+    // Any other key cancels navigation and flows to the editor.
+    this.deactivate();
+    return undefined;
+  }
+
+  /**
+   * True when pi's prompt editor owns the keyboard. pi's editor is an `Editor`
+   * subclass (CustomEditor) while every dialog/selector is not, and the loader
+   * aliases pi-tui to pi's own copy, so `instanceof` is a reliable identity
+   * check. `focusedComponent` is TUI-private (no public accessor), hence the
+   * best-effort peek: unknowable focus (no tui seen yet, nothing focused)
+   * counts as the editor so activation keeps working.
+   */
+  private editorHasFocus(): boolean {
+    const focused = (this.tui as { focusedComponent?: unknown } | undefined)?.focusedComponent;
+    return focused == null || focused instanceof Editor;
+  }
+
+  private deactivate(): void {
+    this.active = false;
+    this.selectedIndex = 0;
+    this.update();
+  }
+
+  private openSelected(): void {
+    const entry = this.roster()[this.selectedIndex];
+    if (!entry || entry.kind === "main") {
+      // `main` = return to the prompt; the native transcript is already shown.
+      this.deactivate();
+      return;
+    }
+    const record = entry.record;
+    if (!this.ui) return;
+    if (!record.session) {
+      this.ui.notify(`Agent is ${record.status} — no session available.`, "info");
+      return;
+    }
+    const session = record.session;
+    const activity = this.agentActivity.get(record.id);
+    this.viewingAgentId = record.id;
+
+    void this.ui.custom<undefined>(
+      (tui, theme, keybindings, done) => {
+        this.viewerClose = () => done(undefined);
+        return new ConversationViewer(
+          tui,
+          session,
+          record,
+          activity,
+          theme,
+          done,
+          () => {
+            if (this.manager.abort(record.id)) this.ui?.notify(`Stopped "${record.description}".`, "info");
+          },
+          keybindings,
+          (message: string) => this.manager.steer(record.id, message),
+        );
+      },
+      {
+        overlay: true,
+        overlayOptions: { anchor: "center", width: "90%", maxHeight: `${VIEWPORT_HEIGHT_PCT}%` },
+      },
+    ).then(() => this.clearViewer(), () => this.clearViewer());
+  }
+
+  /** Reset overlay state and return to the list (on close, auto-close, or error). */
+  private clearViewer(): void {
+    // Keep the cursor on the agent we were viewing — re-resolve by id so it
+    // still feels natural if the list reordered (an earlier agent finished)
+    // while the overlay was open. If that agent is gone, leave the index for
+    // update()'s clamp to settle.
+    if (this.viewingAgentId) {
+      const idx = this.roster().findIndex(e => e.kind === "agent" && e.record.id === this.viewingAgentId);
+      if (idx >= 0) this.selectedIndex = idx;
+    }
+    this.viewerClose = undefined;
+    this.viewingAgentId = undefined;
+    this.update();
+  }
+
+  // ---- Rendering ----
+
+  private renderBar(width: number, theme: Theme): string[] {
+    const agents = this.roster().slice(1) as AgentEntry[];
+    if (agents.length === 0) return [];
+    // Clamp locally so a render between a roster shrink and the next update()
+    // (e.g. on terminal resize) never loses the selection marker.
+    const sel = Math.min(this.selectedIndex, agents.length);
+
+    const hint = this.active
+      ? "↑↓ select · enter view · esc back"
+      : "esc to interrupt · ← for agents · ↓ to manage";
+    const lines: string[] = [];
+    lines.push(truncateToWidth("  " + theme.fg("dim", hint), width));
+    lines.push("");
+    lines.push(truncateToWidth(`  ${this.bullet(0, sel, theme)} main`, width));
+
+    // Window the agent rows so the selected one stays visible.
+    const visible = Math.min(MAX_AGENT_ROWS, agents.length);
+    const selAgent = Math.max(0, sel - 1);
+    const start = selAgent < visible ? 0 : selAgent - visible + 1;
+    const hiddenBelow = agents.length - (start + visible);
+
+    if (start > 0) lines.push(rightAlign("", theme.fg("dim", `↑ ${start} more`), width));
+    for (let a = start; a < start + visible; a++) {
+      lines.push(this.renderAgentRow(a + 1, sel, agents[a].record, width, theme));
+    }
+    if (hiddenBelow > 0) lines.push(rightAlign("", theme.fg("dim", `↓ ${hiddenBelow} more`), width));
+
+    return lines;
+  }
+
+  private bullet(rosterIndex: number, sel: number, theme: Theme): string {
+    return rosterIndex === sel ? theme.fg("accent", "●") : theme.fg("dim", "○");
+  }
+
+  private renderAgentRow(rosterIndex: number, sel: number, record: AgentRecord, width: number, theme: Theme): string {
+    const left = `  ${this.bullet(rosterIndex, sel, theme)} ${theme.fg("muted", getDisplayName(record.type))}  ${record.description}`;
+    const tokens = getLifetimeTotal(this.agentActivity.get(record.id)?.lifetimeUsage ?? record.lifetimeUsage);
+    const elapsedMs = (record.completedAt ?? Date.now()) - record.startedAt; // freezes once finished
+    const right = theme.fg("dim", `${formatFleetElapsed(elapsedMs)} · ${formatFleetTokens(tokens)}`);
+    return rightAlign(left, right, width);
+  }
+}

--- a/packages/pi-subagents/src/ui/schedule-menu.ts
+++ b/packages/pi-subagents/src/ui/schedule-menu.ts
@@ -1,0 +1,104 @@
+/**
+ * schedule-menu.ts — `/agents → Scheduled jobs` submenu.
+ *
+ * Minimal v1 surface: list scheduled jobs, select one to inspect details +
+ * confirm cancellation. No create wizard (the `Agent` tool's `schedule` param
+ * is the canonical creation path), no toggle/cleanup (cancel is enough for
+ * "I scheduled something dumb, get rid of it"). Add management surfaces here
+ * if real demand emerges.
+ */
+
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { SubagentScheduler } from "../schedule.js";
+import type { ScheduledSubagent } from "../types.js";
+
+/** Format an ISO timestamp as relative time ("in 4h", "2d ago", "—"). */
+function relTime(iso: string | undefined, now = Date.now()): string {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "—";
+  const diff = t - now;
+  const abs = Math.abs(diff);
+  const future = diff > 0;
+  if (abs < 60_000) return future ? "in <1m" : "<1m ago";
+  const m = Math.round(abs / 60_000);
+  if (m < 60) return future ? `in ${m}m` : `${m}m ago`;
+  const h = Math.round(abs / 3_600_000);
+  if (h < 24) return future ? `in ${h}h` : `${h}h ago`;
+  const d = Math.round(abs / 86_400_000);
+  return future ? `in ${d}d` : `${d}d ago`;
+}
+
+/** One-line status icon. */
+function statusIcon(j: ScheduledSubagent): string {
+  if (!j.enabled) return "✗";
+  if (j.lastStatus === "error") return "!";
+  if (j.lastStatus === "running") return "⋯";
+  return "✓";
+}
+
+/** Compact selectable row — name, schedule, agent type, next/last run, count. */
+function formatJob(j: ScheduledSubagent, scheduler: SubagentScheduler): string {
+  const next = scheduler.getNextRun(j.id);
+  return [
+    statusIcon(j),
+    j.name.padEnd(18).slice(0, 18),
+    j.schedule.padEnd(14).slice(0, 14),
+    `[${j.subagent_type}]`,
+    `next ${relTime(next)}`,
+    `last ${relTime(j.lastRun)}`,
+    `runs ${j.runCount}`,
+  ].join("  ");
+}
+
+/** Multi-line details block for the cancel confirm. */
+function formatDetails(j: ScheduledSubagent, scheduler: SubagentScheduler): string {
+  const next = scheduler.getNextRun(j.id) ?? "—";
+  return [
+    `name:      ${j.name}`,
+    `schedule:  ${j.schedule} (${j.scheduleType})`,
+    `agent:     ${j.subagent_type}`,
+    `prompt:    ${j.prompt.slice(0, 200)}${j.prompt.length > 200 ? "…" : ""}`,
+    `created:   ${j.createdAt}`,
+    `last run:  ${j.lastRun ?? "—"} (${j.lastStatus ?? "—"})`,
+    `next run:  ${next}`,
+    `runs:      ${j.runCount}`,
+  ].join("\n");
+}
+
+/**
+ * List scheduled jobs; selecting one opens a cancel-confirm with details.
+ * Returns when the user backs out or after a cancellation.
+ */
+export async function showSchedulesMenu(
+  ctx: ExtensionCommandContext,
+  scheduler: SubagentScheduler,
+): Promise<void> {
+  if (!scheduler.isActive()) {
+    ctx.ui.notify("Scheduler is not active in this session.", "warning");
+    return;
+  }
+
+  const jobs = scheduler.list();
+  if (jobs.length === 0) {
+    ctx.ui.notify("No scheduled jobs.", "info");
+    return;
+  }
+
+  const labels = jobs.map(j => formatJob(j, scheduler));
+  const choice = await ctx.ui.select(
+    `Scheduled jobs (${jobs.length}) — select to cancel`,
+    labels,
+  );
+  if (!choice) return;
+
+  const idx = labels.indexOf(choice);
+  if (idx < 0) return;
+  const job = jobs[idx];
+
+  const ok = await ctx.ui.confirm(`Cancel "${job.name}"?`, formatDetails(job, scheduler));
+  if (!ok) return;
+
+  scheduler.removeJob(job.id);
+  ctx.ui.notify(`Cancelled "${job.name}".`, "info");
+}

--- a/packages/pi-subagents/src/ui/tool-render.ts
+++ b/packages/pi-subagents/src/ui/tool-render.ts
@@ -1,0 +1,203 @@
+/**
+ * tool-render.ts — Shared collapsed/expanded TUI helpers for subagent tools.
+ *
+ * Without a custom renderResult, Pi dumps the full tool content and ignores the
+ * transcript expand toggle — get_subagent_result was the worst offender.
+ *
+ * Expanded bodies use Markdown (same path as pi-context7); collapsed stays a
+ * one-line preview so the main TUI stays scannable.
+ */
+
+import { getMarkdownTheme, keyHint } from "@earendil-works/pi-coding-agent";
+import { Container, Markdown, Text, type Component } from "@earendil-works/pi-tui";
+import type { AgentDetails, Theme } from "./agent-widget.js";
+import { fgPreservingNestedStyles, formatMs, formatTurns, SPINNER } from "./agent-widget.js";
+
+/** Collapsed preview: first non-empty line, hard-capped. */
+export const RESULT_COLLAPSED_PREVIEW_CHARS = 100;
+
+export type TextResultLike = {
+  content?: Array<{ type?: string; text?: string }>;
+  details?: unknown;
+};
+
+/** Join text blocks from a tool result. */
+export function toolResultText(result: TextResultLike): string {
+  if (!result.content?.length) return "";
+  return result.content
+    .filter((c) => c.type === "text" && typeof c.text === "string")
+    .map((c) => c.text ?? "")
+    .join("\n");
+}
+
+/** First non-empty line, collapsed to a single visual line. */
+export function firstLinePreview(text: string, maxChars = RESULT_COLLAPSED_PREVIEW_CHARS): string {
+  const line =
+    text
+      .replace(/\r\n/g, "\n")
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => l.length > 0) ?? "";
+  const one = line.replace(/\s+/g, " ");
+  if (one.length <= maxChars) return one;
+  if (maxChars <= 1) return "…";
+  return `${one.slice(0, maxChars - 1)}…`;
+}
+
+/**
+ * Prefer the body after the first blank line (status header · body), else whole text.
+ * Used so collapsed previews / expanded markdown show the agent answer, not
+ * "Agent completed in 1.2s…".
+ */
+export function resultBodyText(text: string): string {
+  const normalized = text.replace(/\r\n/g, "\n").trim();
+  if (!normalized) return "";
+  const parts = normalized.split(/\n\n+/);
+  if (parts.length >= 2) {
+    const body = parts.slice(1).join("\n\n").trim();
+    if (body) return body;
+  }
+  return normalized;
+}
+
+/** Expand-key hint, matching pi-context7. */
+export function expandHint(): string {
+  try {
+    const styled = keyHint("app.tools.expand", "to expand");
+    const plain = styled.replace(/\x1b\[[0-9;]*m/g, "").trim();
+    if (!plain || plain === "to expand") return "Ctrl+O to expand";
+    return plain;
+  } catch {
+    return "Ctrl+O to expand";
+  }
+}
+
+export function renderExpandedMarkdown(content: string): Component {
+  return new Markdown(content, 0, 0, getMarkdownTheme());
+}
+
+export function appendCollapsedPreviewLine(
+  base: string,
+  text: string,
+  theme: Pick<Theme, "fg">,
+  emptyLabel: string,
+  opts?: { withExpandHint?: boolean },
+): string {
+  const preview = firstLinePreview(resultBodyText(text));
+  const label = preview || emptyLabel;
+  const hint = opts?.withExpandHint === false ? "" : ` (${expandHint()})`;
+  return base + "\n" + theme.fg("dim", `  ⎿  ${label}${hint}`);
+}
+
+/** Build "haiku · ↻5≤30 · 3 tool uses · 33.8k token" stats fragment. */
+export function formatAgentDetailsStats(d: AgentDetails, theme: Theme): string {
+  const parts: string[] = [];
+  if (d.modelName) parts.push(d.modelName);
+  if (d.tags) parts.push(...d.tags);
+  if (d.turnCount != null && d.turnCount > 0) {
+    parts.push(formatTurns(d.turnCount, d.maxTurns));
+  }
+  if (d.toolUses > 0) parts.push(`${d.toolUses} tool use${d.toolUses === 1 ? "" : "s"}`);
+  if (d.tokens) parts.push(d.tokens);
+  if (!parts.length) return "";
+  return parts.map((p) => fgPreservingNestedStyles(theme, "dim", p)).join(" " + theme.fg("dim", "·") + " ");
+}
+
+export function isErrorStatus(status: string | undefined): boolean {
+  return status === "error" || status === "aborted" || status === "stopped";
+}
+
+export function isActiveStatus(status: string | undefined): boolean {
+  return status === "running" || status === "queued";
+}
+
+/** Compact call title: `▸ Label  muted…`. */
+export function renderToolCallTitle(label: string, muted: string | undefined, theme: Theme, dimExtra?: string): Text {
+  let line = "▸ " + theme.fg("toolTitle", theme.bold(label));
+  if (muted) line += "  " + theme.fg("muted", muted);
+  if (dimExtra) line += "  " + theme.fg("dim", dimExtra);
+  return new Text(line, 0, 0);
+}
+
+function withHeaderAndMarkdown(header: string, markdownBody: string): Component {
+  const container = new Container();
+  container.addChild(new Text(header, 0, 0));
+  const body = markdownBody.trim() || "_(no output)_";
+  container.addChild(renderExpandedMarkdown(body));
+  return container;
+}
+
+/**
+ * Shared Agent / get_subagent_result result chrome.
+ * `resultText` is the full tool content (model-facing); only a preview is shown collapsed.
+ * Expanded renders the body as Markdown under a one-line status header.
+ */
+export function renderAgentLikeResult(
+  details: AgentDetails,
+  resultText: string,
+  opts: { expanded: boolean; isPartial?: boolean },
+  theme: Theme,
+): Component {
+  const s = formatAgentDetailsStats(details, theme);
+  const duration =
+    details.durationMs > 0 && !isActiveStatus(details.status)
+      ? formatMs(details.durationMs)
+      : undefined;
+
+  if (opts.isPartial || isActiveStatus(details.status)) {
+    const frame = SPINNER[details.spinnerFrame ?? 0] ?? SPINNER[0];
+    let line = theme.fg("accent", frame!) + (s ? " " + s : "");
+    if (details.agentId) line += " " + theme.fg("dim", "·") + " " + theme.fg("dim", details.agentId);
+    const activity =
+      details.activity ??
+      (details.status === "queued" ? "queued…" : "running…");
+    line += "\n" + theme.fg("dim", `  ⎿  ${activity}`);
+    return new Text(line, 0, 0);
+  }
+
+  if (details.status === "background") {
+    return new Text(
+      theme.fg("dim", `  ⎿  Running in background (ID: ${details.agentId ?? "?"})`),
+      0,
+      0,
+    );
+  }
+
+  if (details.status === "completed" || details.status === "steered") {
+    const isSteered = details.status === "steered";
+    const icon = isSteered ? theme.fg("warning", "✓") : theme.fg("success", "✓");
+    let header = icon + (s ? " " + s : "");
+    if (duration) header += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
+
+    if (opts.expanded) {
+      const body = resultBodyText(resultText) || resultText.trim();
+      return withHeaderAndMarkdown(header, body);
+    }
+
+    const empty = isSteered ? "Wrapped up (turn limit)" : "Done";
+    return new Text(appendCollapsedPreviewLine(header, resultText, theme, empty), 0, 0);
+  }
+
+  if (details.status === "stopped") {
+    let header = theme.fg("dim", "■") + (s ? " " + s : "");
+    if (duration) header += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
+    if (opts.expanded && resultText.trim()) {
+      return withHeaderAndMarkdown(header + "\n" + theme.fg("dim", "  ⎿  Stopped"), resultBodyText(resultText) || resultText);
+    }
+    return new Text(header + "\n" + theme.fg("dim", "  ⎿  Stopped"), 0, 0);
+  }
+
+  // error / aborted
+  let header = theme.fg("error", "✗") + (s ? " " + s : "");
+  if (duration) header += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
+  if (details.status === "error") {
+    const err = details.error?.trim() || firstLinePreview(resultBodyText(resultText)) || "unknown";
+    header += "\n" + theme.fg("error", `  ⎿  Error: ${firstLinePreview(err, 120)}`);
+  } else {
+    header += "\n" + theme.fg("warning", "  ⎿  Aborted (max turns exceeded)");
+  }
+  if (opts.expanded && resultText.trim()) {
+    return withHeaderAndMarkdown(header, resultBodyText(resultText) || resultText);
+  }
+  return new Text(header, 0, 0);
+}

--- a/packages/pi-subagents/src/ui/tool-render.ts
+++ b/packages/pi-subagents/src/ui/tool-render.ts
@@ -106,18 +106,64 @@ export function appendCollapsedPreviewLine(
   return base + "\n" + theme.fg(color, `  ⎿  ${label}${hint}`);
 }
 
-/** Build "haiku · ↻5≤30 · 3 tool uses · 33.8k token" stats fragment. */
+/**
+ * Call-line / stats meta chips: model · effort · bg · …
+ * `model` omitted → "model: inherit" so the call node never hides the default.
+ */
+export function formatAgentCallMeta(opts: {
+  model?: string;
+  /** When true, append (inherit) after the model chip. */
+  modelInherited?: boolean;
+  effort?: string;
+  background?: boolean;
+  extra?: string[];
+}): string {
+  const parts: string[] = [];
+  const model = opts.model?.trim();
+  if (model) {
+    parts.push(opts.modelInherited ? `${model} (inherit)` : model);
+  } else {
+    parts.push("model: inherit");
+  }
+  const effort = opts.effort?.trim();
+  if (effort) parts.push(`effort: ${effort}`);
+  if (opts.background) parts.push("bg");
+  if (opts.extra?.length) {
+    for (const x of opts.extra) {
+      const t = x.trim();
+      if (t) parts.push(t);
+    }
+  }
+  return parts.join(" · ");
+}
+
+/** Build "haiku · effort: high · ↻5≤30 · 3 tool uses · 33.8k token" stats fragment. */
 export function formatAgentDetailsStats(d: AgentDetails, theme: Theme): string {
   const parts: string[] = [];
-  if (d.modelName) parts.push(d.modelName);
-  if (d.tags) parts.push(...d.tags);
-  if (d.turnCount != null && d.turnCount > 0) {
-    parts.push(formatTurns(d.turnCount, d.maxTurns));
+  if (d.modelName) {
+    parts.push(d.modelInherited ? `${d.modelName} (inherit)` : d.modelName);
   }
-  if (d.toolUses > 0) parts.push(`${d.toolUses} tool use${d.toolUses === 1 ? "" : "s"}`);
-  if (d.tokens) parts.push(d.tokens);
-  if (!parts.length) return "";
-  return parts.map((p) => fgPreservingNestedStyles(theme, "dim", p)).join(" " + theme.fg("dim", "·") + " ");
+  if (d.effort) parts.push(`effort: ${d.effort}`);
+  // Tags from buildInvocationTags — skip effort: (already explicit above).
+  if (d.tags) {
+    for (const tag of d.tags) {
+      if (tag.startsWith("effort:")) continue;
+      parts.push(tag);
+    }
+  }
+  const seen = new Set<string>();
+  const unique = parts.filter((p) => {
+    if (seen.has(p)) return false;
+    seen.add(p);
+    return true;
+  });
+  if (d.turnCount != null && d.turnCount > 0) {
+    unique.push(formatTurns(d.turnCount, d.maxTurns));
+  }
+  if (d.toolUses > 0) unique.push(`${d.toolUses} tool use${d.toolUses === 1 ? "" : "s"}`);
+  if (d.tokens) unique.push(d.tokens);
+  if (!unique.length) return "";
+  return unique.map((p) => fgPreservingNestedStyles(theme, "dim", p)).join(" " + theme.fg("dim", "·") + " ");
 }
 
 export function isErrorStatus(status: string | undefined): boolean {

--- a/packages/pi-subagents/src/ui/tool-render.ts
+++ b/packages/pi-subagents/src/ui/tool-render.ts
@@ -47,15 +47,19 @@ export function firstLinePreview(text: string, maxChars = RESULT_COLLAPSED_PREVI
 /**
  * True when the first `\n\n`-delimited block looks like our tool status header
  * (safe to peel). Plain multi-paragraph errors must NOT match.
+ *
+ * Deliberately strict:
+ * - Does NOT peel "Note: Unknown agent type…" (user must see the fallback warning).
+ * - `Agent:` + `Type:` only match the real get_subagent_result meta shape
+ *   (`Type: … | Status: …`), so agent-authored reports are not eaten.
  */
 export function looksLikeStatusHeader(block: string): boolean {
   const head = block.replace(/\r\n/g, "\n").trim();
   if (!head) return false;
   if (/^Agent completed in \d/i.test(head)) return true;
   if (/^Agent failed:/i.test(head)) return true;
-  if (/^Note: Unknown agent type/i.test(head)) return true;
-  // get_subagent_result / background spawn multi-line meta block
-  if (/^Agent:\s+\S+/m.test(head) && /^Type:\s+/m.test(head)) return true;
+  // get_subagent_result multi-line meta block (requires Status on the Type line)
+  if (/^Agent:\s+\S+/m.test(head) && /^Type:\s+.+\|\s*Status:\s*/m.test(head)) return true;
   if (/^Agent (queued|started) in background/i.test(head)) return true;
   return false;
 }
@@ -132,10 +136,12 @@ export function formatAgentDetailsStats(d: AgentDetails, theme: Theme): string {
     parts.push(d.modelInherited ? `${d.modelName} (inherit)` : d.modelName);
   }
   if (d.effort) parts.push(`effort: ${d.effort}`);
-  // Tags from buildInvocationTags — skip effort: (already explicit above).
+  // Tags from buildInvocationTags — skip effort: / max turns: (already explicit via
+  // effort field and formatTurns below).
   if (d.tags) {
     for (const tag of d.tags) {
       if (tag.startsWith("effort:")) continue;
+      if (tag.startsWith("max turns:")) continue;
       parts.push(tag);
     }
   }
@@ -162,19 +168,28 @@ export function isActiveStatus(status: string | undefined): boolean {
   return status === "running" || status === "queued";
 }
 
-/** Lightweight heuristic when structured details are missing. */
+/**
+ * Lightweight heuristic when structured details / explicit isError are missing.
+ * Only matches strong *leading* failure markers — never free-word scans of user
+ * content (schedule names like "Investigate failed tests" must not go red).
+ */
 export function looksLikeFailureText(text: string): boolean {
   const head = text.trim().slice(0, 240);
   return (
     /^error\b/i.test(head) ||
-    /\bfailed\b/i.test(head) ||
-    /\bnot found\b/i.test(head) ||
-    /\bcannot\b/i.test(head) ||
-    /\bnot in scope\b/i.test(head) ||
-    /\bunavailable\b/i.test(head) ||
-    /\binvalid\b/i.test(head) ||
-    /\bdisabled\b/i.test(head)
+    /^failed\b/i.test(head) ||
+    /^agent failed:/i.test(head) ||
+    /^model not in scope\b/i.test(head) ||
+    /^agent not found\b/i.test(head) ||
+    /^cannot combine\b/i.test(head) ||
+    /^scheduling is disabled\b/i.test(head) ||
+    /^failed to (resume|steer)\b/i.test(head)
   );
+}
+
+/** Statuses that should flip Pi's tool-result `isError` (error shell / model flag). */
+export function isFailureDetailsStatus(status: string | undefined): boolean {
+  return status === "error" || status === "aborted" || status === "stopped";
 }
 
 /**
@@ -219,7 +234,14 @@ export function renderUndetailedResult(
   opts: { expanded: boolean; isError?: boolean },
   theme: Theme,
 ): Component {
-  const failed = opts.isError === true || looksLikeFailureText(resultText);
+  // Explicit false wins (success paths); explicit true forces error; undefined
+  // falls back to a tight leading-marker heuristic only.
+  const failed =
+    opts.isError === true
+      ? true
+      : opts.isError === false
+        ? false
+        : looksLikeFailureText(resultText);
   const icon = failed ? theme.fg("error", "✗") : theme.fg("dim", "•");
   const preview = firstLinePreview(resultBodyText(resultText)) || (failed ? "failed" : "ok");
   const clerk = formatClerkLine(theme, failed ? `Error: ${preview}` : preview, failed ? "error" : "dim");
@@ -255,13 +277,15 @@ export function renderAgentLikeResult(
   if (opts.isPartial || isActiveStatus(details.status)) {
     const frame = SPINNER[details.spinnerFrame ?? 0] ?? SPINNER[0];
     const top = theme.fg("accent", frame!) + (s ? " " + s : "");
+    // Queued must never show thinking… even if a stale activity string was attached.
     const activity =
-      details.activity ??
-      (details.status === "queued" ? "queued…" : "thinking…");
+      details.status === "queued"
+        ? "queued…"
+        : (details.activity ?? "thinking…");
     return new Text(top + "\n" + formatClerkLine(theme, activity), 0, 0);
   }
 
-  // Background launch — single clerk line (upstream CC style)
+  // Background launch — single clerk line (upstream CC style). Queued is handled above.
   if (details.status === "background") {
     return new Text(
       formatClerkLine(theme, `Running in background (ID: ${details.agentId ?? "?"})`),

--- a/packages/pi-subagents/src/ui/tool-render.ts
+++ b/packages/pi-subagents/src/ui/tool-render.ts
@@ -92,27 +92,17 @@ export function renderExpandedMarkdown(content: string): Component {
   return new Markdown(content, 0, 0, getMarkdownTheme());
 }
 
-export function appendCollapsedPreviewLine(
-  base: string,
-  text: string,
-  theme: Pick<Theme, "fg">,
-  emptyLabel: string,
-  opts?: { withExpandHint?: boolean; previewColor?: string },
-): string {
-  const preview = firstLinePreview(resultBodyText(text));
-  const label = preview || emptyLabel;
-  const hint = opts?.withExpandHint === false ? "" : ` (${expandHint()})`;
-  const color = opts?.previewColor ?? "dim";
-  return base + "\n" + theme.fg(color, `  ⎿  ${label}${hint}`);
+/** Claude Code-style secondary line: `  ⎿  …`. */
+export function formatClerkLine(theme: Pick<Theme, "fg">, text: string, color = "dim"): string {
+  return theme.fg(color, `  ⎿  ${text}`);
 }
 
 /**
- * Call-line / stats meta chips: model · effort · bg · …
- * `model` omitted → "model: inherit" so the call node never hides the default.
+ * Optional call-line chips (Claude Code keeps the title clean).
+ * Only emits chips for **explicit** args — never invents "model: inherit".
  */
 export function formatAgentCallMeta(opts: {
   model?: string;
-  /** When true, append (inherit) after the model chip. */
   modelInherited?: boolean;
   effort?: string;
   background?: boolean;
@@ -122,8 +112,6 @@ export function formatAgentCallMeta(opts: {
   const model = opts.model?.trim();
   if (model) {
     parts.push(opts.modelInherited ? `${model} (inherit)` : model);
-  } else {
-    parts.push("model: inherit");
   }
   const effort = opts.effort?.trim();
   if (effort) parts.push(`effort: ${effort}`);
@@ -189,25 +177,42 @@ export function looksLikeFailureText(text: string): boolean {
   );
 }
 
-/** Compact call title: `▸ Label  muted…`. */
+/**
+ * Claude Code-style call title:
+ *   ▸ Explore  Find auth files
+ * Optional trailing dim chips only when explicitly set (model / effort / bg).
+ */
 export function renderToolCallTitle(label: string, muted: string | undefined, theme: Theme, dimExtra?: string): Text {
   let line = "▸ " + theme.fg("toolTitle", theme.bold(label));
   if (muted) line += "  " + theme.fg("muted", muted);
-  if (dimExtra) line += "  " + theme.fg("dim", dimExtra);
+  if (dimExtra?.trim()) line += "  " + theme.fg("dim", dimExtra.trim());
   return new Text(line, 0, 0);
 }
 
-function withHeaderAndMarkdown(header: string, markdownBody: string): Component {
+function withHeaderAndMarkdown(headerLines: string, markdownBody: string): Component {
   const container = new Container();
-  container.addChild(new Text(header, 0, 0));
+  for (const raw of headerLines.split("\n")) {
+    container.addChild(new Text(raw, 0, 0));
+  }
   const body = markdownBody.trim() || "_(no output)_";
   container.addChild(renderExpandedMarkdown(body));
   return container;
 }
 
+function statusHeaderLine(
+  icon: string,
+  stats: string,
+  duration: string | undefined,
+  theme: Theme,
+): string {
+  let line = icon + (stats ? " " + stats : "");
+  if (duration) line += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
+  return line;
+}
+
 /**
  * Fallback when execute returned plain text without AgentDetails.
- * Never assumes success — missing details + failure-ish text → ✗; else neutral •.
+ * Claude Code shape: icon line + ⎿ message (never green ✓ on failures).
  */
 export function renderUndetailedResult(
   resultText: string,
@@ -216,21 +221,23 @@ export function renderUndetailedResult(
 ): Component {
   const failed = opts.isError === true || looksLikeFailureText(resultText);
   const icon = failed ? theme.fg("error", "✗") : theme.fg("dim", "•");
-  if (opts.expanded) {
-    return withHeaderAndMarkdown(icon, resultText.trim() || "_(empty)_");
-  }
   const preview = firstLinePreview(resultBodyText(resultText)) || (failed ? "failed" : "ok");
-  return new Text(
-    icon + " " + theme.fg(failed ? "error" : "dim", `${preview} (${expandHint()})`),
-    0,
-    0,
-  );
+  const clerk = formatClerkLine(theme, failed ? `Error: ${preview}` : preview, failed ? "error" : "dim");
+  if (opts.expanded) {
+    return withHeaderAndMarkdown(icon + "\n" + clerk, resultText.trim() || "_(empty)_");
+  }
+  return new Text(icon + "\n" + clerk, 0, 0);
 }
 
 /**
- * Shared Agent / get_subagent_result result chrome.
- * `resultText` is the full tool content (model-facing); only a preview is shown collapsed.
- * Expanded renders the body as Markdown under a one-line status header.
+ * Shared Agent / get_subagent_result result chrome — Claude Code transcript shape:
+ *
+ *   ⠹ ↻3 · 3 tool uses · 12.4k token
+ *     ⎿  searching…
+ *   ✓ ↻8 · 5 tool uses · 33.8k token · 12.3s
+ *     ⎿  Done
+ *
+ * Collapsed never dumps the model-facing body; expanded adds Markdown under the chrome.
  */
 export function renderAgentLikeResult(
   details: AgentDetails,
@@ -244,20 +251,20 @@ export function renderAgentLikeResult(
       ? formatMs(details.durationMs)
       : undefined;
 
+  // Running / queued — match upstream renderRunningAgentStatus layout
   if (opts.isPartial || isActiveStatus(details.status)) {
     const frame = SPINNER[details.spinnerFrame ?? 0] ?? SPINNER[0];
-    let line = theme.fg("accent", frame!) + (s ? " " + s : "");
-    if (details.agentId) line += " " + theme.fg("dim", "·") + " " + theme.fg("dim", details.agentId);
+    const top = theme.fg("accent", frame!) + (s ? " " + s : "");
     const activity =
       details.activity ??
-      (details.status === "queued" ? "queued…" : "running…");
-    line += "\n" + theme.fg("dim", `  ⎿  ${activity}`);
-    return new Text(line, 0, 0);
+      (details.status === "queued" ? "queued…" : "thinking…");
+    return new Text(top + "\n" + formatClerkLine(theme, activity), 0, 0);
   }
 
+  // Background launch — single clerk line (upstream CC style)
   if (details.status === "background") {
     return new Text(
-      theme.fg("dim", `  ⎿  Running in background (ID: ${details.agentId ?? "?"})`),
+      formatClerkLine(theme, `Running in background (ID: ${details.agentId ?? "?"})`),
       0,
       0,
     );
@@ -266,42 +273,41 @@ export function renderAgentLikeResult(
   if (details.status === "completed" || details.status === "steered") {
     const isSteered = details.status === "steered";
     const icon = isSteered ? theme.fg("warning", "✓") : theme.fg("success", "✓");
-    let header = icon + (s ? " " + s : "");
-    if (duration) header += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
+    const header = statusHeaderLine(icon, s, duration, theme);
+    const doneText = isSteered ? "Wrapped up (turn limit)" : "Done";
+    const clerk = formatClerkLine(theme, doneText);
 
     if (opts.expanded) {
       const body = resultBodyText(resultText) || resultText.trim();
-      return withHeaderAndMarkdown(header, body);
+      return withHeaderAndMarkdown(header + "\n" + clerk, body);
     }
-
-    const empty = isSteered ? "Wrapped up (turn limit)" : "Done";
-    return new Text(appendCollapsedPreviewLine(header, resultText, theme, empty), 0, 0);
+    return new Text(header + "\n" + clerk, 0, 0);
   }
 
   if (details.status === "stopped") {
-    let header = theme.fg("dim", "■") + (s ? " " + s : "");
-    if (duration) header += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
+    const header = statusHeaderLine(theme.fg("dim", "■"), s, duration, theme);
+    const clerk = formatClerkLine(theme, "Stopped");
     if (opts.expanded && resultText.trim()) {
-      return withHeaderAndMarkdown(header + "\n" + theme.fg("dim", "  ⎿  Stopped"), resultBodyText(resultText) || resultText);
+      return withHeaderAndMarkdown(header + "\n" + clerk, resultBodyText(resultText) || resultText);
     }
-    return new Text(header + "\n" + theme.fg("dim", "  ⎿  Stopped"), 0, 0);
+    return new Text(header + "\n" + clerk, 0, 0);
   }
 
   // error / aborted
-  let header = theme.fg("error", "✗") + (s ? " " + s : "");
-  if (duration) header += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
+  const header = statusHeaderLine(theme.fg("error", "✗"), s, duration, theme);
+  let clerk: string;
   if (details.status === "error") {
     const err =
       details.error?.trim() ||
       firstLinePreview(resultBodyText(resultText)) ||
       firstLinePreview(resultText) ||
       "unknown";
-    header += "\n" + theme.fg("error", `  ⎿  Error: ${firstLinePreview(err, 120)}`);
+    clerk = formatClerkLine(theme, `Error: ${firstLinePreview(err, 120)}`, "error");
   } else {
-    header += "\n" + theme.fg("warning", "  ⎿  Aborted (max turns exceeded)");
+    clerk = formatClerkLine(theme, "Aborted (max turns exceeded)", "warning");
   }
   if (opts.expanded && resultText.trim()) {
-    return withHeaderAndMarkdown(header, resultBodyText(resultText) || resultText);
+    return withHeaderAndMarkdown(header + "\n" + clerk, resultBodyText(resultText) || resultText);
   }
-  return new Text(header, 0, 0);
+  return new Text(header + "\n" + clerk, 0, 0);
 }

--- a/packages/pi-subagents/src/ui/tool-render.ts
+++ b/packages/pi-subagents/src/ui/tool-render.ts
@@ -45,15 +45,31 @@ export function firstLinePreview(text: string, maxChars = RESULT_COLLAPSED_PREVI
 }
 
 /**
- * Prefer the body after the first blank line (status header · body), else whole text.
- * Used so collapsed previews / expanded markdown show the agent answer, not
- * "Agent completed in 1.2s…".
+ * True when the first `\n\n`-delimited block looks like our tool status header
+ * (safe to peel). Plain multi-paragraph errors must NOT match.
+ */
+export function looksLikeStatusHeader(block: string): boolean {
+  const head = block.replace(/\r\n/g, "\n").trim();
+  if (!head) return false;
+  if (/^Agent completed in \d/i.test(head)) return true;
+  if (/^Agent failed:/i.test(head)) return true;
+  if (/^Note: Unknown agent type/i.test(head)) return true;
+  // get_subagent_result / background spawn multi-line meta block
+  if (/^Agent:\s+\S+/m.test(head) && /^Type:\s+/m.test(head)) return true;
+  if (/^Agent (queued|started) in background/i.test(head)) return true;
+  return false;
+}
+
+/**
+ * Prefer the body after a recognized status header; otherwise keep full text.
+ * Prevents multi-paragraph errors like "Model not in scope…\n\nAllowed…" from
+ * losing their first (most important) paragraph in previews.
  */
 export function resultBodyText(text: string): string {
   const normalized = text.replace(/\r\n/g, "\n").trim();
   if (!normalized) return "";
   const parts = normalized.split(/\n\n+/);
-  if (parts.length >= 2) {
+  if (parts.length >= 2 && looksLikeStatusHeader(parts[0] ?? "")) {
     const body = parts.slice(1).join("\n\n").trim();
     if (body) return body;
   }
@@ -81,12 +97,13 @@ export function appendCollapsedPreviewLine(
   text: string,
   theme: Pick<Theme, "fg">,
   emptyLabel: string,
-  opts?: { withExpandHint?: boolean },
+  opts?: { withExpandHint?: boolean; previewColor?: string },
 ): string {
   const preview = firstLinePreview(resultBodyText(text));
   const label = preview || emptyLabel;
   const hint = opts?.withExpandHint === false ? "" : ` (${expandHint()})`;
-  return base + "\n" + theme.fg("dim", `  ⎿  ${label}${hint}`);
+  const color = opts?.previewColor ?? "dim";
+  return base + "\n" + theme.fg(color, `  ⎿  ${label}${hint}`);
 }
 
 /** Build "haiku · ↻5≤30 · 3 tool uses · 33.8k token" stats fragment. */
@@ -111,6 +128,21 @@ export function isActiveStatus(status: string | undefined): boolean {
   return status === "running" || status === "queued";
 }
 
+/** Lightweight heuristic when structured details are missing. */
+export function looksLikeFailureText(text: string): boolean {
+  const head = text.trim().slice(0, 240);
+  return (
+    /^error\b/i.test(head) ||
+    /\bfailed\b/i.test(head) ||
+    /\bnot found\b/i.test(head) ||
+    /\bcannot\b/i.test(head) ||
+    /\bnot in scope\b/i.test(head) ||
+    /\bunavailable\b/i.test(head) ||
+    /\binvalid\b/i.test(head) ||
+    /\bdisabled\b/i.test(head)
+  );
+}
+
 /** Compact call title: `▸ Label  muted…`. */
 export function renderToolCallTitle(label: string, muted: string | undefined, theme: Theme, dimExtra?: string): Text {
   let line = "▸ " + theme.fg("toolTitle", theme.bold(label));
@@ -125,6 +157,28 @@ function withHeaderAndMarkdown(header: string, markdownBody: string): Component 
   const body = markdownBody.trim() || "_(no output)_";
   container.addChild(renderExpandedMarkdown(body));
   return container;
+}
+
+/**
+ * Fallback when execute returned plain text without AgentDetails.
+ * Never assumes success — missing details + failure-ish text → ✗; else neutral •.
+ */
+export function renderUndetailedResult(
+  resultText: string,
+  opts: { expanded: boolean; isError?: boolean },
+  theme: Theme,
+): Component {
+  const failed = opts.isError === true || looksLikeFailureText(resultText);
+  const icon = failed ? theme.fg("error", "✗") : theme.fg("dim", "•");
+  if (opts.expanded) {
+    return withHeaderAndMarkdown(icon, resultText.trim() || "_(empty)_");
+  }
+  const preview = firstLinePreview(resultBodyText(resultText)) || (failed ? "failed" : "ok");
+  return new Text(
+    icon + " " + theme.fg(failed ? "error" : "dim", `${preview} (${expandHint()})`),
+    0,
+    0,
+  );
 }
 
 /**
@@ -191,7 +245,11 @@ export function renderAgentLikeResult(
   let header = theme.fg("error", "✗") + (s ? " " + s : "");
   if (duration) header += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
   if (details.status === "error") {
-    const err = details.error?.trim() || firstLinePreview(resultBodyText(resultText)) || "unknown";
+    const err =
+      details.error?.trim() ||
+      firstLinePreview(resultBodyText(resultText)) ||
+      firstLinePreview(resultText) ||
+      "unknown";
     header += "\n" + theme.fg("error", `  ⎿  Error: ${firstLinePreview(err, 120)}`);
   } else {
     header += "\n" + theme.fg("warning", "  ⎿  Aborted (max turns exceeded)");

--- a/packages/pi-subagents/src/ui/viewer-keys.ts
+++ b/packages/pi-subagents/src/ui/viewer-keys.ts
@@ -1,0 +1,39 @@
+/**
+ * viewer-keys.ts — Scroll key matchers for the conversation viewer.
+ *
+ * Resolves `tui.select.*` through the user's keybindings when pi provides a
+ * manager, falling back to the previous hardcoded keys otherwise. The viewer's
+ * k/j and shift+arrow aliases always work alongside whatever is bound.
+ */
+
+import { type KeyId, matchesKey } from "@earendil-works/pi-tui";
+
+/** The `tui.select.*` keybinding ids the viewer resolves. */
+export type ViewerScrollKeybinding =
+  | "tui.select.up"
+  | "tui.select.down"
+  | "tui.select.pageUp"
+  | "tui.select.pageDown";
+
+/** Structural subset of pi-tui's `KeybindingsManager` (which satisfies it). */
+export interface ViewerKeybindings {
+  matches(data: string, keybinding: ViewerScrollKeybinding): boolean;
+}
+
+export interface ViewerKeys {
+  scrollUp(data: string): boolean;
+  scrollDown(data: string): boolean;
+  pageUp(data: string): boolean;
+  pageDown(data: string): boolean;
+}
+
+export function createViewerKeys(keybindings?: ViewerKeybindings): ViewerKeys {
+  const matches = (data: string, id: ViewerScrollKeybinding, fallback: KeyId): boolean =>
+    keybindings ? keybindings.matches(data, id) : matchesKey(data, fallback);
+  return {
+    scrollUp: (data) => matches(data, "tui.select.up", "up") || matchesKey(data, "k"),
+    scrollDown: (data) => matches(data, "tui.select.down", "down") || matchesKey(data, "j"),
+    pageUp: (data) => matches(data, "tui.select.pageUp", "pageUp") || matchesKey(data, "shift+up"),
+    pageDown: (data) => matches(data, "tui.select.pageDown", "pageDown") || matchesKey(data, "shift+down"),
+  };
+}

--- a/packages/pi-subagents/src/usage.ts
+++ b/packages/pi-subagents/src/usage.ts
@@ -1,0 +1,60 @@
+/** usage.ts — Token usage: shapes, accumulator operators, session-stats readers. */
+
+/**
+ * Lifetime usage components, accumulated via `message_end` events. Survives
+ * compaction (which replaces session.state.messages and would reset any
+ * stats-derived sum). cacheRead is excluded because each turn's cacheRead is
+ * the cumulative cached prefix re-read on that one call — summing across
+ * turns counts the prefix N times. See issue #38.
+ */
+export type LifetimeUsage = { input: number; output: number; cacheWrite: number };
+
+/** Sum of lifetime usage components, or 0 if undefined. */
+export function getLifetimeTotal(u?: LifetimeUsage): number {
+  return u ? u.input + u.output + u.cacheWrite : 0;
+}
+
+/** Add a usage delta into a target accumulator (mutates target). */
+export function addUsage(into: LifetimeUsage, delta: LifetimeUsage): void {
+  into.input += delta.input;
+  into.output += delta.output;
+  into.cacheWrite += delta.cacheWrite;
+}
+
+/** Minimal shape we read from upstream `getSessionStats()`. */
+export type SessionStatsLike = {
+  tokens: { input: number; output: number; cacheWrite: number };
+  contextUsage?: { percent: number | null };
+};
+export type SessionLike = { getSessionStats(): SessionStatsLike };
+
+/**
+ * Session-scoped token count: input + output + cacheWrite as reported by
+ * upstream `getSessionStats().tokens` for the *current* session window.
+ *
+ * RESETS at compaction — upstream replaces `session.state.messages` and the
+ * stats are derived from that array. For a lifetime total that survives
+ * compaction, use `getLifetimeTotal(lifetimeUsage)` instead, which reads
+ * from an independent accumulator fed by `message_end` events.
+ *
+ * Avoids upstream's `tokens.total` field, which sums per-turn `cacheRead`
+ * and so counts the cumulative cached prefix N times across N turns
+ * (issue #38).
+ */
+export function getSessionTokens(session: SessionLike | undefined): number {
+  if (!session) return 0;
+  try {
+    const t = session.getSessionStats().tokens;
+    return t.input + t.output + t.cacheWrite;
+  } catch { return 0; }
+}
+
+/**
+ * Context-window utilization (0–100), or null when unavailable
+ * (no model contextWindow, or post-compaction before the next response).
+ */
+export function getSessionContextPercent(session: SessionLike | undefined): number | null {
+  if (!session) return null;
+  try { return session.getSessionStats().contextUsage?.percent ?? null; }
+  catch { return null; }
+}

--- a/packages/pi-subagents/src/worktree.ts
+++ b/packages/pi-subagents/src/worktree.ts
@@ -1,0 +1,191 @@
+/**
+ * worktree.ts — Git worktree isolation for agents.
+ *
+ * Creates a temporary git worktree so the agent works on an isolated copy of the repo.
+ * On completion, if no changes were made, the worktree is cleaned up.
+ * If changes exist, a branch is created and returned in the result.
+ */
+
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+
+export interface WorktreeInfo {
+  /** Absolute path to the worktree directory (the copied repo's root). */
+  path: string;
+  /** Branch name created for this worktree (if changes exist). */
+  branch: string;
+  /** Commit SHA that the worktree was created from. */
+  baseSha: string;
+  /**
+   * Where the agent should work inside the worktree: the equivalent of the
+   * cwd the worktree was created from. Equals `path` when that cwd was the
+   * repo root; points at the copied subdirectory when it was deeper (e.g. a
+   * monorepo package), so the requested scoping survives isolation.
+   */
+  workPath: string;
+}
+
+export interface WorktreeCleanupResult {
+  /** Whether changes were found in the worktree. */
+  hasChanges: boolean;
+  /** Branch name if changes were committed. */
+  branch?: string;
+  /** Worktree path if it was kept. */
+  path?: string;
+}
+
+/**
+ * Create a temporary git worktree for an agent.
+ * Returns the worktree path, or undefined if not in a git repo.
+ */
+export function createWorktree(cwd: string, agentId: string): WorktreeInfo | undefined {
+  // Verify we're in a git repo with at least one commit (HEAD must exist)
+  let baseSha: string;
+  let subdir: string;
+  try {
+    execFileSync("git", ["rev-parse", "--is-inside-work-tree"], { cwd, stdio: "pipe", timeout: 5000 });
+    baseSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd, stdio: "pipe", timeout: 5000 })
+      .toString()
+      .trim();
+    // Where cwd sits inside the repo ("" at the root): the agent must work at
+    // the same subdirectory inside the copy, or a monorepo-package cwd would
+    // silently widen to the whole repo. realpath both sides — git emits
+    // resolved paths while cwd may arrive through a symlink (macOS /tmp).
+    const topLevel = execFileSync("git", ["rev-parse", "--show-toplevel"], { cwd, stdio: "pipe", timeout: 5000 })
+      .toString()
+      .trim();
+    subdir = relative(realpathSync(topLevel), realpathSync(cwd));
+  } catch {
+    return undefined;
+  }
+
+  const branch = `pi-agent-${agentId}`;
+  const suffix = randomUUID().slice(0, 8);
+  const worktreePath = join(tmpdir(), `pi-agent-${agentId}-${suffix}`);
+
+  try {
+    // Create detached worktree at HEAD
+    execFileSync("git", ["worktree", "add", "--detach", worktreePath, "HEAD"], {
+      cwd,
+      stdio: "pipe",
+      timeout: 30000,
+    });
+    return { path: worktreePath, branch, baseSha, workPath: subdir ? join(worktreePath, subdir) : worktreePath };
+  } catch {
+    // If worktree creation fails, return undefined (agent runs in normal cwd)
+    return undefined;
+  }
+}
+
+/**
+ * Clean up a worktree after agent completion.
+ * - If no changes: remove worktree entirely.
+ * - If changes exist: create a branch, commit changes, return branch info.
+ */
+export function cleanupWorktree(
+  cwd: string,
+  worktree: WorktreeInfo,
+  agentDescription: string,
+): WorktreeCleanupResult {
+  if (!existsSync(worktree.path)) {
+    return { hasChanges: false };
+  }
+
+  try {
+    // Check for uncommitted changes in the worktree
+    const status = execFileSync("git", ["status", "--porcelain"], {
+      cwd: worktree.path,
+      stdio: "pipe",
+      timeout: 10000,
+    }).toString().trim();
+
+    if (status) {
+      // Changes exist — stage, commit, and create a branch
+      execFileSync("git", ["add", "-A"], { cwd: worktree.path, stdio: "pipe", timeout: 10000 });
+      // Truncate description for commit message (no shell sanitization needed — execFileSync uses argv)
+      const safeDesc = agentDescription.slice(0, 200);
+      const commitMsg = `pi-agent: ${safeDesc}`;
+      execFileSync("git", ["commit", "--no-verify", "-m", commitMsg], {
+        cwd: worktree.path,
+        stdio: "pipe",
+        timeout: 10000,
+      });
+    } else {
+      const currentSha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: worktree.path,
+        stdio: "pipe",
+        timeout: 5000,
+      }).toString().trim();
+
+      if (currentSha === worktree.baseSha) {
+        // No changes — remove worktree
+        removeWorktree(cwd, worktree.path);
+        return { hasChanges: false };
+      }
+    }
+
+    // Create a branch pointing to the worktree's HEAD.
+    // If the branch already exists, append a suffix to avoid overwriting previous work.
+    let branchName = worktree.branch;
+    try {
+      execFileSync("git", ["branch", branchName], {
+        cwd: worktree.path,
+        stdio: "pipe",
+        timeout: 5000,
+      });
+    } catch {
+      // Branch already exists — use a unique suffix
+      branchName = `${worktree.branch}-${Date.now()}`;
+      execFileSync("git", ["branch", branchName], {
+        cwd: worktree.path,
+        stdio: "pipe",
+        timeout: 5000,
+      });
+    }
+    // Update branch name in worktree info for the caller
+    worktree.branch = branchName;
+
+    // Remove the worktree (branch persists in main repo)
+    removeWorktree(cwd, worktree.path);
+
+    return {
+      hasChanges: true,
+      branch: worktree.branch,
+      path: worktree.path,
+    };
+  } catch {
+    // Best effort cleanup on error
+    try { removeWorktree(cwd, worktree.path); } catch { /* ignore */ }
+    return { hasChanges: false };
+  }
+}
+
+/**
+ * Force-remove a worktree.
+ */
+function removeWorktree(cwd: string, worktreePath: string): void {
+  try {
+    execFileSync("git", ["worktree", "remove", "--force", worktreePath], {
+      cwd,
+      stdio: "pipe",
+      timeout: 10000,
+    });
+  } catch {
+    // If git worktree remove fails, try pruning
+    try {
+      execFileSync("git", ["worktree", "prune"], { cwd, stdio: "pipe", timeout: 5000 });
+    } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Prune any orphaned worktrees (crash recovery).
+ */
+export function pruneWorktrees(cwd: string): void {
+  try {
+    execFileSync("git", ["worktree", "prune"], { cwd, stdio: "pipe", timeout: 5000 });
+  } catch { /* ignore */ }
+}

--- a/packages/pi-subagents/test/agent-manager.test.ts
+++ b/packages/pi-subagents/test/agent-manager.test.ts
@@ -1,0 +1,1024 @@
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentManager } from "../src/agent-manager.js";
+import type { AgentRecord } from "../src/types.js";
+
+vi.mock("../src/agent-runner.js", () => ({
+  runAgent: vi.fn(),
+  resumeAgent: vi.fn(),
+}));
+
+vi.mock("../src/worktree.js", () => ({
+  createWorktree: vi.fn(),
+  cleanupWorktree: vi.fn(() => ({ hasChanges: false })),
+  pruneWorktrees: vi.fn(),
+}));
+
+import { runAgent } from "../src/agent-runner.js";
+
+const mockPi = {} as any;
+const mockCtx = { cwd: "/tmp" } as any;
+
+const mockSession = () => ({ dispose: vi.fn() } as any);
+
+const resolvedRun = () =>
+  vi.mocked(runAgent).mockResolvedValue({
+    responseText: "done",
+    session: mockSession(),
+    aborted: false,
+    steered: false,
+  });
+
+describe("AgentManager — Bug 1 race condition (resultConsumed vs onComplete)", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("reproduces bug: onComplete fires with resultConsumed=false when set after await", async () => {
+    let seenConsumed: boolean | undefined;
+    manager = new AgentManager((r) => {
+      seenConsumed = r.resultConsumed;
+    });
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+
+    // Simulate the buggy get_subagent_result: await THEN mark consumed
+    await record.promise;
+    record.resultConsumed = true; // too late — onComplete already fired
+
+    // onComplete saw resultConsumed as falsy (undefined) — would queue a notification (the bug)
+    expect(seenConsumed).toBeFalsy();
+  });
+
+  it("fix: onComplete sees resultConsumed=true when pre-marked before await", async () => {
+    let seenConsumed: boolean | undefined;
+    manager = new AgentManager((r) => {
+      seenConsumed = r.resultConsumed;
+    });
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+
+    // The fix: pre-mark BEFORE awaiting
+    record.resultConsumed = true;
+    await record.promise;
+
+    expect(seenConsumed).toBe(true);
+  });
+
+  it("normal case: onComplete fires with resultConsumed falsy when no explicit polling", async () => {
+    let completedRecord: AgentRecord | undefined;
+    manager = new AgentManager((r) => {
+      completedRecord = r;
+    });
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    expect(completedRecord).toBeDefined();
+    expect(completedRecord!.resultConsumed).toBeFalsy();
+  });
+
+  it("onComplete IS called for foreground agents (lifecycle symmetry)", async () => {
+    let completedRecord: AgentRecord | undefined;
+    manager = new AgentManager((r) => {
+      completedRecord = r;
+    });
+    resolvedRun();
+
+    const { record } = await manager.spawnAndWait(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+    });
+
+    expect(completedRecord).toBeDefined();
+    expect(completedRecord!.status).toBe("completed");
+    // resultConsumed is set by spawnAndWait so onComplete skips notifications
+    expect(completedRecord!.resultConsumed).toBe(true);
+    expect(record).toBe(completedRecord);
+  });
+});
+
+describe("AgentManager — spawnAndWait onSpawned + foreground output file wiring (#105)", () => {
+  let manager: AgentManager;
+  afterEach(() => manager?.dispose());
+
+  it("fields set on the record in onSpawned are visible when onSessionCreated fires", async () => {
+    // The load-bearing ordering guarantee: onSpawned fires synchronously inside
+    // spawn(), before runAgent's async onSessionCreated fires. index.ts relies on
+    // this to set record.outputFile so streamToOutputFile can pick it up.
+    manager = new AgentManager();
+    let capturedId: string | undefined;
+    let outputFileSeenAtSessionCreated: string | undefined;
+
+    vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, opts: any) => {
+      const session = mockSession();
+      // Yield one microtask to mirror real behavior: in production, onSessionCreated
+      // fires async (after network/session setup). onSpawned fires synchronously
+      // inside spawn() before runAgent's promise even starts. This await lets the
+      // remainder of startAgent (record.promise = …, onSpawned?.()) finish first.
+      await Promise.resolve();
+      opts.onSessionCreated?.(session);
+      outputFileSeenAtSessionCreated = capturedId
+        ? manager.getRecord(capturedId)?.outputFile
+        : undefined;
+      return { responseText: "done", session, aborted: false, steered: false };
+    });
+
+    await manager.spawnAndWait(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+    }, (fgId) => {
+      capturedId = fgId;
+      manager.getRecord(fgId)!.outputFile = "/fake/agent.jsonl";
+    });
+
+    expect(outputFileSeenAtSessionCreated).toBe("/fake/agent.jsonl");
+  });
+
+  it("onSpawned id matches the id returned by spawnAndWait", async () => {
+    manager = new AgentManager();
+    let spawnedId: string | undefined;
+    resolvedRun();
+
+    const { id } = await manager.spawnAndWait(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+    }, (fgId) => { spawnedId = fgId; });
+
+    expect(spawnedId).toBe(id);
+  });
+
+  it("onComplete fires on the error path with resultConsumed=true", async () => {
+    // The .then path is covered by the lifecycle-symmetry test above; this guards
+    // the .catch path which lacks try/catch around onComplete (a known asymmetry).
+    let completedRecord: AgentRecord | undefined;
+    manager = new AgentManager((r) => { completedRecord = r; });
+    vi.mocked(runAgent).mockRejectedValue(new Error("agent failed"));
+
+    const { record } = await manager.spawnAndWait(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+    });
+
+    expect(completedRecord).toBeDefined();
+    expect(completedRecord!.status).toBe("error");
+    expect(completedRecord!.resultConsumed).toBe(true);
+    expect(record).toBe(completedRecord);
+  });
+});
+
+describe("AgentManager — completion callbacks", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("does not let onComplete errors turn a completed agent into a failed run", async () => {
+    manager = new AgentManager(() => {
+      throw new Error("stale extension context");
+    });
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await expect(manager.getRecord(id)!.promise).resolves.toBe("done");
+
+    expect(manager.getRecord(id)!.status).toBe("completed");
+  });
+});
+
+describe("AgentManager — cleanup timer", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("does not keep the process alive on its own", () => {
+    manager = new AgentManager();
+
+    expect((manager as any).cleanupInterval.hasRef()).toBe(false);
+  });
+});
+
+describe("AgentManager — Bug 3 clearCompleted", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("clearCompleted removes completed records", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    expect(manager.listAgents()).toHaveLength(1);
+    manager.clearCompleted();
+    expect(manager.listAgents()).toHaveLength(0);
+  });
+
+  it("clearCompleted does not remove running or queued agents", async () => {
+    // Use maxConcurrent=0 to keep agents queued, then spawn one running via foreground
+    manager = new AgentManager(undefined, 1);
+
+    // Mock runAgent to never resolve (keeps agent "running")
+    vi.mocked(runAgent).mockImplementation(
+      () => new Promise(() => {}), // hangs forever
+    );
+
+    const id1 = manager.spawn(mockPi, mockCtx, "general-purpose", "test1", {
+      description: "running agent",
+      isBackground: true,
+    });
+    // Second agent should be queued (limit=1)
+    const id2 = manager.spawn(mockPi, mockCtx, "general-purpose", "test2", {
+      description: "queued agent",
+      isBackground: true,
+    });
+
+    expect(manager.getRecord(id1)!.status).toBe("running");
+    expect(manager.getRecord(id2)!.status).toBe("queued");
+
+    manager.clearCompleted();
+
+    // Both should still be present
+    expect(manager.getRecord(id1)).toBeDefined();
+    expect(manager.getRecord(id2)).toBeDefined();
+
+    // Abort to allow cleanup
+    manager.abort(id1);
+    manager.abort(id2);
+  });
+
+  it("clearCompleted calls dispose on sessions of removed records", async () => {
+    manager = new AgentManager();
+    const disposeSpy = vi.fn();
+    const sess = { dispose: disposeSpy };
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: sess as any,
+      aborted: false,
+      steered: false,
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    manager.clearCompleted();
+
+    expect(disposeSpy).toHaveBeenCalledOnce();
+  });
+
+  it("clearCompleted removes error and stopped records", async () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockRejectedValue(new Error("boom"));
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+    expect(manager.getRecord(id)!.status).toBe("error");
+
+    manager.clearCompleted();
+    expect(manager.getRecord(id)).toBeUndefined();
+  });
+
+  it("clearCompleted(true) preserves completed records with resultConsumed=false", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+    expect(manager.getRecord(id)!.status).toBe("completed");
+    expect(manager.getRecord(id)!.resultConsumed).toBeFalsy();
+
+    manager.clearCompleted(true);
+    expect(manager.getRecord(id)).toBeDefined();
+  });
+
+  it("clearCompleted(true) removes completed records with resultConsumed=true", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+    await record.promise;
+    record.resultConsumed = true;
+
+    manager.clearCompleted(true);
+    expect(manager.getRecord(id)).toBeUndefined();
+  });
+
+  it("clearCompleted(true) still removes running=false queued=false records when resultConsumed=false for error status", async () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockRejectedValue(new Error("boom"));
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+    expect(manager.getRecord(id)!.status).toBe("error");
+    expect(manager.getRecord(id)!.resultConsumed).toBeFalsy();
+
+    // Error records with unread results are also preserved — the LLM should
+    // be able to read the error message via get_subagent_result before the
+    // record is evicted.
+    manager.clearCompleted(true);
+    expect(manager.getRecord(id)).toBeDefined();
+  });
+});
+
+// Eager init removes the optional/required asymmetry that previously required
+// `??=` defaults at the callback sites and `?? 0` / `?? 1` at the read sites.
+describe("AgentManager — lifetime usage + compaction count are eagerly initialized", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("spawn initializes lifetimeUsage to zeros and compactionCount to 0", () => {
+    manager = new AgentManager();
+    // Don't resolve the run — we just want to inspect the record at spawn time.
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+
+    expect(record.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0 });
+    expect(record.compactionCount).toBe(0);
+
+    manager.abort(id);
+  });
+
+  it("onAssistantUsage from runAgent accumulates into record.lifetimeUsage", async () => {
+    manager = new AgentManager();
+
+    // Capture the options passed to runAgent so we can drive callbacks
+    let captured: any;
+    vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, opts: any) => {
+      captured = opts;
+      // Two assistant messages with usage
+      opts.onAssistantUsage?.({ input: 100, output: 50, cacheWrite: 10 });
+      opts.onAssistantUsage?.({ input: 200, output: 80, cacheWrite: 20 });
+      return { responseText: "done", session: mockSession(), aborted: false, steered: false };
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    expect(captured).toBeDefined();
+    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({
+      input: 300, output: 130, cacheWrite: 30,
+    });
+  });
+
+  it("onCompaction from runAgent increments record.compactionCount", async () => {
+    manager = new AgentManager();
+    const compactSeen: any[] = [];
+
+    vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, opts: any) => {
+      // Compaction fires while the agent is still running — the record passed to
+      // onCompact should reflect the just-incremented count.
+      opts.onCompaction?.({ reason: "threshold", tokensBefore: 12345 });
+      opts.onCompaction?.({ reason: "manual", tokensBefore: 22222 });
+      return { responseText: "done", session: mockSession(), aborted: false, steered: false };
+    });
+
+    manager = new AgentManager(undefined, undefined, undefined, (record, info) => {
+      compactSeen.push({ count: record.compactionCount, reason: info.reason });
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    expect(compactSeen).toEqual([
+      { count: 1, reason: "threshold" },
+      { count: 2, reason: "manual" },
+    ]);
+    expect(manager.getRecord(id)!.compactionCount).toBe(2);
+  });
+
+  it("resume() also accumulates usage and increments compactions on the same record", async () => {
+    manager = new AgentManager();
+
+    // First, spawn with a session that resume can latch onto
+    const session = { ...mockSession() };
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "first",
+      session: session as any,
+      aborted: false,
+      steered: false,
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isBackground: true,
+    });
+    await manager.getRecord(id)!.promise;
+
+    // Pre-resume: lifetimeUsage from spawn was zero (mock didn't call onAssistantUsage)
+    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0 });
+    expect(manager.getRecord(id)!.compactionCount).toBe(0);
+
+    // Now resume — drive callbacks via the mocked resumeAgent
+    const { resumeAgent: resumeMock } = await import("../src/agent-runner.js");
+    vi.mocked(resumeMock).mockImplementation(async (_session, _prompt, opts: any) => {
+      opts.onAssistantUsage?.({ input: 70, output: 30, cacheWrite: 5 });
+      opts.onCompaction?.({ reason: "overflow", tokensBefore: 999 });
+      return { text: "second" };
+    });
+
+    await manager.resume(id, "more");
+
+    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 70, output: 30, cacheWrite: 5 });
+    expect(manager.getRecord(id)!.compactionCount).toBe(1);
+  });
+});
+
+// Regression: `isolation: "worktree"` MUST fail loud when the cwd can't host
+// a worktree. The previous behavior silently fell back to the main tree and
+// injected a warning into the LLM's prompt — invisible to the caller.
+describe("AgentManager — isolation: worktree fails loud, no silent fallback", () => {
+  let manager: AgentManager;
+
+  afterEach(() => {
+    manager?.dispose();
+  });
+
+  it("spawn() throws when createWorktree returns undefined; no orphan record left behind", async () => {
+    const { createWorktree } = await import("../src/worktree.js");
+    vi.mocked(createWorktree).mockReturnValueOnce(undefined);
+    vi.mocked(runAgent).mockClear();
+
+    manager = new AgentManager();
+    expect(() => manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isolation: "worktree",
+    })).toThrow(/isolation: "worktree"/);
+
+    // Cleaned up — no orphan in listAgents()
+    expect(manager.listAgents()).toEqual([]);
+    // runAgent never invoked — strict, no silent fallback
+    expect(runAgent).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentManager — SpawnOptions.cwd passthrough (#96)", () => {
+  let manager: AgentManager;
+  afterEach(() => manager?.dispose());
+
+  it("passes cwd to runAgent as the working dir, parent cwd as configCwd", async () => {
+    resolvedRun();
+    manager = new AgentManager();
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      cwd: "/", // absolute and always exists
+    });
+    await manager.getRecord(id)!.promise;
+
+    expect(runAgent).toHaveBeenCalledWith(
+      mockCtx, "general-purpose", "test",
+      expect.objectContaining({ cwd: "/", configCwd: "/tmp" }),
+    );
+  });
+
+  it("without cwd, configCwd stays unset — existing behavior untouched", async () => {
+    // mockClear + lastCall: toHaveBeenCalledWith would scan the file's whole
+    // accumulated call history, where earlier no-cwd spawns already match.
+    vi.mocked(runAgent).mockClear();
+    resolvedRun();
+    manager = new AgentManager();
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+    });
+    await manager.getRecord(id)!.promise;
+
+    const opts = vi.mocked(runAgent).mock.lastCall![3];
+    expect(opts.cwd).toBeUndefined();
+    expect(opts.configCwd).toBeUndefined();
+  });
+
+  it("cwd: null (RPC 'unset') behaves exactly like omitting cwd", async () => {
+    vi.mocked(runAgent).mockClear();
+    resolvedRun();
+    manager = new AgentManager();
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      cwd: null as any,
+    });
+    await manager.getRecord(id)!.promise;
+
+    const opts = vi.mocked(runAgent).mock.lastCall![3];
+    expect(opts.cwd).toBeUndefined();
+    expect(opts.configCwd).toBeUndefined();
+  });
+
+  it("cwd + isolation: worktree — worktree created FROM cwd, session runs at the copy's workPath, cleanup targets cwd's repo", async () => {
+    const { createWorktree, cleanupWorktree } = await import("../src/worktree.js");
+    vi.mocked(createWorktree).mockReturnValueOnce({
+      path: "/wt/copy", branch: "pi-agent-x", baseSha: "abc", workPath: "/wt/copy/packages/api",
+    });
+    resolvedRun();
+
+    manager = new AgentManager();
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      cwd: "/",
+      isolation: "worktree",
+    });
+    await manager.getRecord(id)!.promise;
+
+    expect(createWorktree).toHaveBeenCalledWith("/", id);
+    // Worktree wins for the working dir — at workPath, so subdirectory scoping
+    // survives isolation. Config still anchored to the parent.
+    expect(runAgent).toHaveBeenCalledWith(
+      mockCtx, "general-purpose", "test",
+      expect.objectContaining({ cwd: "/wt/copy/packages/api", configCwd: "/tmp" }),
+    );
+    expect(cleanupWorktree).toHaveBeenCalledWith("/", expect.anything(), "test");
+  });
+
+  it("plain worktree (no cwd) keeps the historical root working dir even when workPath differs", async () => {
+    // Parent session sitting in a repo subdirectory: workPath would point at
+    // the copied subdir. Without SpawnOptions.cwd the agent must stay at the
+    // copy's root — moving it would also move .pi config discovery.
+    const { createWorktree } = await import("../src/worktree.js");
+    vi.mocked(createWorktree).mockReturnValueOnce({
+      path: "/wt/copy", branch: "pi-agent-x", baseSha: "abc", workPath: "/wt/copy/sub/dir",
+    });
+    vi.mocked(runAgent).mockClear();
+    resolvedRun();
+
+    manager = new AgentManager();
+    const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      isolation: "worktree",
+    });
+    await manager.getRecord(id)!.promise;
+
+    const opts = vi.mocked(runAgent).mock.lastCall![3];
+    expect(opts.cwd).toBe("/wt/copy");
+    expect(opts.configCwd).toBeUndefined();
+  });
+
+  it("relative cwd throws immediately; no orphan record", () => {
+    vi.mocked(runAgent).mockClear();
+    manager = new AgentManager();
+    expect(() => manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      cwd: "relative/path",
+    })).toThrow(/absolute path/);
+    expect(manager.listAgents()).toEqual([]);
+    expect(runAgent).not.toHaveBeenCalled();
+  });
+
+  it("nonexistent cwd throws immediately; no orphan record", () => {
+    vi.mocked(runAgent).mockClear();
+    manager = new AgentManager();
+    expect(() => manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      cwd: "/nonexistent-pi-subagents-test-dir",
+    })).toThrow(/does not exist/);
+    expect(manager.listAgents()).toEqual([]);
+    expect(runAgent).not.toHaveBeenCalled();
+  });
+
+  it("cwd pointing at a regular file throws a curated 'not a directory' error", () => {
+    vi.mocked(runAgent).mockClear();
+    manager = new AgentManager();
+    expect(() => manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      cwd: fileURLToPath(import.meta.url), // this test file: absolute, exists, not a directory
+    })).toThrow(/not a directory/);
+    expect(manager.listAgents()).toEqual([]);
+    expect(runAgent).not.toHaveBeenCalled();
+  });
+
+  it("non-string cwd (RPC junk) throws the curated error, not a TypeError from path internals", () => {
+    vi.mocked(runAgent).mockClear();
+    manager = new AgentManager();
+    expect(() => manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
+      description: "test",
+      cwd: 123 as any,
+    })).toThrow(/must be an absolute path/);
+    expect(manager.listAgents()).toEqual([]);
+  });
+});
+
+describe("AgentManager — abort() state machine", () => {
+  let manager: AgentManager;
+  afterEach(() => manager?.dispose());
+
+  it("returns false for an unknown id (no record, no side-effects)", () => {
+    manager = new AgentManager();
+    expect(manager.abort("does-not-exist")).toBe(false);
+  });
+
+  it("removes a queued agent from the queue and marks it stopped", () => {
+    // Concurrency=1: the second background spawn queues behind the first
+    manager = new AgentManager(undefined, 1);
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+
+    manager.spawn(mockPi, mockCtx, "X", "blocker", { description: "block", isBackground: true });
+    const queuedId = manager.spawn(mockPi, mockCtx, "Y", "queued", {
+      description: "q",
+      isBackground: true,
+    });
+    const queuedRecord = manager.getRecord(queuedId)!;
+    expect(queuedRecord.status).toBe("queued");
+
+    expect(manager.abort(queuedId)).toBe(true);
+    expect(queuedRecord.status).toBe("stopped");
+    expect(queuedRecord.completedAt).toBeGreaterThan(0);
+    // Aborting again is a no-op — status is no longer "queued" or "running"
+    expect(manager.abort(queuedId)).toBe(false);
+  });
+
+  it("aborts a running agent by firing its AbortController and setting status='stopped'", () => {
+    manager = new AgentManager();
+    let receivedSignal: AbortSignal | undefined;
+    vi.mocked(runAgent).mockImplementation((_ctx, _type, _prompt, opts) => {
+      receivedSignal = (opts as { signal?: AbortSignal })?.signal;
+      return new Promise(() => {});
+    });
+
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", {
+      description: "r",
+      isBackground: true,
+    });
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("running");
+    expect(receivedSignal?.aborted).toBe(false);
+
+    expect(manager.abort(id)).toBe(true);
+    expect(record.status).toBe("stopped");
+    expect(record.completedAt).toBeGreaterThan(0);
+    expect(receivedSignal?.aborted).toBe(true);
+  });
+
+  it("returns false (and does not change status) for an already-completed agent", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", {
+      description: "x",
+      isBackground: false,
+    });
+    await manager.getRecord(id)?.promise;
+    expect(manager.getRecord(id)?.status).toBe("completed");
+
+    expect(manager.abort(id)).toBe(false);
+    expect(manager.getRecord(id)?.status).toBe("completed");
+  });
+
+  it("a user abort survives the agent settling — stays 'stopped', never 'completed'", async () => {
+    // Guards the `if (record.status !== "stopped")` check in the completion
+    // handler: after a user abort, runAgent's promise still settles (here with
+    // aborted:false, as a non-cooperative mock would), and must NOT flip the
+    // user-stopped status back to "completed" — otherwise the parent agent
+    // would read the partial output as a finished result.
+    manager = new AgentManager();
+    let resolveRun!: (v: unknown) => void;
+    vi.mocked(runAgent).mockImplementation(() => new Promise((res) => { resolveRun = res as (v: unknown) => void; }));
+
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "r", isBackground: true });
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("running");
+
+    expect(manager.abort(id)).toBe(true);
+    expect(record.status).toBe("stopped");
+
+    // The agent loop ends and the promise settles "normally".
+    resolveRun({ responseText: "partial output", session: mockSession(), aborted: false, steered: false });
+    await record.promise;
+
+    expect(record.status).toBe("stopped");        // not overwritten to "completed"
+    expect(record.result).toBe("partial output"); // partial result still captured
+  });
+});
+
+// Regression for #44: ESC during a foreground Agent call must propagate to
+// the child. Pi delivers parent abort via AbortSignal; the manager wires the
+// signal's "abort" event to this.abort(id).
+describe("AgentManager — steer()", () => {
+  let manager: AgentManager;
+  afterEach(() => manager?.dispose());
+
+  it("returns false for an unknown id", () => {
+    manager = new AgentManager();
+    expect(manager.steer("nope", "hi")).toBe(false);
+  });
+
+  it("delivers to a live session via session.steer()", () => {
+    manager = new AgentManager();
+    const steer = vi.fn(() => Promise.resolve());
+    let captured: ((s: any) => void) | undefined;
+    vi.mocked(runAgent).mockImplementation((_ctx, _type, _prompt, opts) => {
+      captured = (opts as any)?.onSessionCreated;
+      return new Promise(() => {});
+    });
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "r", isBackground: true });
+    // Simulate the session becoming ready.
+    captured?.({ steer, dispose: vi.fn() });
+
+    expect(manager.steer(id, "go left")).toBe(true);
+    expect(steer).toHaveBeenCalledWith("go left");
+  });
+
+  it("queues onto pendingSteers when the session isn't ready yet", () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "r", isBackground: true });
+    const record = manager.getRecord(id)!;
+    record.session = undefined; // not ready
+
+    expect(manager.steer(id, "first")).toBe(true);
+    expect(manager.steer(id, "second")).toBe(true);
+    expect(record.pendingSteers).toEqual(["first", "second"]);
+  });
+
+  it("refuses to steer an agent that is no longer running", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: false });
+    await manager.getRecord(id)?.promise;
+    expect(manager.getRecord(id)?.status).toBe("completed");
+    expect(manager.steer(id, "too late")).toBe(false);
+  });
+});
+
+describe("AgentManager — parent abort signal forwarding (#44)", () => {
+  let manager: AgentManager;
+  afterEach(() => manager?.dispose());
+
+  it("aborts the child when the parent signal aborts", () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+
+    const parent = new AbortController();
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", {
+      description: "x",
+      isBackground: false,
+      signal: parent.signal,
+    });
+    const record = manager.getRecord(id)!;
+    expect(record.status).toBe("running");
+
+    parent.abort();
+    expect(record.status).toBe("stopped");
+    expect(record.completedAt).toBeGreaterThan(0);
+  });
+});
+
+describe("AgentManager — listAgents() ordering", () => {
+  let manager: AgentManager;
+  afterEach(() => manager?.dispose());
+
+  it("returns records sorted by startedAt descending (most recent first)", () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    const a = manager.spawn(mockPi, mockCtx, "X", "1", { description: "a" });
+    const b = manager.spawn(mockPi, mockCtx, "X", "2", { description: "b" });
+    const c = manager.spawn(mockPi, mockCtx, "X", "3", { description: "c" });
+
+    // Force deterministic startedAt — Date.now() can collide on fast runs
+    manager.getRecord(a)!.startedAt = 100;
+    manager.getRecord(b)!.startedAt = 200;
+    manager.getRecord(c)!.startedAt = 300;
+
+    expect(manager.listAgents().map((r) => r.id)).toEqual([c, b, a]);
+  });
+});
+
+describe("AgentManager — abortAll", () => {
+  let manager: AgentManager;
+  afterEach(() => manager?.dispose());
+
+  it("stops both queued and running agents and returns the total count", () => {
+    manager = new AgentManager(undefined, 1);
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+
+    const running = manager.spawn(mockPi, mockCtx, "X", "r", {
+      description: "r",
+      isBackground: true,
+    });
+    const queued = manager.spawn(mockPi, mockCtx, "Y", "q", {
+      description: "q",
+      isBackground: true,
+    });
+    expect(manager.getRecord(running)?.status).toBe("running");
+    expect(manager.getRecord(queued)?.status).toBe("queued");
+
+    expect(manager.abortAll()).toBe(2);
+    expect(manager.getRecord(running)?.status).toBe("stopped");
+    expect(manager.getRecord(queued)?.status).toBe("stopped");
+    expect(manager.hasRunning()).toBe(false);
+  });
+
+  it("returns 0 when there are no running or queued agents", () => {
+    manager = new AgentManager();
+    expect(manager.abortAll()).toBe(0);
+  });
+});
+
+describe("AgentManager — hasRunning", () => {
+  let manager: AgentManager;
+  afterEach(() => manager?.dispose());
+
+  it("is true while a background agent is running, false after it completes", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+
+    expect(manager.hasRunning()).toBe(false);
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", {
+      description: "x",
+      isBackground: true,
+    });
+    expect(manager.hasRunning()).toBe(true);
+
+    await manager.getRecord(id)?.promise;
+    expect(manager.hasRunning()).toBe(false);
+  });
+
+  it("is true when an agent is queued behind the concurrency limit", () => {
+    manager = new AgentManager(undefined, 1);
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+
+    manager.spawn(mockPi, mockCtx, "X", "r", { description: "r", isBackground: true });
+    manager.spawn(mockPi, mockCtx, "Y", "q", { description: "q", isBackground: true });
+    expect(manager.hasRunning()).toBe(true);
+  });
+});
+
+describe("AgentManager — runAgent rejection leaves the record visible with error status", () => {
+  let manager: AgentManager;
+  afterEach(() => manager?.dispose());
+
+  it("sets status='error', captures the error message, and stamps completedAt", async () => {
+    manager = new AgentManager();
+    vi.mocked(runAgent).mockRejectedValue(new Error("boom"));
+
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", {
+      description: "x",
+      isBackground: false,
+    });
+    const record = manager.getRecord(id)!;
+    await record.promise;
+
+    expect(record.status).toBe("error");
+    expect(record.error).toBe("boom");
+    expect(record.completedAt).toBeGreaterThan(0);
+  });
+});
+
+// #144 — a run that RESOLVES with a failed final turn (pi never rejects on
+// retry exhaustion) must map to status "error", not "completed".
+describe("AgentManager — resolved runs with a failed final turn map to error (#144)", () => {
+  let manager: AgentManager;
+  afterEach(() => manager?.dispose());
+
+  const failedRun = (failure: string, responseText = "") =>
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText,
+      session: mockSession(),
+      aborted: false,
+      steered: false,
+      failure,
+    } as any);
+
+  it("sets status='error' and captures the provider message", async () => {
+    manager = new AgentManager();
+    failedRun("retries exhausted: 529 overloaded");
+
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    const record = manager.getRecord(id)!;
+    await record.promise;
+
+    expect(record.status).toBe("error");
+    expect(record.error).toBe("retries exhausted: 529 overloaded");
+    expect(record.completedAt).toBeGreaterThan(0);
+  });
+
+  it("keeps earlier-turn text available as result context, but never as a clean completion", async () => {
+    manager = new AgentManager();
+    failedRun("provider died", "partial progress from an earlier turn");
+
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    const record = manager.getRecord(id)!;
+    await record.promise;
+
+    expect(record.status).toBe("error");
+    expect(record.result).toBe("partial progress from an earlier turn");
+  });
+
+  it("onComplete sees the error status (routes to subagents:failed in the host)", async () => {
+    let completed: AgentRecord | undefined;
+    manager = new AgentManager((r) => { completed = r; });
+    failedRun("boom");
+
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    await manager.getRecord(id)!.promise;
+
+    expect(completed?.status).toBe("error");
+  });
+
+  it("an external stop still wins over a late failure resolution", async () => {
+    manager = new AgentManager();
+    let resolveRun: ((v: unknown) => void) | undefined;
+    const session = mockSession();
+    vi.mocked(runAgent).mockImplementation(() => new Promise((r) => { resolveRun = r; }));
+
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    const record = manager.getRecord(id)!;
+    record.status = "stopped"; // external abort() path
+    resolveRun!({ responseText: "", session, aborted: false, steered: false, failure: "late error" });
+    await record.promise;
+
+    expect(record.status).toBe("stopped");
+    expect(record.error).toBeUndefined();
+  });
+
+  it("resume(): a failed final turn on the resumed prompt maps to error too", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    const record = manager.getRecord(id)!;
+    await record.promise;
+    expect(record.status).toBe("completed");
+
+    const { resumeAgent: resumeMock } = await import("../src/agent-runner.js");
+    // resumeAgent bounds its fallback to this invocation, so a failed empty
+    // resume yields text "" — never the prior turn's answer (#144 root-fix).
+    vi.mocked(resumeMock).mockResolvedValue({
+      text: "",
+      failure: "retries exhausted on resume",
+    });
+
+    await manager.resume(id, "more");
+
+    expect(record.status).toBe("error");
+    expect(record.error).toBe("retries exhausted on resume");
+    expect(record.result).toBe(""); // no stale prior answer
+  });
+
+  it("resume(): partial text produced before the failure is kept as result", async () => {
+    manager = new AgentManager();
+    resolvedRun();
+    const id = manager.spawn(mockPi, mockCtx, "X", "p", { description: "x", isBackground: true });
+    const record = manager.getRecord(id)!;
+    await record.promise;
+
+    const { resumeAgent: resumeMock } = await import("../src/agent-runner.js");
+    vi.mocked(resumeMock).mockResolvedValue({
+      text: "new partial progress",
+      failure: "provider died mid-turn",
+    });
+
+    await manager.resume(id, "more");
+
+    expect(record.status).toBe("error");
+    expect(record.result).toBe("new partial progress"); // salvageable, this-run text
+  });
+});

--- a/packages/pi-subagents/test/agent-runner-e2e.test.ts
+++ b/packages/pi-subagents/test/agent-runner-e2e.test.ts
@@ -1,0 +1,161 @@
+/**
+ * agent-runner-e2e.test.ts — End-to-end test against the REAL pi-mono runtime.
+ *
+ * Every other agent-runner test mocks `@earendil-works/pi-coding-agent`: it
+ * asserts that `runAgent` hands the right `tools:` allowlist to a *simulated*
+ * `createAgentSession`. That proves our allowlist math, but not the assumption
+ * the math rests on — that real pi-mono actually gates a session to that
+ * allowlist, admitting extension-registered tools (the #47 fix) and dropping
+ * the rest.
+ *
+ * This test closes that loop with NO pi-mono mock:
+ *   - a real extension fixture (`fixtures/e2e-probe-ext.mjs`) registers a tool,
+ *   - the real `DefaultResourceLoader` loads it via `additionalExtensionPaths`,
+ *   - the real `createAgentSession` builds the session,
+ *   - we read the real `session.getActiveToolNames()` at `onSessionCreated`
+ *     (fires after construction, before any prompt) and assert what the LLM
+ *     would actually be allowed to call.
+ *
+ * No network/LLM: a faux Model object satisfies `createAgentSession`'s `model`
+ * param, and we never depend on a turn completing — the assertion is on the
+ * gated tool set, which is fixed at construction. (Driving a live faux model
+ * through `session.prompt()` is intentionally avoided: under Vite the faux
+ * provider registers in a different `pi-ai` module instance than the one
+ * pi-coding-agent streams through, which is brittle and orthogonal to gating.)
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { extensionCanonicalName, runAgent } from "../src/agent-runner.js";
+import { registerAgents } from "../src/agent-types.js";
+import type { AgentConfig } from "../src/types.js";
+import { registerFauxProvider } from "./helpers/pi-ai.js";
+
+// These tests spin up the REAL pi-mono runtime (loader + dynamic extension
+// import + session construction), so a cold first run under full-suite CPU
+// contention can exceed vitest's 5s default. Give the file generous headroom —
+// a genuine hang still fails, just later.
+vi.setConfig({ testTimeout: 30_000 });
+
+const FIXTURE = resolve(fileURLToPath(new URL("./fixtures/e2e-probe-ext.mjs", import.meta.url)));
+/** The fixture registers exactly this tool. */
+const EXT_TOOL = "e2e_probe";
+const BUILTINS = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+
+/** Minimal `pi` stub — `detectEnv` only needs `exec` (returns non-git). */
+function makePi() {
+  return { exec: async () => ({ code: 1, stdout: "", stderr: "" }) } as any;
+}
+
+describe("agent-runner end-to-end (real pi-mono session + real extension)", () => {
+  let cwd: string;
+  let faux: ReturnType<typeof registerFauxProvider>;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "subagents-e2e-"));
+    // Only used as a valid Model object for createAgentSession; we never rely
+    // on it actually streaming (we assert on the pre-prompt gated tool set).
+    faux = registerFauxProvider({ provider: "faux", models: [{ id: "faux-1", contextWindow: 200_000 }] });
+  });
+  afterEach(() => {
+    faux.unregister();
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  /**
+   * Register `cfg` as agent type "e2e", run it through the REAL runAgent, and
+   * return the real session's active tool names captured at construction time.
+   */
+  async function activeToolsFor(cfg: Partial<AgentConfig>): Promise<string[]> {
+    registerAgents(
+      new Map([
+        [
+          "e2e",
+          {
+            name: "e2e",
+            description: "e2e",
+            builtinToolNames: BUILTINS,
+            skills: false,
+            systemPrompt: "You are e2e.",
+            promptMode: "replace",
+            inheritContext: false,
+            runInBackground: false,
+            isolated: false,
+            ...cfg,
+          } as AgentConfig,
+        ],
+      ]),
+    );
+    const model = faux.getModel();
+    const modelRegistry: any = {
+      find: () => model,
+      getAll: () => [model],
+      getAvailable: () => [model],
+      hasConfiguredAuth: () => true,
+      isUsingOAuth: () => false,
+      getApiKeyAndHeaders: async () => ({ apiKey: "faux", headers: {} }),
+      registerProvider: () => {},
+      unregisterProvider: () => {},
+    };
+    const ctx: any = { cwd, getSystemPrompt: () => "PARENT", model, modelRegistry };
+
+    let active: string[] = [];
+    try {
+      await runAgent(ctx, "e2e", "go", {
+        pi: makePi(),
+        model,
+        onSessionCreated: (s) => {
+          active = s.getActiveToolNames();
+        },
+      });
+    } catch {
+      // A no-op/erroring prompt turn is fine — the gated tool set is fixed at
+      // construction, which `onSessionCreated` already captured.
+    }
+    return active;
+  }
+
+  it("real pi-mono admits an extension-registered tool when it's in the allowlist (#47)", async () => {
+    const active = await activeToolsFor({ extensions: [FIXTURE] });
+    // The extension actually loaded and its tool reached the live session.
+    expect(active).toContain(EXT_TOOL);
+    for (const b of BUILTINS) expect(active).toContain(b);
+  });
+
+  it("an extension tool is absent when extensions are disabled (not loaded)", async () => {
+    const active = await activeToolsFor({ extensions: false });
+    expect(active).not.toContain(EXT_TOOL);
+    for (const b of BUILTINS) expect(active).toContain(b);
+  });
+
+  it("disallowedTools removes a real extension tool from the live session", async () => {
+    const active = await activeToolsFor({ extensions: [FIXTURE], disallowedTools: [EXT_TOOL] });
+    expect(active).not.toContain(EXT_TOOL); // loaded, then denied at construction
+    expect(active).toContain("read");
+  });
+
+  it("the ext: allowlist flip mutes a loaded-but-unselected extension in real pi-mono", async () => {
+    // Extension loads (extensions: [FIXTURE]), but a single ext: selector for a
+    // *different* name flips extension tools to an allowlist — the unselected
+    // fixture contributes nothing, even though it loaded and ran its handlers.
+    const active = await activeToolsFor({ extensions: [FIXTURE], extSelectors: ["ext:not-the-fixture"] });
+    expect(active).not.toContain(EXT_TOOL);
+    for (const b of BUILTINS) expect(active).toContain(b);
+  });
+
+  it("an ext: selector surfaces the loaded extension's tool through the flip", async () => {
+    // Derive the canonical name the loader/selector matcher uses, so the test
+    // tracks `extensionCanonicalName` rather than hard-coding a filename form.
+    const canon = extensionCanonicalName(FIXTURE);
+    const active = await activeToolsFor({
+      extensions: [FIXTURE],
+      builtinToolNames: ["read"],
+      extSelectors: [`ext:${canon}`],
+    });
+    expect(active).toContain(EXT_TOOL); // selected → surfaces despite the flip
+    expect(active).toContain("read");
+    expect(active).not.toContain("bash"); // builtinToolNames: ["read"] only
+  });
+});

--- a/packages/pi-subagents/test/agent-runner-settings.test.ts
+++ b/packages/pi-subagents/test/agent-runner-settings.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getDefaultMaxTurns,
+  getGraceTurns,
+  normalizeMaxTurns,
+  setDefaultMaxTurns,
+  setGraceTurns,
+} from "../src/agent-runner.js";
+
+describe("setDefaultMaxTurns / getDefaultMaxTurns", () => {
+  beforeEach(() => {
+    setDefaultMaxTurns(undefined);
+  });
+
+  it("defaults to undefined (unlimited)", () => {
+    expect(getDefaultMaxTurns()).toBeUndefined();
+  });
+
+  it("stores a positive integer", () => {
+    setDefaultMaxTurns(30);
+    expect(getDefaultMaxTurns()).toBe(30);
+  });
+
+  it("accepts boundary value 1", () => {
+    setDefaultMaxTurns(1);
+    expect(getDefaultMaxTurns()).toBe(1);
+  });
+
+  it("treats 0 as unlimited", () => {
+    setDefaultMaxTurns(0);
+    expect(getDefaultMaxTurns()).toBeUndefined();
+  });
+
+  it("clamps negative values to 1", () => {
+    setDefaultMaxTurns(-10);
+    expect(getDefaultMaxTurns()).toBe(1);
+  });
+
+  it("undefined resets to unlimited after being set", () => {
+    setDefaultMaxTurns(50);
+    expect(getDefaultMaxTurns()).toBe(50);
+    setDefaultMaxTurns(undefined);
+    expect(getDefaultMaxTurns()).toBeUndefined();
+  });
+});
+
+describe("normalizeMaxTurns", () => {
+  it("treats undefined as unlimited", () => {
+    expect(normalizeMaxTurns(undefined)).toBeUndefined();
+  });
+
+  it("treats 0 as unlimited", () => {
+    expect(normalizeMaxTurns(0)).toBeUndefined();
+  });
+
+  it("keeps positive values", () => {
+    expect(normalizeMaxTurns(7)).toBe(7);
+  });
+
+  it("clamps negative values to 1", () => {
+    expect(normalizeMaxTurns(-3)).toBe(1);
+  });
+});
+
+describe("setGraceTurns / getGraceTurns", () => {
+  beforeEach(() => {
+    setGraceTurns(5);
+  });
+
+  it("defaults to 5", () => {
+    expect(getGraceTurns()).toBe(5);
+  });
+
+  it("stores a positive integer", () => {
+    setGraceTurns(10);
+    expect(getGraceTurns()).toBe(10);
+  });
+
+  it("accepts boundary value 1", () => {
+    setGraceTurns(1);
+    expect(getGraceTurns()).toBe(1);
+  });
+
+  it("clamps 0 to 1", () => {
+    setGraceTurns(0);
+    expect(getGraceTurns()).toBe(1);
+  });
+
+  it("clamps negative values to 1", () => {
+    setGraceTurns(-5);
+    expect(getGraceTurns()).toBe(1);
+  });
+});

--- a/packages/pi-subagents/test/agent-runner.test.ts
+++ b/packages/pi-subagents/test/agent-runner.test.ts
@@ -1,0 +1,1857 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  createAgentSession,
+  defaultResourceLoaderCtor,
+  loaderExtensionsRef,
+  getAgentDir,
+  sessionManagerInMemory,
+  sessionManagerCreate,
+  settingsManagerCreate,
+  settingsManagerGetSessionDir,
+} = vi.hoisted(() => ({
+  createAgentSession: vi.fn(),
+  defaultResourceLoaderCtor: vi.fn(),
+  loaderExtensionsRef: {
+    current: { extensions: [], errors: [], runtime: {} } as {
+      extensions: Array<{ path: string; tools: Map<string, unknown> }>;
+      errors: Array<{ path: string; error: string }>;
+      runtime: Record<string, unknown>;
+    },
+  },
+  getAgentDir: vi.fn(() => "/mock/agent-dir"),
+  sessionManagerInMemory: vi.fn(() => ({ kind: "memory-session-manager" })),
+  sessionManagerCreate: vi.fn(() => ({ kind: "persistent-session-manager" })),
+  settingsManagerGetSessionDir: vi.fn(() => undefined as string | undefined),
+  settingsManagerCreate: vi.fn(() => ({ kind: "settings-manager", getSessionDir: settingsManagerGetSessionDir })),
+}));
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+  createAgentSession,
+  // Mock loader simulates pi-mono: reload() applies additionalExtensionPaths
+  // (an unknown path becomes an error row, mirroring a failed load) and then
+  // runs extensionsOverride over the result.
+  DefaultResourceLoader: class {
+    opts: any;
+    constructor(options: any) {
+      this.opts = options;
+      defaultResourceLoaderCtor(options);
+    }
+
+    async reload() {
+      // Mirror the real loader: `noExtensions: true` zeros out the discovered set
+      // entirely. Otherwise tests pre-register the extensions a path should
+      // resolve to; an unregistered path simply yields no extension (a failed load).
+      if (this.opts.noExtensions) {
+        loaderExtensionsRef.current = { extensions: [], errors: [], runtime: {} };
+        return;
+      }
+      if (this.opts.extensionsOverride) {
+        loaderExtensionsRef.current = this.opts.extensionsOverride(loaderExtensionsRef.current);
+      }
+    }
+
+    getExtensions() {
+      return loaderExtensionsRef.current;
+    }
+  },
+  getAgentDir,
+  SessionManager: { inMemory: sessionManagerInMemory, create: sessionManagerCreate },
+  SettingsManager: { create: settingsManagerCreate },
+}));
+
+vi.mock("../src/agent-types.js", () => ({
+  BUILTIN_TOOL_NAMES: ["read", "bash", "edit", "write", "grep", "find", "ls"],
+  getConfig: vi.fn(() => ({
+    displayName: "Explore",
+    description: "Explore",
+    builtinToolNames: ["read"],
+    extensions: false,
+    skills: false,
+    promptMode: "replace",
+  })),
+  getAgentConfig: vi.fn(() => ({
+    name: "Explore",
+    description: "Explore",
+    builtinToolNames: ["read"],
+    extensions: false,
+    skills: false,
+    systemPrompt: "You are Explore.",
+    promptMode: "replace",
+    inheritContext: false,
+    runInBackground: false,
+    isolated: false,
+  })),
+  getMemoryToolNames: vi.fn(() => []),
+  getReadOnlyMemoryToolNames: vi.fn(() => []),
+  getToolNamesForType: vi.fn(() => ["read"]),
+}));
+
+vi.mock("../src/env.js", () => ({
+  detectEnv: vi.fn(async () => ({ isGitRepo: false, branch: "", platform: "linux" })),
+}));
+
+vi.mock("../src/prompts.js", () => ({
+  buildAgentPrompt: vi.fn(() => "system prompt"),
+}));
+
+vi.mock("../src/memory.js", () => ({
+  buildMemoryBlock: vi.fn(() => ""),
+  buildReadOnlyMemoryBlock: vi.fn(() => ""),
+}));
+
+vi.mock("../src/skill-loader.js", () => ({
+  preloadSkills: vi.fn(() => []),
+}));
+
+import {
+  extensionCanonicalName,
+  extensionCanonicalNames,
+  getAgentConversation,
+  parseExtensionsSpec,
+  parseExtSelectors,
+  resumeAgent,
+  runAgent,
+  SUBAGENT_TOOL_NAMES,
+} from "../src/agent-runner.js";
+
+/** The most recent session built by `createSession` — read by `lastToolsPassed()`. */
+let lastSession: ReturnType<typeof createSession>["session"] | undefined;
+
+function createSession(finalText: string) {
+  const listeners: Array<(event: any) => void> = [];
+  // pi activates only these four by default when no allowlist is given
+  // (agent-session.js `defaultActiveToolNames`).
+  let activeToolNames: string[] = ["read", "bash", "edit", "write"];
+  const session = {
+    messages: [] as any[],
+    subscribe: vi.fn((listener: (event: any) => void) => {
+      listeners.push(listener);
+      return () => {};
+    }),
+    prompt: vi.fn(async () => {
+      session.messages.push({
+        role: "assistant",
+        content: [{ type: "text", text: finalText }],
+      });
+    }),
+    abort: vi.fn(),
+    steer: vi.fn(),
+    // Stateful, so the active set reflects what the scope installer actually did
+    // and `renarrow`'s no-op guard behaves as it does against real pi.
+    getActiveToolNames: vi.fn(() => activeToolNames),
+    setActiveToolsByName: vi.fn((names: string[]) => {
+      activeToolNames = [...names];
+    }),
+    // pi's tool REGISTRY (`_toolDefinitions`), read live so tests can simulate an
+    // extension registering after bind by mutating `loaderExtensionsRef`.
+    getAllTools: vi.fn(() => {
+      const opts = createAgentSession.mock.calls[0]?.[0];
+      return opts ? mockRegistry(opts).map((name) => ({ name })) : [];
+    }),
+    // pi's Agent; `beforeToolCall` is an optional, assignable hook the scope
+    // installer wraps to block out-of-scope calls on turn 1.
+    agent: { beforeToolCall: undefined } as {
+      beforeToolCall?: (context: any, signal?: any) => Promise<any>;
+    },
+    setSessionName: vi.fn(),
+    bindExtensions: vi.fn(async () => {}),
+  };
+  lastSession = session;
+  return { session, listeners };
+}
+
+const ctx = {
+  cwd: "/tmp",
+  model: undefined,
+  modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+  getSystemPrompt: vi.fn(() => "parent prompt"),
+  sessionManager: { getBranch: vi.fn(() => []) },
+} as any;
+
+const pi = {} as any;
+
+beforeEach(() => {
+  createAgentSession.mockReset();
+  defaultResourceLoaderCtor.mockClear();
+  getAgentDir.mockClear();
+  sessionManagerInMemory.mockClear();
+  sessionManagerCreate.mockClear();
+  settingsManagerGetSessionDir.mockReset();
+  settingsManagerGetSessionDir.mockReturnValue(undefined);
+  settingsManagerCreate.mockClear();
+  loaderExtensionsRef.current = { extensions: [], errors: [], runtime: {} };
+  lastSession = undefined;
+});
+
+describe("agent-runner final output capture", () => {
+  it("returns the final assistant text even when no text_delta events were streamed", async () => {
+    const { session } = createSession("LOCKED");
+    createAgentSession.mockResolvedValue({ session });
+
+    const result = await runAgent(ctx, "Explore", "Say LOCKED", { pi });
+
+    expect(result.responseText).toBe("LOCKED");
+  });
+
+  it("binds extensions before prompting", async () => {
+    const { session } = createSession("BOUND");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "Say BOUND", { pi });
+
+    expect(session.bindExtensions).toHaveBeenCalledTimes(1);
+    expect(session.bindExtensions).toHaveBeenCalledWith(
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+
+    const bindOrder = session.bindExtensions.mock.invocationCallOrder[0];
+    const promptOrder = session.prompt.mock.invocationCallOrder[0];
+    expect(bindOrder).toBeLessThan(promptOrder);
+  });
+
+  it("passes effective cwd and agentDir to the loader and settings manager", async () => {
+    const { session } = createSession("CONFIGURED");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "Say CONFIGURED", { pi, cwd: "/tmp/worktree" });
+
+    expect(getAgentDir).toHaveBeenCalledTimes(1);
+    expect(defaultResourceLoaderCtor).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: "/tmp/worktree",
+      agentDir: "/mock/agent-dir",
+    }));
+    expect(settingsManagerCreate).toHaveBeenCalledWith("/tmp/worktree", "/mock/agent-dir");
+    expect(sessionManagerInMemory).toHaveBeenCalledWith("/tmp/worktree");
+    expect(createAgentSession).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: "/tmp/worktree",
+      agentDir: "/mock/agent-dir",
+    }));
+  });
+
+  it("passes the parent model runtime while retaining the legacy model registry", async () => {
+    const { session } = createSession("AUTHENTICATED");
+    createAgentSession.mockResolvedValue({ session });
+    const modelRuntime = { getAuth: vi.fn(), hasConfiguredAuth: vi.fn() };
+    const context = {
+      ...ctx,
+      modelRegistry: { ...ctx.modelRegistry, runtime: modelRuntime },
+    };
+
+    await runAgent(context, "Explore", "Say AUTHENTICATED", { pi });
+
+    expect(createAgentSession).toHaveBeenCalledWith(expect.objectContaining({
+      modelRegistry: context.modelRegistry,
+      modelRuntime,
+    }));
+  });
+
+  it("omits modelRuntime when the legacy registry does not expose one", async () => {
+    const { session } = createSession("LEGACY");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "Say LEGACY", { pi });
+
+    expect(createAgentSession.mock.calls[0][0]).not.toHaveProperty("modelRuntime");
+  });
+
+  it("suppresses AGENTS.md/CLAUDE.md/APPEND_SYSTEM.md for subagents", async () => {
+    const { session } = createSession("ISOLATED");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "Say ISOLATED", { pi });
+
+    // noContextFiles skips AGENTS.md/CLAUDE.md at the loader source;
+    // appendSystemPromptOverride suppresses APPEND_SYSTEM.md (no flag equivalent).
+    expect(defaultResourceLoaderCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        noContextFiles: true,
+        appendSystemPromptOverride: expect.any(Function),
+      }),
+    );
+    // The override returns an empty list so any loaded sources are discarded.
+    const ctorArgs = defaultResourceLoaderCtor.mock.calls[0][0];
+    expect(ctorArgs.appendSystemPromptOverride(["would-be-loaded"])).toEqual([]);
+  });
+
+  it("resumeAgent also falls back to the final assistant message text", async () => {
+    const { session } = createSession("RESUMED");
+
+    const result = await resumeAgent(session as any, "Continue");
+
+    expect(result.text).toBe("RESUMED");
+    expect(result.failure).toBeUndefined();
+  });
+
+  it("sets the agent name as session name before binding extensions", async () => {
+    const { session } = createSession("NAMED");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(session.setSessionName).toHaveBeenCalledWith("Explore");
+    const setOrder = session.setSessionName.mock.invocationCallOrder[0];
+    const bindOrder = session.bindExtensions.mock.invocationCallOrder[0];
+    expect(setOrder).toBeLessThan(bindOrder);
+  });
+
+  it("suffixes the session name with a short agentId so parallel spawns are distinguishable", async () => {
+    const { session } = createSession("NAMED");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi, agentId: "a1b2c3d4e5f6" });
+
+    expect(session.setSessionName).toHaveBeenCalledWith("Explore#a1b2c3d4");
+  });
+});
+
+// #144 — a failed FINAL assistant turn (stopReason "error") must surface as
+// `failure`; how the turn STOPPED decides, never whether it produced text.
+describe("agent-runner failed-final-turn detection (#144)", () => {
+  /** Session whose prompt() appends the given messages to history. */
+  function sessionEnding(...messages: any[]) {
+    const { session } = createSession("");
+    session.prompt = vi.fn(async () => {
+      session.messages.push(...messages);
+    }) as any;
+    return session;
+  }
+
+  const errorFinal = {
+    role: "assistant",
+    content: [],
+    stopReason: "error",
+    errorMessage: "retries exhausted: 529 overloaded",
+  };
+
+  it("flags a run whose final turn is an empty provider error", async () => {
+    const session = sessionEnding(errorFinal);
+    createAgentSession.mockResolvedValue({ session });
+
+    const result = await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(result.failure).toBe("retries exhausted: 529 overloaded");
+  });
+
+  it("flags the failure even when an EARLIER turn produced text (no masking)", async () => {
+    const session = sessionEnding(
+      { role: "assistant", content: [{ type: "text", text: "partial progress" }] },
+      { role: "toolResult", content: [] },
+      errorFinal,
+    );
+    createAgentSession.mockResolvedValue({ session });
+
+    const result = await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(result.failure).toBe("retries exhausted: 529 overloaded");
+    // The earlier text stays available as context — status honesty, not data loss.
+    expect(result.responseText).toBe("partial progress");
+  });
+
+  it("flags a provider error that left partial text in the SAME final message", async () => {
+    const session = sessionEnding({
+      role: "assistant",
+      content: [{ type: "text", text: "truncated answ" }],
+      stopReason: "error",
+      errorMessage: "stream ended before message_stop",
+    });
+    createAgentSession.mockResolvedValue({ session });
+
+    const result = await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(result.failure).toBe("stream ended before message_stop");
+    expect(result.responseText).toBe("truncated answ");
+  });
+
+  it("flags a run whose final turn hit the token limit with no text (#144 residual)", async () => {
+    // stopReason "length" with empty content is a silent max-token death — it
+    // reproduces the #144 "completed with No output." symptom, so it must fail.
+    const session = sessionEnding({ role: "assistant", content: [], stopReason: "length" });
+    createAgentSession.mockResolvedValue({ session });
+
+    const result = await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(result.failure).toBe("run hit the output token limit before producing any text");
+  });
+
+  it("does NOT flag a length stop that produced text (truncated answer completes)", async () => {
+    const session = sessionEnding({
+      role: "assistant",
+      content: [{ type: "text", text: "truncated but useful answer" }],
+      stopReason: "length",
+    });
+    createAgentSession.mockResolvedValue({ session });
+
+    const result = await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(result.failure).toBeUndefined();
+    expect(result.responseText).toBe("truncated but useful answer");
+  });
+
+  it("does NOT flag an empty final turn that stopped cleanly (no false failures)", async () => {
+    const session = sessionEnding(
+      { role: "assistant", content: [{ type: "text", text: "did the work" }] },
+      { role: "toolResult", content: [] },
+      { role: "assistant", content: [], stopReason: "stop" },
+    );
+    createAgentSession.mockResolvedValue({ session });
+
+    const result = await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(result.failure).toBeUndefined();
+    expect(result.responseText).toBe("did the work"); // walk-back fallback preserved
+  });
+
+  it("resumeAgent applies the same rule", async () => {
+    const { session } = createSession("");
+    session.prompt = vi.fn(async () => {
+      session.messages.push(errorFinal);
+    }) as any;
+
+    const result = await resumeAgent(session as any, "Continue");
+
+    expect(result.failure).toBe("retries exhausted: 529 overloaded");
+  });
+
+  it("resume whose new turn fails empty does NOT return the previous turn's answer (#144)", async () => {
+    // The session already carries a completed prior turn; the resume prompt then
+    // fails empty. The walk-back must be bounded to this resume — result "".
+    const { session } = createSession("");
+    session.messages.push(
+      { role: "user", content: "first question" },
+      { role: "assistant", content: [{ type: "text", text: "PREVIOUS ANSWER" }], stopReason: "stop" },
+    );
+    session.prompt = vi.fn(async () => {
+      session.messages.push({ role: "user", content: "follow-up" }, errorFinal);
+    }) as any;
+
+    const result = await resumeAgent(session as any, "follow-up");
+
+    expect(result.failure).toBe("retries exhausted: 529 overloaded");
+    expect(result.text).toBe(""); // NOT "PREVIOUS ANSWER"
+  });
+
+  it("resume that produces partial text before failing returns only THIS resume's text", async () => {
+    const { session } = createSession("");
+    session.messages.push(
+      { role: "assistant", content: [{ type: "text", text: "PREVIOUS ANSWER" }], stopReason: "stop" },
+    );
+    session.prompt = vi.fn(async () => {
+      session.messages.push(
+        { role: "assistant", content: [{ type: "text", text: "new partial" }] },
+        { role: "toolResult", content: [] },
+        errorFinal,
+      );
+    }) as any;
+
+    const result = await resumeAgent(session as any, "go");
+
+    expect(result.failure).toBe("retries exhausted: 529 overloaded");
+    expect(result.text).toBe("new partial"); // this resume's progress, not the prior answer
+  });
+
+  it("collector: a toolResult/user message_start no longer wipes collected assistant text", async () => {
+    const { session, listeners } = createSession("");
+    createAgentSession.mockResolvedValue({ session });
+    session.prompt = vi.fn(async () => {
+      for (const l of listeners) {
+        l({ type: "message_start", message: { role: "assistant" } });
+        l({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "STREAMED" } });
+        // pi emits message_start for tool results and queued user messages too.
+        l({ type: "message_start", message: { role: "toolResult" } });
+        l({ type: "message_start", message: { role: "user" } });
+      }
+    }) as any;
+
+    const result = await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(result.responseText).toBe("STREAMED");
+  });
+});
+
+// ─── message_end → onAssistantUsage wiring (issue #38) ─────────────────
+// Both runAgent and resumeAgent dispatch usage to the caller via this
+// callback. The callback feeds the AgentRecord lifetime accumulator, which
+// is the source of truth for total tokens (survives compaction).
+describe("agent-runner usage callback wiring", () => {
+  function emitMessageEnd(listeners: Array<(e: any) => void>, usage: any) {
+    const event = { type: "message_end", message: { role: "assistant", usage } };
+    for (const l of listeners) l(event);
+  }
+
+  it("runAgent forwards full usage from message_end events", async () => {
+    const { session, listeners } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    const seen: Array<{ input: number; output: number; cacheWrite: number }> = [];
+    session.prompt = vi.fn(async () => {
+      // Two assistant messages over the run
+      emitMessageEnd(listeners, { input: 100, output: 50, cacheWrite: 10 });
+      emitMessageEnd(listeners, { input: 200, output: 80, cacheWrite: 20 });
+      session.messages.push({ role: "assistant", content: [{ type: "text", text: "OK" }] });
+    });
+
+    await runAgent(ctx, "Explore", "go", {
+      pi,
+      onAssistantUsage: (u) => seen.push(u),
+    });
+
+    expect(seen).toEqual([
+      { input: 100, output: 50, cacheWrite: 10 },
+      { input: 200, output: 80, cacheWrite: 20 },
+    ]);
+  });
+
+  it("runAgent normalizes partial usage objects to 0 for missing fields", async () => {
+    const { session, listeners } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    const seen: any[] = [];
+    session.prompt = vi.fn(async () => {
+      emitMessageEnd(listeners, { input: 50 }); // output, cacheWrite missing
+      session.messages.push({ role: "assistant", content: [{ type: "text", text: "OK" }] });
+    });
+
+    await runAgent(ctx, "Explore", "go", {
+      pi,
+      onAssistantUsage: (u) => seen.push(u),
+    });
+
+    expect(seen).toEqual([{ input: 50, output: 0, cacheWrite: 0 }]);
+  });
+
+  it("runAgent skips the callback when message_end has no usage field", async () => {
+    const { session, listeners } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    const cb = vi.fn();
+    session.prompt = vi.fn(async () => {
+      emitMessageEnd(listeners, undefined);
+      session.messages.push({ role: "assistant", content: [{ type: "text", text: "OK" }] });
+    });
+
+    await runAgent(ctx, "Explore", "go", { pi, onAssistantUsage: cb });
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("resumeAgent forwards usage on message_end the same way", async () => {
+    const { session, listeners } = createSession("RESUMED");
+    const seen: any[] = [];
+
+    session.prompt = vi.fn(async () => {
+      emitMessageEnd(listeners, { input: 10, output: 20, cacheWrite: 5 });
+      session.messages.push({ role: "assistant", content: [{ type: "text", text: "RESUMED" }] });
+    });
+
+    await resumeAgent(session as any, "continue", {
+      onAssistantUsage: (u) => seen.push(u),
+    });
+
+    expect(seen).toEqual([{ input: 10, output: 20, cacheWrite: 5 }]);
+  });
+
+  it("forwards compaction_end events to onCompaction (only when not aborted)", async () => {
+    const { session, listeners } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    const seen: any[] = [];
+    session.prompt = vi.fn(async () => {
+      // Successful compaction — should fire
+      for (const l of listeners) l({
+        type: "compaction_end",
+        aborted: false,
+        reason: "threshold",
+        result: { tokensBefore: 12345 },
+      });
+      // Aborted compaction — should NOT fire
+      for (const l of listeners) l({
+        type: "compaction_end",
+        aborted: true,
+        reason: "manual",
+        result: { tokensBefore: 99999 },
+      });
+      session.messages.push({ role: "assistant", content: [{ type: "text", text: "OK" }] });
+    });
+
+    await runAgent(ctx, "Explore", "go", {
+      pi,
+      onCompaction: (info) => seen.push(info),
+    });
+
+    expect(seen).toEqual([{ reason: "threshold", tokensBefore: 12345 }]);
+  });
+});
+
+// getAgentConversation renders the subagent transcript shown in the /agents
+// inspect overlay. Pure function over session.messages — no mocks needed
+// beyond a literal-object session.
+describe("getAgentConversation", () => {
+  function fakeSession(messages: unknown[]) {
+    return { messages } as never;
+  }
+
+  it("returns an empty string for a session with no messages", () => {
+    expect(getAgentConversation(fakeSession([]))).toBe("");
+  });
+
+  it("formats a user-then-assistant exchange with role-prefixed lines joined by blank lines", () => {
+    const out = getAgentConversation(
+      fakeSession([
+        { role: "user", content: "hi" },
+        { role: "assistant", content: [{ type: "text", text: "hello" }] },
+      ]),
+    );
+    expect(out).toBe("[User]: hi\n\n[Assistant]: hello");
+  });
+
+  it("accepts user content as content-blocks (not just strings)", () => {
+    const out = getAgentConversation(
+      fakeSession([{ role: "user", content: [{ type: "text", text: "from blocks" }] }]),
+    );
+    expect(out).toBe("[User]: from blocks");
+  });
+
+  it("emits a [Tool Calls] block listing each toolCall by name or toolName, falling back to 'unknown'", () => {
+    const out = getAgentConversation(
+      fakeSession([
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "calling tools" },
+            { type: "toolCall", name: "search" },
+            { type: "toolCall", toolName: "edit" },
+            { type: "toolCall" },
+          ],
+        },
+      ]),
+    );
+    expect(out).toContain("[Assistant]: calling tools");
+    expect(out).toContain("[Tool Calls]:\n  Tool: search\n  Tool: edit\n  Tool: unknown");
+  });
+
+  it("truncates toolResult content beyond 200 chars and tags it with the tool name", () => {
+    const longText = "x".repeat(300);
+    const out = getAgentConversation(
+      fakeSession([
+        {
+          role: "toolResult",
+          toolName: "bash",
+          content: [{ type: "text", text: longText }],
+        },
+      ]),
+    );
+    expect(out.startsWith("[Tool Result (bash)]: ")).toBe(true);
+    expect(out.endsWith("...")).toBe(true);
+    // prefix + 200 chars + "..."
+    expect(out.length).toBe("[Tool Result (bash)]: ".length + 200 + 3);
+  });
+
+  it("emits [Tool Calls] but no [Assistant] when the assistant only made tool calls", () => {
+    const out = getAgentConversation(
+      fakeSession([
+        { role: "user", content: "do it" },
+        { role: "assistant", content: [{ type: "toolCall", name: "search" }] },
+      ]),
+    );
+    expect(out).toContain("[User]: do it");
+    expect(out).not.toContain("[Assistant]:");
+    expect(out).toContain("[Tool Calls]:\n  Tool: search");
+  });
+});
+
+// ─── tool scoping (issues #47, #125) ─────────────────────────────────────
+// runAgent scopes a subagent's tools in one of two ways:
+//   • Static allowlist (`tools:`) — ONLY for noExtensions/isolated. Nothing can
+//     register asynchronously there, so pi-mono's `allowedToolNames` gating both
+//     registration and the initial active set is exactly right.
+//   • Live scoping — whenever extensions load. `tools:` is left unset so pi's
+//     live `isAllowedTool` admits tools whenever they register (pi-mcp registers
+//     on session_start, context-mode on before_agent_start); `excludeTools:`
+//     carries the name-stable permanent scope; and `installExtensionToolScope`
+//     narrows the ACTIVE set for `ext:` selectors, re-deriving on every turn_end
+//     so late arrivals are judged too.
+// `lastToolsPassed()` returns what the LLM can actually call under either shape.
+
+import {
+  getAgentConfig,
+  getConfig,
+  getToolNamesForType,
+} from "../src/agent-types.js";
+
+const BUILTINS_7 = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+
+function makeAgentConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "test-agent",
+    description: "Test",
+    builtinToolNames: BUILTINS_7,
+    extensions: true as boolean | string[],
+    skills: false as boolean | string[],
+    systemPrompt: "Test.",
+    promptMode: "replace" as const,
+    inheritContext: false,
+    runInBackground: false,
+    isolated: false,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    displayName: "test-agent",
+    description: "Test",
+    builtinToolNames: BUILTINS_7,
+    extensions: true as boolean | string[],
+    skills: false as boolean | string[],
+    promptMode: "replace" as const,
+    ...overrides,
+  };
+}
+
+/** Register extensions for the mock loader, keyed by extension path → tool names. */
+function withExtensions(spec: Record<string, string[]>) {
+  loaderExtensionsRef.current = {
+    extensions: Object.entries(spec).map(([path, tools]) => ({
+      path,
+      tools: new Map(tools.map((n) => [n, {}])),
+    })),
+    errors: [],
+    runtime: {},
+  };
+}
+
+/**
+ * The tool REGISTRY pi would build for a given `createAgentSession` call —
+ * mirroring `_refreshToolRegistry`'s `isAllowedTool`:
+ *   - `tools:` set   → the allowlist gates the registry (nothing else registers).
+ *   - `tools:` unset → every built-in plus every loaded extension tool, minus
+ *     `excludeTools`, and it keeps growing as extensions register later.
+ * Read live from `loaderExtensionsRef`, so a test can simulate late registration.
+ */
+function mockRegistry(opts: Record<string, any>): string[] {
+  const excluded = new Set<string>(opts.excludeTools ?? []);
+  const all: string[] = opts.tools
+    ? [...opts.tools]
+    : [
+        ...BUILTINS_7,
+        ...loaderExtensionsRef.current.extensions.flatMap((e) => [...e.tools.keys()]),
+      ];
+  return [...new Set(all)].filter((t) => !excluded.has(t));
+}
+
+/**
+ * What the LLM can actually call.
+ *
+ * Under the static allowlist (`noExtensions`/`isolated`) that is `tools:` verbatim.
+ * Otherwise the registry is scoped by `excludeTools` and then narrowed to the ACTIVE
+ * set by `installExtensionToolScope` — so the active set is the real answer, and
+ * asserting on it means these tests exercise the narrowing rather than a
+ * reimplementation of pi's gate.
+ */
+function lastToolsPassed(): string[] {
+  const opts = createAgentSession.mock.calls[0][0];
+  if (opts.tools) return opts.tools;
+  return lastSession?.getActiveToolNames() ?? [];
+}
+
+function lastLoaderOpts(): Record<string, unknown> {
+  return defaultResourceLoaderCtor.mock.calls[0][0];
+}
+
+describe("agent-runner session persistence", () => {
+  it("uses an in-memory session by default", async () => {
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig());
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(sessionManagerInMemory).toHaveBeenCalledWith("/tmp");
+    expect(sessionManagerCreate).not.toHaveBeenCalled();
+    expect(createAgentSession).toHaveBeenCalledWith(expect.objectContaining({
+      sessionManager: { kind: "memory-session-manager" },
+    }));
+  });
+
+  it("uses pi's normal persistent session location when persistSession is true", async () => {
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig({ persistSession: true }));
+    settingsManagerGetSessionDir.mockReturnValue("/normal/pi/sessions");
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(sessionManagerInMemory).not.toHaveBeenCalled();
+    expect(sessionManagerCreate).toHaveBeenCalledWith("/tmp", "/normal/pi/sessions");
+    expect(createAgentSession).toHaveBeenCalledWith(expect.objectContaining({
+      sessionManager: { kind: "persistent-session-manager" },
+    }));
+  });
+
+  it("uses a frontmatter sessionDir when persistSession is true and sessionDir is configured", async () => {
+    vi.mocked(getAgentConfig).mockReturnValueOnce(
+      makeAgentConfig({ persistSession: true, sessionDir: ".seams/pi-sessions/seam-plan-reviewer" }),
+    );
+    settingsManagerGetSessionDir.mockReturnValue("/normal/pi/sessions");
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi, cwd: "/repo" });
+
+    expect(sessionManagerCreate).toHaveBeenCalledWith(
+      "/repo",
+      "/repo/.seams/pi-sessions/seam-plan-reviewer",
+    );
+  });
+});
+
+describe("agent-runner master tool allowlist", () => {
+  it("extensions: true with extension tools — all 7 built-ins plus extension tools land in the allowlist", async () => {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: true }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig({ extensions: true }));
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
+    withExtensions({ "/ext/mcp.ts": ["mcp", "mcp_call"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    // Order is not semantically meaningful (pi-mono dedupes via Set);
+    // assert membership and exact size instead.
+    const tools = lastToolsPassed();
+    expect(tools).toHaveLength(BUILTINS_7.length + 2);
+    expect(new Set(tools)).toEqual(new Set([...BUILTINS_7, "mcp", "mcp_call"]));
+  });
+
+  it("enumerates tools across multiple loaded extensions", async () => {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: true }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig({ extensions: true }));
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
+    withExtensions({ "/ext/a.ts": ["tool_a"], "/ext/b.ts": ["tool_b"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    expect(tools).toContain("tool_a");
+    expect(tools).toContain("tool_b");
+  });
+
+  it("disallowedTools removes both built-ins and extension tools", async () => {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: true }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(
+      makeAgentConfig({ extensions: true, disallowedTools: ["bash", "mcp"] }),
+    );
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
+    withExtensions({ "/ext/mcp.ts": ["mcp", "mcp_call"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    expect(tools).not.toContain("bash");
+    expect(tools).not.toContain("mcp");
+    expect(tools).toContain("mcp_call");
+    expect(tools).toContain("read");
+  });
+
+  it("EXCLUDED_TOOL_NAMES never reach the allowlist even if an extension registers them", async () => {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: true }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig({ extensions: true }));
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
+    withExtensions({
+      "/ext/evil.ts": ["Agent", "get_subagent_result", "steer_subagent", "ok_ext"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    expect(tools).not.toContain("Agent");
+    expect(tools).not.toContain("get_subagent_result");
+    expect(tools).not.toContain("steer_subagent");
+    expect(tools).toContain("ok_ext");
+  });
+
+  it("extensions: false with disallowedTools — denylist applies to built-ins", async () => {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: false }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(
+      makeAgentConfig({ extensions: false, disallowedTools: ["bash"] }),
+    );
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    expect(tools).not.toContain("bash");
+    expect(tools).toEqual(BUILTINS_7.filter((t) => t !== "bash"));
+  });
+
+  it("dynamic mode: leaves the allowlist unset, denies via excludeTools, activates post-bind", async () => {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: true }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(
+      makeAgentConfig({ extensions: true, disallowedTools: ["bash"] }),
+    );
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
+    withExtensions({ "/ext/mcp.ts": ["mcp"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    // Allowlist unset so async tools (e.g. MCP on session_start) can register;
+    // scope is a denylist of this extension's own tools plus `disallowedTools`.
+    const opts = createAgentSession.mock.calls[0][0];
+    expect(opts.tools).toBeUndefined();
+    expect(new Set(opts.excludeTools)).toEqual(
+      new Set([...Object.values(SUBAGENT_TOOL_NAMES), "bash"]),
+    );
+
+    // The active set is repaired AFTER bindExtensions (tools may register during
+    // session_start), activating the full allowed registry — the extension tool
+    // included, the denied built-in excluded.
+    expect(session.setActiveToolsByName).toHaveBeenCalledTimes(1);
+    const setOrder = session.setActiveToolsByName.mock.invocationCallOrder[0];
+    const bindOrder = session.bindExtensions.mock.invocationCallOrder[0];
+    expect(setOrder).toBeGreaterThan(bindOrder);
+    const activated = new Set(session.setActiveToolsByName.mock.calls[0][0]);
+    expect(activated.has("mcp")).toBe(true);
+    expect(activated.has("read")).toBe(true);
+    expect(activated.has("bash")).toBe(false);
+  });
+});
+
+// ─── asynchronously-registered extension tools (issue #125) ──────────────
+// pi-mcp calls registerTool from `session_start`, context-mode from
+// `before_agent_start` — both long after loader.reload(). `registerTool` writes
+// into the live `extension.tools` map, which is what these tests simulate.
+describe("agent-runner async extension tool registration", () => {
+  /** Simulate `pi.registerTool` on an already-loaded extension. */
+  function registerLate(extPath: string, toolName: string) {
+    const ext = loaderExtensionsRef.current.extensions.find((e) => e.path === extPath);
+    if (!ext) throw new Error(`no loaded extension at ${extPath}`);
+    ext.tools.set(toolName, {});
+  }
+
+  function setup(o: { builtinToolNames?: string[]; extSelectors?: string[] } = {}) {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: true }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(
+      makeAgentConfig({ extensions: true, extSelectors: o.extSelectors }),
+    );
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(o.builtinToolNames ?? ["read"]);
+  }
+
+  it("a tool registered during session_start reaches the active set", async () => {
+    setup();
+    withExtensions({ "/ext/mcp.ts": [] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    // pi-mcp's real shape: nothing at load, tools appear when bindExtensions
+    // fires session_start and the MCP servers connect.
+    session.bindExtensions.mockImplementation(async () => {
+      registerLate("/ext/mcp.ts", "mcp_search");
+    });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(lastToolsPassed()).toContain("mcp_search");
+  });
+
+  it("a tool registered after bind is picked up on the next turn_end", async () => {
+    setup();
+    withExtensions({ "/ext/mcp.ts": [] });
+    const { session, listeners } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+    expect(session.getActiveToolNames()).not.toContain("mcp_search");
+
+    // A lazy MCP server connects mid-conversation (context-mode registers at
+    // before_agent_start, i.e. after runAgent already installed the scope).
+    registerLate("/ext/mcp.ts", "mcp_search");
+    for (const l of listeners) l({ type: "turn_end" });
+
+    expect(session.getActiveToolNames()).toContain("mcp_search");
+  });
+
+  it("ext: admits a late tool from the selected extension but not from others", async () => {
+    setup({ extSelectors: ["ext:foo"] });
+    withExtensions({ "/ext/foo.ts": [], "/ext/bar.ts": [] });
+    const { session, listeners } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    registerLate("/ext/foo.ts", "foo_late");
+    registerLate("/ext/bar.ts", "bar_late");
+    for (const l of listeners) l({ type: "turn_end" });
+
+    const active = session.getActiveToolNames();
+    expect(active).toContain("foo_late");
+    // This is the case the static allowlist could never express: bar_late did
+    // not exist at construction, so it could not have been denied by name.
+    expect(active).not.toContain("bar_late");
+  });
+
+  it("ext:foo/bar narrowing still applies to late-registered siblings", async () => {
+    setup({ extSelectors: ["ext:foo/keep_me"] });
+    withExtensions({ "/ext/foo.ts": [] });
+    const { session, listeners } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    registerLate("/ext/foo.ts", "keep_me");
+    registerLate("/ext/foo.ts", "drop_me");
+    for (const l of listeners) l({ type: "turn_end" });
+
+    expect(session.getActiveToolNames()).toContain("keep_me");
+    expect(session.getActiveToolNames()).not.toContain("drop_me");
+  });
+
+  it("beforeToolCall blocks an out-of-scope tool and delegates otherwise", async () => {
+    // Turn 1 cannot be narrowed — before_agent_start fires inside prompt() and
+    // may widen the set after the turn's tools are snapshotted — so a call-time
+    // guard is the only correct enforcement there.
+    setup({ extSelectors: ["ext:foo"] });
+    withExtensions({ "/ext/foo.ts": ["foo_tool"], "/ext/bar.ts": ["bar_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    await expect(
+      session.agent.beforeToolCall?.({ toolCall: { name: "bar_tool" } }),
+    ).resolves.toMatchObject({ block: true });
+    await expect(
+      session.agent.beforeToolCall?.({ toolCall: { name: "foo_tool" } }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("beforeToolCall preserves a hook pi installed before us", async () => {
+    setup();
+    withExtensions({ "/ext/foo.ts": ["foo_tool"] });
+    const { session } = createSession("OK");
+    const prior = vi.fn(async () => undefined);
+    session.agent.beforeToolCall = prior;
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+    await session.agent.beforeToolCall?.({ toolCall: { name: "foo_tool" } });
+
+    expect(prior).toHaveBeenCalledTimes(1);
+  });
+
+  it("scope outlives runAgent so resumed turns stay narrowed", async () => {
+    // runAgent tears down its own turn subscription in `finally`; the scope
+    // hooks must NOT be torn down with it, or resume/steer would drift.
+    setup({ extSelectors: ["ext:foo"] });
+    withExtensions({ "/ext/foo.ts": [], "/ext/bar.ts": [] });
+    const { session, listeners } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+    await resumeAgent(session as any, "keep going");
+
+    registerLate("/ext/foo.ts", "foo_late");
+    registerLate("/ext/bar.ts", "bar_late");
+    for (const l of listeners) l({ type: "turn_end" });
+
+    expect(session.getActiveToolNames()).toContain("foo_late");
+    expect(session.getActiveToolNames()).not.toContain("bar_late");
+    await expect(
+      session.agent.beforeToolCall?.({ toolCall: { name: "bar_late" } }),
+    ).resolves.toMatchObject({ block: true });
+  });
+
+  it("isolated keeps the static allowlist — no live scoping installed", async () => {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: false }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig({ extensions: false }));
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(["read"]);
+    withExtensions({ "/ext/foo.ts": ["foo_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi, isolated: true });
+
+    // A hard registry gate is the right boundary here: nothing can register
+    // asynchronously, so there is no active-set narrowing to maintain.
+    expect(createAgentSession.mock.calls[0][0].tools).toEqual(["read"]);
+    expect(session.setActiveToolsByName).not.toHaveBeenCalled();
+    expect(session.agent.beforeToolCall).toBeUndefined();
+  });
+});
+
+// ─── extensions: string[] as a loader-level extension filter ────────────
+// An array entry is a bare name (filters default-discovered extensions),
+// a path (loads that extension fresh), or "*" (keep all defaults).
+// Filtering happens at the loader via additionalExtensionPaths +
+// extensionsOverride — excluded extensions never bind handlers or register
+// tools.
+
+describe("extensionCanonicalName", () => {
+  it("strips .ts/.js from a single-file extension basename", () => {
+    expect(extensionCanonicalName("/x/foo.ts")).toBe("foo");
+    expect(extensionCanonicalName("/x/foo.js")).toBe("foo");
+  });
+  it("uses the parent directory name for index.{ts,js} extensions", () => {
+    expect(extensionCanonicalName("/x/foo/index.ts")).toBe("foo");
+    expect(extensionCanonicalName("/x/foo/index.js")).toBe("foo");
+  });
+  it("lowercases the result for case-insensitive matching", () => {
+    expect(extensionCanonicalName("/x/MCP.ts")).toBe("mcp");
+    expect(extensionCanonicalName("/x/MyExt.js")).toBe("myext");
+    expect(extensionCanonicalName("/x/Foo/index.ts")).toBe("foo");
+  });
+});
+
+describe("extensionCanonicalNames (#143 — package short name alias)", () => {
+  const tmpDirs: string[] = [];
+  function pkgDir(name: string, piExtensions: unknown): string {
+    const dir = mkdtempSync(join(tmpdir(), "subagents-pkg-"));
+    tmpDirs.push(dir);
+    const manifest: Record<string, unknown> = { name };
+    if (piExtensions !== undefined) manifest.pi = { extensions: piExtensions };
+    writeFileSync(join(dir, "package.json"), JSON.stringify(manifest));
+    mkdirSync(join(dir, "src"));
+    writeFileSync(join(dir, "src", "index.ts"), "export default () => {};");
+    return dir;
+  }
+  afterEach(() => {
+    while (tmpDirs.length) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  });
+
+  it("aliases a package-declared index.ts entry to the unscoped, lowercased package name", () => {
+    // Without this, `pi.extensions: ["./src/index.ts"]` only ever matches as "src".
+    const dir = pkgDir("@tintinweb/Pi-Subagents", ["./src/index.ts"]);
+    expect(extensionCanonicalNames(join(dir, "src", "index.ts"))).toEqual(["src", "pi-subagents"]);
+  });
+
+  it("adds no alias for a loose file with no enclosing package.json", () => {
+    const dir = mkdtempSync(join(tmpdir(), "subagents-loose-"));
+    tmpDirs.push(dir);
+    writeFileSync(join(dir, "foo.ts"), "export default () => {};");
+    expect(extensionCanonicalNames(join(dir, "foo.ts"))).toEqual(["foo"]);
+  });
+
+  it("adds no alias when the nearest manifest does not declare this entry", () => {
+    // The package.json is a real pi package but lists a *different* entry — so a
+    // co-located file (e.g. our own test fixtures under this repo) is not falsely
+    // stamped with the package name.
+    const dir = pkgDir("@scope/other-ext", ["./src/other.ts"]);
+    expect(extensionCanonicalNames(join(dir, "src", "index.ts"))).toEqual(["src"]);
+  });
+
+  it("adds no alias when the nearest package.json has no pi manifest", () => {
+    const dir = pkgDir("just-a-project", undefined);
+    expect(extensionCanonicalNames(join(dir, "src", "index.ts"))).toEqual(["src"]);
+  });
+
+  it("does not climb past a node_modules boundary into a consumer's manifest", () => {
+    // A consumer that *declares* a dependency's entry must not lend its name to
+    // that dependency: the walk stops at node_modules before reading it.
+    const root = mkdtempSync(join(tmpdir(), "subagents-consumer-"));
+    tmpDirs.push(root);
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({ name: "consumer", pi: { extensions: ["./node_modules/inner-ext/index.ts"] } }),
+    );
+    const inner = join(root, "node_modules", "inner-ext");
+    mkdirSync(inner, { recursive: true });
+    writeFileSync(join(inner, "index.ts"), "export default () => {};");
+    // Only the path-derived name — never "consumer".
+    expect(extensionCanonicalNames(join(inner, "index.ts"))).toEqual(["inner-ext"]);
+  });
+});
+
+describe("parseExtensionsSpec", () => {
+  it("classifies bare entries as names", () => {
+    const spec = parseExtensionsSpec(["mcp", "logger"], "/work");
+    expect(spec.names).toEqual(new Set(["mcp", "logger"]));
+    expect(spec.paths).toEqual([]);
+    expect(spec.wildcard).toBe(false);
+  });
+  it("treats '*' as the wildcard", () => {
+    const spec = parseExtensionsSpec(["*"], "/work");
+    expect(spec.wildcard).toBe(true);
+    expect(spec.names.size).toBe(0);
+    expect(spec.paths).toEqual([]);
+  });
+  it("resolves a relative path against cwd and adds its canonical name", () => {
+    const spec = parseExtensionsSpec(["./rel/foo.ts"], "/work");
+    expect(spec.paths).toEqual(["/work/rel/foo.ts"]);
+    expect(spec.names).toEqual(new Set(["foo"]));
+  });
+  it("keeps an absolute path as-is", () => {
+    const spec = parseExtensionsSpec(["/abs/bar.ts"], "/work");
+    expect(spec.paths).toEqual(["/abs/bar.ts"]);
+    expect(spec.names).toEqual(new Set(["bar"]));
+  });
+  it("expands a leading ~ to the home directory", () => {
+    const spec = parseExtensionsSpec(["~/ext/baz.ts"], "/work");
+    expect(spec.paths[0]).toBe(`${homedir()}/ext/baz.ts`);
+    expect(spec.names).toEqual(new Set(["baz"]));
+  });
+  it("composes wildcard, names, and paths", () => {
+    const spec = parseExtensionsSpec(["*", "mcp", "/abs/foo.ts"], "/work");
+    expect(spec.wildcard).toBe(true);
+    expect(spec.names).toEqual(new Set(["mcp", "foo"]));
+    expect(spec.paths).toEqual(["/abs/foo.ts"]);
+  });
+  it("lowercases bare-name entries — extension names match case-insensitively", () => {
+    const spec = parseExtensionsSpec(["Mcp", "LOGGER"], "/work");
+    expect(spec.names).toEqual(new Set(["mcp", "logger"]));
+  });
+  it("ignores empty entries (defensive — upstream parsers already strip them)", () => {
+    const spec = parseExtensionsSpec(["", "mcp", ""], "/work");
+    expect(spec.names).toEqual(new Set(["mcp"]));
+    expect(spec.wildcard).toBe(false);
+  });
+});
+
+describe("agent-runner extension allowlist", () => {
+  function setupArrayAgent(extensions: string[]) {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig({ extensions }));
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
+  }
+
+  it("['*'] short-circuits — no extensionsOverride, behaves like extensions: true", async () => {
+    setupArrayAgent(["*"]);
+    withExtensions({ "/ext/a.ts": ["tool_a"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const opts = lastLoaderOpts();
+    expect(opts.extensionsOverride).toBeUndefined();
+    expect(opts.additionalExtensionPaths).toBeUndefined();
+    expect(lastToolsPassed()).toContain("tool_a");
+  });
+
+  it("['mcp'] keeps only the mcp-named extension, drops others", async () => {
+    setupArrayAgent(["mcp"]);
+    withExtensions({
+      "/ext/mcp.ts": ["mcp", "mcp_call"],
+      "/ext/other.ts": ["other_tool"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    expect(tools).toContain("mcp");
+    expect(tools).toContain("mcp_call");
+    expect(tools).not.toContain("other_tool");
+  });
+
+  it("matches a package-installed extension by its package short name, not just its src dir (#143)", async () => {
+    // A package whose entry is `src/index.ts` canonicalizes to "src"; a child
+    // agent must still be able to allowlist it by the package name.
+    const dir = mkdtempSync(join(tmpdir(), "subagents-match-"));
+    try {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "@tintinweb/pi-subagents", pi: { extensions: ["./src/index.ts"] } }),
+      );
+      mkdirSync(join(dir, "src"));
+      writeFileSync(join(dir, "src", "index.ts"), "export default () => {};");
+      const entry = join(dir, "src", "index.ts");
+
+      setupArrayAgent(["pi-subagents"]);
+      withExtensions({ [entry]: ["pkg_tool"] });
+      const { session } = createSession("OK");
+      createAgentSession.mockResolvedValue({ session });
+
+      await runAgent(ctx, "Explore", "go", { pi });
+
+      // Before the fix keepNames={pi-subagents} but the extension only answered
+      // to "src", so it was filtered out and pkg_tool never reached the allowlist.
+      expect(lastToolsPassed()).toContain("pkg_tool");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("an absolute path is added to additionalExtensionPaths and its extension survives", async () => {
+    setupArrayAgent(["/abs/foo.ts"]);
+    // Pre-register the path so the mock loader treats it as a successful load.
+    withExtensions({ "/abs/foo.ts": ["foo_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(lastLoaderOpts().additionalExtensionPaths).toEqual(["/abs/foo.ts"]);
+    expect(lastToolsPassed()).toContain("foo_tool");
+  });
+
+  it("['*', path] keeps all defaults plus the extra path", async () => {
+    setupArrayAgent(["*", "/abs/foo.ts"]);
+    withExtensions({
+      "/ext/default.ts": ["default_tool"],
+      "/abs/foo.ts": ["foo_tool"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    expect(tools).toContain("default_tool");
+    expect(tools).toContain("foo_tool");
+  });
+
+  it("['mcp', path] keeps exactly those two, drops other defaults (no wildcard)", async () => {
+    // Changelog: `["mcp", "/abs/foo.ts"]` is *just* those two. Distinct from
+    // `['*', path]` (all defaults + path) and `['mcp']` (name only).
+    setupArrayAgent(["mcp", "/abs/foo.ts"]);
+    withExtensions({
+      "/ext/mcp.ts": ["mcp_tool"],
+      "/abs/foo.ts": ["foo_tool"],
+      "/ext/other.ts": ["other_tool"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const opts = lastLoaderOpts();
+    expect(opts.additionalExtensionPaths).toEqual(["/abs/foo.ts"]);
+    // No "*" → the loader override is in force (narrowing, not load-all).
+    expect(opts.extensionsOverride).toBeDefined();
+    const tools = lastToolsPassed();
+    expect(tools).toContain("mcp_tool");
+    expect(tools).toContain("foo_tool");
+    expect(tools).not.toContain("other_tool");
+  });
+
+  it("disallowedTools still applies to tools from an allowlisted extension", async () => {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: ["mcp"] }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(
+      makeAgentConfig({ extensions: ["mcp"], disallowedTools: ["mcp"] }),
+    );
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
+    withExtensions({ "/ext/mcp.ts": ["mcp", "mcp_call"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    expect(tools).not.toContain("mcp");
+    expect(tools).toContain("mcp_call");
+  });
+
+  it("warns but proceeds when a bare name matches no loaded extension", async () => {
+    setupArrayAgent(["mcp", "typo"]);
+    withExtensions({ "/ext/mcp.ts": ["mcp_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    const result = await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(result.responseText).toBe("OK");
+    expect(onToolActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: expect.stringContaining('extension-error:extension "typo"'),
+      }),
+    );
+  });
+
+  it("warns but proceeds when a path entry fails to load", async () => {
+    setupArrayAgent(["/abs/missing.ts"]);
+    // Not pre-registered → the mock loader records a load error; the path's
+    // canonical name ("missing") is what the unmatched-name check reports.
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    const result = await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(result.responseText).toBe("OK");
+    expect(onToolActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: expect.stringContaining('extension-error:extension "missing"'),
+      }),
+    );
+  });
+
+  it("matches `extensions: [Mcp]` against `mcp.ts` (case-insensitive)", async () => {
+    setupArrayAgent(["Mcp"]);
+    withExtensions({ "/ext/mcp.ts": ["mcp_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    // No extension-error warning — the name resolved.
+    const errorCalls = onToolActivity.mock.calls.filter((c) =>
+      typeof c[0]?.toolName === "string" && c[0].toolName.startsWith("extension-error:"),
+    );
+    expect(errorCalls).toEqual([]);
+    expect(lastToolsPassed()).toContain("mcp_tool");
+  });
+});
+
+// ─── exclude_extensions: denylist (#94) ──────────────────────────────────
+describe("agent-runner exclude_extensions", () => {
+  function setupAgent(overrides: Record<string, unknown>) {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig(overrides));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(makeAgentConfig(overrides));
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(BUILTINS_7);
+  }
+  function extensionErrors(onToolActivity: ReturnType<typeof vi.fn>): string[] {
+    return onToolActivity.mock.calls
+      .map((c) => c[0]?.toolName)
+      .filter((n): n is string => typeof n === "string" && n.startsWith("extension-error:"));
+  }
+
+  it("extensions: true + exclude — override installed, excluded tools dropped, others kept", async () => {
+    setupAgent({ extensions: true, excludeExtensions: ["notify"] });
+    withExtensions({
+      "/ext/notify.ts": ["notify_send"],
+      "/ext/mcp.ts": ["mcp_tool"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(lastLoaderOpts().extensionsOverride).toBeDefined();
+    const tools = lastToolsPassed();
+    expect(tools).not.toContain("notify_send");
+    expect(tools).toContain("mcp_tool");
+    expect(extensionErrors(onToolActivity)).toEqual([]);
+  });
+
+  it("['*'] + exclude — wildcard no longer short-circuits, exclusion applies", async () => {
+    setupAgent({ extensions: ["*"], excludeExtensions: ["notify"] });
+    withExtensions({
+      "/ext/notify.ts": ["notify_send"],
+      "/ext/mcp.ts": ["mcp_tool"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(lastLoaderOpts().extensionsOverride).toBeDefined();
+    const tools = lastToolsPassed();
+    expect(tools).not.toContain("notify_send");
+    expect(tools).toContain("mcp_tool");
+  });
+
+  it("allowlist + exclude of a listed name — subtracted, 'in both' warning fires", async () => {
+    setupAgent({ extensions: ["mcp", "other"], excludeExtensions: ["other"] });
+    withExtensions({
+      "/ext/mcp.ts": ["mcp_tool"],
+      "/ext/other.ts": ["other_tool"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    const tools = lastToolsPassed();
+    expect(tools).toContain("mcp_tool");
+    expect(tools).not.toContain("other_tool");
+    expect(extensionErrors(onToolActivity)).toEqual([
+      expect.stringContaining('in both extensions: and exclude_extensions:'),
+    ]);
+  });
+
+  it("exclude typo — warning fires, all extensions still load", async () => {
+    setupAgent({ extensions: true, excludeExtensions: ["nope"] });
+    withExtensions({ "/ext/mcp.ts": ["mcp_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(lastToolsPassed()).toContain("mcp_tool");
+    expect(extensionErrors(onToolActivity)).toEqual([
+      expect.stringContaining('exclude_extensions: "nope"'),
+    ]);
+  });
+
+  it("extensions: false + exclude — orphan warning, no override", async () => {
+    setupAgent({ extensions: false, excludeExtensions: ["notify"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(lastLoaderOpts().extensionsOverride).toBeUndefined();
+    expect(extensionErrors(onToolActivity)).toEqual([
+      expect.stringContaining("exclude_extensions has no effect"),
+    ]);
+  });
+
+  it("isolated: true + exclude — excludes nulled, no warnings", async () => {
+    setupAgent({ extensions: true, excludeExtensions: ["notify"] });
+    withExtensions({ "/ext/notify.ts": ["notify_send"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity, isolated: true });
+
+    expect(lastToolsPassed()).not.toContain("notify_send");
+    expect(extensionErrors(onToolActivity)).toEqual([]);
+  });
+
+  it("tools: ext:foo referencing an excluded extension — existing orphan warning fires", async () => {
+    setupAgent({
+      extensions: true,
+      excludeExtensions: ["beta"],
+      extSelectors: ["ext:beta"],
+    });
+    withExtensions({
+      "/ext/beta.ts": ["beta_tool"],
+      "/ext/mcp.ts": ["mcp_tool"],
+    });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(lastToolsPassed()).not.toContain("beta_tool");
+    expect(extensionErrors(onToolActivity)).toEqual([
+      expect.stringContaining("extension-error:ext:beta"),
+    ]);
+  });
+
+  it("exclude matches case-insensitively", async () => {
+    setupAgent({ extensions: true, excludeExtensions: ["MCP"] });
+    withExtensions({ "/ext/mcp.ts": ["mcp_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(lastToolsPassed()).not.toContain("mcp_tool");
+    expect(extensionErrors(onToolActivity)).toEqual([]);
+  });
+});
+
+// ─── unknown built-in tool names in `tools:` (#75) ──────────────────────
+describe("agent-runner unknown built-in tools", () => {
+  it("emits a tools-error warning for each plain entry not in BUILTIN_TOOL_NAMES", async () => {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: false }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(
+      makeAgentConfig({ extensions: false, builtinToolNames: ["read", "reed", "grep", "edt"] }),
+    );
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(["read", "reed", "grep", "edt"]);
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    const result = await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(result.responseText).toBe("OK");
+    const errorMessages = onToolActivity.mock.calls
+      .map((c) => c[0]?.toolName)
+      .filter((n): n is string => typeof n === "string" && n.startsWith("tools-error:"));
+    expect(errorMessages).toHaveLength(2);
+    expect(errorMessages.some((m) => m.includes('"reed"'))).toBe(true);
+    expect(errorMessages.some((m) => m.includes('"edt"'))).toBe(true);
+  });
+
+  it("stays quiet when all plain tool names are valid built-ins", async () => {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: false }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(
+      makeAgentConfig({ extensions: false, builtinToolNames: ["read", "grep"] }),
+    );
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(["read", "grep"]);
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    const errorMessages = onToolActivity.mock.calls
+      .map((c) => c[0]?.toolName)
+      .filter((n): n is string => typeof n === "string" && n.startsWith("tools-error:"));
+    expect(errorMessages).toEqual([]);
+  });
+});
+
+// ─── ext: tool selectors in `tools:` (opt-in flip) ──────────────────────
+describe("parseExtSelectors", () => {
+  it("bare ext:foo → name only, no narrowing", () => {
+    const { extNames, narrowing } = parseExtSelectors(["ext:foo"]);
+    expect(extNames).toEqual(new Set(["foo"]));
+    expect(narrowing.size).toBe(0);
+  });
+  it("ext:foo/bar → name plus a narrowing entry", () => {
+    const { extNames, narrowing } = parseExtSelectors(["ext:foo/bar"]);
+    expect(extNames).toEqual(new Set(["foo"]));
+    expect(narrowing.get("foo")).toEqual(new Set(["bar"]));
+  });
+  it("multiple ext:foo/* entries union", () => {
+    expect(parseExtSelectors(["ext:foo/a", "ext:foo/b"]).narrowing.get("foo")).toEqual(
+      new Set(["a", "b"]),
+    );
+  });
+  it("ext:foo + ext:foo/bar → narrowing wins", () => {
+    const { narrowing } = parseExtSelectors(["ext:foo", "ext:foo/bar"]);
+    expect(narrowing.get("foo")).toEqual(new Set(["bar"]));
+  });
+  it("splits on the first / so tool names may contain /", () => {
+    expect(parseExtSelectors(["ext:foo/bar/baz"]).narrowing.get("foo")).toEqual(
+      new Set(["bar/baz"]),
+    );
+  });
+  it("skips empty name and empty tool halves", () => {
+    const { extNames, narrowing } = parseExtSelectors(["ext:", "ext:foo/"]);
+    expect(extNames).toEqual(new Set(["foo"]));
+    expect(narrowing.size).toBe(0);
+  });
+  it("lowercases the extension name but preserves tool-name case", () => {
+    // The extension half matches the loader's canonical name (also lowercased);
+    // the tool half is matched against pi-mono's registered identifiers, which
+    // are case-sensitive.
+    const { extNames, narrowing } = parseExtSelectors(["ext:Mcp/SomeTool", "ext:FOO"]);
+    expect(extNames).toEqual(new Set(["mcp", "foo"]));
+    expect(narrowing.get("mcp")).toEqual(new Set(["SomeTool"]));
+  });
+});
+
+describe("agent-runner ext: tool selectors", () => {
+  function setupExtAgent(o: {
+    extensions: boolean | string[];
+    builtinToolNames: string[];
+    extSelectors?: string[];
+    disallowedTools?: string[];
+  }) {
+    vi.mocked(getConfig).mockReturnValueOnce(makeConfig({ extensions: o.extensions }));
+    vi.mocked(getAgentConfig).mockReturnValueOnce(
+      makeAgentConfig({
+        extensions: o.extensions,
+        extSelectors: o.extSelectors,
+        disallowedTools: o.disallowedTools,
+      }),
+    );
+    vi.mocked(getToolNamesForType).mockReturnValueOnce(o.builtinToolNames);
+  }
+
+  it("any ext: entry flips extension tools to an allowlist — non-selected extensions muted", async () => {
+    // `tools: ext:foo` → zero built-ins, opt-in flip active.
+    setupExtAgent({ extensions: true, builtinToolNames: [], extSelectors: ["ext:foo"] });
+    withExtensions({ "/ext/foo.ts": ["foo_tool"], "/ext/other.ts": ["other_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    expect(tools).toContain("foo_tool");
+    expect(tools).not.toContain("other_tool"); // loaded but muted
+    expect(tools).not.toContain("read"); // tools: ext:foo → no built-ins
+    // both extensions still load — no loader override needed under extensions: true
+    expect(lastLoaderOpts().extensionsOverride).toBeUndefined();
+  });
+
+  it("'*' alongside ext: keeps all built-ins while the flip still applies", async () => {
+    // `tools: *, ext:foo` → all built-ins, opt-in flip active.
+    setupExtAgent({ extensions: true, builtinToolNames: BUILTINS_7, extSelectors: ["ext:foo"] });
+    withExtensions({ "/ext/foo.ts": ["foo_tool"], "/ext/other.ts": ["other_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    for (const b of BUILTINS_7) expect(tools).toContain(b);
+    expect(tools).toContain("foo_tool");
+    expect(tools).not.toContain("other_tool");
+  });
+
+  it("ext:foo/bar narrows foo to a single tool", async () => {
+    setupExtAgent({ extensions: true, builtinToolNames: ["read"], extSelectors: ["ext:foo/bar"] });
+    withExtensions({ "/ext/foo.ts": ["bar", "baz"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    expect(tools).toContain("read");
+    expect(tools).toContain("bar");
+    expect(tools).not.toContain("baz");
+  });
+
+  it("ext:foo is orphaned when extensions: false — no extension loads, warning fires", async () => {
+    // `extensions:` is the sole loading authority. `ext:` selectors can only narrow
+    // within the loaded set; they cannot pull an excluded extension back in.
+    setupExtAgent({ extensions: false, builtinToolNames: ["read"], extSelectors: ["ext:foo"] });
+    withExtensions({ "/ext/foo.ts": ["foo_tool"], "/ext/other.ts": ["other_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(lastLoaderOpts().noExtensions).toBe(true);
+    const tools = lastToolsPassed();
+    expect(tools).toEqual(["read"]);
+    expect(tools).not.toContain("foo_tool");
+    expect(onToolActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: expect.stringContaining('extension-error:ext:foo'),
+      }),
+    );
+  });
+
+  it("ext: cannot pull an extension that `extensions: [...]` excludes — warns, no surfacing", async () => {
+    // extensions: [a] loads only a. ext:foo references foo, which isn't loaded;
+    // the opt-in flip still mutes a (it isn't named in ext:), so the agent gets
+    // zero extension tools and a warning fires.
+    setupExtAgent({ extensions: ["a"], builtinToolNames: [], extSelectors: ["ext:foo"] });
+    withExtensions({ "/ext/a.ts": ["a_tool"], "/ext/foo.ts": ["foo_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    const tools = lastToolsPassed();
+    expect(tools).not.toContain("foo_tool"); // foo never loaded
+    expect(tools).not.toContain("a_tool");   // a loaded but muted by the ext: opt-in flip
+    expect(onToolActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: expect.stringContaining('extension-error:ext:foo'),
+      }),
+    );
+  });
+
+  it("['*'] short-circuit survives ext: narrowing", async () => {
+    setupExtAgent({ extensions: ["*"], builtinToolNames: ["read"], extSelectors: ["ext:foo/bar"] });
+    withExtensions({ "/ext/foo.ts": ["bar", "baz"], "/ext/other.ts": ["other_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    expect(lastLoaderOpts().extensionsOverride).toBeUndefined(); // pure-["*"] short-circuit holds
+    const tools = lastToolsPassed();
+    expect(tools).toContain("bar");
+    expect(tools).not.toContain("baz");
+    expect(tools).not.toContain("other_tool"); // flip mutes the unselected extension
+  });
+
+  it("warns but proceeds when an ext: name doesn't match any loaded extension", async () => {
+    setupExtAgent({ extensions: true, builtinToolNames: ["read"], extSelectors: ["ext:ghost"] });
+    withExtensions({ "/ext/real.ts": ["real_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    const result = await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(result.responseText).toBe("OK");
+    expect(onToolActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: expect.stringContaining('extension-error:ext:ghost'),
+      }),
+    );
+  });
+
+  it("isolated: true ignores extSelectors — no extension tools", async () => {
+    setupExtAgent({ extensions: true, builtinToolNames: ["read"], extSelectors: ["ext:foo"] });
+    withExtensions({ "/ext/foo.ts": ["foo_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi, isolated: true });
+
+    const tools = lastToolsPassed();
+    expect(tools).toContain("read");
+    expect(tools).not.toContain("foo_tool");
+    expect(lastLoaderOpts().noExtensions).toBe(true);
+  });
+
+  it("ext: composes with a path-loaded extension via its canonical name", async () => {
+    // Changelog: `ext:` is name-only (matched by canonical name), so it composes
+    // with extensions loaded by path through `extensions:`. The path "/abs/foo.ts"
+    // has canonical name "foo", which `ext:foo` then surfaces — no orphan warning.
+    setupExtAgent({
+      extensions: ["/abs/foo.ts"],
+      builtinToolNames: ["read"],
+      extSelectors: ["ext:foo"],
+    });
+    withExtensions({ "/abs/foo.ts": ["foo_tool"], "/ext/other.ts": ["other_tool"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+    const onToolActivity = vi.fn();
+
+    await runAgent(ctx, "Explore", "go", { pi, onToolActivity });
+
+    expect(lastLoaderOpts().additionalExtensionPaths).toEqual(["/abs/foo.ts"]);
+    const tools = lastToolsPassed();
+    expect(tools).toContain("foo_tool"); // path-loaded ext surfaced via ext:foo
+    expect(tools).toContain("read");
+    expect(tools).not.toContain("other_tool"); // dropped at the loader (not in keepNames)
+    // ext:foo resolved against the path's canonical name → not orphaned.
+    const errorCalls = onToolActivity.mock.calls.filter(
+      (c) => typeof c[0]?.toolName === "string" && c[0].toolName.startsWith("extension-error:"),
+    );
+    expect(errorCalls).toEqual([]);
+  });
+
+  it("ext:foo/Bar narrowing is case-sensitive on the tool half", async () => {
+    // The extension half is canonicalised (lowercased); the tool half is matched
+    // verbatim against pi-mono's registered identifiers, so `Bar` must not match `bar`.
+    setupExtAgent({ extensions: true, builtinToolNames: ["read"], extSelectors: ["ext:foo/Bar"] });
+    withExtensions({ "/ext/foo.ts": ["Bar", "bar"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    expect(tools).toContain("Bar");
+    expect(tools).not.toContain("bar"); // case-sensitive: not the selected tool
+  });
+
+  it("disallowedTools removes a tool reached via an ext: selector", async () => {
+    // The denylist applies uniformly to extension tools, including those surfaced
+    // by the ext: opt-in flip — same construction-time `allowedTools` filter.
+    setupExtAgent({
+      extensions: true,
+      builtinToolNames: ["read"],
+      extSelectors: ["ext:foo"],
+      disallowedTools: ["foo_tool"],
+    });
+    withExtensions({ "/ext/foo.ts": ["foo_tool", "foo_other"] });
+    const { session } = createSession("OK");
+    createAgentSession.mockResolvedValue({ session });
+
+    await runAgent(ctx, "Explore", "go", { pi });
+
+    const tools = lastToolsPassed();
+    expect(tools).toContain("read");
+    expect(tools).toContain("foo_other");
+    expect(tools).not.toContain("foo_tool"); // denylisted even though ext:foo selects it
+  });
+});

--- a/packages/pi-subagents/test/agent-types.test.ts
+++ b/packages/pi-subagents/test/agent-types.test.ts
@@ -1,0 +1,376 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  BUILTIN_TOOL_NAMES,
+  getAgentConfig,
+  getAvailableTypes,
+  getConfig,
+  getDefaultAgentNames,
+  getMemoryToolNames,
+  getReadOnlyMemoryToolNames,
+  getToolNamesForType,
+  getUserAgentNames,
+  isDefaultsDisabled,
+  isValidType,
+  registerAgents,
+  resolveType,
+  setDefaultsDisabled,
+} from "../src/agent-types.js";
+import { DEFAULT_AGENTS } from "../src/default-agents.js";
+import type { AgentConfig } from "../src/types.js";
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    name: "test-agent",
+    description: "Test agent",
+    builtinToolNames: ["read", "grep"],
+    extensions: false,
+    skills: false,
+    systemPrompt: "You are a test agent.",
+    promptMode: "replace",
+    inheritContext: false,
+    runInBackground: false,
+    isolated: false,
+    ...overrides,
+  };
+}
+
+describe("agent type registry", () => {
+  beforeEach(() => {
+    registerAgents(new Map());
+  });
+
+  describe("default agents", () => {
+    it("recognizes all default agent types", () => {
+      expect(isValidType("general-purpose")).toBe(true);
+      expect(isValidType("Explore")).toBe(true);
+      expect(isValidType("Plan")).toBe(true);
+    });
+
+    it("does not include removed agents", () => {
+      expect(isValidType("statusline-setup")).toBe(false);
+      expect(isValidType("claude-code-guide")).toBe(false);
+    });
+
+    it("rejects unknown types", () => {
+      expect(isValidType("nonexistent")).toBe(false);
+      expect(isValidType("")).toBe(false);
+    });
+
+    it("case-insensitive lookup works for isValidType", () => {
+      expect(isValidType("explore")).toBe(true);
+      expect(isValidType("EXPLORE")).toBe(true);
+      expect(isValidType("General-Purpose")).toBe(true);
+      expect(isValidType("plan")).toBe(true);
+    });
+
+    it("case-insensitive lookup works for getAgentConfig", () => {
+      const config = getAgentConfig("explore");
+      expect(config?.name).toBe("Explore");
+      expect(config?.model).toBe("anthropic/claude-haiku-4-5");
+    });
+
+    it("resolveType returns canonical key or undefined", () => {
+      expect(resolveType("Explore")).toBe("Explore");
+      expect(resolveType("explore")).toBe("Explore");
+      expect(resolveType("GENERAL-PURPOSE")).toBe("general-purpose");
+      expect(resolveType("nonexistent")).toBeUndefined();
+    });
+
+    it("returns correct config for default types", () => {
+      const config = getConfig("general-purpose");
+      expect(config.displayName).toBe("Agent");
+      expect(config.builtinToolNames).toEqual(BUILTIN_TOOL_NAMES);
+      expect(config.extensions).toBe(true);
+      expect(config.skills).toBe(true);
+    });
+
+    it("Explore has read-only tools", () => {
+      const config = getConfig("Explore");
+      expect(config.builtinToolNames).toEqual(["read", "bash", "grep", "find", "ls"]);
+      expect(config.builtinToolNames).not.toContain("edit");
+      expect(config.builtinToolNames).not.toContain("write");
+    });
+
+    it("Explore has haiku model in config", () => {
+      const cfg = getAgentConfig("Explore");
+      expect(cfg?.model).toBe("anthropic/claude-haiku-4-5");
+    });
+
+    it("default agents are marked isDefault", () => {
+      const cfg = getAgentConfig("general-purpose");
+      expect(cfg?.isDefault).toBe(true);
+    });
+
+    // Regression guard for #37 — default agents must not bake in callsite-strategy fields.
+    // An explicit `false` here would silently win over the caller's `true` via `??` in
+    // resolveAgentInvocationConfig, breaking documented Agent tool params.
+    it("default agents do not lock strategy fields (run_in_background / inherit_context / isolated)", () => {
+      for (const name of ["general-purpose", "Explore", "Plan"]) {
+        const cfg = getAgentConfig(name);
+        expect(cfg?.runInBackground, `${name}.runInBackground`).toBeUndefined();
+        expect(cfg?.inheritContext, `${name}.inheritContext`).toBeUndefined();
+        expect(cfg?.isolated, `${name}.isolated`).toBeUndefined();
+      }
+    });
+
+    it("getDefaultAgentNames returns default agent names", () => {
+      const names = getDefaultAgentNames();
+      expect(names).toContain("general-purpose");
+      expect(names).toContain("Explore");
+      expect(names).toContain("Plan");
+    });
+
+    it("BUILTIN_TOOL_NAMES includes all built-in tools", () => {
+      expect(BUILTIN_TOOL_NAMES).toContain("read");
+      expect(BUILTIN_TOOL_NAMES).toContain("bash");
+      expect(BUILTIN_TOOL_NAMES).toContain("edit");
+      expect(BUILTIN_TOOL_NAMES).toContain("write");
+      expect(BUILTIN_TOOL_NAMES).toContain("grep");
+      expect(BUILTIN_TOOL_NAMES).toContain("find");
+      expect(BUILTIN_TOOL_NAMES).toContain("ls");
+      expect(BUILTIN_TOOL_NAMES.length).toBeGreaterThanOrEqual(7);
+    });
+  });
+
+  describe("disable defaults", () => {
+    // Module-level flag — always reset so later describes see the default roster.
+    afterEach(() => {
+      setDefaultsDisabled(false);
+      registerAgents(new Map());
+    });
+
+    it("defaults to enabled", () => {
+      expect(isDefaultsDisabled()).toBe(false);
+    });
+
+    it("registerAgents skips DEFAULT_AGENTS when disabled", () => {
+      setDefaultsDisabled(true);
+      registerAgents(new Map());
+
+      expect(getAvailableTypes()).toEqual([]);
+      expect(isValidType("general-purpose")).toBe(false);
+      expect(isValidType("Explore")).toBe(false);
+      expect(isValidType("Plan")).toBe(false);
+    });
+
+    it("user agents are unaffected when defaults are disabled", () => {
+      setDefaultsDisabled(true);
+      registerAgents(new Map([["auditor", makeAgentConfig({ name: "auditor" })]]));
+
+      expect(getAvailableTypes()).toEqual(["auditor"]);
+      expect(isValidType("auditor")).toBe(true);
+      expect(getDefaultAgentNames()).toEqual([]);
+    });
+
+    it("re-enabling restores defaults on next registerAgents", () => {
+      setDefaultsDisabled(true);
+      registerAgents(new Map());
+      expect(isValidType("general-purpose")).toBe(false);
+
+      setDefaultsDisabled(false);
+      registerAgents(new Map());
+      expect(isValidType("general-purpose")).toBe(true);
+      expect(isValidType("Explore")).toBe(true);
+      expect(isValidType("Plan")).toBe(true);
+    });
+
+    it("getConfig falls back to the hardcoded config when defaults are disabled and no user agents exist", () => {
+      setDefaultsDisabled(true);
+      registerAgents(new Map());
+
+      const config = getConfig("general-purpose");
+      expect(config.displayName).toBe("Agent");
+      expect(config.builtinToolNames).toEqual(BUILTIN_TOOL_NAMES);
+      expect(config.promptMode).toBe("append");
+    });
+  });
+
+  describe("user agents", () => {
+    it("registers and retrieves user agents", () => {
+      const agents = new Map([["auditor", makeAgentConfig({ name: "auditor", description: "Auditor" })]]);
+      registerAgents(agents);
+
+      expect(isValidType("auditor")).toBe(true);
+      expect(getAgentConfig("auditor")?.description).toBe("Auditor");
+    });
+
+    it("includes user agents in available types", () => {
+      const agents = new Map([["auditor", makeAgentConfig({ name: "auditor" })]]);
+      registerAgents(agents);
+
+      const types = getAvailableTypes();
+      expect(types).toContain("general-purpose");
+      expect(types).toContain("Explore");
+      expect(types).toContain("auditor");
+    });
+
+    it("lists user agent names separately", () => {
+      const agents = new Map([
+        ["auditor", makeAgentConfig({ name: "auditor" })],
+        ["reviewer", makeAgentConfig({ name: "reviewer" })],
+      ]);
+      registerAgents(agents);
+
+      const names = getUserAgentNames();
+      expect(names).toEqual(["auditor", "reviewer"]);
+      expect(names).not.toContain("general-purpose");
+    });
+
+    it("getConfig returns config for user agents", () => {
+      const agents = new Map([["auditor", makeAgentConfig({
+        name: "auditor",
+        description: "Security auditor",
+        builtinToolNames: ["read", "grep"],
+        extensions: false,
+        skills: true,
+      })]]);
+      registerAgents(agents);
+
+      const config = getConfig("auditor");
+      expect(config.displayName).toBe("auditor");
+      expect(config.description).toBe("Security auditor");
+      expect(config.builtinToolNames).toEqual(["read", "grep"]);
+      expect(config.extensions).toBe(false);
+      expect(config.skills).toBe(true);
+    });
+
+    it("getConfig returns extension allowlist for user agents", () => {
+      const agents = new Map([["partial", makeAgentConfig({
+        name: "partial",
+        extensions: ["web-search"],
+        skills: ["planning"],
+      })]]);
+      registerAgents(agents);
+
+      const config = getConfig("partial");
+      expect(config.extensions).toEqual(["web-search"]);
+      expect(config.skills).toEqual(["planning"]);
+    });
+
+    it("getToolNamesForType works for user agents", () => {
+      const agents = new Map([["auditor", makeAgentConfig({
+        name: "auditor",
+        builtinToolNames: ["read", "grep", "find"],
+      })]]);
+      registerAgents(agents);
+
+      const names = getToolNamesForType("auditor");
+      expect(names).toEqual(["read", "grep", "find"]);
+    });
+
+    it("getToolNamesForType honors an explicit empty builtinToolNames as zero built-ins", () => {
+      // `tools: none` and `tools:` with only `ext:` entries both produce `[]`.
+      const agents = new Map([["ext-only", makeAgentConfig({
+        name: "ext-only",
+        builtinToolNames: [],
+      })]]);
+      registerAgents(agents);
+
+      expect(getToolNamesForType("ext-only")).toEqual([]);
+    });
+
+    it("getConfig falls back to general-purpose for unknown types", () => {
+      const config = getConfig("nonexistent");
+      expect(config.displayName).toBe("Agent");
+      expect(config.description).toBe(DEFAULT_AGENTS.get("general-purpose")?.description);
+    });
+
+    it("clearing user agents works (defaults remain)", () => {
+      const agents = new Map([["auditor", makeAgentConfig({ name: "auditor" })]]);
+      registerAgents(agents);
+      expect(isValidType("auditor")).toBe(true);
+
+      registerAgents(new Map());
+      expect(isValidType("auditor")).toBe(false);
+      expect(isValidType("general-purpose")).toBe(true);
+    });
+
+    it("user agent overrides default with same name", () => {
+      const agents = new Map([["Explore", makeAgentConfig({
+        name: "Explore",
+        description: "Custom Explore",
+        builtinToolNames: BUILTIN_TOOL_NAMES,
+      })]]);
+      registerAgents(agents);
+
+      const config = getConfig("Explore");
+      expect(config.description).toBe("Custom Explore");
+      expect(config.builtinToolNames).toEqual(BUILTIN_TOOL_NAMES);
+    });
+
+    it("disabled agent is excluded from available types", () => {
+      const agents = new Map([["Plan", makeAgentConfig({
+        name: "Plan",
+        enabled: false,
+      })]]);
+      registerAgents(agents);
+
+      expect(isValidType("Plan")).toBe(false);
+      expect(getAvailableTypes()).not.toContain("Plan");
+    });
+
+    it("general-purpose can be disabled but fallback still works", () => {
+      const agents = new Map([["general-purpose", makeAgentConfig({
+        name: "general-purpose",
+        enabled: false,
+      })]]);
+      registerAgents(agents);
+
+      expect(isValidType("general-purpose")).toBe(false);
+      // getConfig fallback should still return something reasonable
+      const config = getConfig("general-purpose");
+      expect(config.displayName).toBe("Agent");
+    });
+  });
+
+  describe("getMemoryToolNames", () => {
+    it("returns read, write, edit when none exist", () => {
+      const names = getMemoryToolNames(new Set());
+      expect(names).toContain("read");
+      expect(names).toContain("write");
+      expect(names).toContain("edit");
+      expect(names).toHaveLength(3);
+    });
+
+    it("skips tools that already exist", () => {
+      const names = getMemoryToolNames(new Set(["read", "edit"]));
+      expect(names).toEqual(["write"]);
+    });
+
+    it("returns empty when all memory tools already exist", () => {
+      const names = getMemoryToolNames(new Set(["read", "write", "edit"]));
+      expect(names).toHaveLength(0);
+    });
+  });
+
+  describe("getReadOnlyMemoryToolNames", () => {
+    it("returns only read when missing", () => {
+      const names = getReadOnlyMemoryToolNames(new Set());
+      expect(names).toEqual(["read"]);
+    });
+
+    it("returns empty when read already exists", () => {
+      const names = getReadOnlyMemoryToolNames(new Set(["read"]));
+      expect(names).toHaveLength(0);
+    });
+  });
+
+  describe("BUILTIN_TOOL_NAMES", () => {
+    // BUILTIN_TOOL_NAMES is derived dynamically from pi's tool factories
+    // (createCodingTools + createReadOnlyTools). This guards against pi-mono
+    // dropping/renaming a built-in: the set must still contain at least these
+    // 7. It's a superset check ("at least") — pi adding a new built-in is fine
+    // and won't fail this test.
+    const EXPECTED = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+
+    it("contains at least the 7 known built-ins", () => {
+      for (const name of EXPECTED) {
+        expect(BUILTIN_TOOL_NAMES).toContain(name);
+      }
+    });
+
+    it("has no duplicate entries", () => {
+      expect(new Set(BUILTIN_TOOL_NAMES).size).toBe(BUILTIN_TOOL_NAMES.length);
+    });
+  });
+});

--- a/packages/pi-subagents/test/agent-widget.test.ts
+++ b/packages/pi-subagents/test/agent-widget.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { renderRunningAgentStatus } from "../src/index.js";
+import type { WidgetMode } from "../src/types.js";
+import { type AgentActivity, AgentWidget, fgPreservingNestedStyles, formatSessionTokens } from "../src/ui/agent-widget.js";
+
+describe("formatSessionTokens", () => {
+  const theme = { fg: (c: string, s: string) => `<${c}>${s}</${c}>`, bold: (s: string) => s };
+  const ansiTheme = {
+    fg: (c: string, s: string) => {
+      const codes: Record<string, string> = { dim: "2", warning: "33", accent: "35" };
+      return `\u001b[${codes[c] ?? "31"}m${s}\u001b[39m`;
+    },
+    bold: (s: string) => s,
+  };
+
+  it("applies threshold colors (<70 dim, 70–85 warning, ≥85 error)", () => {
+    expect(formatSessionTokens(1234, null, theme)).toBe("1.2k token");
+    expect(formatSessionTokens(1234, 50, theme)).toBe("1.2k token (<dim>50%</dim>)");
+    expect(formatSessionTokens(1234, 70, theme)).toBe("1.2k token (<warning>70%</warning>)");
+    expect(formatSessionTokens(1234, 84, theme)).toBe("1.2k token (<warning>84%</warning>)");
+    expect(formatSessionTokens(1234, 85, theme)).toBe("1.2k token (<error>85%</error>)");
+    expect(formatSessionTokens(1234, 99, theme)).toBe("1.2k token (<error>99%</error>)");
+  });
+
+  it("annotates compaction count alongside percent", () => {
+    // compactions only (e.g. immediately post-compaction, percent null)
+    expect(formatSessionTokens(1234, null, theme, 1)).toBe("1.2k token (<dim>⇊1</dim>)");
+    expect(formatSessionTokens(1234, null, theme, 3)).toBe("1.2k token (<dim>⇊3</dim>)");
+    // percent + compactions, joined with ` · `
+    expect(formatSessionTokens(1234, 45, theme, 2)).toBe("1.2k token (<dim>45%</dim> · <dim>⇊2</dim>)");
+    expect(formatSessionTokens(1234, 88, theme, 4)).toBe("1.2k token (<error>88%</error> · <dim>⇊4</dim>)");
+    // compactions=0 omitted
+    expect(formatSessionTokens(1234, 45, theme, 0)).toBe("1.2k token (<dim>45%</dim>)");
+  });
+
+  it("preserves the outer style after nested annotation styles reset", () => {
+    const tokenText = formatSessionTokens(1234, 70, ansiTheme);
+
+    expect(fgPreservingNestedStyles(ansiTheme, "accent", tokenText)).toBe(
+      "\u001b[35m1.2k token (\u001b[33m70%\u001b[39m\u001b[35m)\u001b[39m",
+    );
+  });
+});
+
+describe("renderRunningAgentStatus", () => {
+  it("renders running status as separate component lines", () => {
+    const theme = { fg: (_c: string, s: string) => s };
+    const component = renderRunningAgentStatus("⠋", "thinking: xhigh · 4 tool uses", "thinking…", theme);
+
+    expect(component.render(120).map((line) => line.trimEnd())).toEqual([
+      "⠋ thinking: xhigh · 4 tool uses",
+      "  ⎿  thinking…",
+    ]);
+  });
+});
+
+describe("AgentWidget", () => {
+  const theme = { fg: (_c: string, s: string) => s, bold: (s: string) => s };
+
+  function makeActivity(): AgentActivity {
+    return {
+      activeTools: new Map(),
+      toolUses: 0,
+      responseText: "",
+      turnCount: 1,
+      lifetimeUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    };
+  }
+
+  function makeRecord(id: string, opts: { isBackground?: boolean } = {}) {
+    return {
+      id,
+      type: "general-purpose",
+      description: `${id} description`,
+      status: "running",
+      toolUses: 0,
+      startedAt: Date.now(),
+      lifetimeUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      compactionCount: 0,
+      isBackground: opts.isBackground,
+    };
+  }
+
+  /** Render the widget for a manager and return the produced lines ("" if nothing rendered). */
+  function renderLines(manager: unknown, activityId: string, mode?: () => WidgetMode): string {
+    const widget = new AgentWidget(
+      manager as any,
+      new Map([[activityId, makeActivity()]]),
+      mode,
+    );
+    let factory: any;
+    widget.setUICtx({
+      setStatus: () => {},
+      setWidget: (_key, content) => { factory = content; },
+    });
+    widget.update();
+    if (!factory) return "";
+    return factory({ terminal: { columns: 120 }, requestRender: () => {} }, theme)
+      .render()
+      .join("\n");
+  }
+
+  // "all" (and the no-policy constructor default) shows every agent.
+  it("shows foreground agents in 'all' mode (and by default)", () => {
+    const manager = { listAgents: () => [makeRecord("foreground", { isBackground: false })] };
+    expect(renderLines(manager, "foreground")).toContain("foreground description");
+    expect(renderLines(manager, "foreground", () => "all")).toContain("foreground description");
+  });
+
+  it("excludes foreground agents in 'background' mode", () => {
+    const manager = { listAgents: () => [makeRecord("foreground", { isBackground: false })] };
+    expect(renderLines(manager, "foreground", () => "background")).toBe("");
+  });
+
+  // Also covers scheduler-spawned agents (isBackground=true, no `invocation`
+  // snapshot): if the filter still keyed off `invocation.runInBackground` —
+  // #118's original approach — this would wrongly vanish.
+  it("renders background agents in 'background' mode", () => {
+    const manager = { listAgents: () => [makeRecord("background", { isBackground: true })] };
+    const lines = renderLines(manager, "background", () => "background");
+    expect(lines).toContain("Agents");
+    expect(lines).toContain("background description");
+  });
+
+  // 'background' excludes only agents *known* to be foreground; one with no
+  // isBackground flag (e.g. a cross-extension RPC spawn) is kept, not hidden.
+  it("keeps agents with no isBackground flag in 'background' mode", () => {
+    const manager = { listAgents: () => [makeRecord("unflagged", {})] };
+    expect(renderLines(manager, "unflagged", () => "background")).toContain("unflagged description");
+  });
+
+  // "off" hides the widget entirely — even a background agent renders nothing.
+  it("renders nothing in 'off' mode", () => {
+    const manager = { listAgents: () => [makeRecord("background", { isBackground: true })] };
+    expect(renderLines(manager, "background", () => "off")).toBe("");
+  });
+});

--- a/packages/pi-subagents/test/agent-widget.test.ts
+++ b/packages/pi-subagents/test/agent-widget.test.ts
@@ -45,10 +45,10 @@ describe("formatSessionTokens", () => {
 describe("renderRunningAgentStatus", () => {
   it("renders running status as separate component lines", () => {
     const theme = { fg: (_c: string, s: string) => s };
-    const component = renderRunningAgentStatus("⠋", "thinking: xhigh · 4 tool uses", "thinking…", theme);
+    const component = renderRunningAgentStatus("⠋", "effort: xhigh · 4 tool uses", "thinking…", theme);
 
     expect(component.render(120).map((line) => line.trimEnd())).toEqual([
-      "⠋ thinking: xhigh · 4 tool uses",
+      "⠋ effort: xhigh · 4 tool uses",
       "  ⎿  thinking…",
     ]);
   });

--- a/packages/pi-subagents/test/agent-widget.test.ts
+++ b/packages/pi-subagents/test/agent-widget.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { renderRunningAgentStatus } from "../src/index.js";
 import type { WidgetMode } from "../src/types.js";
-import { type AgentActivity, AgentWidget, fgPreservingNestedStyles, formatSessionTokens } from "../src/ui/agent-widget.js";
+import {
+  type AgentActivity,
+  AgentWidget,
+  describeActivity,
+  fgPreservingNestedStyles,
+  formatActiveToolSummary,
+  formatSessionTokens,
+} from "../src/ui/agent-widget.js";
 
 describe("formatSessionTokens", () => {
   const theme = { fg: (c: string, s: string) => `<${c}>${s}</${c}>`, bold: (s: string) => s };
@@ -133,5 +140,25 @@ describe("AgentWidget", () => {
   it("renders nothing in 'off' mode", () => {
     const manager = { listAgents: () => [makeRecord("background", { isBackground: true })] };
     expect(renderLines(manager, "background", () => "off")).toBe("");
+  });
+});
+
+describe("formatActiveToolSummary / describeActivity", () => {
+  it("summarizes read/bash/grep args into a step line", () => {
+    expect(formatActiveToolSummary("read", { path: "src/a.ts" })).toBe("reading src/a.ts");
+    expect(formatActiveToolSummary("bash", { command: 'rg "auth" -n' })).toBe('running rg "auth" -n');
+    expect(formatActiveToolSummary("grep", { pattern: "foo", glob: "*.ts" })).toBe('searching "foo" *.ts');
+    expect(formatActiveToolSummary("edit", {})).toBe("editing");
+  });
+
+  it("describeActivity prefers in-flight step summaries over thinking…", () => {
+    const tools = new Map<string, string>([
+      ["c1", "reading src/a.ts"],
+      ["c2", "running rg auth"],
+    ]);
+    expect(describeActivity(tools)).toBe("reading src/a.ts, running rg auth…");
+    expect(describeActivity(new Map([["c1", "searching \"x\""]]))).toBe('searching "x"…');
+    expect(describeActivity(new Map(), " partial answer ")).toBe("partial answer");
+    expect(describeActivity(new Map())).toBe("thinking…");
   });
 });

--- a/packages/pi-subagents/test/agent-widget.test.ts
+++ b/packages/pi-subagents/test/agent-widget.test.ts
@@ -8,6 +8,7 @@ import {
   fgPreservingNestedStyles,
   formatActiveToolSummary,
   formatSessionTokens,
+  formatSubagentsStatusText,
 } from "../src/ui/agent-widget.js";
 
 describe("formatSessionTokens", () => {
@@ -140,6 +141,63 @@ describe("AgentWidget", () => {
   it("renders nothing in 'off' mode", () => {
     const manager = { listAgents: () => [makeRecord("background", { isBackground: true })] };
     expect(renderLines(manager, "background", () => "off")).toBe("");
+  });
+});
+
+describe("formatSubagentsStatusText", () => {
+  it("formats running/queued counts and returns undefined when idle", () => {
+    expect(formatSubagentsStatusText(0, 0)).toBeUndefined();
+    expect(formatSubagentsStatusText(1, 0)).toBe("1 running agent");
+    expect(formatSubagentsStatusText(2, 1)).toBe("2 running, 1 queued agents");
+  });
+});
+
+describe("AgentWidget status bar policy", () => {
+  function makeRecord(id: string, opts: { isBackground?: boolean; status?: string } = {}) {
+    return {
+      id,
+      type: "general-purpose",
+      description: `${id} description`,
+      status: opts.status ?? "running",
+      toolUses: 0,
+      startedAt: Date.now(),
+      lifetimeUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      compactionCount: 0,
+      isBackground: opts.isBackground ?? true,
+    };
+  }
+
+  function captureStatus(mode: () => import("../src/types.js").WidgetMode, agents: unknown[]) {
+    const statuses: Array<string | undefined> = [];
+    const widget = new AgentWidget(
+      { listAgents: () => agents } as any,
+      new Map(),
+      mode,
+    );
+    widget.setUICtx({
+      setStatus: (_key, text) => { statuses.push(text); },
+      setWidget: () => {},
+    });
+    widget.update();
+    return statuses.at(-1);
+  }
+
+  it("clears status when the widget tree is active (background mode)", () => {
+    expect(captureStatus(() => "background", [makeRecord("bg")])).toBeUndefined();
+  });
+
+  it("clears status when the widget tree is active (all mode)", () => {
+    expect(captureStatus(() => "all", [makeRecord("fg", { isBackground: false })])).toBeUndefined();
+  });
+
+  it("uses compact status only when widget mode is off", () => {
+    expect(captureStatus(() => "off", [makeRecord("bg")])).toBe("1 running agent");
+    expect(
+      captureStatus(() => "off", [
+        makeRecord("a"),
+        makeRecord("b", { status: "queued" }),
+      ]),
+    ).toBe("1 running, 1 queued agents");
   });
 });
 

--- a/packages/pi-subagents/test/clear-completed-wiring.test.ts
+++ b/packages/pi-subagents/test/clear-completed-wiring.test.ts
@@ -1,0 +1,172 @@
+/**
+ * clear-completed-wiring.test.ts — reproduces issue #108 end-to-end through the
+ * REAL session lifecycle handlers + the REAL get_subagent_result tool.
+ *
+ * Bug: a background agent that has COMPLETED but whose result the LLM hasn't read
+ * yet (resultConsumed=false) was wiped by clearCompleted() on session_start /
+ * session_before_switch, so the next get_subagent_result returned "Agent not
+ * found". The fix makes both handlers call clearCompleted(true), preserving
+ * unread records (the 10-minute timer evicts them later).
+ *
+ * These tests exercise the wiring, not the manager method in isolation: spawn a
+ * real background agent, let it complete, fire the real session event, then read
+ * it back through the real tool — the exact path the reporter hit.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>(); // pi.on(...) — session_start, session_before_switch, session_shutdown
+  const events = new Map<string, any>(); // pi.events.on(...) — subagents:rpc:*, etc.
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((t: any) => tools.set(t.name, t)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: {
+      emit: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        events.set(event, handler);
+        return vi.fn();
+      }),
+    },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  return { pi, tools, lifecycle, events };
+}
+
+function ctx() {
+  return {
+    hasUI: false,
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    cwd: process.cwd(),
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: vi.fn(() => "s1"), getBranch: vi.fn(() => []) },
+    getSystemPrompt: vi.fn(() => "parent"),
+  } as any;
+}
+
+const textOf = (r: any): string => r.content[0].text;
+// Let runAgent's resolved .then() chain settle so the record reaches "completed".
+const flush = async () => {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+};
+
+// Spawn a real background agent and drive it to status "completed" with
+// resultConsumed=false (only get_subagent_result sets that flag for background).
+async function spawnCompletedBackgroundAgent(tools: Map<string, any>): Promise<string> {
+  vi.mocked(runAgent).mockResolvedValue({
+    responseText: "THE-RESULT-PAYLOAD",
+    session: { dispose: vi.fn() } as any,
+    aborted: false,
+    steered: false,
+  });
+  const spawn = await tools.get("Agent").execute(
+    "tc-spawn",
+    { prompt: "go", description: "Review monero_en.rs in depth", subagent_type: "general-purpose", run_in_background: true },
+    undefined,
+    undefined,
+    ctx(),
+  );
+  const id = textOf(spawn).match(/Agent ID: (\S+)/)?.[1];
+  expect(id, "background spawn should surface an agent id").toBeTruthy();
+  await flush();
+  return id as string;
+}
+
+describe("issue #108: unread completed background agents survive session events", () => {
+  let tmpDir: string;
+  let agentDir: string;
+  let prevCwd: string;
+  let prevAgentDir: string | undefined;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    // Hermetic cwd + global dir, scheduling off, so session_start doesn't spin a
+    // scheduler or touch the dev's filesystem — isolates the clearCompleted path.
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-108-"));
+    agentDir = mkdtempSync(join(tmpdir(), "pi-108-agentdir-"));
+    prevAgentDir = process.env.PI_CODING_AGENT_DIR;
+    prevHome = process.env.HOME;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.HOME = agentDir;
+    prevCwd = process.cwd();
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(join(tmpDir, ".pi", "subagents.json"), JSON.stringify({ schedulingEnabled: false }));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    if (prevAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = prevAgentDir;
+    if (prevHome == null) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(agentDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("session_before_switch (user switches sessions) does NOT wipe the unread result", async () => {
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+    const id = await spawnCompletedBackgroundAgent(tools);
+
+    // The exact #108 trigger: a session switch fires before the LLM read the result.
+    await lifecycle.get("session_before_switch")?.();
+
+    const res = await tools.get("get_subagent_result").execute("tc-read", { agent_id: id }, undefined, undefined, ctx());
+    const out = textOf(res);
+    expect(out).not.toContain("Agent not found");
+    expect(out).toContain("THE-RESULT-PAYLOAD");
+
+    await lifecycle.get("session_shutdown")?.({}, ctx());
+  });
+
+  it("session_start (/resume) does NOT wipe the unread result", async () => {
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+    const id = await spawnCompletedBackgroundAgent(tools);
+
+    await lifecycle.get("session_start")?.({}, ctx());
+
+    const res = await tools.get("get_subagent_result").execute("tc-read", { agent_id: id }, undefined, undefined, ctx());
+    const out = textOf(res);
+    expect(out).not.toContain("Agent not found");
+    expect(out).toContain("THE-RESULT-PAYLOAD");
+
+    await lifecycle.get("session_shutdown")?.({}, ctx());
+  });
+
+  it("once read, a session switch DOES evict it — the fix stays surgical, no leak", async () => {
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+    const id = await spawnCompletedBackgroundAgent(tools);
+
+    // LLM reads the result → resultConsumed=true.
+    const first = await tools.get("get_subagent_result").execute("tc-read1", { agent_id: id }, undefined, undefined, ctx());
+    expect(textOf(first)).toContain("THE-RESULT-PAYLOAD");
+
+    // Now a session switch SHOULD clean it up (consumed records are not preserved).
+    await lifecycle.get("session_before_switch")?.();
+
+    const second = await tools.get("get_subagent_result").execute("tc-read2", { agent_id: id }, undefined, undefined, ctx());
+    expect(textOf(second)).toContain("Agent not found");
+
+    await lifecycle.get("session_shutdown")?.({}, ctx());
+  });
+});

--- a/packages/pi-subagents/test/context.test.ts
+++ b/packages/pi-subagents/test/context.test.ts
@@ -1,0 +1,129 @@
+/**
+ * context.test.ts — Parent conversation context extraction for inherit_context spawns.
+ *
+ * buildParentContext shapes what a subagent sees from its parent; silent bugs
+ * here would feed wrong context into spawns. Tests use realistic SessionEntry
+ * shapes and a minimal ExtensionContext stub — no mocking beyond the one
+ * getBranch() call the function actually reads.
+ */
+
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { buildParentContext, extractText } from "../src/context.js";
+
+function makeCtx(entries: unknown[]): ExtensionContext {
+  return { sessionManager: { getBranch: () => entries } } as unknown as ExtensionContext;
+}
+
+function userMsg(content: string | unknown[]) {
+  return { type: "message", message: { role: "user", content } };
+}
+
+function assistantMsg(blocks: unknown[]) {
+  return { type: "message", message: { role: "assistant", content: blocks } };
+}
+
+describe("extractText", () => {
+  it("joins multiple text blocks with newlines", () => {
+    expect(extractText([{ type: "text", text: "a" }, { type: "text", text: "b" }])).toBe("a\nb");
+  });
+
+  it("filters out non-text blocks (tool_use, etc.)", () => {
+    expect(
+      extractText([
+        { type: "text", text: "keep" },
+        { type: "tool_use", name: "x", input: {} },
+        { type: "text", text: "also keep" },
+      ]),
+    ).toBe("keep\nalso keep");
+  });
+
+  it("treats a text block with missing text field as empty", () => {
+    expect(extractText([{ type: "text" }, { type: "text", text: "x" }])).toBe("\nx");
+  });
+
+  it("returns empty string for an empty content array", () => {
+    expect(extractText([])).toBe("");
+  });
+});
+
+describe("buildParentContext", () => {
+  it("returns empty string for an empty branch", () => {
+    expect(buildParentContext(makeCtx([]))).toBe("");
+  });
+
+  it("returns empty string when no entries produce extractable content", () => {
+    // toolResult is skipped, empty-summary compaction is skipped
+    const out = buildParentContext(
+      makeCtx([
+        { type: "message", message: { role: "tool_result", content: "..." } },
+        { type: "compaction", summary: "" },
+      ]),
+    );
+    expect(out).toBe("");
+  });
+
+  it("wraps a user+assistant exchange with the parent-context header and task footer", () => {
+    const out = buildParentContext(
+      makeCtx([userMsg("hello"), assistantMsg([{ type: "text", text: "hi back" }])]),
+    );
+    expect(out).toContain("# Parent Conversation Context");
+    expect(out).toContain("[User]: hello");
+    expect(out).toContain("[Assistant]: hi back");
+    expect(out).toMatch(/# Your Task \(below\)\n$/);
+    // Entries are joined with a blank line, preserving conversation order
+    expect(out).toContain("[User]: hello\n\n[Assistant]: hi back");
+  });
+
+  it("accepts user messages whose content is content-blocks (not just a string)", () => {
+    const out = buildParentContext(makeCtx([userMsg([{ type: "text", text: "from blocks" }])]));
+    expect(out).toContain("[User]: from blocks");
+  });
+
+  it("includes compaction summaries inline in their original position", () => {
+    const out = buildParentContext(
+      makeCtx([
+        userMsg("orig question"),
+        { type: "compaction", summary: "we discussed X" },
+        assistantMsg([{ type: "text", text: "follow-up" }]),
+      ]),
+    );
+    expect(out.indexOf("[User]: orig question"))
+      .toBeLessThan(out.indexOf("[Summary]: we discussed X"));
+    expect(out.indexOf("[Summary]: we discussed X"))
+      .toBeLessThan(out.indexOf("[Assistant]: follow-up"));
+  });
+
+  it("skips tool_result messages — they're too verbose for inherited context", () => {
+    const out = buildParentContext(
+      makeCtx([
+        userMsg("real user"),
+        { type: "message", message: { role: "tool_result", content: "noisy tool output" } },
+        assistantMsg([{ type: "text", text: "real assistant" }]),
+      ]),
+    );
+    expect(out).not.toContain("noisy tool output");
+    expect(out).toContain("[User]: real user");
+    expect(out).toContain("[Assistant]: real assistant");
+  });
+
+  it("trims and skips whitespace-only messages", () => {
+    const out = buildParentContext(
+      makeCtx([userMsg("   \n  "), assistantMsg([{ type: "text", text: "non-empty" }])]),
+    );
+    expect(out).not.toMatch(/\[User\]:/);
+    expect(out).toContain("[Assistant]: non-empty");
+  });
+
+  it("ignores assistant messages whose only content is non-text blocks", () => {
+    // Assistant emitted only a tool_use — nothing extractable, so it shouldn't appear
+    const out = buildParentContext(
+      makeCtx([
+        userMsg("question"),
+        assistantMsg([{ type: "tool_use", name: "x", input: {} }]),
+      ]),
+    );
+    expect(out).toContain("[User]: question");
+    expect(out).not.toContain("[Assistant]:");
+  });
+});

--- a/packages/pi-subagents/test/conversation-brief.test.ts
+++ b/packages/pi-subagents/test/conversation-brief.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildConversationBrief,
+  formatStepLine,
+  summarizeToolArgs,
+  summarizeToolResult,
+  truncatePromptLines,
+} from "../src/ui/conversation-brief.js";
+
+describe("summarizeToolArgs", () => {
+  it("prefers path for read/write/edit", () => {
+    expect(summarizeToolArgs("read", { path: "src/a.ts" })).toBe("src/a.ts");
+    expect(summarizeToolArgs("edit", { file_path: "pkg/b.ts", oldText: "x" })).toBe("pkg/b.ts");
+  });
+
+  it("prefers command for bash", () => {
+    expect(summarizeToolArgs("bash", { command: 'rg "auth" -n' })).toBe('rg "auth" -n');
+  });
+
+  it("formats grep pattern + path/glob", () => {
+    expect(summarizeToolArgs("grep", { pattern: "auth", path: "src" })).toBe('"auth" src');
+    expect(summarizeToolArgs("grep", { pattern: "foo", glob: "*.ts" })).toBe('"foo" *.ts');
+  });
+
+  it("falls back to compact JSON", () => {
+    expect(summarizeToolArgs("custom", { a: 1, b: "two" })).toBe('{"a":1,"b":"two"}');
+  });
+
+  it("truncates long values", () => {
+    const long = "x".repeat(200);
+    const out = summarizeToolArgs("bash", { command: long }, 40);
+    expect(out.length).toBeLessThanOrEqual(40);
+    expect(out.endsWith("…")).toBe(true);
+  });
+});
+
+describe("summarizeToolResult", () => {
+  it("reports ok with line count for multi-line bodies", () => {
+    expect(summarizeToolResult("a\nb\nc", false)).toMatch(/^ok · 3 lines/);
+  });
+
+  it("includes a short first-line preview for single-line ok", () => {
+    expect(summarizeToolResult("hello world", false)).toBe("ok · hello world");
+  });
+
+  it("marks errors", () => {
+    expect(summarizeToolResult("boom", true)).toBe("error · boom");
+  });
+});
+
+describe("buildConversationBrief", () => {
+  it("extracts prompt, steps, and final result without dumping tool bodies", () => {
+    const brief = buildConversationBrief([
+      { role: "user", content: "Find auth files" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I'll search." },
+          { type: "toolCall", id: "c1", name: "grep", arguments: { pattern: "auth", path: "src" } },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "c1",
+        toolName: "grep",
+        isError: false,
+        content: [{ type: "text", text: "src/a.ts:1\nsrc/b.ts:2\nsrc/c.ts:3" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Found three files." }],
+      },
+    ]);
+
+    expect(brief.prompt).toBe("Find auth files");
+    expect(brief.steps).toHaveLength(1);
+    expect(brief.steps[0]?.toolName).toBe("grep");
+    expect(brief.steps[0]?.status).toBe("completed");
+    expect(brief.steps[0]?.summary).toContain("auth");
+    expect(brief.steps[0]?.resultNote).toMatch(/ok · 3 lines/);
+    expect(brief.steps[0]?.resultText).toContain("src/a.ts");
+    // Intermediate assistant chatter is not the final result.
+    expect(brief.result).toBe("Found three files.");
+  });
+
+  it("keeps running steps open until a toolResult arrives", () => {
+    const brief = buildConversationBrief([
+      { role: "user", content: "read it" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "r1", name: "read", arguments: { path: "a.ts" } }],
+      },
+    ]);
+    expect(brief.steps[0]?.status).toBe("running");
+    expect(brief.result).toBeUndefined();
+  });
+
+  it("marks failed tool results", () => {
+    const brief = buildConversationBrief([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "b1", name: "bash", arguments: { command: "false" } }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "b1",
+        toolName: "bash",
+        isError: true,
+        content: [{ type: "text", text: "exit 1" }],
+      },
+    ]);
+    expect(brief.steps[0]?.status).toBe("error");
+    expect(brief.steps[0]?.isError).toBe(true);
+    expect(formatStepLine(brief.steps[0]!).startsWith("✗")).toBe(true);
+  });
+
+  it("accepts legacy toolUseId / input shapes from older fixtures", () => {
+    const brief = buildConversationBrief([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", toolUseId: "t1", name: "read", input: { path: "legacy.ts" } }],
+      },
+      {
+        role: "toolResult",
+        toolUseId: "t1",
+        content: [{ type: "text", text: "ok" }],
+      },
+    ]);
+    expect(brief.steps).toHaveLength(1);
+    expect(brief.steps[0]?.summary).toBe("legacy.ts");
+    expect(brief.steps[0]?.status).toBe("completed");
+  });
+
+  it("captures steer user messages separately from the dispatch prompt", () => {
+    const brief = buildConversationBrief([
+      { role: "user", content: "original task" },
+      { role: "assistant", content: [{ type: "text", text: "working" }] },
+      { role: "user", content: "please also check tests" },
+    ]);
+    expect(brief.prompt).toBe("original task");
+    expect(brief.steers).toEqual(["please also check tests"]);
+    expect(brief.result).toBe("working");
+  });
+
+  it("includes bashExecution as a completed bash step", () => {
+    const brief = buildConversationBrief([
+      {
+        role: "bashExecution",
+        command: "ls -la",
+        output: "a\nb\n",
+      },
+    ]);
+    expect(brief.steps[0]?.toolName).toBe("bash");
+    expect(brief.steps[0]?.summary).toBe("ls -la");
+    expect(brief.steps[0]?.status).toBe("completed");
+  });
+});
+
+describe("truncatePromptLines", () => {
+  it("keeps short prompts intact", () => {
+    const { lines, truncated } = truncatePromptLines("a\nb\nc", 30);
+    expect(truncated).toBe(false);
+    expect(lines).toEqual(["a", "b", "c"]);
+  });
+
+  it("truncates long prompts with a note", () => {
+    const prompt = Array.from({ length: 40 }, (_, i) => `line ${i}`).join("\n");
+    const { lines, truncated } = truncatePromptLines(prompt, 30);
+    expect(truncated).toBe(true);
+    expect(lines).toHaveLength(31);
+    expect(lines[30]).toMatch(/10 more lines truncated/);
+  });
+});
+
+describe("formatStepLine", () => {
+  it("renders status icon + tool + summary", () => {
+    expect(
+      formatStepLine({
+        id: "1",
+        toolName: "read",
+        summary: "src/a.ts",
+        status: "completed",
+        isError: false,
+        resultNote: "ok · 12 lines",
+      }),
+    ).toBe("✓ read   src/a.ts  · ok · 12 lines");
+  });
+});

--- a/packages/pi-subagents/test/conversation-brief.test.ts
+++ b/packages/pi-subagents/test/conversation-brief.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildConversationBrief,
   formatStepLine,
+  settleDanglingBriefSteps,
   summarizeToolArgs,
   summarizeToolResult,
   truncatePromptLines,
@@ -201,6 +202,49 @@ describe("truncatePromptLines", () => {
     expect(truncated).toBe(true);
     expect(lines).toHaveLength(31);
     expect(lines[30]).toMatch(/10 more lines truncated/);
+  });
+
+  it("keeps the tail when prompt embeds parent conversation context", () => {
+    const parent = Array.from({ length: 40 }, (_, i) => `parent ${i}`).join("\n");
+    const prompt = `# Parent Conversation Context\n${parent}\n\nDo the real dispatch task now.`;
+    const { lines, truncated } = truncatePromptLines(prompt, 10);
+    expect(truncated).toBe(true);
+    const joined = lines.join("\n");
+    expect(joined).toMatch(/earlier line/);
+    expect(joined).toContain("Do the real dispatch task now.");
+    expect(joined).not.toContain("parent 0");
+  });
+});
+
+describe("settleDanglingBriefSteps", () => {
+  it("marks unmatched running steps as error when record is stopped", () => {
+    const steps = [
+      {
+        id: "1",
+        toolName: "bash",
+        summary: "sleep 999",
+        status: "running" as const,
+        isError: false,
+      },
+    ];
+    settleDanglingBriefSteps(steps, "stopped");
+    expect(steps[0]?.status).toBe("error");
+    expect(steps[0]?.isError).toBe(true);
+    expect(steps[0]?.resultNote).toMatch(/interrupted/);
+  });
+
+  it("leaves steps alone while still running", () => {
+    const steps = [
+      {
+        id: "1",
+        toolName: "read",
+        summary: "a.ts",
+        status: "running" as const,
+        isError: false,
+      },
+    ];
+    settleDanglingBriefSteps(steps, "running");
+    expect(steps[0]?.status).toBe("running");
   });
 });
 

--- a/packages/pi-subagents/test/conversation-brief.test.ts
+++ b/packages/pi-subagents/test/conversation-brief.test.ts
@@ -148,11 +148,43 @@ describe("buildConversationBrief", () => {
         role: "bashExecution",
         command: "ls -la",
         output: "a\nb\n",
+        exitCode: 0,
       },
     ]);
     expect(brief.steps[0]?.toolName).toBe("bash");
     expect(brief.steps[0]?.summary).toBe("ls -la");
     expect(brief.steps[0]?.status).toBe("completed");
+    expect(brief.steps[0]?.isError).toBe(false);
+  });
+
+  it("marks bashExecution with non-zero exitCode as error", () => {
+    const brief = buildConversationBrief([
+      {
+        role: "bashExecution",
+        command: "false",
+        output: "failed",
+        exitCode: 1,
+      },
+    ]);
+    expect(brief.steps[0]?.status).toBe("error");
+    expect(brief.steps[0]?.isError).toBe(true);
+    expect(brief.steps[0]?.resultNote).toMatch(/^error/);
+    expect(formatStepLine(brief.steps[0]!).startsWith("✗")).toBe(true);
+  });
+
+  it("marks cancelled bashExecution as error", () => {
+    const brief = buildConversationBrief([
+      {
+        role: "bashExecution",
+        command: "sleep 999",
+        output: "",
+        exitCode: 130,
+        cancelled: true,
+      },
+    ]);
+    expect(brief.steps[0]?.status).toBe("error");
+    expect(brief.steps[0]?.isError).toBe(true);
+    expect(brief.steps[0]?.resultNote).toMatch(/cancelled/);
   });
 });
 

--- a/packages/pi-subagents/test/conversation-viewer-keybindings.test.ts
+++ b/packages/pi-subagents/test/conversation-viewer-keybindings.test.ts
@@ -1,0 +1,140 @@
+import { KeybindingsManager, TUI_KEYBINDINGS } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRecord } from "../src/types.js";
+import { ConversationViewer } from "../src/ui/conversation-viewer.js";
+import type { ViewerKeybindings } from "../src/ui/viewer-keys.js";
+import { createViewerKeys } from "../src/ui/viewer-keys.js";
+
+const CTRL_P = "\x10";
+const CTRL_N = "\x0e";
+const UP = "\x1b[A";
+const DOWN = "\x1b[B";
+const SHIFT_UP = "\x1b[1;2A";
+const SHIFT_DOWN = "\x1b[1;2B";
+const PAGE_UP = "\x1b[5~";
+const PAGE_DOWN = "\x1b[6~";
+
+function createEmacsKeybindings(): KeybindingsManager {
+  return new KeybindingsManager(TUI_KEYBINDINGS, {
+    "tui.select.up": ["up", "ctrl+p"],
+    "tui.select.down": ["down", "ctrl+n"],
+  });
+}
+
+function createViewer(keybindings?: ViewerKeybindings) {
+  const tui = {
+    terminal: { rows: 20, columns: 80 },
+    requestRender: vi.fn(),
+  } as any;
+  const messages = Array.from({ length: 60 }, (_, i) => ({
+    role: "user",
+    content: `message ${i}`,
+  }));
+  const session = {
+    messages,
+    subscribe: vi.fn(() => vi.fn()),
+  } as any;
+  const record = {
+    id: "test-1",
+    type: "general-purpose",
+    description: "test agent",
+    status: "completed",
+    toolUses: 0,
+    startedAt: Date.now(),
+  } as AgentRecord;
+  const theme = {
+    fg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  } as any;
+  const viewer = new ConversationViewer(tui, session, record, undefined, theme, vi.fn(), undefined, keybindings);
+  viewer.render(80); // sets lastInnerW and scrolls to bottom (autoScroll)
+  return viewer;
+}
+
+function scrollOffset(viewer: ConversationViewer): number {
+  return (viewer as any).scrollOffset;
+}
+
+describe("viewer-keys", () => {
+  it("honors user keybindings when a manager is provided", () => {
+    const keys = createViewerKeys(createEmacsKeybindings());
+    expect(keys.scrollUp(CTRL_P)).toBe(true);
+    expect(keys.scrollUp(UP)).toBe(true);
+    expect(keys.scrollDown(CTRL_N)).toBe(true);
+    expect(keys.scrollDown(DOWN)).toBe(true);
+  });
+
+  it("falls back to hardcoded defaults without a manager", () => {
+    const keys = createViewerKeys();
+    expect(keys.scrollUp(UP)).toBe(true);
+    expect(keys.scrollUp(CTRL_P)).toBe(false);
+    expect(keys.scrollDown(DOWN)).toBe(true);
+    expect(keys.scrollDown(CTRL_N)).toBe(false);
+    expect(keys.pageUp(PAGE_UP)).toBe(true);
+    expect(keys.pageDown(PAGE_DOWN)).toBe(true);
+  });
+
+  it("keeps the k/j and shift+arrow aliases with and without a manager", () => {
+    for (const keys of [createViewerKeys(), createViewerKeys(createEmacsKeybindings())]) {
+      expect(keys.scrollUp("k")).toBe(true);
+      expect(keys.scrollDown("j")).toBe(true);
+      expect(keys.pageUp(SHIFT_UP)).toBe(true);
+      expect(keys.pageDown(SHIFT_DOWN)).toBe(true);
+    }
+  });
+
+  it("manager with no user overrides behaves like the hardcoded defaults", () => {
+    const keys = createViewerKeys(new KeybindingsManager(TUI_KEYBINDINGS, {}));
+    expect(keys.scrollUp(UP)).toBe(true);
+    expect(keys.scrollDown(DOWN)).toBe(true);
+    expect(keys.pageUp(PAGE_UP)).toBe(true);
+    expect(keys.pageDown(PAGE_DOWN)).toBe(true);
+    expect(keys.scrollUp(CTRL_P)).toBe(false);
+    expect(keys.scrollDown(CTRL_N)).toBe(false);
+  });
+
+  it("respects rebinding that removes a default key", () => {
+    const manager = new KeybindingsManager(TUI_KEYBINDINGS, {
+      "tui.select.up": "ctrl+p",
+    });
+    const keys = createViewerKeys(manager);
+    expect(keys.scrollUp(CTRL_P)).toBe(true);
+    expect(keys.scrollUp(UP)).toBe(false);
+  });
+});
+
+describe("ConversationViewer custom keybindings", () => {
+  it("scrolls with ctrl+p/ctrl+n when bound to tui.select.up/down", () => {
+    const viewer = createViewer(createEmacsKeybindings());
+    const bottom = scrollOffset(viewer);
+    expect(bottom).toBeGreaterThan(0);
+
+    viewer.handleInput(CTRL_P);
+    expect(scrollOffset(viewer)).toBe(bottom - 1);
+    viewer.handleInput(CTRL_N);
+    expect(scrollOffset(viewer)).toBe(bottom);
+  });
+
+  it("keeps arrows and k/j working alongside custom bindings", () => {
+    const viewer = createViewer(createEmacsKeybindings());
+    const bottom = scrollOffset(viewer);
+
+    viewer.handleInput(UP);
+    viewer.handleInput("k");
+    expect(scrollOffset(viewer)).toBe(bottom - 2);
+    viewer.handleInput(DOWN);
+    viewer.handleInput("j");
+    expect(scrollOffset(viewer)).toBe(bottom);
+  });
+
+  it("treats ctrl+p/ctrl+n as unbound without a keybindings manager", () => {
+    const viewer = createViewer();
+    const bottom = scrollOffset(viewer);
+
+    viewer.handleInput(CTRL_P);
+    viewer.handleInput(CTRL_N);
+    expect(scrollOffset(viewer)).toBe(bottom);
+    viewer.handleInput(UP);
+    expect(scrollOffset(viewer)).toBe(bottom - 1);
+  });
+});

--- a/packages/pi-subagents/test/conversation-viewer.test.ts
+++ b/packages/pi-subagents/test/conversation-viewer.test.ts
@@ -560,3 +560,36 @@ describe("ConversationViewer brief layout (scheme A)", () => {
     expect(viewer.render(W).join("\n")).not.toContain(hiddenLine);
   });
 });
+
+describe("ConversationViewer failed terminal result", () => {
+  const W = 80;
+
+  it("shows record.error instead of intermediate assistant text when status is error", () => {
+    const messages = [
+      { role: "user", content: "do work" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "I'll start looking around first." }],
+      },
+    ];
+    const viewer = new ConversationViewer(
+      mockTui(40, W),
+      mockSession(messages),
+      mockRecord({ status: "error", error: "Model blew up: rate limit" }),
+      undefined,
+      ansiTheme(),
+      vi.fn(),
+    );
+    const out = viewer.render(W).join("\n");
+    expect(out).toContain("Model blew up: rate limit");
+    expect(out).toContain("last assistant text before failure");
+    expect(out).toContain("I'll start looking around first.");
+    // Error line should appear in Result section before the intermediate text label.
+    const resultIdx = out.indexOf("Result");
+    const errIdx = out.indexOf("Model blew up");
+    const midIdx = out.indexOf("I'll start looking");
+    expect(resultIdx).toBeGreaterThan(-1);
+    expect(errIdx).toBeGreaterThan(resultIdx);
+    expect(midIdx).toBeGreaterThan(errIdx);
+  });
+});

--- a/packages/pi-subagents/test/conversation-viewer.test.ts
+++ b/packages/pi-subagents/test/conversation-viewer.test.ts
@@ -196,7 +196,7 @@ describe("ConversationViewer", () => {
 
     it("no line exceeds width with running activity indicator", () => {
       const activity = {
-        activeTools: new Map([["read", "file.ts"], ["grep", "pattern"]]),
+        activeTools: new Map([["c1", "reading file.ts"], ["c2", "searching pattern"]]),
         toolUses: 5, tokens: "10k", responseText: "R".repeat(400),
         session: { getSessionStats: () => ({ tokens: { total: 50000 } }) },
       };

--- a/packages/pi-subagents/test/conversation-viewer.test.ts
+++ b/packages/pi-subagents/test/conversation-viewer.test.ts
@@ -1,0 +1,562 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentRecord } from "../src/types.js";
+
+// ── Mock wrapTextWithAnsi ──────────────────────────────────────────────
+// We need to control what wrapTextWithAnsi returns to simulate the
+// upstream bug (returning lines wider than requested width).
+// vi.mock is hoisted and intercepts before conversation-viewer.ts binds
+// its import.
+
+let wrapOverride: ((text: string, width: number) => string[]) | null = null;
+
+vi.mock("@earendil-works/pi-tui", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@earendil-works/pi-tui")>();
+  return {
+    ...original,
+    wrapTextWithAnsi: (...args: [string, number]) => {
+      if (wrapOverride) return wrapOverride(...args);
+      return original.wrapTextWithAnsi(...args);
+    },
+  };
+});
+
+// Must import AFTER vi.mock declaration (vitest hoists vi.mock but the
+// dynamic import of the test subject must happen after)
+const { visibleWidth } = await import("@earendil-works/pi-tui");
+const { ConversationViewer } = await import("../src/ui/conversation-viewer.js");
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function mockTui(rows = 40, columns = 80) {
+  return {
+    terminal: { rows, columns },
+    requestRender: vi.fn(),
+  } as any;
+}
+
+function mockSession(messages: any[] = []) {
+  return {
+    messages,
+    subscribe: vi.fn(() => vi.fn()),
+    dispose: vi.fn(),
+    getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheWrite: 0 } }),
+  } as any;
+}
+
+function mockRecord(overrides: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    id: "test-1",
+    type: "general-purpose",
+    description: "test agent",
+    status: "running",
+    toolUses: 0,
+    startedAt: Date.now(),
+    ...overrides,
+  } as AgentRecord;
+}
+
+function ansiTheme() {
+  return {
+    fg: (_color: string, text: string) => `\x1b[38;5;240m${text}\x1b[0m`,
+    bold: (text: string) => `\x1b[1m${text}\x1b[22m`,
+  } as any;
+}
+
+function assertAllLinesFit(lines: string[], width: number) {
+  for (let i = 0; i < lines.length; i++) {
+    const vw = visibleWidth(lines[i]);
+    expect(vw, `line ${i} exceeds width (${vw} > ${width}): ${JSON.stringify(lines[i])}`).toBeLessThanOrEqual(width);
+  }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  wrapOverride = null;
+});
+
+describe("ConversationViewer", () => {
+  describe("render width safety", () => {
+    const widths = [40, 80, 120, 216];
+
+    it("no line exceeds width with empty messages", () => {
+      for (const w of widths) {
+        const viewer = new ConversationViewer(
+          mockTui(30, w), mockSession([]), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        );
+        assertAllLinesFit(viewer.render(w), w);
+      }
+    });
+
+    it("no line exceeds width with plain text messages", () => {
+      const messages = [
+        { role: "user", content: "Hello, how are you?" },
+        { role: "assistant", content: [{ type: "text", text: "I am fine, thank you for asking." }] },
+      ];
+      for (const w of widths) {
+        const viewer = new ConversationViewer(
+          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        );
+        assertAllLinesFit(viewer.render(w), w);
+      }
+    });
+
+    it("keeps bordered rows exact-width at a double-width truncation boundary", () => {
+      const width = 40;
+      for (let prefixLength = 0; prefixLength < width; prefixLength++) {
+        const viewer = new ConversationViewer(
+          mockTui(30, width),
+          mockSession([]),
+          mockRecord({ description: `${"a".repeat(prefixLength)}界more` }),
+          undefined,
+          ansiTheme(),
+          vi.fn(),
+        );
+
+        for (const line of viewer.render(width)) {
+          expect(
+            visibleWidth(line),
+            `prefix ${prefixLength} produced an under-width bordered row: ${JSON.stringify(line)}`,
+          ).toBe(width);
+        }
+      }
+    });
+
+    it("no line exceeds width when text is longer than viewport", () => {
+      const longLine = "A".repeat(500);
+      const messages = [
+        { role: "user", content: longLine },
+        { role: "assistant", content: [{ type: "text", text: longLine }] },
+        { role: "toolResult", toolUseId: "t1", content: [{ type: "text", text: longLine }] },
+      ];
+      for (const w of widths) {
+        const viewer = new ConversationViewer(
+          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        );
+        assertAllLinesFit(viewer.render(w), w);
+      }
+    });
+
+    it("no line exceeds width with embedded ANSI escape codes in content", () => {
+      const ansiText = `\x1b[1mBold heading\x1b[22m and \x1b[31mred text\x1b[0m ${"X".repeat(300)}`;
+      const messages = [
+        { role: "toolResult", toolUseId: "t1", content: [{ type: "text", text: ansiText }] },
+      ];
+      for (const w of widths) {
+        const viewer = new ConversationViewer(
+          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        );
+        assertAllLinesFit(viewer.render(w), w);
+      }
+    });
+
+    it("no line exceeds width with long URLs", () => {
+      const url = "https://example.com/" + "a/b/c/d/e/".repeat(30) + "?q=" + "x".repeat(100);
+      const messages = [
+        { role: "assistant", content: [{ type: "text", text: `Check this link: ${url}` }] },
+      ];
+      for (const w of widths) {
+        const viewer = new ConversationViewer(
+          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        );
+        assertAllLinesFit(viewer.render(w), w);
+      }
+    });
+
+    it("no line exceeds width with wide table-like content", () => {
+      const header = "| " + Array.from({ length: 20 }, (_, i) => `Column${i}`).join(" | ") + " |";
+      const dataRow = "| " + Array.from({ length: 20 }, () => "value123").join(" | ") + " |";
+      const table = [header, dataRow, dataRow, dataRow].join("\n");
+      const messages = [
+        { role: "toolResult", toolUseId: "t1", content: [{ type: "text", text: table }] },
+      ];
+      for (const w of widths) {
+        const viewer = new ConversationViewer(
+          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        );
+        assertAllLinesFit(viewer.render(w), w);
+      }
+    });
+
+    it("no line exceeds width with bashExecution messages", () => {
+      const messages = [
+        {
+          role: "bashExecution", command: "cat " + "/very/long/path/".repeat(20) + "file.txt",
+          output: "O".repeat(600),
+          exitCode: 0, cancelled: false, truncated: false, timestamp: Date.now(),
+        },
+      ];
+      for (const w of widths) {
+        const viewer = new ConversationViewer(
+          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        );
+        assertAllLinesFit(viewer.render(w), w);
+      }
+    });
+
+    it("no line exceeds width with running activity indicator", () => {
+      const activity = {
+        activeTools: new Map([["read", "file.ts"], ["grep", "pattern"]]),
+        toolUses: 5, tokens: "10k", responseText: "R".repeat(400),
+        session: { getSessionStats: () => ({ tokens: { total: 50000 } }) },
+      };
+      const messages = [
+        { role: "user", content: "do the thing" },
+        { role: "assistant", content: [{ type: "text", text: "working on it" }] },
+      ];
+      for (const w of widths) {
+        const viewer = new ConversationViewer(
+          mockTui(30, w), mockSession(messages), mockRecord({ status: "running" }), activity as any, ansiTheme(), vi.fn(),
+        );
+        assertAllLinesFit(viewer.render(w), w);
+      }
+    });
+
+    it("no line exceeds width with tool calls", () => {
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me check that." },
+            { type: "toolCall", toolUseId: "t1", name: "very_long_tool_name_" + "x".repeat(200), input: {} },
+          ],
+        },
+      ];
+      for (const w of widths) {
+        const viewer = new ConversationViewer(
+          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        );
+        assertAllLinesFit(viewer.render(w), w);
+      }
+    });
+
+    it("no line exceeds width at narrow terminal", () => {
+      const messages = [
+        { role: "user", content: "Hello world, this is a normal sentence." },
+        { role: "assistant", content: [{ type: "text", text: "Sure, here's the answer." }] },
+      ];
+      for (const w of [8, 10, 15, 20]) {
+        const viewer = new ConversationViewer(
+          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        );
+        assertAllLinesFit(viewer.render(w), w);
+      }
+    });
+
+    it("no line exceeds width with mixed ANSI + unicode content", () => {
+      const text = `\x1b[32m✓\x1b[0m Test passed — 日本語テスト ${"あ".repeat(50)} \x1b[33m⚠\x1b[0m`;
+      const messages = [
+        { role: "toolResult", toolUseId: "t1", content: [{ type: "text", text }] },
+      ];
+      for (const w of widths) {
+        const viewer = new ConversationViewer(
+          mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+        );
+        assertAllLinesFit(viewer.render(w), w);
+      }
+    });
+  });
+
+  describe("safety net against upstream wrapTextWithAnsi bugs", () => {
+    // These tests call buildContentLines() directly (via the private method)
+    // because render() has its own truncation via row(). The safety net in
+    // buildContentLines is what prevents the TUI crash — it must clamp
+    // independently of render().
+
+    /** Call the private buildContentLines method directly. */
+    function callBuildContentLines(viewer: InstanceType<typeof ConversationViewer>, width: number): string[] {
+      return (viewer as any).buildContentLines(width);
+    }
+
+    it("mock is intercepting wrapTextWithAnsi", async () => {
+      const { wrapTextWithAnsi } = await import("@earendil-works/pi-tui");
+      wrapOverride = () => ["MOCK_SENTINEL"];
+      expect(wrapTextWithAnsi("anything", 10)).toEqual(["MOCK_SENTINEL"]);
+      wrapOverride = null;
+    });
+
+    it("clamps overwidth lines from toolResult content", () => {
+      const w = 80;
+      wrapOverride = () => ["X".repeat(w + 50)];
+
+      const messages = [
+        { role: "toolResult", toolUseId: "t1", content: [{ type: "text", text: "output" }] },
+      ];
+      const viewer = new ConversationViewer(
+        mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+      );
+      assertAllLinesFit(callBuildContentLines(viewer, w), w);
+    });
+
+    it("clamps overwidth lines from user message content", () => {
+      const w = 80;
+      wrapOverride = () => ["Y".repeat(w + 100)];
+
+      const messages = [{ role: "user", content: "hello" }];
+      const viewer = new ConversationViewer(
+        mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+      );
+      assertAllLinesFit(callBuildContentLines(viewer, w), w);
+    });
+
+    it("clamps overwidth lines from assistant message content", () => {
+      const w = 80;
+      wrapOverride = () => ["Z".repeat(w + 100)];
+
+      const messages = [
+        { role: "assistant", content: [{ type: "text", text: "response" }] },
+      ];
+      const viewer = new ConversationViewer(
+        mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+      );
+      assertAllLinesFit(callBuildContentLines(viewer, w), w);
+    });
+
+    it("clamps overwidth lines from bashExecution output", () => {
+      const w = 80;
+      wrapOverride = () => ["B".repeat(w + 100)];
+
+      const messages = [
+        {
+          role: "bashExecution", command: "ls", output: "out",
+          exitCode: 0, cancelled: false, truncated: false, timestamp: Date.now(),
+        },
+      ];
+      const viewer = new ConversationViewer(
+        mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+      );
+      assertAllLinesFit(callBuildContentLines(viewer, w), w);
+    });
+
+    it("clamps overwidth lines that also contain ANSI codes", () => {
+      const w = 80;
+      wrapOverride = () => [`\x1b[1m\x1b[31m${"W".repeat(w + 30)}\x1b[0m`];
+
+      const messages = [
+        { role: "toolResult", toolUseId: "t1", content: [{ type: "text", text: "output" }] },
+      ];
+      const viewer = new ConversationViewer(
+        mockTui(30, w), mockSession(messages), mockRecord(), undefined, ansiTheme(), vi.fn(),
+      );
+      assertAllLinesFit(callBuildContentLines(viewer, w), w);
+    });
+  });
+
+  describe("stop key", () => {
+    const W = 80;
+
+    it("two-press x stops a running agent (first arms, second aborts)", () => {
+      const onStop = vi.fn();
+      const tui = mockTui(30, W);
+      const viewer = new ConversationViewer(
+        tui, mockSession(), mockRecord({ status: "running" }), undefined, ansiTheme(), vi.fn(), onStop,
+      );
+
+      // Idle footer offers the stop affordance.
+      expect(viewer.render(W).join("\n")).toContain("x stop");
+
+      // First press arms (no abort yet) and re-renders.
+      viewer.handleInput("x");
+      expect(onStop).not.toHaveBeenCalled();
+      expect(tui.requestRender).toHaveBeenCalled();
+      expect(viewer.render(W).join("\n")).toContain("x again to STOP");
+
+      // Second press aborts.
+      viewer.handleInput("x");
+      expect(onStop).toHaveBeenCalledTimes(1);
+    });
+
+    it("any other key disarms the confirm", () => {
+      const onStop = vi.fn();
+      const viewer = new ConversationViewer(
+        mockTui(30, W), mockSession(), mockRecord({ status: "running" }), undefined, ansiTheme(), vi.fn(), onStop,
+      );
+
+      viewer.handleInput("x");                       // arm
+      viewer.handleInput("j");                       // scroll → disarm
+      expect(viewer.render(W).join("\n")).toContain("x stop");
+      expect(viewer.render(W).join("\n")).not.toContain("x again to STOP");
+
+      viewer.handleInput("x");                       // arms again, does NOT stop
+      expect(onStop).not.toHaveBeenCalled();
+    });
+
+    it("does not offer or perform stop once the agent is no longer running", () => {
+      const onStop = vi.fn();
+      const viewer = new ConversationViewer(
+        mockTui(30, W), mockSession(), mockRecord({ status: "completed" }), undefined, ansiTheme(), vi.fn(), onStop,
+      );
+
+      expect(viewer.render(W).join("\n")).not.toContain("x stop");
+      viewer.handleInput("x");
+      viewer.handleInput("x");
+      expect(onStop).not.toHaveBeenCalled();
+    });
+
+    it("no stop affordance when no onStop handler is provided (read-only history)", () => {
+      const viewer = new ConversationViewer(
+        mockTui(30, W), mockSession(), mockRecord({ status: "running" }), undefined, ansiTheme(), vi.fn(),
+      );
+      expect(viewer.render(W).join("\n")).not.toContain("x stop");
+      expect(() => { viewer.handleInput("x"); viewer.handleInput("x"); }).not.toThrow();
+    });
+  });
+
+  describe("steer composer", () => {
+    const W = 80;
+
+    function makeViewer(opts: { status?: AgentRecord["status"]; onSteer?: (m: string) => void } = {}) {
+      const onSteer = opts.onSteer ?? vi.fn();
+      const tui = mockTui(30, W);
+      const viewer = new ConversationViewer(
+        tui, mockSession(), mockRecord({ status: opts.status ?? "running" }),
+        undefined, ansiTheme(), vi.fn(), undefined, undefined, onSteer,
+      );
+      return { viewer, tui, onSteer };
+    }
+
+    it("offers the steer affordance for a running agent and opens on Enter", () => {
+      const { viewer } = makeViewer();
+      expect(viewer.render(W).join("\n")).toContain("Enter steer");
+
+      viewer.handleInput("\r"); // Enter
+      // Composer is shown (its prompt + send/cancel hint), idle footer is gone.
+      const out = viewer.render(W).join("\n");
+      expect(out).toContain("Enter send · Esc cancel");
+      expect(out).not.toContain("Enter steer");
+    });
+
+    it("typing then Enter sends the trimmed message and closes the composer", () => {
+      const { viewer, onSteer } = makeViewer();
+      viewer.handleInput("\r"); // open composer
+      for (const ch of "  hello  ") viewer.handleInput(ch);
+      viewer.handleInput("\r"); // send
+
+      expect(onSteer).toHaveBeenCalledWith("hello");
+      expect(viewer.render(W).join("\n")).not.toContain("Enter send"); // composer closed
+    });
+
+    it("Esc cancels the composer without sending", () => {
+      const { viewer, onSteer } = makeViewer();
+      viewer.handleInput("\r"); // open composer
+      for (const ch of "draft") viewer.handleInput(ch);
+      viewer.handleInput("\x1b"); // Esc
+
+      expect(onSteer).not.toHaveBeenCalled();
+      expect(viewer.render(W).join("\n")).not.toContain("Enter send");
+    });
+
+    it("an empty submit just returns (like Esc), without calling onSteer", () => {
+      const { viewer, onSteer } = makeViewer();
+      viewer.handleInput("\r"); // open composer
+      viewer.handleInput("\r"); // empty submit
+      expect(onSteer).not.toHaveBeenCalled();
+      expect(viewer.render(W).join("\n")).not.toContain("Enter send"); // composer closed
+    });
+
+    it("scroll keys are inert while composing (input owns them)", () => {
+      const { viewer } = makeViewer();
+      viewer.handleInput("\r"); // open composer
+      // 'j' would normally scroll, but here it types into the composer.
+      viewer.handleInput("j");
+      expect(viewer.render(W).join("\n")).toContain("Enter send · Esc cancel");
+    });
+
+    it("no steer affordance once the agent is no longer running", () => {
+      const { viewer, onSteer } = makeViewer({ status: "completed" });
+      expect(viewer.render(W).join("\n")).not.toContain("Enter steer");
+      viewer.handleInput("\r");
+      expect(viewer.render(W).join("\n")).not.toContain("Enter send");
+      expect(onSteer).not.toHaveBeenCalled();
+    });
+
+    it("no steer affordance when no onSteer handler is provided", () => {
+      const viewer = new ConversationViewer(
+        mockTui(30, W), mockSession(), mockRecord({ status: "running" }), undefined, ansiTheme(), vi.fn(),
+      );
+      expect(viewer.render(W).join("\n")).not.toContain("Enter steer");
+      expect(() => viewer.handleInput("\r")).not.toThrow();
+    });
+
+    it("composer rows never exceed width", () => {
+      for (const w of [40, 80, 120]) {
+        const tui = mockTui(30, w);
+        const viewer = new ConversationViewer(
+          tui, mockSession(), mockRecord({ status: "running" }),
+          undefined, ansiTheme(), vi.fn(), undefined, undefined, vi.fn(),
+        );
+        viewer.handleInput("\r"); // open composer
+        for (const ch of "x".repeat(200)) viewer.handleInput(ch);
+        assertAllLinesFit(viewer.render(w), w);
+      }
+    });
+  });
+});
+
+describe("ConversationViewer brief layout (scheme A)", () => {
+  const W = 80;
+
+  it("shows Prompt / Steps / Result sections and folds tool result bodies by default", () => {
+    const hugeResult = "LINE_SHOULD_NOT_APPEAR_IN_DEFAULT_VIEW\n".repeat(40);
+    const messages = [
+      { role: "user", content: "Dispatch me to find auth" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Searching…" },
+          { type: "toolCall", id: "c1", name: "grep", arguments: { pattern: "auth", path: "src" } },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "c1",
+        toolName: "grep",
+        isError: false,
+        content: [{ type: "text", text: hugeResult }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "All done with auth search." }],
+      },
+    ];
+    const viewer = new ConversationViewer(
+      mockTui(40, W), mockSession(messages), mockRecord({ status: "completed", toolUses: 1 }), undefined, ansiTheme(), vi.fn(),
+    );
+    const out = viewer.render(W).join("\n");
+    expect(out).toContain("Prompt");
+    expect(out).toContain("Dispatch me to find auth");
+    expect(out).toContain("Steps");
+    expect(out).toMatch(/grep/);
+    expect(out).toContain("Result");
+    expect(out).toContain("All done with auth search.");
+    // Default view must not dump the huge tool body.
+    expect(out).not.toContain("LINE_SHOULD_NOT_APPEAR_IN_DEFAULT_VIEW");
+  });
+
+  it("o toggles expanded tool detail that reveals folded multi-line result text", () => {
+    // Multi-line bodies are folded to a stats note by default; expand reveals the full text.
+    const hiddenLine = "SECRET_EXPANDED_BODY_LINE_2";
+    const messages = [
+      { role: "user", content: "go" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "c1", name: "read", arguments: { path: "a.ts" } }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "c1",
+        toolName: "read",
+        isError: false,
+        content: [{ type: "text", text: `first line\n${hiddenLine}\nthird` }],
+      },
+    ];
+    const viewer = new ConversationViewer(
+      mockTui(40, W), mockSession(messages), mockRecord({ status: "completed" }), undefined, ansiTheme(), vi.fn(),
+    );
+    expect(viewer.render(W).join("\n")).not.toContain(hiddenLine);
+    viewer.handleInput("o");
+    expect(viewer.render(W).join("\n")).toContain(hiddenLine);
+    viewer.handleInput("o");
+    expect(viewer.render(W).join("\n")).not.toContain(hiddenLine);
+  });
+});

--- a/packages/pi-subagents/test/conversation-viewer.test.ts
+++ b/packages/pi-subagents/test/conversation-viewer.test.ts
@@ -592,4 +592,99 @@ describe("ConversationViewer failed terminal result", () => {
     expect(errIdx).toBeGreaterThan(resultIdx);
     expect(midIdx).toBeGreaterThan(errIdx);
   });
+
+  it("steered shows turn-limit notice instead of silent Done", () => {
+    const messages = [
+      { role: "user", content: "long task" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "partial wrap-up text" }],
+      },
+    ];
+    const viewer = new ConversationViewer(
+      mockTui(40, W),
+      mockSession(messages),
+      mockRecord({ status: "steered" }),
+      undefined,
+      ansiTheme(),
+      vi.fn(),
+    );
+    const out = viewer.render(W).join("\n");
+    expect(out).toMatch(/Wrapped up \(turn limit\)/);
+    expect(out).toContain("partial wrap-up text");
+    expect(out).toMatch(/✓/); // warning checkmark in header
+  });
+
+  it("stopped header uses ■ and settles dangling running steps", () => {
+    const messages = [
+      { role: "user", content: "go" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "c1", name: "bash", arguments: { command: "sleep 999" } }],
+      },
+    ];
+    const viewer = new ConversationViewer(
+      mockTui(40, W),
+      mockSession(messages),
+      mockRecord({ status: "stopped" }),
+      undefined,
+      ansiTheme(),
+      vi.fn(),
+    );
+    const out = viewer.render(W).join("\n");
+    expect(out).toMatch(/■/);
+    expect(out).toMatch(/Stopped by user/);
+    expect(out).toMatch(/✗/); // dangling step settled to error
+    expect(out).not.toMatch(/⠹/);
+  });
+
+  it("expanded args are hard-capped so write content cannot flood the overlay", () => {
+    const huge = "X".repeat(2500);
+    const messages = [
+      { role: "user", content: "write it" },
+      {
+        role: "assistant",
+        content: [{
+          type: "toolCall",
+          id: "w1",
+          name: "write",
+          arguments: { path: "big.ts", content: huge },
+        }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "w1",
+        toolName: "write",
+        isError: false,
+        content: [{ type: "text", text: "ok" }],
+      },
+    ];
+    const viewer = new ConversationViewer(
+      mockTui(40, W),
+      mockSession(messages),
+      mockRecord({ status: "completed" }),
+      undefined,
+      ansiTheme(),
+      vi.fn(),
+    );
+    viewer.handleInput("o");
+    const out = viewer.render(W).join("\n");
+    expect(out).toMatch(/truncated/);
+    // Full 2500-char blob must not appear.
+    expect(out.includes(huge)).toBe(false);
+  });
+});
+
+describe("headerStatusIcon", () => {
+  it("maps terminal statuses consistently", async () => {
+    const { headerStatusIcon } = await import("../src/ui/conversation-viewer.js");
+    const th = { fg: (_c: string, t: string) => t, bold: (t: string) => t } as any;
+    expect(headerStatusIcon("running", th)).toBe("●");
+    expect(headerStatusIcon("queued", th)).toBe("○");
+    expect(headerStatusIcon("completed", th)).toBe("✓");
+    expect(headerStatusIcon("steered", th)).toBe("✓");
+    expect(headerStatusIcon("error", th)).toBe("✗");
+    expect(headerStatusIcon("aborted", th)).toBe("✗");
+    expect(headerStatusIcon("stopped", th)).toBe("■");
+  });
 });

--- a/packages/pi-subagents/test/cross-extension-rpc.test.ts
+++ b/packages/pi-subagents/test/cross-extension-rpc.test.ts
@@ -1,0 +1,320 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type EventBus, PROTOCOL_VERSION, type RpcDeps, registerRpcHandlers, type SpawnCapable } from "../src/cross-extension-rpc.js";
+
+/** Simple in-process event bus for testing. */
+function createEventBus(): EventBus {
+  const listeners = new Map<string, Set<(data: unknown) => void>>();
+  return {
+    on(event, handler) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(handler);
+      return () => { listeners.get(event)?.delete(handler); };
+    },
+    emit(event, data) {
+      for (const handler of listeners.get(event) ?? []) handler(data);
+    },
+  };
+}
+
+describe("cross-extension RPC", () => {
+  let events: EventBus;
+  let manager: SpawnCapable;
+  let ctx: object | undefined;
+  let deps: RpcDeps;
+
+  beforeEach(() => {
+    events = createEventBus();
+    manager = { spawn: vi.fn().mockReturnValue("agent-42"), abort: vi.fn().mockReturnValue(true) };
+    ctx = { session: true };
+    deps = { events, pi: { events }, getCtx: () => ctx, manager };
+  });
+
+  // --- ping ---
+
+  describe("ping RPC", () => {
+    it("replies with protocol version", async () => {
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:ping:reply:req-1", reply);
+      events.emit("subagents:rpc:ping", { requestId: "req-1" });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(reply).toHaveBeenCalledWith({ success: true, data: { version: PROTOCOL_VERSION } });
+    });
+
+    it("scopes replies — other requestIds do not receive it", async () => {
+      registerRpcHandlers(deps);
+      const wrongReply = vi.fn();
+      events.on("subagents:rpc:ping:reply:req-other", wrongReply);
+      events.emit("subagents:rpc:ping", { requestId: "req-1" });
+
+      await new Promise((r) => setTimeout(r, 20));
+      expect(wrongReply).not.toHaveBeenCalled();
+    });
+
+    it("unsub stops responding to pings", async () => {
+      const { unsubPing } = registerRpcHandlers(deps);
+      unsubPing();
+
+      const reply = vi.fn();
+      events.on("subagents:rpc:ping:reply:req-1", reply);
+      events.emit("subagents:rpc:ping", { requestId: "req-1" });
+
+      await new Promise((r) => setTimeout(r, 20));
+      expect(reply).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- spawn ---
+
+  describe("spawn RPC", () => {
+    it("returns agent id on success", async () => {
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:spawn:reply:req-s1", reply);
+      events.emit("subagents:rpc:spawn", {
+        requestId: "req-s1", type: "general-purpose", prompt: "do stuff",
+      });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(reply).toHaveBeenCalledWith({ success: true, data: { id: "agent-42" } });
+      expect(manager.spawn).toHaveBeenCalledWith(
+        deps.pi, ctx, "general-purpose", "do stuff", {},
+      );
+    });
+
+    it("passes options through to manager.spawn", async () => {
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:spawn:reply:req-s2", reply);
+      events.emit("subagents:rpc:spawn", {
+        requestId: "req-s2", type: "Explore", prompt: "find it",
+        options: { description: "search", isBackground: true },
+      });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(manager.spawn).toHaveBeenCalledWith(
+        deps.pi, ctx, "Explore", "find it",
+        { description: "search", isBackground: true },
+      );
+    });
+
+    it("returns error when no active session", async () => {
+      ctx = undefined;
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:spawn:reply:req-s3", reply);
+      events.emit("subagents:rpc:spawn", {
+        requestId: "req-s3", type: "general-purpose", prompt: "x",
+      });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(reply).toHaveBeenCalledWith({ success: false, error: "No active session" });
+      expect(manager.spawn).not.toHaveBeenCalled();
+    });
+
+    it("returns error when manager.spawn throws", async () => {
+      (manager.spawn as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error("unknown agent type");
+      });
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:spawn:reply:req-s4", reply);
+      events.emit("subagents:rpc:spawn", {
+        requestId: "req-s4", type: "bad-type", prompt: "x",
+      });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(reply).toHaveBeenCalledWith({ success: false, error: "unknown agent type" });
+    });
+
+    it("scopes replies — other requestIds do not receive it", async () => {
+      registerRpcHandlers(deps);
+      const wrongReply = vi.fn();
+      const rightReply = vi.fn();
+      events.on("subagents:rpc:spawn:reply:req-other", wrongReply);
+      events.on("subagents:rpc:spawn:reply:req-s5", rightReply);
+      events.emit("subagents:rpc:spawn", {
+        requestId: "req-s5", type: "general-purpose", prompt: "x",
+      });
+
+      await vi.waitFor(() => expect(rightReply).toHaveBeenCalled());
+      expect(wrongReply).not.toHaveBeenCalled();
+    });
+
+    it("unsub stops responding to spawns", async () => {
+      const { unsubSpawn } = registerRpcHandlers(deps);
+      unsubSpawn();
+
+      const reply = vi.fn();
+      events.on("subagents:rpc:spawn:reply:req-s6", reply);
+      events.emit("subagents:rpc:spawn", {
+        requestId: "req-s6", type: "general-purpose", prompt: "x",
+      });
+
+      // Give any potential async handler time to fire
+      await new Promise((r) => setTimeout(r, 20));
+      expect(reply).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- stop ---
+
+  describe("stop RPC", () => {
+    it("returns success when agent is aborted", async () => {
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:stop:reply:req-st1", reply);
+      events.emit("subagents:rpc:stop", { requestId: "req-st1", agentId: "agent-42" });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(reply).toHaveBeenCalledWith({ success: true });
+      expect(manager.abort).toHaveBeenCalledWith("agent-42");
+    });
+
+    it("returns error when agent not found", async () => {
+      (manager.abort as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:stop:reply:req-st2", reply);
+      events.emit("subagents:rpc:stop", { requestId: "req-st2", agentId: "nonexistent" });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(reply).toHaveBeenCalledWith({ success: false, error: "Agent not found" });
+    });
+
+    it("scopes replies — other requestIds do not receive it", async () => {
+      registerRpcHandlers(deps);
+      const wrongReply = vi.fn();
+      const rightReply = vi.fn();
+      events.on("subagents:rpc:stop:reply:req-other", wrongReply);
+      events.on("subagents:rpc:stop:reply:req-st3", rightReply);
+      events.emit("subagents:rpc:stop", { requestId: "req-st3", agentId: "agent-42" });
+
+      await vi.waitFor(() => expect(rightReply).toHaveBeenCalled());
+      expect(wrongReply).not.toHaveBeenCalled();
+    });
+
+    it("unsub stops responding to stop requests", async () => {
+      const { unsubStop } = registerRpcHandlers(deps);
+      unsubStop();
+
+      const reply = vi.fn();
+      events.on("subagents:rpc:stop:reply:req-st4", reply);
+      events.emit("subagents:rpc:stop", { requestId: "req-st4", agentId: "agent-42" });
+
+      await new Promise((r) => setTimeout(r, 20));
+      expect(reply).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- concurrent requests ---
+
+  describe("concurrent requests", () => {
+    it("handles multiple simultaneous spawn requests independently", async () => {
+      let callCount = 0;
+      (manager.spawn as ReturnType<typeof vi.fn>).mockImplementation(() => `agent-${++callCount}`);
+      registerRpcHandlers(deps);
+
+      const reply1 = vi.fn();
+      const reply2 = vi.fn();
+      events.on("subagents:rpc:spawn:reply:req-a", reply1);
+      events.on("subagents:rpc:spawn:reply:req-b", reply2);
+
+      events.emit("subagents:rpc:spawn", { requestId: "req-a", type: "Explore", prompt: "first" });
+      events.emit("subagents:rpc:spawn", { requestId: "req-b", type: "Plan", prompt: "second" });
+
+      await vi.waitFor(() => {
+        expect(reply1).toHaveBeenCalled();
+        expect(reply2).toHaveBeenCalled();
+      });
+
+      expect(reply1).toHaveBeenCalledWith({ success: true, data: { id: "agent-1" } });
+      expect(reply2).toHaveBeenCalledWith({ success: true, data: { id: "agent-2" } });
+    });
+  });
+
+  // --- model override resolution (regression for cross-extension callers
+  //     that forward a serializable string instead of a Model object) ---
+
+  describe("spawn RPC model override", () => {
+    const fakeModel = { id: "gpt-5.5", provider: "openai-codex", name: "GPT 5.5" };
+    const registry = {
+      find: (provider: string, id: string) =>
+        provider === fakeModel.provider && id === fakeModel.id ? fakeModel : null,
+      getAll: () => [fakeModel],
+      getAvailable: () => [fakeModel],
+    };
+
+    beforeEach(() => {
+      ctx = { session: true, modelRegistry: registry };
+      deps = { events, pi: { events }, getCtx: () => ctx, manager };
+    });
+
+    it("resolves a string model to a Model instance before manager.spawn", async () => {
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:spawn:reply:req-m1", reply);
+      events.emit("subagents:rpc:spawn", {
+        requestId: "req-m1", type: "general-purpose", prompt: "x",
+        options: { model: "openai-codex/gpt-5.5" },
+      });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(reply).toHaveBeenCalledWith({ success: true, data: { id: "agent-42" } });
+      expect(manager.spawn).toHaveBeenCalledWith(
+        deps.pi, ctx, "general-purpose", "x",
+        { model: fakeModel },
+      );
+    });
+
+    it("passes a Model object through unchanged", async () => {
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:spawn:reply:req-m2", reply);
+      events.emit("subagents:rpc:spawn", {
+        requestId: "req-m2", type: "general-purpose", prompt: "x",
+        options: { model: fakeModel },
+      });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(manager.spawn).toHaveBeenCalledWith(
+        deps.pi, ctx, "general-purpose", "x",
+        { model: fakeModel },
+      );
+    });
+
+    it("surfaces a clear error when the model string can't be resolved", async () => {
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:spawn:reply:req-m3", reply);
+      events.emit("subagents:rpc:spawn", {
+        requestId: "req-m3", type: "general-purpose", prompt: "x",
+        options: { model: "nope/does-not-exist" },
+      });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      const call = (reply as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.success).toBe(false);
+      expect(call.error).toMatch(/Model not found/);
+      expect(manager.spawn).not.toHaveBeenCalled();
+    });
+
+    it("errors when ctx has no modelRegistry but a string model is given", async () => {
+      ctx = { session: true }; // no modelRegistry
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:spawn:reply:req-m4", reply);
+      events.emit("subagents:rpc:spawn", {
+        requestId: "req-m4", type: "general-purpose", prompt: "x",
+        options: { model: "openai-codex/gpt-5.5" },
+      });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      const call = (reply as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.success).toBe(false);
+      expect(call.error).toMatch(/modelRegistry is unavailable/);
+      expect(manager.spawn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/pi-subagents/test/custom-agents.test.ts
+++ b/packages/pi-subagents/test/custom-agents.test.ts
@@ -1,0 +1,664 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { BUILTIN_TOOL_NAMES } from "../src/agent-types.js";
+import { loadCustomAgents } from "../src/custom-agents.js";
+
+describe("loadCustomAgents", () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+  let originalAgentDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-test-"));
+    originalHome = process.env.HOME;
+    originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.HOME = tmpDir;
+    delete process.env.PI_CODING_AGENT_DIR;
+  });
+
+  afterEach(() => {
+    if (originalHome == null) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeAgentIn(projectDir: ".agents" | ".pi", name: string, content: string) {
+    const dir = join(tmpDir, projectDir, "agents");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${name}.md`), content);
+  }
+
+  function writeAgent(name: string, content: string) {
+    writeAgentIn(".pi", name, content);
+  }
+
+  function writeWorkspaceAgent(name: string, content: string) {
+    writeAgentIn(".agents", name, content);
+  }
+
+  it("returns empty map when custom agent dirs do not exist", () => {
+    const result = loadCustomAgents(tmpDir);
+    expect(result.size).toBe(0);
+  });
+
+  it("loads a workspace project agent from .agents/agents", () => {
+    writeWorkspaceAgent("reviewer", `---
+description: Workspace Reviewer
+---
+
+Workspace prompt.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.size).toBe(1);
+    expect(result.get("reviewer")?.description).toBe("Workspace Reviewer");
+    expect(result.get("reviewer")?.systemPrompt).toBe("Workspace prompt.");
+    expect(result.get("reviewer")?.source).toBe("project");
+  });
+
+  it(".pi/agents overrides .agents/agents on a name clash", () => {
+    writeWorkspaceAgent("dupe", `---
+description: Workspace Project
+---
+
+Workspace prompt.`);
+    writeAgent("dupe", `---
+description: Pi Project
+---
+
+Pi prompt.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.size).toBe(1);
+    expect(result.get("dupe")?.description).toBe("Pi Project");
+    expect(result.get("dupe")?.systemPrompt).toBe("Pi prompt.");
+  });
+
+  it("workspace project agents override global agents", () => {
+    const globalAgentDir = join(tmpDir, "global-agent-dir");
+    process.env.PI_CODING_AGENT_DIR = globalAgentDir;
+    const globalAgents = join(globalAgentDir, "agents");
+    mkdirSync(globalAgents, { recursive: true });
+    writeFileSync(join(globalAgents, "dupe.md"), `---
+description: Global
+---
+
+Global prompt.`);
+    writeWorkspaceAgent("dupe", `---
+description: Workspace Project
+---
+
+Workspace prompt.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.size).toBe(1);
+    expect(result.get("dupe")?.description).toBe("Workspace Project");
+    expect(result.get("dupe")?.systemPrompt).toBe("Workspace prompt.");
+  });
+
+  it("loads a basic agent with all frontmatter fields", () => {
+    writeAgent("auditor", `---
+description: Security Auditor
+tools: read, grep, find
+model: anthropic/claude-opus-4-6
+thinking: high
+max_turns: 30
+persist_session: true
+output_transcript: false
+session_dir: .seams/pi-sessions/seam-plan-reviewer
+prompt_mode: replace
+inherit_context: true
+run_in_background: true
+isolated: true
+---
+
+You are a security auditor.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.size).toBe(1);
+
+    const agent = result.get("auditor")!;
+    expect(agent.name).toBe("auditor");
+    expect(agent.description).toBe("Security Auditor");
+    expect(agent.builtinToolNames).toEqual(["read", "grep", "find"]);
+    expect(agent.model).toBe("anthropic/claude-opus-4-6");
+    expect(agent.thinking).toBe("high");
+    expect(agent.maxTurns).toBe(30);
+    expect(agent.persistSession).toBe(true);
+    expect(agent.outputTranscript).toBe(false);
+    expect(agent.sessionDir).toBe(".seams/pi-sessions/seam-plan-reviewer");
+    expect(agent.promptMode).toBe("replace");
+    expect(agent.inheritContext).toBe(true);
+    expect(agent.runInBackground).toBe(true);
+    expect(agent.isolated).toBe(true);
+    expect(agent.systemPrompt).toBe("You are a security auditor.");
+  });
+
+  it("uses sensible defaults when frontmatter is empty", () => {
+    writeAgent("minimal", `---
+---
+
+Just a prompt.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("minimal")!;
+
+    expect(agent.name).toBe("minimal");
+    expect(agent.description).toBe("minimal"); // defaults to filename
+    expect(agent.builtinToolNames).toEqual(BUILTIN_TOOL_NAMES); // all tools
+    expect(agent.extensions).toBe(true); // inherit all
+    expect(agent.skills).toBe(true); // inherit all
+    expect(agent.model).toBeUndefined();
+    expect(agent.thinking).toBeUndefined();
+    expect(agent.maxTurns).toBeUndefined();
+    expect(agent.persistSession).toBeUndefined();
+    expect(agent.outputTranscript).toBeUndefined();
+    expect(agent.sessionDir).toBeUndefined();
+    expect(agent.promptMode).toBe("replace");
+    expect(agent.inheritContext).toBeUndefined();
+    expect(agent.runInBackground).toBeUndefined();
+    expect(agent.isolated).toBeUndefined();
+    expect(agent.systemPrompt).toBe("Just a prompt.");
+  });
+
+  it("uses sensible defaults when no frontmatter at all", () => {
+    writeAgent("bare", "Just a system prompt, no frontmatter.");
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("bare")!;
+
+    expect(agent.name).toBe("bare");
+    expect(agent.description).toBe("bare");
+    expect(agent.builtinToolNames).toEqual(BUILTIN_TOOL_NAMES);
+    expect(agent.systemPrompt).toBe("Just a system prompt, no frontmatter.");
+  });
+
+  it("handles tools: none → empty array", () => {
+    writeAgent("notool", `---
+tools: none
+---
+
+No tools.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("notool")!.builtinToolNames).toEqual([]);
+  });
+
+  it("handles extensions: false → no extensions", () => {
+    writeAgent("noext", `---
+extensions: false
+skills: false
+---
+
+No extensions.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("noext")!;
+    expect(agent.extensions).toBe(false);
+    expect(agent.skills).toBe(false);
+  });
+
+  it("handles extension allowlist", () => {
+    writeAgent("partial", `---
+extensions: web-search, mcp-server
+skills: planning, review
+---
+
+Partial access.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("partial")!;
+    expect(agent.extensions).toEqual(["web-search", "mcp-server"]);
+    expect(agent.skills).toEqual(["planning", "review"]);
+  });
+
+  it("parses exclude_extensions CSV", () => {
+    writeAgent("no-notify", `---
+extensions: true
+exclude_extensions: pi-notify, telemetry
+---
+
+No notifications.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("no-notify")!;
+    expect(agent.extensions).toBe(true);
+    expect(agent.excludeExtensions).toEqual(["pi-notify", "telemetry"]);
+  });
+
+  it("parses exclude_extensions YAML list", () => {
+    writeAgent("no-notify-yaml", `---
+exclude_extensions:
+  - pi-notify
+---
+
+No notifications.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("no-notify-yaml")!.excludeExtensions).toEqual(["pi-notify"]);
+  });
+
+  it("exclude_extensions omitted or none → undefined", () => {
+    writeAgent("plain", `---
+description: plain
+---
+
+Plain.`);
+    writeAgent("explicit-none", `---
+exclude_extensions: none
+---
+
+None.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("plain")!.excludeExtensions).toBeUndefined();
+    expect(result.get("explicit-none")!.excludeExtensions).toBeUndefined();
+  });
+
+  it("passes through unknown tool names (not filtered)", () => {
+    writeAgent("custom-tools", `---
+tools: read, my_custom_tool, grep
+---
+
+Custom tools.`);
+
+    const result = loadCustomAgents(tmpDir);
+    // Unknown tool names are passed through — filtering happens at tool creation time
+    expect(result.get("custom-tools")!.builtinToolNames).toEqual(["read", "my_custom_tool", "grep"]);
+  });
+
+  it("partitions tools: ext: entries out of builtinToolNames into extSelectors", () => {
+    writeAgent("ext-agent", `---
+tools: read, ext:foo, ext:bar/x
+---
+
+Extension selectors.`);
+
+    const agent = loadCustomAgents(tmpDir).get("ext-agent")!;
+    expect(agent.builtinToolNames).toEqual(["read"]);
+    expect(agent.extSelectors).toEqual(["ext:foo", "ext:bar/x"]);
+  });
+
+  it("tools: with only ext: entries yields zero built-ins", () => {
+    writeAgent("ext-only", `---
+tools: ext:foo/bar
+---
+
+Ext only.`);
+
+    const agent = loadCustomAgents(tmpDir).get("ext-only")!;
+    expect(agent.builtinToolNames).toEqual([]);
+    expect(agent.extSelectors).toEqual(["ext:foo/bar"]);
+  });
+
+  it("tools: '*' expands to all built-ins and composes with ext: selectors", () => {
+    writeAgent("wild", `---
+tools: "*, ext:foo"
+---
+
+Wildcard plus ext.`);
+
+    const agent = loadCustomAgents(tmpDir).get("wild")!;
+    expect(agent.builtinToolNames).toEqual(BUILTIN_TOOL_NAMES);
+    expect(agent.extSelectors).toEqual(["ext:foo"]);
+  });
+
+  it("tools: 'all' is a case-insensitive alias for '*' (closes #75)", () => {
+    // `tools: all` previously parsed "all" as a single tool name → allowlist
+    // containing the non-existent tool "all" → silent zero-tool agent.
+    for (const [name, value] of [["all-lower", "all"], ["all-upper", "ALL"], ["all-mixed", "All"]]) {
+      writeAgent(name, `---\ntools: ${value}\n---\n\nAlias.`);
+      const agent = loadCustomAgents(tmpDir).get(name)!;
+      expect(agent.builtinToolNames).toEqual(BUILTIN_TOOL_NAMES);
+      expect(agent.extSelectors).toBeUndefined();
+    }
+  });
+
+  it("tools: 'all' composes with ext: selectors like '*'", () => {
+    writeAgent("all-plus-ext", `---
+tools: "all, ext:foo"
+---
+
+All plus ext.`);
+
+    const agent = loadCustomAgents(tmpDir).get("all-plus-ext")!;
+    expect(agent.builtinToolNames).toEqual(BUILTIN_TOOL_NAMES);
+    expect(agent.extSelectors).toEqual(["ext:foo"]);
+  });
+
+  it("leaves extSelectors undefined when tools: has no ext: entries", () => {
+    writeAgent("plain", `---
+tools: read, bash
+---
+
+Plain tools.`);
+
+    const agent = loadCustomAgents(tmpDir).get("plain")!;
+    expect(agent.builtinToolNames).toEqual(["read", "bash"]);
+    expect(agent.extSelectors).toBeUndefined();
+  });
+
+  it("passes through thinking level as-is (no validation)", () => {
+    writeAgent("anythink", `---
+thinking: turbo
+---
+
+Any thinking.`);
+
+    const result = loadCustomAgents(tmpDir);
+    // Pi validates at session creation — we just pass through
+    expect(result.get("anythink")!.thinking).toBe("turbo");
+  });
+
+  it("loads thinking: max (pi 0.80's top level) unchanged (#147)", () => {
+    writeAgent("deepthink", `---
+thinking: max
+---
+
+Think hard.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("deepthink")!.thinking).toBe("max");
+  });
+
+  it("accepts max_turns: 0 as unlimited", () => {
+    writeAgent("unlimited", `---
+max_turns: 0
+---
+
+Unlimited turns.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("unlimited")!.maxTurns).toBe(0);
+  });
+
+  it("rejects negative max_turns", () => {
+    writeAgent("negturns", `---
+max_turns: -5
+---
+
+Negative turns.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("negturns")!.maxTurns).toBeUndefined();
+  });
+
+  it("handles prompt_mode: append", () => {
+    writeAgent("appender", `---
+prompt_mode: append
+---
+
+Extra instructions.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("appender")!.promptMode).toBe("append");
+  });
+
+  it("defaults unknown prompt_mode to replace", () => {
+    writeAgent("badmode", `---
+prompt_mode: merge
+---
+
+Unknown mode.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("badmode")!.promptMode).toBe("replace");
+  });
+
+  it("loads multiple agents", () => {
+    writeAgent("agent1", `---
+description: First
+---
+
+First agent.`);
+    writeAgent("agent2", `---
+description: Second
+---
+
+Second agent.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.size).toBe(2);
+    expect(result.has("agent1")).toBe(true);
+    expect(result.has("agent2")).toBe(true);
+  });
+
+  it("skips non-.md files", () => {
+    const dir = join(tmpDir, ".pi", "agents");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "notes.txt"), "not an agent");
+    writeFileSync(join(dir, "real.md"), `---
+description: Real Agent
+---
+
+Real.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.size).toBe(1);
+    expect(result.has("real")).toBe(true);
+  });
+
+  it("allows agents with names matching defaults (overrides them)", () => {
+    writeAgent("Explore", `---
+description: Custom Explore
+---
+
+Custom explore agent.`);
+    writeAgent("custom", `---
+description: Custom Agent
+---
+
+Should be loaded.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.has("Explore")).toBe(true);
+    expect(result.get("Explore")!.description).toBe("Custom Explore");
+    expect(result.has("custom")).toBe(true);
+  });
+
+  it("handles empty body with frontmatter", () => {
+    writeAgent("nobody", `---
+description: No body
+tools: read
+---
+`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("nobody")!.systemPrompt).toBe("");
+  });
+
+  it("supports inherit_extensions as alternative to extensions", () => {
+    writeAgent("altkey", `---
+inherit_extensions: false
+inherit_skills: false
+---
+
+Alt keys.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("altkey")!;
+    expect(agent.extensions).toBe(false);
+    expect(agent.skills).toBe(false);
+  });
+
+  it("extensions: none → false", () => {
+    writeAgent("extnone", `---
+extensions: none
+skills: none
+---
+
+None.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("extnone")!;
+    expect(agent.extensions).toBe(false);
+    expect(agent.skills).toBe(false);
+  });
+
+  it("extensions: true → true (inherit all)", () => {
+    writeAgent("exttrue", `---
+extensions: true
+skills: true
+---
+
+All.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("exttrue")!;
+    expect(agent.extensions).toBe(true);
+    expect(agent.skills).toBe(true);
+  });
+
+  it("handles enabled: false frontmatter", () => {
+    writeAgent("disabled", `---
+enabled: false
+---
+`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("disabled")!;
+    expect(agent.enabled).toBe(false);
+  });
+
+  it("parses display_name frontmatter", () => {
+    writeAgent("myagent", `---
+description: My Agent
+display_name: MyAgent
+---
+
+Agent prompt.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("myagent")!.displayName).toBe("MyAgent");
+  });
+
+  it("parses disallowed_tools as csv list", () => {
+    writeAgent("restricted", `---
+description: Restricted Agent
+disallowed_tools: bash, write
+---
+
+No bash or write.`);
+
+    const result = loadCustomAgents(tmpDir);
+    const agent = result.get("restricted")!;
+    expect(agent.disallowedTools).toEqual(["bash", "write"]);
+  });
+
+  it("disallowed_tools defaults to undefined when omitted", () => {
+    writeAgent("unrestricted", `---
+description: Unrestricted
+---
+
+All tools.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("unrestricted")!.disallowedTools).toBeUndefined();
+  });
+
+  it("parses memory scope", () => {
+    writeAgent("rememberer", `---
+description: Agent with memory
+memory: project
+---
+
+Remember things.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("rememberer")!.memory).toBe("project");
+  });
+
+  it("parses memory: user scope", () => {
+    writeAgent("global-mem", `---
+memory: user
+---
+
+User memory.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("global-mem")!.memory).toBe("user");
+  });
+
+  it("memory defaults to undefined when omitted", () => {
+    writeAgent("no-mem", `---
+description: No memory
+---
+
+Stateless.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("no-mem")!.memory).toBeUndefined();
+  });
+
+  it("rejects invalid memory scope", () => {
+    writeAgent("bad-mem", `---
+memory: invalid
+---
+
+Bad memory.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("bad-mem")!.memory).toBeUndefined();
+  });
+
+  it("parses isolation: worktree", () => {
+    writeAgent("isolated-wt", `---
+description: Worktree agent
+isolation: worktree
+---
+
+Isolated.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("isolated-wt")!.isolation).toBe("worktree");
+  });
+
+  it("isolation defaults to undefined when omitted", () => {
+    writeAgent("no-isolation", `---
+description: Normal
+---
+
+Normal.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("no-isolation")!.isolation).toBeUndefined();
+  });
+
+  it("rejects invalid isolation mode", () => {
+    writeAgent("bad-isolation", `---
+isolation: docker
+---
+
+Bad isolation.`);
+
+    const result = loadCustomAgents(tmpDir);
+    expect(result.get("bad-isolation")!.isolation).toBeUndefined();
+  });
+
+  it("honors PI_CODING_AGENT_DIR for global custom agent discovery", () => {
+    const altAgentDir = mkdtempSync(join(tmpdir(), "pi-alt-agent-"));
+    const originalEnv = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = altAgentDir;
+    try {
+      const globalAgentsDir = join(altAgentDir, "agents");
+      mkdirSync(globalAgentsDir, { recursive: true });
+      writeFileSync(
+        join(globalAgentsDir, "via-env.md"),
+        "---\ndescription: Discovered via env var\n---\n\nTest body.",
+      );
+
+      const result = loadCustomAgents(tmpDir);
+
+      // Agent is found at $PI_CODING_AGENT_DIR/agents, not at $HOME/.pi/agent/agents
+      expect(result.has("via-env")).toBe(true);
+      expect(result.get("via-env")!.description).toBe("Discovered via env var");
+    } finally {
+      if (originalEnv == null) delete process.env.PI_CODING_AGENT_DIR;
+      else process.env.PI_CODING_AGENT_DIR = originalEnv;
+      rmSync(altAgentDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/pi-subagents/test/e2e/isolated-provider.e2e.test.ts
+++ b/packages/pi-subagents/test/e2e/isolated-provider.e2e.test.ts
@@ -1,0 +1,80 @@
+/**
+ * isolated-provider.e2e.test.ts — reachability guard for PR #152 (issue #151).
+ *
+ * PR #152 fixes isolated subagents dropping extension-registered custom providers
+ * on Pi >= 0.80.8 (the `modelRegistry` → `modelRuntime` migration). agent-runner
+ * forwards the parent's runtime, read off the ModelRegistry facade as
+ * `ctx.modelRegistry.runtime` via `as unknown as { runtime }`.
+ *
+ * That forwarding is already guarded by the unit test in test/agent-runner.test.ts
+ * ("passes the parent model runtime …") — but against a MOCK whose `.runtime` is
+ * hand-set. The mock cannot catch the one thing that would silently break the fix:
+ * `.runtime` is a `private readonly` field on the real ModelRegistry, absent from
+ * the public type AND the package exports. If a future Pi renames it, makes it a
+ * true #private, or moves the module, the cast quietly yields `undefined`, the fix
+ * omits `modelRuntime`, and the bug returns with no failing test.
+ *
+ * This test closes exactly that gap and nothing else: it asserts the real facade
+ * exposes a runtime-reachable `.runtime` that IS the runtime it wraps. It is not a
+ * guard for the forwarding itself (that's the unit test's job) — a fuller e2e that
+ * drives real `runAgent` end-to-end is tracked as a follow-up.
+ *
+ * VERSION GATE: `.runtime` only exists in the post-migration facade world (Pi >=
+ * 0.80.8, where `ModelRuntime` is first exported). The repo's dev dependency is
+ * pinned pre-migration (0.80.6), so we DYNAMICALLY import Pi and skip cleanly when
+ * it predates the migration. CI runs a dedicated job on `pi@latest` (see
+ * .github/workflows/ci.yml) so this guard actually runs against current Pi.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+// Dynamic, so this file LOADS on pre-migration Pi (a static `import { ModelRuntime }`
+// would be a link-time error there — 0.80.6 doesn't export it).
+const pi = (await import("@earendil-works/pi-coding-agent")) as Record<string, unknown>;
+const ModelRuntime = pi.ModelRuntime as
+  | { create(opts?: Record<string, unknown>): Promise<ModelRuntimeLike> }
+  | undefined;
+
+// The migration is exactly "ModelRuntime now exists". Absent ⇒ pre-0.80.8 ⇒ there
+// is no `.runtime` facade to guard.
+const MIGRATED = typeof ModelRuntime?.create === "function";
+const RT = ModelRuntime as { create(opts?: Record<string, unknown>): Promise<ModelRuntimeLike> };
+
+// The one method the reach scenario needs; `.runtime` itself is private (reached below).
+interface ModelRuntimeLike {
+  registerProvider(id: string, config: Record<string, unknown>): void;
+}
+
+const tmpDirs: string[] = [];
+afterAll(() => {
+  for (const d of tmpDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe.skipIf(!MIGRATED)("PR #152 reach: real ModelRegistry exposes .runtime (Pi >= 0.80.8)", () => {
+  it("ctx.modelRegistry.runtime is reachable and IS the runtime it wraps", async () => {
+    // A real, configured runtime — as an extension leaves it after registerProvider.
+    const dir = mkdtempSync(join(tmpdir(), "iso-prov-"));
+    tmpDirs.push(dir);
+    const runtime = await RT.create({
+      authPath: join(dir, "auth.json"),
+      modelsPath: join(dir, "models.json"),
+      allowModelNetwork: false,
+    });
+
+    // `.runtime` is private and not in the package exports — reach the compiled
+    // class by file path, exactly the field the patch's cast depends on. If Pi
+    // moves/renames/#privates it, THIS line fails loudly instead of the fix
+    // silently no-op'ing back to the #151 bug.
+    const indexUrl = import.meta.resolve("@earendil-works/pi-coding-agent");
+    const mrUrl = indexUrl.replace(/index\.js$/, "core/model-registry.js");
+    const { ModelRegistry } = (await import(mrUrl)) as {
+      ModelRegistry: new (rt: ModelRuntimeLike) => { runtime?: unknown };
+    };
+
+    const facade = new ModelRegistry(runtime);
+    // This is the exact expression agent-runner reads (`ctx.modelRegistry.runtime`).
+    expect((facade as { runtime?: unknown }).runtime).toBe(runtime);
+  });
+});

--- a/packages/pi-subagents/test/e2e/tool-veto-reachability.e2e.test.ts
+++ b/packages/pi-subagents/test/e2e/tool-veto-reachability.e2e.test.ts
@@ -1,0 +1,145 @@
+/**
+ * tool-veto-reachability.e2e.test.ts — reachability guard for the `ext:` turn-1
+ * tool veto (issue #125).
+ *
+ * `installExtensionToolScope` enforces `ext:` narrowing two ways. Re-narrowing the
+ * ACTIVE set on `turn_end` is built entirely on public API (`getAllTools`,
+ * `getActiveToolNames`, `setActiveToolsByName`) and is covered by the unit tests.
+ * The second half is not: turn 1 cannot be narrowed at all — `before_agent_start`
+ * fires INSIDE `prompt()` and may widen the tool set, but `createContextSnapshot()`
+ * freezes that turn's tools immediately after, leaving no window — so out-of-scope
+ * calls are vetoed at call time by wrapping `session.agent.beforeToolCall`.
+ *
+ * That wrap is the one place this extension reaches past the documented surface:
+ *   - `ExtensionBindings` has no tool_call hook, so there is no SDK-level way to
+ *     inject a veto into a session we construct. Pi exposes the veto to EXTENSIONS
+ *     as `pi.on("tool_call") -> { block, reason }`, but we are the SDK caller here,
+ *     not an extension bound to the child session.
+ *   - So we wrap the property Pi itself installs in the AgentSession constructor
+ *     (`_installAgentToolHooks`), chaining to the prior hook so Pi's own `tool_call`
+ *     dispatch still runs.
+ *
+ * The unit tests assert our wrapper's behavior against a MOCK session whose `agent`
+ * is a hand-written `{ beforeToolCall: undefined }`. That mock cannot catch the one
+ * thing that would silently break the veto: if a future Pi renames `beforeToolCall`,
+ * stops installing it, makes `agent` non-enumerable/private, or moves the veto
+ * elsewhere, our assignment lands on a property nothing reads. Every test still
+ * passes, and out-of-scope tools become callable on turn 1 with no failing test.
+ *
+ * This guard closes exactly that gap and nothing else. It asserts against a REAL
+ * session that:
+ *   1. Pi installs its own `beforeToolCall` (so there IS a prior hook to chain), and
+ *   2. after `runAgent`, ours is installed and vetoes an out-of-scope tool in the
+ *      `{ block, reason }` shape Pi honors.
+ *
+ * No network/LLM: a faux Model satisfies `createAgentSession`, and the veto is
+ * invoked directly rather than through a model turn.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runAgent } from "../../src/agent-runner.js";
+import { registerAgents } from "../../src/agent-types.js";
+import type { AgentConfig } from "../../src/types.js";
+import { registerFauxProvider } from "../helpers/pi-ai.js";
+
+// Real pi-mono (loader + dynamic extension import + session construction).
+vi.setConfig({ testTimeout: 30_000 });
+
+/** Registers `alpha_read` / `alpha_write`; reused so no new fixture is needed. */
+const ALPHA = resolve(fileURLToPath(new URL("../fixtures/ext-alpha.mjs", import.meta.url)));
+/** Registers `beta_tool` — loaded but NOT selected by the `ext:` selector below. */
+const BETA = resolve(fileURLToPath(new URL("../fixtures/ext-beta.mjs", import.meta.url)));
+
+function makePi() {
+  return { exec: async () => ({ code: 1, stdout: "", stderr: "" }) } as any;
+}
+
+describe("tool veto reachability against real pi-mono", () => {
+  let cwd: string;
+  let faux: ReturnType<typeof registerFauxProvider>;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "subagents-veto-"));
+    faux = registerFauxProvider({
+      provider: "faux",
+      models: [{ id: "faux-1", contextWindow: 200_000 }],
+    });
+  });
+  afterEach(() => {
+    faux.unregister();
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("pi installs a chainable beforeToolCall, and runAgent's veto blocks out-of-scope tools", async () => {
+    registerAgents(
+      new Map([
+        [
+          "veto",
+          {
+            name: "veto",
+            description: "veto guard",
+            builtinToolNames: ["read"],
+            // Select alpha only — beta loads (its handlers run) but is muted.
+            extensions: [ALPHA, BETA],
+            extSelectors: ["ext:ext-alpha.mjs"],
+            skills: false,
+            systemPrompt: "You are veto.",
+            promptMode: "replace",
+            inheritContext: false,
+            runInBackground: false,
+            isolated: false,
+          } as AgentConfig,
+        ],
+      ]),
+    );
+
+    const model = faux.getModel();
+    const modelRegistry: any = {
+      find: () => model,
+      getAll: () => [model],
+      getAvailable: () => [model],
+      hasConfiguredAuth: () => true,
+      isUsingOAuth: () => false,
+      getApiKeyAndHeaders: async () => ({ apiKey: "faux", headers: {} }),
+      registerProvider: () => {},
+      unregisterProvider: () => {},
+    };
+    const ctx: any = { cwd, getSystemPrompt: () => "PARENT", model, modelRegistry };
+
+    let priorIsFunction: boolean | undefined;
+    let session: any;
+    try {
+      await runAgent(ctx, "veto", "go", {
+        pi: makePi(),
+        model,
+        onSessionCreated: (s: any) => {
+          session = s;
+          // By onSessionCreated our wrapper is already installed, so this being a
+          // function proves the property is reachable and writable. Pi installing
+          // its own in the constructor is what gives us something to chain to —
+          // asserted below via the in-scope path returning undefined rather than
+          // throwing on a missing prior hook.
+          priorIsFunction = typeof s.agent?.beforeToolCall === "function";
+        },
+      });
+    } catch {
+      // A faux-model turn may not complete; the veto is fixed at construction.
+    }
+
+    expect(priorIsFunction).toBe(true);
+
+    // Out of scope: beta loaded but the ext: flip did not select it.
+    await expect(
+      session.agent.beforeToolCall({ toolCall: { name: "beta_tool" }, args: {} }),
+    ).resolves.toMatchObject({ block: true, reason: expect.any(String) });
+
+    // In scope: must NOT be blocked. Reaching Pi's own prior hook without throwing
+    // also proves the chain is intact (a clobbered/absent prior would surface here).
+    await expect(
+      session.agent.beforeToolCall({ toolCall: { name: "alpha_read" }, args: {} }),
+    ).resolves.toSatisfy((r: any) => !r?.block);
+  });
+});

--- a/packages/pi-subagents/test/enabled-models.test.ts
+++ b/packages/pi-subagents/test/enabled-models.test.ts
@@ -1,0 +1,206 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type ModelRegistryRef, readEnabledModels, resolveEnabledModels } from "../src/enabled-models.js";
+
+/** Mock models matching typical registry shape. */
+const MODELS = [
+  { id: "gemma-4-31b-it", name: "Gemma 4 31B", provider: "google" },
+  { id: "claude-opus-4-6", name: "Claude Opus 4.6", provider: "anthropic" },
+  { id: "claude-opus-4-5", name: "Claude Opus 4.5", provider: "anthropic" },
+  { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", provider: "anthropic" },
+  { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", provider: "anthropic" },
+];
+
+function makeRegistry(models = MODELS, available?: typeof MODELS): ModelRegistryRef {
+  return {
+    getAll() { return models; },
+    getAvailable: available ? () => available : undefined,
+  };
+}
+
+describe("readEnabledModels", () => {
+  let agentDir: string;
+  let projectDir: string;
+  let originalEnv: string | undefined;
+
+  const projectFile = () => join(projectDir, ".pi", "settings.json");
+  const globalFile = () => join(agentDir, "settings.json");
+
+  beforeEach(() => {
+    agentDir = mkdtempSync(join(tmpdir(), "pi-em-global-"));
+    projectDir = mkdtempSync(join(tmpdir(), "pi-em-project-"));
+    originalEnv = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+  });
+
+  afterEach(() => {
+    if (originalEnv == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalEnv;
+    rmSync(agentDir, { recursive: true, force: true });
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function writeProject(obj: unknown) {
+    mkdirSync(join(projectDir, ".pi"), { recursive: true });
+    writeFileSync(projectFile(), JSON.stringify(obj));
+  }
+
+  it("returns undefined when both settings files are missing", () => {
+    expect(readEnabledModels(projectDir)).toBeUndefined();
+  });
+
+  it("returns undefined when field absent from both files", () => {
+    writeFileSync(globalFile(), JSON.stringify({ defaultProvider: "openai" }));
+    expect(readEnabledModels(projectDir)).toBeUndefined();
+  });
+
+  it("returns enabledModels from global when project file absent", () => {
+    writeFileSync(globalFile(), JSON.stringify({
+      enabledModels: ["anthropic/claude-sonnet-4-6", "google/gemma-4-31b-it"],
+    }));
+    expect(readEnabledModels(projectDir)).toEqual([
+      "anthropic/claude-sonnet-4-6",
+      "google/gemma-4-31b-it",
+    ]);
+  });
+
+  it("returns enabledModels from project when global file absent", () => {
+    writeProject({ enabledModels: ["anthropic/claude-haiku-4-5"] });
+    expect(readEnabledModels(projectDir)).toEqual(["anthropic/claude-haiku-4-5"]);
+  });
+
+  it("project overrides global (array replaces wholly, mirrors pi's deep-merge)", () => {
+    writeFileSync(globalFile(), JSON.stringify({
+      enabledModels: ["anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-6"],
+    }));
+    writeProject({ enabledModels: ["anthropic/claude-haiku-4-5"] });
+    // Project replaces wholly — globals NOT merged in
+    expect(readEnabledModels(projectDir)).toEqual(["anthropic/claude-haiku-4-5"]);
+  });
+
+  it("falls back to global when project file has no enabledModels field", () => {
+    writeFileSync(globalFile(), JSON.stringify({
+      enabledModels: ["anthropic/claude-sonnet-4-6"],
+    }));
+    writeProject({ defaultProvider: "anthropic" }); // project exists but no enabledModels
+    expect(readEnabledModels(projectDir)).toEqual(["anthropic/claude-sonnet-4-6"]);
+  });
+
+  it("returns undefined when global JSON is corrupt (try/catch swallow)", () => {
+    writeFileSync(globalFile(), "not json {{{");
+    expect(readEnabledModels(projectDir)).toBeUndefined();
+  });
+
+  it("returns undefined when enabledModels is not an array (global)", () => {
+    writeFileSync(globalFile(), JSON.stringify({ enabledModels: "anthropic/claude-sonnet-4-6" }));
+    expect(readEnabledModels(projectDir)).toBeUndefined();
+  });
+
+  it("returns undefined when enabledModels is not an array (project)", () => {
+    writeProject({ enabledModels: "anthropic/claude-haiku-4-5" });
+    // Project's non-array enabledModels is invalid → falls back to global; global empty → undefined
+    expect(readEnabledModels(projectDir)).toBeUndefined();
+  });
+});
+
+describe("resolveEnabledModels", () => {
+  it("returns undefined for empty patterns", () => {
+    expect(resolveEnabledModels([], makeRegistry())).toBeUndefined();
+    expect(resolveEnabledModels(undefined, makeRegistry())).toBeUndefined();
+  });
+
+  it("returns undefined when no matches", () => {
+    expect(resolveEnabledModels(["nonexistent/foo"], makeRegistry())).toBeUndefined();
+  });
+
+  it("skips empty string patterns", () => {
+    const result = resolveEnabledModels(["", "anthropic/claude-haiku-4-5", "anthropic/claude-sonnet-4-6"], makeRegistry());
+    // Empty string should not match — only exact patterns should match
+    expect(result!.size).toBe(2);
+  });
+
+  it("skips whitespace-only patterns", () => {
+    const result = resolveEnabledModels(["  ", "google/gemma-4-31b-it"], makeRegistry());
+    expect(result).toEqual(new Set(["google/gemma-4-31b-it"]));
+  });
+
+  it("returns undefined when getAvailable returns empty array", () => {
+    const result = resolveEnabledModels(
+      ["anthropic/claude-haiku-4-5"],
+      makeRegistry(MODELS, []),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("deduplicates duplicate patterns", () => {
+    const result = resolveEnabledModels(
+      ["anthropic/claude-haiku-4-5", "anthropic/claude-haiku-4-5"],
+      makeRegistry(),
+    );
+    expect(result!.size).toBe(1); // duplicate resolves to one entry
+  });
+
+  describe("exact provider/modelId", () => {
+    it("resolves exact match (key stored lowercase)", () => {
+      const result = resolveEnabledModels(["google/gemma-4-31b-it"], makeRegistry());
+      expect(result).toEqual(new Set(["google/gemma-4-31b-it"]));
+    });
+
+    it("resolves model id with colon (part of id, not split)", () => {
+      const result = resolveEnabledModels(
+        ["anthropic/claude-opus-4-6"],
+        makeRegistry(),
+      );
+      expect(result).toEqual(new Set(["anthropic/claude-opus-4-6"]));
+    });
+
+    it("is case-insensitive", () => {
+      const result = resolveEnabledModels(["GOOGLE/GEMMA-4-31B-IT"], makeRegistry());
+      expect(result).toEqual(new Set(["google/gemma-4-31b-it"]));
+    });
+  });
+
+  describe("no bare modelId or fuzzy matching", () => {
+    it("returns undefined for bare id (pi always writes provider/modelId)", () => {
+      const result = resolveEnabledModels(["gemma-4-31b-it"], makeRegistry());
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined for bare substring patterns", () => {
+      const result = resolveEnabledModels(["Opus"], makeRegistry());
+      expect(result).toBeUndefined();
+    });
+  });
+
+
+
+  describe("mixed patterns", () => {
+    it("combines multiple exact provider/modelId in one call", () => {
+      const result = resolveEnabledModels(
+        ["google/gemma-4-31b-it", "anthropic/claude-haiku-4-5", "anthropic/claude-sonnet-4-6"],
+        makeRegistry(),
+      );
+      expect(result!.has("google/gemma-4-31b-it".toLowerCase())).toBe(true);
+      expect(result!.has("anthropic/claude-haiku-4-5".toLowerCase())).toBe(true);
+      expect(result!.has("anthropic/claude-sonnet-4-6".toLowerCase())).toBe(true);
+      expect(result!.has("google/gemini-2.5-pro".toLowerCase())).toBe(false);
+      expect(result!.has("anthropic/claude-opus-4-6".toLowerCase())).toBe(false);
+    });
+  });
+
+  describe("getAvailable filtering", () => {
+    it("resolves only against available models when getAvailable present", () => {
+      const available = [MODELS[0], MODELS[3]]; // google + haiku only
+      const result = resolveEnabledModels(
+        ["anthropic/claude-haiku-4-5", "anthropic/claude-sonnet-4-6", "google/gemma-4-31b-it"],
+        makeRegistry(MODELS, available),
+      );
+      // haiku and google are available; sonnet is not
+      expect(result!.has("anthropic/claude-haiku-4-5".toLowerCase())).toBe(true);
+      expect(result!.has("anthropic/claude-sonnet-4-6".toLowerCase())).toBe(false); // not available
+      expect(result!.has("google/gemma-4-31b-it".toLowerCase())).toBe(true);
+    });
+  });
+});

--- a/packages/pi-subagents/test/env.test.ts
+++ b/packages/pi-subagents/test/env.test.ts
@@ -1,0 +1,61 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { detectEnv } from "../src/env.js";
+
+/** Minimal mock of pi.exec() that shells out via child_process. */
+function mockPi(): ExtensionAPI {
+  return {
+    exec: async (command: string, args: string[], options?: { cwd?: string; timeout?: number }) => {
+      try {
+        const stdout = execSync(`${command} ${args.join(" ")}`, {
+          cwd: options?.cwd,
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+          timeout: options?.timeout,
+        });
+        return { stdout, stderr: "", code: 0, killed: false };
+      } catch (err: any) {
+        return { stdout: "", stderr: err.stderr ?? "", code: err.status ?? 1, killed: false };
+      }
+    },
+  } as unknown as ExtensionAPI;
+}
+
+describe("detectEnv", () => {
+  it("detects git repo in current project", async () => {
+    const env = await detectEnv(mockPi(), process.cwd());
+    expect(env.isGitRepo).toBe(true);
+    expect(env.platform).toBe(process.platform);
+  });
+
+  it("returns branch name when on a branch", async () => {
+    // Create a temp repo on a known branch to test branch detection
+    const tmpDir = mkdtempSync(join(tmpdir(), "pi-env-branch-"));
+    try {
+      execSync("git init && git config user.email test@test.com && git config user.name Test && git checkout -b test-branch && git commit --allow-empty -m init", {
+        cwd: tmpDir, stdio: "pipe",
+      });
+      const env = await detectEnv(mockPi(), tmpDir);
+      expect(env.isGitRepo).toBe(true);
+      expect(env.branch).toBe("test-branch");
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects non-git directory", async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "pi-env-test-"));
+    try {
+      const env = await detectEnv(mockPi(), tmpDir);
+      expect(env.isGitRepo).toBe(false);
+      expect(env.branch).toBe("");
+      expect(env.platform).toBe(process.platform);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/pi-subagents/test/ext-templates-e2e.test.ts
+++ b/packages/pi-subagents/test/ext-templates-e2e.test.ts
@@ -1,0 +1,173 @@
+/**
+ * ext-templates-e2e.test.ts — Data-driven, headless end-to-end runner for
+ * `tools:`/`ext:`/`extensions:` scoping against the REAL pi-mono runtime.
+ *
+ * Unlike agent-runner-e2e.test.ts (which builds AgentConfig objects in code),
+ * this exercises the FULL chain from frontmatter onward:
+ *
+ *   test/fixtures/.pi/agents/*.md         (pre-configured agent templates)
+ *     → real loadCustomAgents()           (frontmatter → parseToolsField/ext:)
+ *     → registerAgents()                  (real registry)
+ *     → real runAgent() [headless]        (real DefaultResourceLoader loads the
+ *                                          real .mjs extension fixtures)
+ *     → real createAgentSession()         (real pi-mono tool gating)
+ *     → session.getActiveToolNames()      (what the LLM could actually call)
+ *
+ * Each template is self-describing: its `expect_present` / `expect_absent`
+ * frontmatter declares the tools that must / must not be active. Adding a
+ * scenario = adding a .md file; no test code changes needed.
+ *
+ * Headless: a faux Model object satisfies createAgentSession; we assert on the
+ * pre-prompt gated tool set captured at onSessionCreated, so no LLM/network is
+ * involved. cwd is the fixtures dir so the templates' relative `extensions:`
+ * paths resolve and the .mjs fixtures can import `@sinclair/typebox` from the
+ * repo's node_modules.
+ */
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseFrontmatter } from "@earendil-works/pi-coding-agent";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { runAgent } from "../src/agent-runner.js";
+import { getAgentConfig, registerAgents } from "../src/agent-types.js";
+import { loadCustomAgents } from "../src/custom-agents.js";
+import { resolveAgentInvocationConfig } from "../src/invocation-config.js";
+import { registerFauxProvider } from "./helpers/pi-ai.js";
+
+// Real pi-mono (loader + dynamic extension import + session construction) — a
+// cold run under full-suite contention can exceed vitest's 5s default.
+vi.setConfig({ testTimeout: 30_000 });
+
+const FIXTURES_DIR = resolve(fileURLToPath(new URL("./fixtures", import.meta.url)));
+const TEMPLATES_DIR = join(FIXTURES_DIR, ".pi", "agents");
+
+function csv(val: unknown): string[] {
+  return typeof val === "string" ? val.split(",").map((s) => s.trim()).filter(Boolean) : [];
+}
+
+/** Discover scenarios from the template files at collection time. */
+const SCENARIOS = readdirSync(TEMPLATES_DIR)
+  .filter((f) => f.endsWith(".md"))
+  .map((file) => {
+    const fm = parseFrontmatter<Record<string, unknown>>(
+      readFileSync(join(TEMPLATES_DIR, file), "utf8"),
+    ).frontmatter;
+    return {
+      name: file.replace(/\.md$/, ""), // loadCustomAgents keys agents by filename
+      present: csv(fm.expect_tools_present),
+      absent: csv(fm.expect_tools_absent),
+      promptContains: csv(fm.expect_prompt_contains),
+      promptAbsent: csv(fm.expect_prompt_absent),
+    };
+  });
+
+/** Distinctive marker for the parent system prompt (prompt_mode: append asserts it leaks in). */
+const PARENT_PROMPT = "PARENT_PROMPT_MARKER";
+
+describe("ext: / tools: scoping — template-driven e2e (real pi-mono, headless)", () => {
+  let prevAgentDir: string | undefined;
+  let prevHome: string | undefined;
+  let hermeticDir: string;
+  let faux: ReturnType<typeof registerFauxProvider>;
+
+  beforeAll(() => {
+    // Isolate global discovery (getAgentDir / ~/.pi) so the dev's real agents
+    // and extensions can't bleed into the run.
+    hermeticDir = mkdtempSync(join(tmpdir(), "subagents-tmpl-"));
+    prevAgentDir = process.env.PI_CODING_AGENT_DIR;
+    prevHome = process.env.HOME;
+    process.env.PI_CODING_AGENT_DIR = hermeticDir;
+    process.env.HOME = hermeticDir;
+
+    faux = registerFauxProvider({ provider: "faux", models: [{ id: "faux-1", contextWindow: 200_000 }] });
+
+    // Load the templates through the REAL loader (project agents come from
+    // <cwd>/.pi/agents → FIXTURES_DIR/.pi/agents) and install them in the
+    // registry runAgent reads from.
+    registerAgents(loadCustomAgents(FIXTURES_DIR));
+  });
+
+  afterAll(() => {
+    faux.unregister();
+    if (prevAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = prevAgentDir;
+    if (prevHome == null) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    rmSync(hermeticDir, { recursive: true, force: true });
+  });
+
+  async function runScenario(agentName: string): Promise<{ active: string[]; prompt: string }> {
+    const model = faux.getModel();
+    const modelRegistry: any = {
+      find: () => model,
+      getAll: () => [model],
+      getAvailable: () => [model],
+      hasConfiguredAuth: () => true,
+      isUsingOAuth: () => false,
+      getApiKeyAndHeaders: async () => ({ apiKey: "faux", headers: {} }),
+      registerProvider: () => {},
+      unregisterProvider: () => {},
+    };
+    // cwd = fixtures dir so the templates' relative extensions: paths resolve.
+    // getSystemPrompt returns a distinctive marker so prompt_mode: append can be
+    // proven to inherit the parent prompt.
+    const ctx: any = { cwd: FIXTURES_DIR, getSystemPrompt: () => PARENT_PROMPT, model, modelRegistry };
+    const pi: any = { exec: async () => ({ code: 1, stdout: "", stderr: "" }) };
+
+    // Mirror production: the caller resolves frontmatter-locked fields (isolated,
+    // inherit_context, …) into runAgent options via resolveAgentInvocationConfig.
+    // isolated is the one that affects tool gating (forces extensions:false + drops ext:).
+    const resolved = resolveAgentInvocationConfig(getAgentConfig(agentName), { modelFromParams: false } as any);
+
+    let active: string[] = [];
+    let prompt = "";
+    try {
+      await runAgent(ctx, agentName, "go", {
+        pi,
+        model,
+        cwd: FIXTURES_DIR,
+        isolated: resolved.isolated,
+        inheritContext: resolved.inheritContext,
+        onSessionCreated: (s) => {
+          // Both fixed at construction (before any prompt turn): the gated tool
+          // set and the effective system prompt (built from prompt_mode + skills).
+          active = s.getActiveToolNames();
+          prompt = s.systemPrompt;
+        },
+      });
+    } catch {
+      // Prompt may error (no live provider) — both observables are captured at
+      // onSessionCreated, before the turn.
+    }
+    return { active, prompt };
+  }
+
+  it("every template on disk is discovered, registered, and self-describing", () => {
+    // 1:1 with the .md files in the templates dir — nothing silently dropped.
+    const onDisk = readdirSync(TEMPLATES_DIR).filter((f) => f.endsWith(".md")).length;
+    expect(SCENARIOS.length).toBe(onDisk);
+    expect(SCENARIOS.length).toBeGreaterThanOrEqual(6);
+
+    for (const s of SCENARIOS) {
+      // Each declares at least one expectation, so no scenario is a no-op.
+      expect(s.present.length + s.promptContains.length + s.promptAbsent.length).toBeGreaterThan(0);
+      // Each loaded as ITS OWN agent — guards against runAgent silently falling
+      // back to general-purpose when a template fails to parse/register.
+      const cfg = getAgentConfig(s.name);
+      expect(cfg, `template "${s.name}" did not register (parse error or name mismatch?)`).toBeDefined();
+      expect(cfg?.name).toBe(s.name);
+    }
+  });
+
+  it.each(SCENARIOS)(
+    "$name → active tools and system prompt match the template",
+    async ({ name, present, absent, promptContains, promptAbsent }) => {
+      const { active, prompt } = await runScenario(name);
+      for (const tool of present) expect(active, `${name}: expected "${tool}" active`).toContain(tool);
+      for (const tool of absent) expect(active, `${name}: expected "${tool}" NOT active`).not.toContain(tool);
+      for (const s of promptContains) expect(prompt, `${name}: prompt should contain "${s}"`).toContain(s);
+      for (const s of promptAbsent) expect(prompt, `${name}: prompt should NOT contain "${s}"`).not.toContain(s);
+    },
+  );
+});

--- a/packages/pi-subagents/test/fixtures/e2e-probe-ext.mjs
+++ b/packages/pi-subagents/test/fixtures/e2e-probe-ext.mjs
@@ -1,0 +1,25 @@
+/**
+ * Real extension fixture for the end-to-end test. Loaded by pi-mono's actual
+ * DefaultResourceLoader via `additionalExtensionPaths`. Registers one tool,
+ * `e2e_probe`, that writes a marker file when executed so the test can prove
+ * the model was actually able to call it (not just that it appeared in a list).
+ *
+ * Plain ESM (.mjs) so node imports it without any TS transform step.
+ */
+import { writeFileSync } from "node:fs";
+import { Type } from "@sinclair/typebox";
+
+export default function (pi) {
+  pi.registerTool({
+    name: "e2e_probe",
+    label: "E2E Probe",
+    description: "Writes a marker file. Used only by the end-to-end test.",
+    parameters: Type.Object({
+      marker: Type.String({ description: "Absolute path of the marker file to write." }),
+    }),
+    async execute(_id, params) {
+      writeFileSync(params.marker, "probed");
+      return { content: [{ type: "text", text: `wrote ${params.marker}` }] };
+    },
+  });
+}

--- a/packages/pi-subagents/test/fixtures/ext-alpha.mjs
+++ b/packages/pi-subagents/test/fixtures/ext-alpha.mjs
@@ -1,0 +1,23 @@
+/**
+ * Real extension fixture "alpha" for the template-driven e2e runner.
+ * Registers two tools so narrowing (ext:ext-alpha.mjs/alpha_read) can be
+ * distinguished from exposing the whole extension. Plain ESM so node imports
+ * it without a TS transform; lives inside the repo tree so `@sinclair/typebox`
+ * resolves. Tools are never invoked by the runner — it only inspects the
+ * session's active tool set — so execute() is a trivial stub.
+ */
+import { Type } from "@sinclair/typebox";
+
+export default function (pi) {
+  for (const name of ["alpha_read", "alpha_write"]) {
+    pi.registerTool({
+      name,
+      label: name,
+      description: `Alpha extension tool ${name} (e2e fixture).`,
+      parameters: Type.Object({}),
+      async execute() {
+        return { content: [{ type: "text", text: name }] };
+      },
+    });
+  }
+}

--- a/packages/pi-subagents/test/fixtures/ext-beta.mjs
+++ b/packages/pi-subagents/test/fixtures/ext-beta.mjs
@@ -1,0 +1,18 @@
+/**
+ * Real extension fixture "beta" for the template-driven e2e runner.
+ * Registers a single tool, used to prove that the `ext:` allowlist flip mutes
+ * a loaded-but-unselected extension. See ext-alpha.mjs for the conventions.
+ */
+import { Type } from "@sinclair/typebox";
+
+export default function (pi) {
+  pi.registerTool({
+    name: "beta_tool",
+    label: "beta_tool",
+    description: "Beta extension tool (e2e fixture).",
+    parameters: Type.Object({}),
+    async execute() {
+      return { content: [{ type: "text", text: "beta_tool" }] };
+    },
+  });
+}

--- a/packages/pi-subagents/test/fixtures/ext-lazy.mjs
+++ b/packages/pi-subagents/test/fixtures/ext-lazy.mjs
@@ -1,0 +1,27 @@
+/**
+ * Real extension fixture "lazy" for the template-driven e2e runner.
+ *
+ * Registers its tool from `session_start` rather than at load — the shape that
+ * broke subagents in issue #125. pi-mcp does exactly this (it can only enumerate
+ * tools once its MCP servers connect), and eagerly connecting at load time would
+ * orphan child processes on pi's non-agent code paths.
+ *
+ * The point of the fixture is the TIMING: at `loader.reload()` this extension
+ * contributes no tools at all, so any scoping that snapshots the tool set then
+ * will drop `lazy_tool` permanently. See ext-alpha.mjs for the conventions.
+ */
+import { Type } from "@sinclair/typebox";
+
+export default function (pi) {
+  pi.on("session_start", () => {
+    pi.registerTool({
+      name: "lazy_tool",
+      label: "lazy_tool",
+      description: "Lazily-registered extension tool (e2e fixture).",
+      parameters: Type.Object({}),
+      async execute() {
+        return { content: [{ type: "text", text: "lazy_tool" }] };
+      },
+    });
+  });
+}

--- a/packages/pi-subagents/test/fleet-list.test.ts
+++ b/packages/pi-subagents/test/fleet-list.test.ts
@@ -1,0 +1,428 @@
+import { Editor, visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentManager } from "../src/agent-manager.js";
+import type { AgentRecord } from "../src/types.js";
+import { getDisplayName } from "../src/ui/agent-widget.js";
+import { FleetList, type FleetUICtx, formatFleetElapsed, formatFleetTokens } from "../src/ui/fleet-list.js";
+
+// ---- Key sequences (see node_modules/@earendil-works/pi-tui/dist/keys.js) ----
+const DOWN = "\x1b[B";
+const UP = "\x1b[A";
+const LEFT = "\x1b[D";
+const RIGHT = "\x1b[C";
+const ESC = "\x1b";
+const ENTER = "\r";
+// Kitty-protocol key-RELEASE for ↓ (event type 3) — listeners receive these too.
+const DOWN_RELEASE = "\x1b[1;1:3B";
+
+const theme = { fg: (c: string, s: string) => `<${c}>${s}</${c}>`, bold: (s: string) => `*${s}*` };
+
+/** A no-op session so a record is "openable" by default (the list hides session-less agents). */
+const FAKE_SESSION = { subscribe: () => () => {}, messages: [] };
+
+function makeRecord(over: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    id: "a1",
+    type: "general-purpose",
+    description: "Sleep then report 1",
+    status: "running",
+    toolUses: 0,
+    startedAt: Date.now(),
+    session: FAKE_SESSION as any,
+    lifetimeUsage: { input: 13100, output: 0, cacheWrite: 0 },
+    compactionCount: 0,
+    ...over,
+  } as AgentRecord;
+}
+
+/** Fake manager exposing only what FleetList touches. */
+function fakeManager(agents: AgentRecord[]): AgentManager {
+  return {
+    listAgents: () => agents,
+    abort: () => true,
+    steer: vi.fn(() => true),
+  } as unknown as AgentManager;
+}
+
+interface Harness {
+  fleet: FleetList;
+  ui: FleetUICtx;
+  manager: AgentManager;
+  /** The overlay component (a real ConversationViewer) once one is opened. */
+  overlayComponent: () => { handleInput(data: string): void } | undefined;
+  /** Feed a key to the registered input handler; returns the consume result. */
+  press: (data: string) => { consume?: boolean } | undefined;
+  /** Render the currently-registered below-editor widget at the given width. */
+  render: (width?: number) => string[];
+  setEditorText: (t: string) => void;
+  /** Whether an overlay has been opened. */
+  overlayOpened: () => boolean;
+  /** Whether the most recently opened overlay's `done` was invoked (closed). */
+  overlayClosed: () => boolean;
+  /** Simulate the viewer closing itself (Esc → done); flushes the close microtask. */
+  closeOverlay: () => Promise<void>;
+  /** The fake `tui` handed to the widget factory; tests set `focusedComponent` on it. */
+  widgetTui: { requestRender(): void; focusedComponent?: unknown };
+}
+
+function harness(agents: AgentRecord[]): Harness {
+  let inputHandler: ((data: string) => { consume?: boolean } | undefined) | undefined;
+  let widgetFactory: ((tui: any, theme: any) => { render(w: number): string[] }) | undefined;
+  let editorText = "";
+  let opened = false;
+  let closed = false;
+  let overlayDone: ((r: undefined) => void) | undefined;
+  let overlayComponent: { handleInput(data: string): void } | undefined;
+  const fakeTui = { requestRender: () => {}, terminal: { columns: 120, rows: 40 } };
+
+  const ui: FleetUICtx = {
+    setWidget: (_key, content) => { widgetFactory = content as any; },
+    onTerminalInput: (h) => { inputHandler = h; return () => { inputHandler = undefined; }; },
+    getEditorText: () => editorText,
+    notify: () => {},
+    custom: ((factory: any) => {
+      opened = true;
+      return new Promise<undefined>((resolve) => {
+        const done = (r: undefined) => { closed = true; overlayDone = undefined; resolve(r); };
+        overlayDone = done;
+        // Construct the overlay component so the controller wires viewerClose,
+        // and keep it so tests can drive the real ConversationViewer's input.
+        overlayComponent = factory(fakeTui, theme, undefined, done);
+      });
+    }) as FleetUICtx["custom"],
+  };
+
+  const manager = fakeManager(agents);
+  const fleet = new FleetList(manager, new Map());
+  fleet.setUICtx(ui);
+  fleet.update();
+
+  return {
+    fleet,
+    ui,
+    manager,
+    overlayComponent: () => overlayComponent,
+    press: (data) => inputHandler?.(data),
+    render: (width = 120) => (widgetFactory ? widgetFactory(fakeTui, theme).render(width) : []),
+    setEditorText: (t) => { editorText = t; },
+    overlayOpened: () => opened,
+    overlayClosed: () => closed,
+    closeOverlay: async () => { overlayDone?.(undefined); await Promise.resolve(); },
+    widgetTui: fakeTui,
+  };
+}
+
+describe("formatFleetElapsed", () => {
+  it("renders integer seconds (no decimal, no suffix)", () => {
+    expect(formatFleetElapsed(0)).toBe("0s");
+    expect(formatFleetElapsed(11_000)).toBe("11s");
+    expect(formatFleetElapsed(11_400)).toBe("11s");
+    expect(formatFleetElapsed(11_600)).toBe("12s");
+  });
+  it("floors negatives to 0s", () => {
+    expect(formatFleetElapsed(-500)).toBe("0s");
+  });
+});
+
+describe("formatFleetTokens", () => {
+  it("prefixes a down-arrow and uses plural 'tokens'", () => {
+    expect(formatFleetTokens(13_100)).toBe("↓ 13.1k tokens");
+    expect(formatFleetTokens(950)).toBe("↓ 950 tokens");
+    expect(formatFleetTokens(1_200_000)).toBe("↓ 1.2M tokens");
+  });
+});
+
+describe("FleetList navigation", () => {
+  it("does not register a widget when there are no agents", () => {
+    const h = harness([]);
+    expect(h.render()).toEqual([]);
+  });
+
+  it("activates on ↓ at an empty prompt, consuming the key", () => {
+    const h = harness([makeRecord()]);
+    const res = h.press(DOWN);
+    expect(res).toEqual({ consume: true });
+    // main selected, list active → nav hint shown
+    expect(h.render().some(l => l.includes("enter view"))).toBe(true);
+  });
+
+  it("also activates on ← (matches the '← for agents' hint)", () => {
+    const h = harness([makeRecord()]);
+    expect(h.press(LEFT)).toEqual({ consume: true });
+  });
+
+  it("does NOT activate when the prompt is non-empty (typing is preserved)", () => {
+    const h = harness([makeRecord()]);
+    h.setEditorText("hello");
+    expect(h.press(DOWN)).toBeUndefined();
+  });
+
+  it("ignores key-release events so one tap moves exactly one row", () => {
+    const h = harness([
+      makeRecord({ id: "a1", description: "one" }),
+      makeRecord({ id: "a2", description: "two" }),
+    ]);
+    h.press(DOWN);          // activate → selection on main (idx 0)
+    h.press(DOWN_RELEASE);  // release half of the SAME tap — must be a no-op
+    expect(h.render().find(l => l.includes("main"))).toContain("●");
+    h.press(DOWN);          // a real second tap → first agent
+    h.press(DOWN_RELEASE);
+    expect(h.render().find(l => l.includes("one"))).toContain("●");
+    expect(h.render().find(l => l.includes("two"))).toContain("○");
+  });
+
+  it("moves selection down/up and clamps at the ends", () => {
+    const agents = [
+      makeRecord({ id: "a1", description: "one" }),
+      makeRecord({ id: "a2", description: "two" }),
+    ];
+    const h = harness(agents);
+    h.press(DOWN); // activate → index 0 (main)
+    h.press(DOWN); // → 1 (a1)
+    expect(h.render().find(l => l.includes("one"))).toContain("●");
+    h.press(DOWN); // → 2 (a2)
+    h.press(DOWN); // clamp at 2
+    expect(h.render().find(l => l.includes("two"))).toContain("●");
+    expect(h.render().find(l => l.includes("one"))).toContain("○");
+  });
+
+  it("↑ above 'main' deactivates (returns to the prompt)", () => {
+    const h = harness([makeRecord()]);
+    h.press(DOWN); // activate, index 0
+    expect(h.press(UP)).toEqual({ consume: true });
+    // back to inactive hint
+    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+  });
+
+  it("Esc deactivates", () => {
+    const h = harness([makeRecord()]);
+    h.press(DOWN);
+    expect(h.press(ESC)).toEqual({ consume: true });
+    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+  });
+
+  it("passes non-nav keys through and cancels navigation", () => {
+    const h = harness([makeRecord()]);
+    h.press(DOWN);
+    expect(h.press(RIGHT)).toBeUndefined();
+    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+  });
+
+  it("ignores all input while disabled and hides the widget", () => {
+    const h = harness([makeRecord()]);
+    h.fleet.setEnabled(false);
+    expect(h.press(DOWN)).toBeUndefined();
+    expect(h.render()).toEqual([]);
+  });
+
+  it("re-arms the refresh timer when the list is re-shown (toggle off→on)", () => {
+    vi.useFakeTimers();
+    try {
+      const agents = [makeRecord({ id: "a1" })];
+      const listAgents = vi.fn(() => agents);
+      const manager = { listAgents, abort: () => true } as unknown as AgentManager;
+      const fleet = new FleetList(manager, new Map());
+      fleet.setUICtx({
+        setWidget: () => {}, onTerminalInput: () => () => {}, getEditorText: () => "",
+        notify: () => {}, custom: (() => new Promise<undefined>(() => {})) as FleetUICtx["custom"],
+      });
+      fleet.update();          // shows list, arms the timer
+      fleet.setEnabled(false); // hides, clears the timer
+      fleet.setEnabled(true);  // re-shows — must re-arm the timer
+      const before = listAgents.mock.calls.length;
+      vi.advanceTimersByTime(250); // a tick should fire and re-read the roster
+      expect(listAgents.mock.calls.length).toBeGreaterThan(before);
+      fleet.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("FleetList vs other focused components (#123)", () => {
+  // pi dispatches terminal input to extension listeners BEFORE the focused
+  // component (pi-tui TUI.handleInput), and ctx.ui.select/confirm/input swap
+  // the prompt editor out of the editor container while getEditorText() still
+  // reads the detached (empty) editor. So while another component owns the
+  // keyboard — another extension's selector (rpiv-ask-user-question), pi's own
+  // menus, our /agents settings — the list must not consume its keys.
+
+  /** A minimal real Editor — what pi focuses at the prompt (CustomEditor extends it). */
+  function realEditor(): Editor {
+    const fakeTui = { requestRender: () => {} };
+    const theme = { borderColor: (s: string) => s, selectList: {} };
+    return new Editor(fakeTui as any, theme as any);
+  }
+
+  /** Hand the fleet list its `tui` (happens on first widget render in pi) with the given focus. */
+  function focusInHarness(h: Harness, focused: unknown): void {
+    h.widgetTui.focusedComponent = focused;
+    h.render();
+  }
+
+  it("does not steal ↓ from a focused selector (activation)", () => {
+    const h = harness([makeRecord()]);
+    focusInHarness(h, { kind: "selector" }); // e.g. ExtensionSelectorComponent
+    expect(h.press(DOWN)).toBeUndefined(); // must flow through to the selector
+  });
+
+  it("does not steal navigation keys from a selector opened while the list was active", () => {
+    const h = harness([makeRecord()]);
+    focusInHarness(h, realEditor());
+    expect(h.press(DOWN)).toEqual({ consume: true }); // activate at the prompt
+    focusInHarness(h, { kind: "selector" });          // a dialog takes focus
+    expect(h.press(DOWN)).toBeUndefined();
+    expect(h.press(ENTER)).toBeUndefined();
+    expect(h.press(ESC)).toBeUndefined();
+    // and the list dropped back to its inactive hint
+    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+  });
+
+  it("still activates when the prompt editor has focus", () => {
+    const h = harness([makeRecord()]);
+    focusInHarness(h, realEditor());
+    expect(h.press(DOWN)).toEqual({ consume: true });
+  });
+
+  it("assumes the editor when focus is unknowable (no tui yet / nothing focused)", () => {
+    const h = harness([makeRecord()]);
+    // No render yet → the list has never seen a tui: activation must still work.
+    expect(h.press(DOWN)).toEqual({ consume: true });
+  });
+});
+
+describe("FleetList rendering", () => {
+  it("renders main + agent rows with markers, type, description and right-aligned stats", () => {
+    const h = harness([makeRecord({ description: "Sleep then report 1" })]);
+    const lines = h.render(120);
+    // hint + blank + main + one agent
+    expect(lines[0]).toContain("← for agents");
+    expect(lines.find(l => l.includes("main"))).toContain("●"); // main selected by default
+    const agentLine = lines.find(l => l.includes("Sleep then report 1"))!;
+    expect(agentLine).toContain("○");
+    expect(agentLine).toContain(getDisplayName("general-purpose"));
+    expect(agentLine).toContain("↓ 13.1k tokens");
+    expect(agentLine).toMatch(/\d+s · ↓/); // "<seconds>s · ↓ ..." (timing-agnostic)
+  });
+
+  it("orders agents earliest-launched first (top)", () => {
+    const agents = [
+      makeRecord({ id: "new", description: "newest", startedAt: 2000 }),
+      makeRecord({ id: "old", description: "oldest", startedAt: 1000 }),
+    ];
+    const lines = harness(agents).render();
+    const oldIdx = lines.findIndex(l => l.includes("oldest"));
+    const newIdx = lines.findIndex(l => l.includes("newest"));
+    expect(oldIdx).toBeGreaterThanOrEqual(0);
+    expect(oldIdx).toBeLessThan(newIdx); // earliest sits above the later one
+  });
+
+  it("hides agents that have no session yet (pending)", () => {
+    const agents = [
+      makeRecord({ id: "live", description: "running one" }),
+      makeRecord({ id: "pending", description: "queued one", status: "queued", session: undefined }),
+    ];
+    const lines = harness(agents).render();
+    expect(lines.some(l => l.includes("running one"))).toBe(true);
+    expect(lines.some(l => l.includes("queued one"))).toBe(false);
+  });
+
+  it("collapses overflow into a '↓ N more' indicator", () => {
+    const agents = Array.from({ length: 8 }, (_, i) =>
+      makeRecord({ id: `a${i}`, description: `report ${i}` }));
+    const h = harness(agents);
+    const lines = h.render(120);
+    // 8 agents, cap 5 visible → "↓ 3 more"
+    expect(lines.some(l => l.includes("↓ 3 more"))).toBe(true);
+  });
+
+  it("never emits a line wider than the terminal (guards wrap-induced flicker)", () => {
+    const agents = Array.from({ length: 8 }, (_, i) =>
+      makeRecord({ id: `a${i}`, description: `a very long agent description number ${i} that keeps going` }));
+    const h = harness(agents);
+    for (const w of [4, 8, 12, 20, 40, 80, 200]) {
+      for (const line of h.render(w)) {
+        expect(visibleWidth(line)).toBeLessThanOrEqual(w);
+      }
+    }
+  });
+
+  it("windows the visible agents so the selection stays on screen", () => {
+    const agents = Array.from({ length: 8 }, (_, i) =>
+      makeRecord({ id: `a${i}`, description: `report ${i}` }));
+    const h = harness(agents);
+    h.press(DOWN); // activate (main)
+    // step down to the last agent (8 agents → roster index 8)
+    for (let i = 0; i < 8; i++) h.press(DOWN);
+    const lines = h.render(120);
+    expect(lines.find(l => l.includes("report 7"))).toContain("●");
+    expect(lines.some(l => l.includes("↑"))).toBe(true); // hidden-above indicator
+  });
+});
+
+describe("FleetList overlay lifecycle", () => {
+  it("Enter on 'main' just deactivates (no overlay)", () => {
+    const h = harness([makeRecord()]);
+    h.press(DOWN); // active, index 0 (main)
+    h.press(ENTER);
+    expect(h.overlayOpened()).toBe(false); // never opened an overlay
+    expect(h.render().some(l => l.includes("← for agents"))).toBe(true);
+  });
+
+  it("keeps the cursor on the viewed agent after closing, even if the list reordered", async () => {
+    const fakeSession = { subscribe: () => () => {}, messages: [] };
+    const agents = [
+      makeRecord({ id: "a1", description: "one", session: fakeSession as any }),
+      makeRecord({ id: "a2", description: "two", session: fakeSession as any }),
+      makeRecord({ id: "a3", description: "three", session: fakeSession as any }),
+    ];
+    const h = harness(agents);
+    h.press(DOWN); // activate (main, idx 0)
+    h.press(DOWN); // a1 (idx 1)
+    h.press(DOWN); // a2 (idx 2)
+    h.press(ENTER); // open a2
+    // a1 finishes and drops out while viewing → a2 shifts from idx 2 to idx 1.
+    agents.splice(0, 1);
+    await h.closeOverlay();
+    // Selection follows a2 ("two") to its new position, not whatever is at idx 2 now.
+    expect(h.render().find(l => l.includes("two"))).toContain("●");
+    expect(h.render().find(l => l.includes("three"))).toContain("○");
+  });
+
+  it("wires the viewer's steer composer to manager.steer with the agent id", () => {
+    const agents = [makeRecord({ id: "live", description: "the one" })];
+    const h = harness(agents);
+    h.press(DOWN);  // activate (main)
+    h.press(DOWN);  // → the agent
+    h.press(ENTER); // open the conversation viewer
+
+    const viewer = h.overlayComponent();
+    expect(viewer).toBeDefined();
+    viewer!.handleInput("\r");                       // Enter → open composer
+    for (const ch of "go left") viewer!.handleInput(ch);
+    viewer!.handleInput("\r");                       // Enter → send
+
+    expect(h.manager.steer).toHaveBeenCalledWith("live", "go left");
+  });
+
+  it("does NOT auto-close when the viewed agent finishes (final output stays readable)", () => {
+    const agents = [makeRecord({ id: "live", description: "the one" })];
+    const h = harness(agents);
+    h.press(DOWN); // active (main)
+    h.press(DOWN); // → the agent
+    h.press(ENTER); // opens overlay
+    expect(h.overlayOpened()).toBe(true);
+    // The agent finishes, well past the linger window...
+    agents[0] = makeRecord({ id: "live", description: "the one", status: "completed", completedAt: Date.now() - 60_000 });
+    h.fleet.onAgentFinished("live");
+    expect(h.overlayClosed()).toBe(false);                          // viewer stays open
+    expect(h.render().some(l => l.includes("the one"))).toBe(true); // and stays listed while viewed
+  });
+
+  it("lingers a finished agent in the list, then drops it after the window", () => {
+    const recent = makeRecord({ id: "r", description: "recent done", status: "completed", completedAt: Date.now() });
+    expect(harness([recent]).render().some(l => l.includes("recent done"))).toBe(true);
+    const old = makeRecord({ id: "o", description: "old done", status: "completed", completedAt: Date.now() - 60_000 });
+    expect(harness([old]).render().some(l => l.includes("old done"))).toBe(false);
+  });
+});

--- a/packages/pi-subagents/test/fleet-wiring.test.ts
+++ b/packages/pi-subagents/test/fleet-wiring.test.ts
@@ -1,0 +1,141 @@
+/**
+ * fleet-wiring.test.ts — end-to-end wiring of the FleetView through the REAL
+ * extension (src/index.ts), not the FleetList class in isolation.
+ *
+ * The unit tests in fleet-list.test.ts drive FleetList with a fake ui/manager.
+ * These prove the bits only the extension can: that `tool_execution_start`
+ * hands the fleet the live UI (so it captures input), that spawning a background
+ * agent actually registers the `belowEditor` widget once the agent has a session,
+ * and that `session_shutdown` tears it down. runAgent is mocked (no LLM); the
+ * manager, settings load, completion routing, and lifecycle handlers are real.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((t: any) => tools.set(t.name, t)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: { emit: vi.fn(), on: vi.fn(() => vi.fn()) },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  return { pi, tools, lifecycle };
+}
+
+/** A UI context with the surfaces the widget + fleet touch; setWidget is spied. */
+function uiCtx() {
+  return {
+    setStatus: vi.fn(),
+    setWidget: vi.fn(),
+    notify: vi.fn(),
+    onTerminalInput: vi.fn(() => vi.fn()),
+    getEditorText: vi.fn(() => ""),
+    custom: vi.fn(),
+  };
+}
+
+function ctxWith(ui: ReturnType<typeof uiCtx>) {
+  return {
+    hasUI: true,
+    ui,
+    cwd: process.cwd(),
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: () => "s1", getBranch: () => [] },
+    getSystemPrompt: () => "parent",
+  } as any;
+}
+
+const textOf = (r: any): string => r.content[0].text;
+const flush = async () => {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+};
+
+describe("FleetView wiring (real extension lifecycle)", () => {
+  let tmpDir: string;
+  let agentDir: string;
+  let prevCwd: string;
+  let prevAgentDir: string | undefined;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-fleet-"));
+    agentDir = mkdtempSync(join(tmpdir(), "pi-fleet-agentdir-"));
+    prevAgentDir = process.env.PI_CODING_AGENT_DIR;
+    prevHome = process.env.HOME;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.HOME = agentDir;
+    prevCwd = process.cwd();
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    // async join → completion routes straight to sendIndividualNudge (no batch
+    // debounce), so fleet.onAgentFinished fires synchronously on the result.
+    writeFileSync(join(tmpDir, ".pi", "subagents.json"), JSON.stringify({ schedulingEnabled: false, defaultJoinMode: "async" }));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    if (prevAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = prevAgentDir;
+    if (prevHome == null) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(agentDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("captures terminal input on tool_execution_start (fleet hooked into the UI)", async () => {
+    const { pi, lifecycle } = makePi();
+    subagentsExtension(pi);
+    const ui = uiCtx();
+    await lifecycle.get("tool_execution_start")?.({}, ctxWith(ui));
+    expect(ui.onTerminalInput).toHaveBeenCalled();
+  });
+
+  it("registers the belowEditor widget once a spawned agent has a session, then clears it on shutdown", async () => {
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: { dispose: vi.fn() } as any,
+      aborted: false,
+      steered: false,
+    });
+
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    const ui = uiCtx();
+    await lifecycle.get("tool_execution_start")?.({}, ctxWith(ui)); // fleet captures THIS ui
+
+    const spawn = await tools.get("Agent").execute(
+      "tc",
+      { prompt: "go", description: "live one", subagent_type: "general-purpose", run_in_background: true },
+      undefined,
+      undefined,
+      ctxWith(uiCtx()),
+    );
+    expect(textOf(spawn)).toMatch(/Agent ID:/);
+    await flush(); // completion → fleet.onAgentFinished → update → widget registers
+
+    const fleetRegs = ui.setWidget.mock.calls.filter(c => c[0] === "fleet" && typeof c[1] === "function");
+    expect(fleetRegs.length, "fleet widget should register with a render factory").toBeGreaterThan(0);
+
+    await lifecycle.get("session_shutdown")?.({}, ctxWith(uiCtx()));
+    expect(ui.setWidget).toHaveBeenCalledWith("fleet", undefined); // dispose cleared it
+  });
+});

--- a/packages/pi-subagents/test/group-join.test.ts
+++ b/packages/pi-subagents/test/group-join.test.ts
@@ -1,0 +1,153 @@
+/**
+ * group-join.test.ts — Behavior of GroupJoinManager's state machine and timers.
+ *
+ * Uses fake timers to assert deterministic timeout behavior without flakiness.
+ * The class itself is exercised directly with real records — no mocks beyond
+ * a spy on the delivery callback.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GroupJoinManager } from "../src/group-join.js";
+import type { AgentRecord } from "../src/types.js";
+
+function makeRecord(id: string, overrides: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    id,
+    type: "general-purpose",
+    description: "test",
+    status: "completed",
+    toolUses: 0,
+    startedAt: 0,
+    lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+    ...overrides,
+  };
+}
+
+describe("GroupJoinManager", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("returns 'pass' for unregistered agents and never invokes the callback", () => {
+    const deliver = vi.fn();
+    const mgr = new GroupJoinManager(deliver);
+    expect(mgr.onAgentComplete(makeRecord("a"))).toBe("pass");
+    expect(deliver).not.toHaveBeenCalled();
+    expect(mgr.isGrouped("a")).toBe(false);
+  });
+
+  it("holds the first completion and arms the join timeout", () => {
+    const deliver = vi.fn();
+    const mgr = new GroupJoinManager(deliver, 30_000);
+    mgr.registerGroup("g", ["a", "b"]);
+
+    expect(mgr.isGrouped("a")).toBe(true);
+    expect(mgr.onAgentComplete(makeRecord("a"))).toBe("held");
+
+    vi.advanceTimersByTime(29_999);
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("delivers all records (partial=false) when the final completion arrives in time", () => {
+    const deliver = vi.fn();
+    const mgr = new GroupJoinManager(deliver);
+    mgr.registerGroup("g", ["a", "b"]);
+
+    mgr.onAgentComplete(makeRecord("a", { result: "A" }));
+    expect(mgr.onAgentComplete(makeRecord("b", { result: "B" }))).toBe("delivered");
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    const [records, partial] = deliver.mock.calls[0];
+    expect(records.map((r: AgentRecord) => r.id).sort()).toEqual(["a", "b"]);
+    expect(partial).toBe(false);
+
+    // Group is cleaned up — no future deliveries can fire from these ids
+    expect(mgr.isGrouped("a")).toBe(false);
+    expect(mgr.isGrouped("b")).toBe(false);
+  });
+
+  it("delivers partial=true on timeout and re-arms the group for stragglers", () => {
+    const deliver = vi.fn();
+    const mgr = new GroupJoinManager(deliver, 30_000);
+    mgr.registerGroup("g", ["a", "b", "c"]);
+
+    mgr.onAgentComplete(makeRecord("a"));
+    vi.advanceTimersByTime(30_000);
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    const [records, partial] = deliver.mock.calls[0];
+    expect(records.map((r: AgentRecord) => r.id)).toEqual(["a"]);
+    expect(partial).toBe(true);
+
+    // 'a' was delivered and is dropped from the group; 'b' and 'c' remain as stragglers
+    expect(mgr.isGrouped("a")).toBe(false);
+    expect(mgr.isGrouped("b")).toBe(true);
+    expect(mgr.isGrouped("c")).toBe(true);
+  });
+
+  it("uses the shorter straggler timeout (15s) regardless of the configured group timeout", () => {
+    const deliver = vi.fn();
+    const mgr = new GroupJoinManager(deliver, 30_000);
+    mgr.registerGroup("g", ["a", "b", "c"]);
+
+    // First batch: 'a' alone, partial-delivered after 30s
+    mgr.onAgentComplete(makeRecord("a"));
+    vi.advanceTimersByTime(30_000);
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    // Straggler 'b' arrives — fires at 15s, not 30s
+    mgr.onAgentComplete(makeRecord("b"));
+    vi.advanceTimersByTime(14_999);
+    expect(deliver).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1);
+    expect(deliver).toHaveBeenCalledTimes(2);
+
+    expect(deliver.mock.calls[1][0].map((r: AgentRecord) => r.id)).toEqual(["b"]);
+    expect(deliver.mock.calls[1][1]).toBe(true);
+    expect(mgr.isGrouped("c")).toBe(true); // 'c' is the remaining straggler now
+  });
+
+  it("delivers stragglers as a complete batch (partial=false) when all complete before their timeout", () => {
+    const deliver = vi.fn();
+    const mgr = new GroupJoinManager(deliver, 30_000);
+    mgr.registerGroup("g", ["a", "b", "c"]);
+
+    mgr.onAgentComplete(makeRecord("a"));
+    vi.advanceTimersByTime(30_000); // partial: 'a'
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    mgr.onAgentComplete(makeRecord("b"));
+    expect(mgr.onAgentComplete(makeRecord("c"))).toBe("delivered");
+
+    expect(deliver).toHaveBeenCalledTimes(2);
+    expect(deliver.mock.calls[1][0].map((r: AgentRecord) => r.id).sort()).toEqual(["b", "c"]);
+    expect(deliver.mock.calls[1][1]).toBe(false);
+  });
+
+  it("returns 'pass' for late completions arriving after a group is already delivered", () => {
+    const deliver = vi.fn();
+    const mgr = new GroupJoinManager(deliver);
+    mgr.registerGroup("g", ["a", "b"]);
+
+    mgr.onAgentComplete(makeRecord("a"));
+    mgr.onAgentComplete(makeRecord("b")); // full delivery
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    // A duplicate/late completion must not trigger a second delivery
+    expect(mgr.onAgentComplete(makeRecord("a"))).toBe("pass");
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose() clears pending timers so a partial delivery never fires post-dispose", () => {
+    const deliver = vi.fn();
+    const mgr = new GroupJoinManager(deliver, 30_000);
+    mgr.registerGroup("g", ["a", "b"]);
+
+    mgr.onAgentComplete(makeRecord("a")); // arms 30s timeout
+    mgr.dispose();
+
+    vi.advanceTimersByTime(60_000);
+    expect(deliver).not.toHaveBeenCalled();
+    expect(mgr.isGrouped("a")).toBe(false);
+    expect(mgr.isGrouped("b")).toBe(false);
+  });
+});

--- a/packages/pi-subagents/test/helpers/pi-ai.ts
+++ b/packages/pi-subagents/test/helpers/pi-ai.ts
@@ -1,0 +1,7 @@
+/**
+ * pi-ai.ts — single import point for the two test helpers that pi-ai ≥0.80
+ * exports only from the `/compat` subpath (both lived on the package root in
+ * ≤0.75.x). Upstream deletes `/compat` with its coding-agent ModelManager
+ * migration; the replacement then is `fauxProvider()` + `createModels()`.
+ */
+export { getModel, registerFauxProvider } from "@earendil-works/pi-ai/compat";

--- a/packages/pi-subagents/test/helpers/print-mode-runner.ts
+++ b/packages/pi-subagents/test/helpers/print-mode-runner.ts
@@ -1,0 +1,610 @@
+/**
+ * print-mode-runner.ts — a headless ("print mode") host runner for driving the
+ * pi-subagents extension through REAL end-to-end subagent runs.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The other e2e suites (agent-runner-e2e, ext-templates-e2e) assert on the
+ * *gated tool set captured at construction* — they never drive a turn, so they
+ * never actually spawn a subagent or exercise the background hold condition.
+ * This runner closes that gap: it boots a real headless pi session with the
+ * pi-subagents extension loaded, drives a real assistant turn that calls the
+ * `Agent` tool, and lets the extension spawn a real child session through the
+ * real `runAgent` path — then waits for it to finish exactly like a production
+ * print-mode host does.
+ *
+ * It is the pi-subagents analogue of pi-chonky-step's `src/agent.ts` headless
+ * runner: same shape (DefaultResourceLoader → createAgentSession → prompt loop),
+ * and crucially it replicates pi-chonky-step's SUBAGENT HOLD CONDITION — the
+ * `dequeueFollowUpMessages` monkey-patch that blocks the parent agent loop until
+ * background subagents complete (via the `Symbol.for("pi-subagents:manager")`
+ * global the extension publishes). Without that patch, `session.prompt()`
+ * resolves and the parent finishes before background children report back.
+ *
+ * MODEL BACKEND (faux default, real opt-in)
+ * -----------------------------------------
+ *   - Faux (default): a scripted `registerFauxProvider` model drives both the
+ *     parent and the spawned child deterministically — no network, CI-safe. You
+ *     supply a `respond(context)` function (or raw `steps`) that emits the
+ *     `Agent` tool call on the parent and a reply on the child. `routeBySession`
+ *     does the parent/child branching for the common single-spawn case.
+ *   - Live (opt-in): set `PI_E2E_LIVE=1` or pass `live: {provider, model}`. A real
+ *     model drives the turn; `respond`/`steps` are ignored. Non-deterministic,
+ *     needs creds. With no explicit model pin, it resolves the model from your
+ *     local `pi` config (settings default → first authed model), so a logged-in
+ *     `pi` is picked up automatically — no PI_PROVIDER/PI_MODEL needed.
+ *
+ * ONE PARAMETERIZED RUNNER
+ * ------------------------
+ * The same `runPrintMode()` covers built-in agent types, `.pi/agents/*.md` /
+ * `.agents/agents/*.md` frontmatter agents, and inline-instruction agents — the difference is purely
+ * what you register in `beforeRun` and which `subagent_type` the `Agent` call
+ * names. See `test/subagents-print-mode-e2e.test.ts` for usage.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  type AssistantMessage,
+  type Context,
+  type FauxContentBlock,
+  type FauxResponseStep,
+  fauxAssistantMessage,
+  fauxText,
+  fauxToolCall,
+  type Model,
+  type ToolCall,
+} from "@earendil-works/pi-ai";
+import {
+  type AgentSession,
+  type AgentSessionEvent,
+  createAgentSession,
+  DefaultResourceLoader,
+  getAgentDir,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { getModel, registerFauxProvider } from "./pi-ai.js";
+
+/** Path to the pi-subagents extension entrypoint (repo `src/index.ts`). */
+const EXTENSION_PATH = fileURLToPath(new URL("../../src/index.ts", import.meta.url));
+
+/** The cross-package handle the extension publishes on a global Symbol. */
+const MANAGER_KEY = Symbol.for("pi-subagents:manager");
+
+export interface ManagerHandle {
+  waitForAll(): Promise<void>;
+  hasRunning(): boolean;
+  getRecord(id: string): unknown;
+}
+
+/** A faux reply in any convenient shape; normalized to an AssistantMessage. */
+export type FauxReply = string | FauxContentBlock | FauxContentBlock[] | AssistantMessage;
+
+/**
+ * A context-branching responder. Invoked once per model call (parent OR child)
+ * with that call's own `Context`, so it can decide what to emit from the prompt
+ * it sees — order-independent, unlike a flat FIFO `steps` list.
+ */
+export type FauxResponder = (
+  context: Context,
+  state: { callCount: number },
+) => FauxReply | Promise<FauxReply>;
+
+export interface RunPrintModeOptions {
+  /** The user prompt that kicks off the parent turn. */
+  prompt: string;
+  /**
+   * Working directory for the run. Defaults to a fresh temp dir that `dispose()`
+   * removes. Pass a fixtures dir to make project custom agents discoverable.
+   */
+  cwd?: string;
+  /** Parent host system prompt. Default: a minimal orchestrator prompt. */
+  systemPrompt?: string;
+  /**
+   * Faux mode: context-branching responder (padded to `maxModelCalls` calls).
+   * Ignored in live mode. Mutually exclusive with `steps` (steps wins).
+   */
+  respond?: FauxResponder;
+  /** Faux mode: explicit FIFO response steps. Overrides `respond`. */
+  steps?: FauxResponseStep[];
+  /** Faux mode: how many model calls to pad the queue for. Default 16. */
+  maxModelCalls?: number;
+  /**
+   * Honor the subagent hold condition — block the parent agent loop until
+   * background subagents finish (the pi-chonky-step monkey-patch). Default true.
+   */
+  hold?: boolean;
+  /**
+   * Run before the parent turn, after globals are isolated — e.g.
+   * `registerAgents(loadCustomAgents(cwd))` to install frontmatter agents.
+   */
+  beforeRun?: () => void | Promise<void>;
+  /**
+   * Isolate global discovery (PI_CODING_AGENT_DIR + HOME → temp) so the dev's
+   * real agents/extensions can't bleed into the run. Default true in faux mode,
+   * false in live mode (so real auth/config resolve). Restored on `dispose()`.
+   */
+  isolateGlobals?: boolean;
+  /** Wall-clock guard for the whole run. Default 30_000ms. */
+  timeoutMs?: number;
+  /** Abort the parent (and forwarded children) externally. */
+  signal?: AbortSignal;
+  /**
+   * Force live mode against a specific provider/model (overrides PI_E2E_LIVE).
+   * When omitted, live mode is on iff `PI_E2E_LIVE` is truthy. In live mode, if
+   * neither this nor `PI_PROVIDER`+`PI_MODEL` is set, the model is left for pi to
+   * resolve from your local config (settings default → first authed model) — i.e.
+   * it picks up whatever your `pi` install is logged into, no env required.
+   */
+  live?: { provider: string; model: string };
+}
+
+export interface PrintModeRun {
+  /** Last assistant text the parent produced (the "printed" answer). */
+  responseText: string;
+  /** The live parent session (history, tool calls, etc.). */
+  parentSession: AgentSession;
+  /** The extension's manager handle (undefined if the extension didn't load). */
+  manager: ManagerHandle | undefined;
+  /** Snapshot of all subagent records the manager knew about at the end. */
+  subagents: Array<Record<string, unknown>>;
+  /** Faux model call count (0 in live mode). */
+  modelCalls: number;
+  /**
+   * Tear down: emit session_shutdown (so extensions clear timers), dispose the
+   * session, unregister faux, restore cwd/env, rm temp dir. Async — await it.
+   */
+  dispose: () => Promise<void>;
+}
+
+// --------------------------------------------------------------------------
+// Faux scripting helpers
+// --------------------------------------------------------------------------
+
+/**
+ * Build an `Agent` tool call for a faux assistant turn. `subagent_type` defaults
+ * to "general-purpose"; everything else is passed straight through as tool args.
+ */
+export function agentCall(
+  args: {
+    prompt: string;
+    description: string;
+    subagent_type?: string;
+    run_in_background?: boolean;
+    [k: string]: unknown;
+  },
+  opts?: { id?: string },
+): ToolCall {
+  return fauxToolCall("Agent", { subagent_type: "general-purpose", ...args }, opts);
+}
+
+function resolveReply(
+  reply: FauxReply | ((ctx: Context) => FauxReply),
+  ctx: Context,
+): FauxReply {
+  return typeof reply === "function" ? (reply as (c: Context) => FauxReply)(ctx) : reply;
+}
+
+/**
+ * The common single-spawn flow as a responder. Routes by inspecting the calling
+ * session's own context:
+ *   - PARENT  (its tool set includes `Agent`):
+ *       · `parentInitial` until an `Agent` tool result is in history (the spawn),
+ *       · then `parentFinal` (the answer after the child reports back).
+ *   - SUBAGENT (no `Agent` tool): `subagent`.
+ * Each route may be a value or a `(ctx) => value` function.
+ */
+export function routeBySession(routes: {
+  parentInitial: FauxReply | ((ctx: Context) => FauxReply);
+  parentFinal?: FauxReply | ((ctx: Context) => FauxReply);
+  subagent: FauxReply | ((ctx: Context) => FauxReply);
+}): FauxResponder {
+  return (context) => {
+    const isParent = (context.tools ?? []).some((t) => t.name === "Agent");
+    if (!isParent) return resolveReply(routes.subagent, context);
+    const spawned = context.messages.some(
+      (m) => m.role === "toolResult" && (m as { toolName?: string }).toolName === "Agent",
+    );
+    if (spawned) {
+      return routes.parentFinal != null
+        ? resolveReply(routes.parentFinal, context)
+        : "Done.";
+    }
+    return resolveReply(routes.parentInitial, context);
+  };
+}
+
+/** Normalize any FauxReply into a faux AssistantMessage (tool calls ⇒ stopReason "toolUse"). */
+function toAssistantMessage(reply: FauxReply): AssistantMessage {
+  if (reply && typeof reply === "object" && "role" in reply) {
+    return reply as AssistantMessage;
+  }
+  const content: FauxContentBlock[] =
+    typeof reply === "string" ? [fauxText(reply)] : Array.isArray(reply) ? reply : [reply];
+  const hasToolCall = content.some((b) => (b as { type?: string }).type === "toolCall");
+  return fauxAssistantMessage(content, { stopReason: hasToolCall ? "toolUse" : "stop" });
+}
+
+// --------------------------------------------------------------------------
+// The runner
+// --------------------------------------------------------------------------
+
+const DEFAULT_SYSTEM_PROMPT =
+  "You are a headless orchestrator. Use the Agent tool to delegate, then report the result.";
+
+function isLive(options: RunPrintModeOptions): boolean {
+  return Boolean(options.live) || /^(1|true|yes)$/i.test(process.env.PI_E2E_LIVE ?? "");
+}
+
+export async function runPrintMode(options: RunPrintModeOptions): Promise<PrintModeRun> {
+  const live = isLive(options);
+  const isolateGlobals = options.isolateGlobals ?? !live;
+  const timeoutMs = options.timeoutMs ?? 30_000;
+
+  // --- working dir (own it only if we created it) ---
+  const ownsCwd = options.cwd == null;
+  const cwd = options.cwd ?? mkdtempSync(join(tmpdir(), "subagents-print-"));
+
+  // chdir into cwd: the extension discovers project custom agents from process.cwd()
+  // (not ctx.cwd), and re-reads them on every Agent invocation — so a custom agent
+  // is only spawnable if process.cwd() points at the dir holding it. Restored on
+  // dispose. (Vitest isolates test files per process, so this doesn't race.)
+  const prevCwd = process.cwd();
+  process.chdir(cwd);
+
+  // --- isolate global discovery so the dev env can't bleed in ---
+  const prevAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const prevHome = process.env.HOME;
+  let hermeticDir: string | undefined;
+  if (isolateGlobals) {
+    hermeticDir = mkdtempSync(join(tmpdir(), "subagents-print-home-"));
+    process.env.PI_CODING_AGENT_DIR = hermeticDir;
+    process.env.HOME = hermeticDir;
+  }
+
+  // --- model backend ---
+  let faux: ReturnType<typeof registerFauxProvider> | undefined;
+  let model: Model<string> | undefined;
+  let modelRegistry: unknown;
+  if (live) {
+    // Explicit pin wins (options.live or PI_PROVIDER + PI_MODEL). Otherwise leave
+    // `model` undefined: createAgentSession then calls findInitialModel() against
+    // the real, auth-backed registry + your local settings default — i.e. it
+    // picks up whatever your `pi` install is logged into, no env needed.
+    const provider = options.live?.provider ?? process.env.PI_PROVIDER;
+    const modelId = options.live?.model ?? process.env.PI_MODEL;
+    if (provider && modelId) {
+      // getModel's overloads need the concrete provider literal; cast through.
+      // Since pi-ai 0.80 it is a static builtin-catalog lookup that returns
+      // undefined for unknown models — fail fast instead of letting
+      // createAgentSession silently substitute another model.
+      model = (getModel as (p: string, m: string) => Model<string> | undefined)(provider, modelId);
+      if (!model) {
+        throw new Error(
+          `runPrintMode (live mode): model "${provider}/${modelId}" not found in the builtin catalog`,
+        );
+      }
+    }
+    modelRegistry = undefined; // let createAgentSession build the real, auth-backed registry
+  } else {
+    if (!options.steps && !options.respond) {
+      throw new Error("runPrintMode (faux mode): provide `respond` or `steps`");
+    }
+    faux = registerFauxProvider({ provider: "faux", models: [{ id: "faux-1", contextWindow: 200_000 }] });
+    model = faux.getModel();
+    // Structural faux registry (matches the existing e2e suites): the parent
+    // session uses `model` directly; subagents inherit it via ctx.model since
+    // resolveDefaultModel falls back to the parent model when no model is pinned.
+    modelRegistry = {
+      find: () => model,
+      getAll: () => [model],
+      getAvailable: () => [model],
+      hasConfiguredAuth: () => true,
+      isUsingOAuth: () => false,
+      // createAgentSession's injected streamFn checks `auth.ok` and throws
+      // Error(auth.error) otherwise — so the `ok: true` flag is mandatory, not
+      // cosmetic. Without it the turn dies before streaming (empty error message).
+      getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "faux", headers: {} }),
+      registerProvider: () => {},
+      unregisterProvider: () => {},
+    };
+
+    // Pad the response queue: one context-branching responder per expected model
+    // call. The queue is a single FIFO shared by parent + child, but every entry
+    // is the same responder that decides from its own context, so interleaving
+    // order doesn't matter.
+    if (options.steps) {
+      faux.setResponses(options.steps);
+    } else {
+      const respond = options.respond;
+      if (!respond) {
+        throw new Error("runPrintMode (faux mode): provide `respond` or `steps`");
+      }
+      const max = options.maxModelCalls ?? 16;
+      const factory: FauxResponseStep = async (context, _opts, state) =>
+        toAssistantMessage(await respond(context, state));
+      faux.setResponses(Array.from({ length: max }, () => factory));
+    }
+  }
+
+  // --- build the parent host session with the extension loaded ---
+  // Resolved after globals are isolated, so it honors the hermetic dir.
+  const agentDir = getAgentDir();
+  const loader = new DefaultResourceLoader({
+    cwd,
+    agentDir,
+    additionalExtensionPaths: [EXTENSION_PATH],
+    systemPromptOverride: () => options.systemPrompt ?? DEFAULT_SYSTEM_PROMPT,
+    appendSystemPromptOverride: () => [],
+    noPromptTemplates: true,
+    noThemes: true,
+    noContextFiles: true,
+  });
+  await loader.reload();
+
+  // Run any test-supplied registration (e.g. loadCustomAgents) now that globals
+  // are isolated but before the parent turn spawns anything.
+  await options.beforeRun?.();
+
+  const { session } = await createAgentSession({
+    cwd,
+    agentDir,
+    model,
+    // Structural faux registry in faux mode; undefined in live mode (defaults).
+    modelRegistry: modelRegistry as any,
+    resourceLoader: loader,
+    sessionManager: SessionManager.inMemory(cwd),
+    // Live: real settings so an omitted model resolves to your local default
+    // (settingsManager.getDefaultModel) and retries/compaction match your config.
+    // Faux: in-memory, deterministic, no disk.
+    settingsManager: live
+      ? SettingsManager.create(cwd, agentDir)
+      : SettingsManager.inMemory({ compaction: { enabled: false }, retry: { enabled: false } }),
+  });
+  session.setSessionName("print-mode-host");
+
+  // Binding fires session_start so the extension initializes and publishes its
+  // manager on the global Symbol.
+  await session.bindExtensions({});
+
+  const manager = (globalThis as Record<symbol, unknown>)[MANAGER_KEY] as
+    | ManagerHandle
+    | undefined;
+
+  // --- subagent hold condition (the pi-chonky-step monkey-patch) ---
+  // Block the parent agent loop while background subagents are still running, so
+  // their completion nudges land before the parent's final turn.
+  const hold = options.hold ?? true;
+  if (hold && manager) {
+    // dequeueFollowUpMessages is internal — reach through with a cast.
+    const agent = (session as any).agent;
+    if (agent?.dequeueFollowUpMessages) {
+      const original = agent.dequeueFollowUpMessages.bind(agent);
+      agent.dequeueFollowUpMessages = function patched() {
+        const messages = original();
+        if (messages.length > 0) return messages;
+        if (manager.hasRunning()) {
+          // Returning a Promise is auto-unwrapped by the async loop config —
+          // the loop blocks here until all subagents finish and queue nudges.
+          return manager.waitForAll().then(() => original());
+        }
+        return messages;
+      };
+    }
+  }
+
+  // --- collect the parent's last assistant text ---
+  let responseText = "";
+  const unsubscribe = session.subscribe((event: AgentSessionEvent) => {
+    if (event.type === "message_start") responseText = "";
+    if (
+      event.type === "message_update" &&
+      event.assistantMessageEvent.type === "text_delta"
+    ) {
+      responseText += event.assistantMessageEvent.delta;
+    }
+  });
+
+  // --- forward external abort ---
+  const onAbort = () => session.abort();
+  options.signal?.addEventListener("abort", onAbort, { once: true });
+
+  const dispose = async () => {
+    // Emit session_shutdown FIRST so extensions tear down cleanly — in live mode
+    // the real env loads global extensions (e.g. a status-bar) whose background
+    // timers would otherwise fire after dispose() invalidates the ctx and surface
+    // as unhandled "stale ctx" rejections. dispose() itself does the invalidation,
+    // so shutdown has to happen before it.
+    try {
+      await session.extensionRunner?.emit({ type: "session_shutdown", reason: "quit" });
+    } catch {
+      /* ignore */
+    }
+    try {
+      session.dispose?.();
+    } catch {
+      /* ignore */
+    }
+    faux?.unregister();
+    delete (globalThis as Record<symbol, unknown>)[MANAGER_KEY];
+    // Restore cwd before removing the temp dir (can't rm the dir you're in).
+    try {
+      process.chdir(prevCwd);
+    } catch {
+      /* ignore */
+    }
+    if (isolateGlobals) {
+      if (prevAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
+      else process.env.PI_CODING_AGENT_DIR = prevAgentDir;
+      if (prevHome == null) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (hermeticDir) rmSync(hermeticDir, { recursive: true, force: true });
+    }
+    if (ownsCwd) rmSync(cwd, { recursive: true, force: true });
+  };
+
+  // --- drive the turn under a wall-clock guard ---
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let failed = false;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const stillRunning = manager?.hasRunning() ? " (background subagents still running)" : "";
+      reject(new Error(`print-mode runner timed out after ${timeoutMs}ms${stillRunning}`));
+    }, timeoutMs);
+  });
+  try {
+    await Promise.race([
+      (async () => {
+        await session.prompt(options.prompt);
+        // Fallback for when the hold patch is unavailable: catch any subagents
+        // still running after prompt() returns and process their results.
+        if (hold) {
+          while (!failed && manager?.hasRunning()) {
+            await manager.waitForAll();
+            // prompt() resolves (not rejects) on abort, so after a timeout this
+            // orphaned race arm keeps running — never re-prompt a torn-down session.
+            if (failed) break;
+            await session.prompt("Background agents have completed. Process their results.");
+          }
+        }
+      })(),
+      timeout,
+    ]);
+  } catch (err) {
+    // On timeout (or any turn failure) we throw, so the caller never receives
+    // the dispose handle — without this, a live session and its background
+    // subagents would keep streaming after the test already failed. Subagents
+    // are aborted by dispose()'s session_shutdown emit (the extension's
+    // shutdown handler calls manager.abortAll()).
+    failed = true;
+    try {
+      session.abort();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await dispose();
+    } catch {
+      /* ignore — the turn error below is the diagnostic that matters */
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+    unsubscribe();
+    options.signal?.removeEventListener("abort", onAbort);
+  }
+
+  if (!responseText.trim()) {
+    responseText = lastAssistantText(session);
+  }
+
+  // Snapshot subagent records (manager exposes them via the extension session,
+  // but the cross-package handle only exposes getRecord — read listAgents off
+  // the underlying manager if reachable, else fall back to an empty list).
+  const subagents = snapshotSubagents(manager);
+
+  return {
+    responseText: responseText.trim(),
+    parentSession: session,
+    manager,
+    subagents,
+    modelCalls: faux?.state.callCount ?? 0,
+    dispose,
+  };
+}
+
+/**
+ * Extract the text of every `Agent` tool result in a session's history. This is
+ * the real end-to-end observable: for a foreground spawn it contains the child's
+ * own output; for a background spawn it's the "started in background" envelope.
+ */
+export function agentToolResults(session: AgentSession): string[] {
+  const out: string[] = [];
+  for (const msg of session.messages) {
+    if (msg.role !== "toolResult") continue;
+    if ((msg as { toolName?: string }).toolName !== "Agent") continue;
+    const text = (msg.content as Array<{ type?: string; text?: string }>)
+      .map((b) => (b.type === "text" ? (b.text ?? "") : ""))
+      .join("");
+    out.push(text);
+  }
+  return out;
+}
+
+/**
+ * All text across the whole conversation — assistant turns, user/nudge messages,
+ * and every tool result. Use this to assert a child's output *materialized
+ * somewhere* (a foreground tool result, a get_subagent_result result, a held
+ * nudge), rather than only in the parent's final message which may summarize it.
+ */
+export function conversationText(session: AgentSession): string {
+  const parts: string[] = [];
+  for (const msg of session.messages) {
+    const content = (msg as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content as Array<{ type?: string; text?: string }>) {
+      if (block.type === "text" && block.text) parts.push(block.text);
+    }
+  }
+  return parts.join("\n");
+}
+
+/** Names of every tool the assistant actually invoked (in order). */
+export function invokedToolNames(session: AgentSession): string[] {
+  const out: string[] = [];
+  for (const msg of session.messages) {
+    if (msg.role !== "assistant") continue;
+    for (const block of msg.content as Array<{ type?: string; name?: string }>) {
+      if (block.type === "toolCall" && block.name) out.push(block.name);
+    }
+  }
+  return out;
+}
+
+/**
+ * The arguments of every `Agent` tool call the model actually made — lets a live
+ * smoke assert which feature was exercised (e.g. `run_in_background`,
+ * `subagent_type`) rather than just that *some* spawn happened.
+ */
+export function agentToolCalls(session: AgentSession): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  for (const msg of session.messages) {
+    if (msg.role !== "assistant") continue;
+    for (const block of msg.content as Array<{ type?: string; name?: string; arguments?: unknown }>) {
+      if (block.type === "toolCall" && block.name === "Agent") {
+        out.push((block.arguments ?? {}) as Record<string, unknown>);
+      }
+    }
+  }
+  return out;
+}
+
+/** Walk session history backward for the last non-empty assistant text. */
+function lastAssistantText(session: AgentSession): string {
+  const messages = session.messages;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "assistant") continue;
+    const text = msg.content
+      .map((b) => ((b as { type?: string; text?: string }).type === "text" ? (b as { text?: string }).text ?? "" : ""))
+      .join("")
+      .trim();
+    if (text) return text;
+  }
+  return "";
+}
+
+/** Best-effort snapshot of the manager's agent records for assertions. */
+function snapshotSubagents(manager: ManagerHandle | undefined): Array<Record<string, unknown>> {
+  if (!manager) return [];
+  // The published handle is minimal; the real manager (with listAgents) is the
+  // same object the extension constructed. Try listAgents if present.
+  const m = manager as unknown as { listAgents?: () => Array<Record<string, unknown>> };
+  try {
+    return m.listAgents ? m.listAgents() : [];
+  } catch {
+    return [];
+  }
+}

--- a/packages/pi-subagents/test/invocation-config.test.ts
+++ b/packages/pi-subagents/test/invocation-config.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { resolveAgentInvocationConfig, resolveJoinMode } from "../src/invocation-config.js";
+import type { AgentConfig } from "../src/types.js";
+
+function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    name: "Explore",
+    description: "Explore",
+    builtinToolNames: ["read"],
+    extensions: false,
+    skills: false,
+    systemPrompt: "Test agent",
+    promptMode: "replace",
+    inheritContext: false,
+    runInBackground: false,
+    isolated: false,
+    ...overrides,
+  };
+}
+
+describe("resolveAgentInvocationConfig", () => {
+  it("prefers agent config over tool-call params for locked fields", () => {
+    const resolved = resolveAgentInvocationConfig(
+      makeConfig({
+        model: "provider/config-model",
+        thinking: "high",
+        maxTurns: 42,
+        inheritContext: false,
+        runInBackground: false,
+        isolated: false,
+        isolation: "worktree",
+      }),
+      {
+        model: "provider/param-model",
+        thinking: "minimal",
+        max_turns: 1,
+        inherit_context: true,
+        run_in_background: true,
+        isolated: true,
+        isolation: "worktree",
+      },
+    );
+
+    expect(resolved.modelInput).toBe("provider/config-model");
+    expect(resolved.modelFromParams).toBe(false);
+    expect(resolved.thinking).toBe("high");
+    expect(resolved.maxTurns).toBe(42);
+    expect(resolved.inheritContext).toBe(false);
+    expect(resolved.runInBackground).toBe(false);
+    expect(resolved.isolated).toBe(false);
+    expect(resolved.isolation).toBe("worktree");
+  });
+
+  it("uses tool-call params when no agent config is available", () => {
+    const resolved = resolveAgentInvocationConfig(undefined, {
+      model: "provider/param-model",
+      thinking: "minimal",
+      max_turns: 3,
+      inherit_context: true,
+      run_in_background: true,
+      isolated: true,
+      isolation: "worktree",
+    });
+
+    expect(resolved.modelInput).toBe("provider/param-model");
+    expect(resolved.modelFromParams).toBe(true);
+    expect(resolved.thinking).toBe("minimal");
+    expect(resolved.maxTurns).toBe(3);
+    expect(resolved.inheritContext).toBe(true);
+    expect(resolved.runInBackground).toBe(true);
+    expect(resolved.isolated).toBe(true);
+    expect(resolved.isolation).toBe("worktree");
+  });
+
+  it("lets parent fill in booleans when config leaves them undefined", () => {
+    const resolved = resolveAgentInvocationConfig(
+      makeConfig({
+        inheritContext: undefined,
+        runInBackground: undefined,
+        isolated: undefined,
+      }),
+      {
+        inherit_context: true,
+        run_in_background: true,
+        isolated: true,
+      },
+    );
+
+    expect(resolved.inheritContext).toBe(true);
+    expect(resolved.runInBackground).toBe(true);
+    expect(resolved.isolated).toBe(true);
+  });
+
+  it("defaults booleans to false when neither config nor params set them", () => {
+    const resolved = resolveAgentInvocationConfig(
+      makeConfig({
+        inheritContext: undefined,
+        runInBackground: undefined,
+        isolated: undefined,
+      }),
+      {},
+    );
+
+    expect(resolved.inheritContext).toBe(false);
+    expect(resolved.runInBackground).toBe(false);
+    expect(resolved.isolated).toBe(false);
+  });
+});
+
+describe("resolveJoinMode", () => {
+  it("returns the global default for background agents", () => {
+    expect(resolveJoinMode("smart", true)).toBe("smart");
+    expect(resolveJoinMode("async", true)).toBe("async");
+  });
+
+  it("ignores join mode for foreground agents", () => {
+    expect(resolveJoinMode("smart", false)).toBeUndefined();
+    expect(resolveJoinMode("group", false)).toBeUndefined();
+  });
+});

--- a/packages/pi-subagents/test/manager-registry-guard.test.ts
+++ b/packages/pi-subagents/test/manager-registry-guard.test.ts
@@ -1,0 +1,108 @@
+/**
+ * manager-registry-guard.test.ts — the Symbol.for("pi-subagents:manager")
+ * global registry across multiple activations in one process.
+ *
+ * Subagent sessions re-activate this extension in the same process
+ * (session.bindExtensions in agent-runner.ts). The old code let every
+ * activation overwrite the global slot — pointing cross-package consumers at
+ * a short-lived child manager — and every child's session_shutdown DELETED
+ * the slot, so the root session's entry was lost as soon as any subagent ran.
+ *
+ * The fix: the first activation claims the slot, later activations leave it
+ * alone, and only the owner's shutdown releases it.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+const MANAGER_KEY = Symbol.for("pi-subagents:manager");
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((t: any) => tools.set(t.name, t)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: {
+      emit: vi.fn(),
+      on: vi.fn(() => vi.fn()),
+    },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  return { pi, tools, lifecycle };
+}
+
+function ctx() {
+  return {
+    hasUI: false,
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    cwd: process.cwd(),
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: vi.fn(() => "s1"), getBranch: vi.fn(() => []) },
+    getSystemPrompt: vi.fn(() => "parent"),
+  } as any;
+}
+
+const textOf = (r: any): string => r.content[0].text;
+
+async function spawnBackground(tools: Map<string, any>): Promise<string> {
+  vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}) as any); // never resolves
+  const r = await tools.get("Agent").execute(
+    "tc-spawn",
+    { prompt: "go", description: "registry test agent", subagent_type: "general-purpose", run_in_background: true },
+    undefined,
+    undefined,
+    ctx(),
+  );
+  return /Agent ID: (\S+)/.exec(textOf(r))![1];
+}
+
+// Restore the global slot around every test.
+const priorGlobal = (globalThis as any)[MANAGER_KEY];
+afterEach(() => {
+  if (priorGlobal === undefined) delete (globalThis as any)[MANAGER_KEY];
+  else (globalThis as any)[MANAGER_KEY] = priorGlobal;
+  vi.mocked(runAgent).mockReset();
+});
+
+describe("Symbol.for manager registry across activations", () => {
+  it("child activation does not overwrite the root entry; child shutdown does not delete it", async () => {
+    delete (globalThis as any)[MANAGER_KEY];
+
+    // Root session activates first and owns the registry.
+    const root = makePi();
+    subagentsExtension(root.pi);
+    const rootEntry = (globalThis as any)[MANAGER_KEY];
+    expect(rootEntry).toBeDefined();
+
+    // Spawn a background agent through the ROOT so its record is findable.
+    const id = await spawnBackground(root.tools);
+    expect(rootEntry.getRecord(id)).toBeDefined();
+
+    // A child agent session re-activates the extension in-process.
+    const child = makePi();
+    subagentsExtension(child.pi);
+
+    // Registry still points at the root's entry (child did not clobber it) …
+    expect((globalThis as any)[MANAGER_KEY]).toBe(rootEntry);
+    expect((globalThis as any)[MANAGER_KEY].getRecord(id)).toBeDefined();
+
+    // … and the child's shutdown does not delete the root's entry.
+    await child.lifecycle.get("session_shutdown")?.();
+    expect((globalThis as any)[MANAGER_KEY]).toBe(rootEntry);
+
+    // The root's own shutdown releases the slot.
+    await root.lifecycle.get("session_shutdown")?.();
+    expect((globalThis as any)[MANAGER_KEY]).toBeUndefined();
+  });
+});

--- a/packages/pi-subagents/test/memory-legacy-fallback.test.ts
+++ b/packages/pi-subagents/test/memory-legacy-fallback.test.ts
@@ -1,0 +1,81 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock homedir so the legacy ~/.pi/agent-memory fallback can be exercised
+// against a temp directory instead of the real home. The default return must
+// be a valid string: pi-coding-agent evaluates getAgentDir() at module load
+// (before beforeEach runs), so an undefined homedir would throw at import.
+const mockHomedir = vi.hoisted(() => vi.fn(() => "/tmp"));
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: mockHomedir };
+});
+
+import { resolveMemoryDir } from "../src/memory.js";
+
+describe("resolveMemoryDir user-scope legacy fallback", () => {
+  let tmpDir: string;
+  let fakeHome: string;
+  let agentDir: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-mem-legacy-test-"));
+    fakeHome = join(tmpDir, "home");
+    agentDir = join(tmpDir, "agent-dir");
+    mkdirSync(fakeHome, { recursive: true });
+    mockHomedir.mockReturnValue(fakeHome);
+    originalEnv = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+  });
+
+  afterEach(() => {
+    if (originalEnv == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalEnv;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("uses the agent dir location when no legacy memory exists", () => {
+    const dir = resolveMemoryDir("chronicler", "user", "/workspace");
+    expect(dir).toBe(join(agentDir, "agent-memory", "chronicler"));
+  });
+
+  it("falls back to legacy ~/.pi/agent-memory when it exists and the new location doesn't", () => {
+    const legacy = join(fakeHome, ".pi", "agent-memory", "chronicler");
+    mkdirSync(legacy, { recursive: true });
+
+    const dir = resolveMemoryDir("chronicler", "user", "/workspace");
+    expect(dir).toBe(legacy);
+  });
+
+  it("prefers the new location once it exists, even if legacy also exists", () => {
+    const legacy = join(fakeHome, ".pi", "agent-memory", "chronicler");
+    const current = join(agentDir, "agent-memory", "chronicler");
+    mkdirSync(legacy, { recursive: true });
+    mkdirSync(current, { recursive: true });
+
+    const dir = resolveMemoryDir("chronicler", "user", "/workspace");
+    expect(dir).toBe(current);
+  });
+
+  it("ignores a symlinked legacy directory", () => {
+    const target = join(tmpDir, "elsewhere");
+    mkdirSync(target, { recursive: true });
+    mkdirSync(join(fakeHome, ".pi", "agent-memory"), { recursive: true });
+    symlinkSync(target, join(fakeHome, ".pi", "agent-memory", "chronicler"));
+
+    const dir = resolveMemoryDir("chronicler", "user", "/workspace");
+    expect(dir).toBe(join(agentDir, "agent-memory", "chronicler"));
+  });
+
+  it("scopes the fallback per agent name", () => {
+    const legacyOther = join(fakeHome, ".pi", "agent-memory", "other-agent");
+    mkdirSync(legacyOther, { recursive: true });
+
+    // "other-agent" has legacy memory; "chronicler" doesn't — only the former falls back.
+    expect(resolveMemoryDir("other-agent", "user", "/workspace")).toBe(legacyOther);
+    expect(resolveMemoryDir("chronicler", "user", "/workspace")).toBe(join(agentDir, "agent-memory", "chronicler"));
+  });
+});

--- a/packages/pi-subagents/test/memory.test.ts
+++ b/packages/pi-subagents/test/memory.test.ts
@@ -1,0 +1,343 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock homedir so the user-scope legacy fallback check (~/.pi/agent-memory)
+// resolves against a controlled temp home rather than the developer's real
+// ~/.pi state. The default return must be a valid string: pi-coding-agent
+// evaluates getAgentDir() at module load, so an undefined homedir throws at import.
+const mockHomedir = vi.hoisted(() => vi.fn(() => "/tmp"));
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: mockHomedir };
+});
+
+import { buildMemoryBlock, buildReadOnlyMemoryBlock, ensureMemoryDir, isSymlink, isUnsafeName, readMemoryIndex, resolveMemoryDir, safeReadFile } from "../src/memory.js";
+
+describe("memory", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-mem-test-"));
+    // Point homedir at a clean temp home with no legacy agent-memory dirs, so
+    // user-scope resolution deterministically returns the agent-dir location.
+    const fakeHome = join(tmpDir, "home");
+    mkdirSync(fakeHome, { recursive: true });
+    mockHomedir.mockReturnValue(fakeHome);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("resolveMemoryDir", () => {
+    it("resolves project scope to .pi/agent-memory/<name>", () => {
+      const dir = resolveMemoryDir("auditor", "project", "/workspace");
+      expect(dir).toBe("/workspace/.pi/agent-memory/auditor");
+    });
+
+    it("resolves local scope to .pi/agent-memory-local/<name>", () => {
+      const dir = resolveMemoryDir("auditor", "local", "/workspace");
+      expect(dir).toBe("/workspace/.pi/agent-memory-local/auditor");
+    });
+
+    it("resolves user scope under the agent dir (honors PI_CODING_AGENT_DIR)", () => {
+      const originalEnv = process.env.PI_CODING_AGENT_DIR;
+      process.env.PI_CODING_AGENT_DIR = join(tmpDir, "custom-agent-dir");
+      try {
+        const dir = resolveMemoryDir("auditor", "user", "/workspace");
+        expect(dir).toBe(join(tmpDir, "custom-agent-dir", "agent-memory", "auditor"));
+        expect(dir).not.toContain("/workspace");
+      } finally {
+        if (originalEnv == null) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = originalEnv;
+      }
+    });
+
+    it("throws on names with path traversal (..)", () => {
+      expect(() => resolveMemoryDir("../../etc/evil", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("throws on names with forward slash", () => {
+      expect(() => resolveMemoryDir("foo/bar", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("throws on names with backslash", () => {
+      expect(() => resolveMemoryDir("foo\\bar", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("throws on names with null byte", () => {
+      expect(() => resolveMemoryDir("foo\0bar", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("throws on empty name", () => {
+      expect(() => resolveMemoryDir("", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("throws on names starting with dot", () => {
+      expect(() => resolveMemoryDir(".hidden", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("throws on names with spaces", () => {
+      expect(() => resolveMemoryDir("foo bar", "project", "/workspace")).toThrow("Unsafe agent name");
+    });
+
+    it("allows hyphens, underscores, and dots in names", () => {
+      expect(() => resolveMemoryDir("my-agent_v2.1", "project", "/workspace")).not.toThrow();
+    });
+  });
+
+  describe("isUnsafeName (whitelist validation)", () => {
+    it("rejects empty string", () => {
+      expect(isUnsafeName("")).toBe(true);
+    });
+
+    it("rejects names longer than 128 chars", () => {
+      expect(isUnsafeName("a".repeat(129))).toBe(true);
+    });
+
+    it("rejects path traversal", () => {
+      expect(isUnsafeName("../../etc")).toBe(true);
+    });
+
+    it("rejects names starting with dot", () => {
+      expect(isUnsafeName(".hidden")).toBe(true);
+    });
+
+    it("rejects names with spaces", () => {
+      expect(isUnsafeName("foo bar")).toBe(true);
+    });
+
+    it("rejects names with special characters", () => {
+      expect(isUnsafeName("foo;bar")).toBe(true);
+      expect(isUnsafeName("foo|bar")).toBe(true);
+      expect(isUnsafeName("foo`bar")).toBe(true);
+    });
+
+    it("allows valid names", () => {
+      expect(isUnsafeName("my-agent")).toBe(false);
+      expect(isUnsafeName("agent_v2")).toBe(false);
+      expect(isUnsafeName("Agent123")).toBe(false);
+      expect(isUnsafeName("my-agent.v2")).toBe(false);
+    });
+  });
+
+  describe("ensureMemoryDir", () => {
+    it("creates directory if it doesn't exist", () => {
+      const dir = join(tmpDir, "agent-memory", "test");
+      expect(existsSync(dir)).toBe(false);
+      ensureMemoryDir(dir);
+      expect(existsSync(dir)).toBe(true);
+    });
+
+    it("no-ops if directory already exists", () => {
+      const dir = join(tmpDir, "agent-memory", "test");
+      mkdirSync(dir, { recursive: true });
+      ensureMemoryDir(dir); // should not throw
+      expect(existsSync(dir)).toBe(true);
+    });
+
+    it("throws on symlinked directory", () => {
+      const realDir = join(tmpDir, "real-dir");
+      const linkDir = join(tmpDir, "symlink-dir");
+      mkdirSync(realDir, { recursive: true });
+      symlinkSync(realDir, linkDir);
+      expect(() => ensureMemoryDir(linkDir)).toThrow("symlinked memory directory");
+    });
+  });
+
+  describe("isSymlink", () => {
+    it("returns false for regular file", () => {
+      const file = join(tmpDir, "regular.txt");
+      writeFileSync(file, "content");
+      expect(isSymlink(file)).toBe(false);
+    });
+
+    it("returns true for symlink", () => {
+      const file = join(tmpDir, "real.txt");
+      const link = join(tmpDir, "link.txt");
+      writeFileSync(file, "content");
+      symlinkSync(file, link);
+      expect(isSymlink(link)).toBe(true);
+    });
+
+    it("returns false for nonexistent path", () => {
+      expect(isSymlink(join(tmpDir, "nope"))).toBe(false);
+    });
+  });
+
+  describe("safeReadFile", () => {
+    it("reads regular files", () => {
+      const file = join(tmpDir, "regular.txt");
+      writeFileSync(file, "hello");
+      expect(safeReadFile(file)).toBe("hello");
+    });
+
+    it("rejects symlinked files", () => {
+      const file = join(tmpDir, "real.txt");
+      const link = join(tmpDir, "link.txt");
+      writeFileSync(file, "secret");
+      symlinkSync(file, link);
+      expect(safeReadFile(link)).toBeUndefined();
+    });
+
+    it("returns undefined for nonexistent files", () => {
+      expect(safeReadFile(join(tmpDir, "nope.txt"))).toBeUndefined();
+    });
+  });
+
+  describe("readMemoryIndex", () => {
+    it("returns undefined when MEMORY.md doesn't exist", () => {
+      const result = readMemoryIndex(tmpDir);
+      expect(result).toBeUndefined();
+    });
+
+    it("reads MEMORY.md content", () => {
+      writeFileSync(join(tmpDir, "MEMORY.md"), "# Memories\n- Item 1\n- Item 2");
+      const result = readMemoryIndex(tmpDir);
+      expect(result).toBe("# Memories\n- Item 1\n- Item 2");
+    });
+
+    it("rejects symlinked memory directory", () => {
+      const realDir = join(tmpDir, "real-mem");
+      const linkDir = join(tmpDir, "link-mem");
+      mkdirSync(realDir, { recursive: true });
+      writeFileSync(join(realDir, "MEMORY.md"), "# Secret");
+      symlinkSync(realDir, linkDir);
+      expect(readMemoryIndex(linkDir)).toBeUndefined();
+    });
+
+    it("rejects symlinked MEMORY.md file", () => {
+      const realFile = join(tmpDir, "secret.md");
+      writeFileSync(realFile, "# Secret");
+      const memDir = join(tmpDir, "mem-dir");
+      mkdirSync(memDir);
+      symlinkSync(realFile, join(memDir, "MEMORY.md"));
+      expect(readMemoryIndex(memDir)).toBeUndefined();
+    });
+
+    it("truncates content beyond 200 lines", () => {
+      const lines = Array.from({ length: 250 }, (_, i) => `Line ${i + 1}`);
+      writeFileSync(join(tmpDir, "MEMORY.md"), lines.join("\n"));
+      const result = readMemoryIndex(tmpDir)!;
+      expect(result).toContain("Line 200");
+      expect(result).not.toContain("Line 201");
+      expect(result).toContain("truncated at 200 lines");
+    });
+  });
+
+  describe("buildMemoryBlock", () => {
+    it("builds memory block with no existing MEMORY.md", () => {
+      const block = buildMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).toContain("Agent Memory");
+      expect(block).toContain("agent-memory/test-agent");
+      expect(block).toContain("No MEMORY.md exists yet");
+      expect(block).toContain("Memory Instructions");
+    });
+
+    it("builds memory block with existing MEMORY.md", () => {
+      const memDir = join(tmpDir, ".pi", "agent-memory", "test-agent");
+      mkdirSync(memDir, { recursive: true });
+      writeFileSync(join(memDir, "MEMORY.md"), "# Existing\n- recall this");
+      const block = buildMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).toContain("Existing");
+      expect(block).toContain("recall this");
+      expect(block).not.toContain("No MEMORY.md exists yet");
+    });
+
+    it("creates memory directory if it doesn't exist", () => {
+      const memDir = join(tmpDir, ".pi", "agent-memory", "new-agent");
+      expect(existsSync(memDir)).toBe(false);
+      buildMemoryBlock("new-agent", "project", tmpDir);
+      expect(existsSync(memDir)).toBe(true);
+    });
+
+    it("includes Read/Write/Edit instructions", () => {
+      const block = buildMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).toContain("Read, Write, and Edit tools");
+    });
+
+    it("uses correct directory for local scope", () => {
+      const block = buildMemoryBlock("test-agent", "local", tmpDir);
+      expect(block).toContain("agent-memory-local/test-agent");
+    });
+
+    it("uses correct directory for user scope", () => {
+      // Pin the agent dir to a temp location so the test doesn't create
+      // directories in the real home / agent dir (buildMemoryBlock mkdirs).
+      const originalEnv = process.env.PI_CODING_AGENT_DIR;
+      process.env.PI_CODING_AGENT_DIR = join(tmpDir, "agent-dir");
+      try {
+        const block = buildMemoryBlock("test-agent", "user", join(tmpDir, "workspace"));
+        expect(block).toContain(join(tmpDir, "agent-dir", "agent-memory", "test-agent"));
+        expect(block).not.toContain(join(tmpDir, "workspace"));
+      } finally {
+        if (originalEnv == null) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = originalEnv;
+      }
+    });
+
+    it("includes scope label in header", () => {
+      expect(buildMemoryBlock("a", "project", tmpDir)).toContain("Memory scope: project");
+      expect(buildMemoryBlock("a", "local", tmpDir)).toContain("Memory scope: local");
+      expect(buildMemoryBlock("a", "user", tmpDir)).toContain("Memory scope: user");
+    });
+  });
+
+  describe("buildReadOnlyMemoryBlock", () => {
+    it("returns read-only instructions without write/edit mention", () => {
+      const block = buildReadOnlyMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).toContain("read-only");
+      expect(block).not.toContain("Write");
+      expect(block).not.toContain("Edit");
+      expect(block).not.toContain("Memory Instructions");
+    });
+
+    it("does NOT create the memory directory", () => {
+      const memDir = join(tmpDir, ".pi", "agent-memory", "ro-agent");
+      expect(existsSync(memDir)).toBe(false);
+      buildReadOnlyMemoryBlock("ro-agent", "project", tmpDir);
+      expect(existsSync(memDir)).toBe(false);
+    });
+
+    it("includes existing MEMORY.md content", () => {
+      const memDir = join(tmpDir, ".pi", "agent-memory", "test-agent");
+      mkdirSync(memDir, { recursive: true });
+      writeFileSync(join(memDir, "MEMORY.md"), "# Existing\n- recall this");
+      const block = buildReadOnlyMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).toContain("Existing");
+      expect(block).toContain("recall this");
+    });
+
+    it("returns 'no memory available' when no MEMORY.md exists", () => {
+      const block = buildReadOnlyMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).toContain("No memory is available yet");
+      expect(block).not.toContain("Create one");
+    });
+
+    it("includes scope label in header", () => {
+      expect(buildReadOnlyMemoryBlock("a", "project", tmpDir)).toContain("Memory scope: project");
+      expect(buildReadOnlyMemoryBlock("a", "local", tmpDir)).toContain("Memory scope: local");
+      expect(buildReadOnlyMemoryBlock("a", "user", tmpDir)).toContain("Memory scope: user");
+    });
+
+    it("does not mention memory directory path for write access", () => {
+      const block = buildReadOnlyMemoryBlock("test-agent", "project", tmpDir);
+      expect(block).not.toContain("persistent memory directory at:");
+      expect(block).not.toContain("Create one at");
+    });
+
+    it("rejects symlinked memory directory in read-only mode", () => {
+      const realDir = join(tmpDir, ".pi", "agent-memory", "test-agent");
+      mkdirSync(realDir, { recursive: true });
+      writeFileSync(join(realDir, "MEMORY.md"), "# Secret");
+      const linkDir = join(tmpDir, ".pi", "agent-memory", "linked-agent");
+      mkdirSync(join(tmpDir, ".pi", "agent-memory"), { recursive: true });
+      symlinkSync(realDir, linkDir);
+      // Should not read through the symlink
+      const block = buildReadOnlyMemoryBlock("linked-agent", "project", tmpDir);
+      expect(block).toContain("No memory is available yet");
+    });
+  });
+});

--- a/packages/pi-subagents/test/model-resolver.test.ts
+++ b/packages/pi-subagents/test/model-resolver.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import { type ModelRegistry, resolveModel } from "../src/model-resolver.js";
+
+// Mock model entries matching typical pi model registry shape
+const MODELS = [
+  { id: "claude-opus-4-6", name: "Claude Opus 4.6", provider: "anthropic" },
+  { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", provider: "anthropic" },
+  { id: "claude-haiku-4-5-20251001", name: "Claude Haiku 4.5", provider: "anthropic" },
+  { id: "gpt-4o", name: "GPT-4o", provider: "openai" },
+  { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", provider: "google" },
+];
+
+function makeRegistry(models = MODELS, available?: typeof MODELS): ModelRegistry {
+  return {
+    find(provider: string, modelId: string) {
+      return models.find(m => m.provider === provider && m.id === modelId);
+    },
+    getAll() {
+      return models;
+    },
+    getAvailable: available ? () => available : undefined,
+  };
+}
+
+describe("resolveModel", () => {
+  describe("exact match (provider/modelId)", () => {
+    it("resolves exact provider/modelId", () => {
+      const result = resolveModel("anthropic/claude-opus-4-6", makeRegistry());
+      expect(result).toEqual(MODELS[0]);
+    });
+
+    it("resolves another exact provider/modelId", () => {
+      const result = resolveModel("openai/gpt-4o", makeRegistry());
+      expect(result).toEqual(MODELS[3]);
+    });
+
+    it("falls through to fuzzy when exact provider/modelId not found", () => {
+      // "anthropic/haiku" is not an exact match, but fuzzy should find it
+      const result = resolveModel("anthropic/haiku", makeRegistry());
+      expect(result).toEqual(MODELS[2]); // haiku
+    });
+  });
+
+  describe("fuzzy match — exact id", () => {
+    it("matches exact model id without provider", () => {
+      const result = resolveModel("claude-opus-4-6", makeRegistry());
+      expect(result).toEqual(MODELS[0]);
+    });
+
+    it("is case-insensitive", () => {
+      const result = resolveModel("Claude-Opus-4-6", makeRegistry());
+      expect(result).toEqual(MODELS[0]);
+    });
+
+    it("matches exact id for non-anthropic models", () => {
+      const result = resolveModel("gpt-4o", makeRegistry());
+      expect(result).toEqual(MODELS[3]);
+    });
+  });
+
+  describe("fuzzy match — substring", () => {
+    it("matches 'haiku' to claude-haiku model", () => {
+      const result = resolveModel("haiku", makeRegistry());
+      expect(result).toEqual(MODELS[2]);
+    });
+
+    it("matches 'sonnet' to claude-sonnet model", () => {
+      const result = resolveModel("sonnet", makeRegistry());
+      expect(result).toEqual(MODELS[1]);
+    });
+
+    it("matches 'opus' to claude-opus model", () => {
+      const result = resolveModel("opus", makeRegistry());
+      expect(result).toEqual(MODELS[0]);
+    });
+
+    it("matches 'gemini' to gemini model", () => {
+      const result = resolveModel("gemini", makeRegistry());
+      expect(result).toEqual(MODELS[4]);
+    });
+
+    it("is case-insensitive for substring", () => {
+      const result = resolveModel("HAIKU", makeRegistry());
+      expect(result).toEqual(MODELS[2]);
+    });
+  });
+
+  describe("fuzzy match — separator equivalence (dash vs dot)", () => {
+    // id uses dashes and the name carries no version number — the case that
+    // failed before separators were normalized (the "4.5" token couldn't be
+    // found anywhere, so the dotted query matched nothing).
+    const HAIKU = { id: "claude-haiku-4-5", name: "Claude Haiku", provider: "anthropic" };
+    const dashReg = makeRegistry([HAIKU]);
+
+    it("matches a dotted query to a dashed id", () => {
+      expect(resolveModel("claude-haiku-4.5", dashReg)).toEqual(HAIKU);
+    });
+
+    it("matches a dotted provider/id query to a dashed id", () => {
+      expect(resolveModel("anthropic/claude-haiku-4.5", dashReg)).toEqual(HAIKU);
+    });
+
+    it("matches a dashed query to a dotted id", () => {
+      expect(resolveModel("gemini-2-5-pro", makeRegistry())).toEqual(MODELS[4]);
+    });
+  });
+
+  describe("fuzzy match — trailing date-stamp is optional", () => {
+    // A date-pinned config (e.g. an agent's frontmatter, or a shipped default)
+    // should still resolve when the registry lists the model without the stamp.
+    const HAIKU_DASH = { id: "claude-haiku-4-5", name: "Claude Haiku", provider: "anthropic" };
+    const HAIKU_DOT = { id: "claude-haiku-4.5", name: "Claude Haiku", provider: "anthropic" };
+
+    it("matches a dated provider/id config to an undated registry id", () => {
+      expect(resolveModel("anthropic/claude-haiku-4-5-20251001", makeRegistry([HAIKU_DASH]))).toEqual(HAIKU_DASH);
+    });
+
+    it("matches a dated config to an undated *dotted* registry id (date + separator)", () => {
+      expect(resolveModel("anthropic/claude-haiku-4-5-20251001", makeRegistry([HAIKU_DOT]))).toEqual(HAIKU_DOT);
+    });
+
+    it("still prefers an exact dated id when the registry has it", () => {
+      const dated = { id: "claude-haiku-4-5-20251001", name: "Claude Haiku 4.5", provider: "anthropic" };
+      expect(resolveModel("anthropic/claude-haiku-4-5-20251001", makeRegistry([dated]))).toEqual(dated);
+    });
+  });
+
+  describe("provider fallback (prefer named provider, else any)", () => {
+    const gatewayHaiku = { id: "claude-haiku-4-5", name: "Claude Haiku", provider: "openrouter" };
+    const anthropicHaiku = { id: "claude-haiku-4-5", name: "Claude Haiku", provider: "anthropic" };
+
+    it("falls back to another provider when the named one lacks the model", () => {
+      expect(resolveModel("anthropic/claude-haiku-4-5", makeRegistry([gatewayHaiku]))).toEqual(gatewayHaiku);
+    });
+
+    it("prefers the named provider when it has the model", () => {
+      expect(resolveModel("anthropic/claude-haiku-4-5", makeRegistry([gatewayHaiku, anthropicHaiku]))).toEqual(anthropicHaiku);
+    });
+
+    it("still errors when no provider has the model", () => {
+      expect(typeof resolveModel("anthropic/nonexistent-xyz", makeRegistry([gatewayHaiku]))).toBe("string");
+    });
+  });
+
+  describe("fuzzy match — name contains", () => {
+    it("matches 'Opus 4.6' via model name", () => {
+      const result = resolveModel("Opus 4.6", makeRegistry());
+      expect(result).toEqual(MODELS[0]);
+    });
+
+    it("matches 'Haiku 4.5' via model name", () => {
+      const result = resolveModel("Haiku 4.5", makeRegistry());
+      expect(result).toEqual(MODELS[2]);
+    });
+  });
+
+  describe("fuzzy match — multi-part", () => {
+    it("matches 'anthropic opus' across provider and id", () => {
+      const result = resolveModel("anthropic opus", makeRegistry());
+      expect(result).toEqual(MODELS[0]);
+    });
+
+    it("matches 'google pro' across provider and id", () => {
+      const result = resolveModel("google pro", makeRegistry());
+      expect(result).toEqual(MODELS[4]);
+    });
+  });
+
+  describe("fuzzy match — prefers tighter matches", () => {
+    it("prefers exact id over substring", () => {
+      const result = resolveModel("gpt-4o", makeRegistry());
+      expect(result).toEqual(MODELS[3]);
+    });
+
+    it("substring match prefers shorter model id (tighter fit)", () => {
+      // Both opus and sonnet contain their query as substring, but "opus" is a tighter match
+      // for "opus" than "sonnet" is for "sonnet" — each should resolve to itself
+      expect(resolveModel("opus", makeRegistry())).toEqual(MODELS[0]);
+      expect(resolveModel("sonnet", makeRegistry())).toEqual(MODELS[1]);
+    });
+  });
+
+  describe("no match", () => {
+    it("returns error string for unknown model", () => {
+      const result = resolveModel("nonexistent-model", makeRegistry());
+      expect(typeof result).toBe("string");
+      expect(result).toContain('Model not found: "nonexistent-model"');
+      expect(result).toContain("Available models:");
+    });
+
+    it("error lists available models", () => {
+      const result = resolveModel("xyz", makeRegistry());
+      expect(result).toContain("anthropic/claude-opus-4-6");
+      expect(result).toContain("openai/gpt-4o");
+    });
+
+    it("empty string matches a model (multi-part vacuous truth)", () => {
+      // Empty string splits to empty parts; every() on empty array is true
+      // This is fine — callers guard against empty input
+      const result = resolveModel("", makeRegistry());
+      expect(typeof result).toBe("object");
+    });
+  });
+
+  describe("getAvailable filtering", () => {
+    it("uses getAvailable when present (filters to configured models)", () => {
+      const available = [MODELS[0], MODELS[2]]; // only opus and haiku
+      const result = resolveModel("sonnet", makeRegistry(MODELS, available));
+      // sonnet is in getAll but not in getAvailable — should not fuzzy match
+      expect(typeof result).toBe("string");
+      expect(result).toContain("Model not found");
+    });
+
+    it("exact match fails when model is not in getAvailable (no auth)", () => {
+      const available = [MODELS[0]]; // only opus available
+      const result = resolveModel("anthropic/claude-sonnet-4-6", makeRegistry(MODELS, available));
+      expect(typeof result).toBe("string");
+      expect(result).toContain("Model not found");
+    });
+
+    it("fuzzy matches against available models only", () => {
+      const available = [MODELS[2]]; // only haiku available
+      const result = resolveModel("haiku", makeRegistry(MODELS, available));
+      expect(result).toEqual(MODELS[2]);
+    });
+  });
+
+  describe("ambiguous matches", () => {
+    const SIMILAR_MODELS = [
+      { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", provider: "anthropic" },
+      { id: "claude-sonnet-4-5-20241022", name: "Claude Sonnet 4.5", provider: "anthropic" },
+      { id: "claude-haiku-4-5-20251001", name: "Claude Haiku 4.5", provider: "anthropic" },
+    ];
+
+    it("'sonnet' prefers tighter id match (shorter id)", () => {
+      const result = resolveModel("sonnet", makeRegistry(SIMILAR_MODELS));
+      // "sonnet" is a larger fraction of "claude-sonnet-4-6" than "claude-sonnet-4-5-20241022"
+      expect(result).toEqual(SIMILAR_MODELS[0]);
+    });
+
+    it("'sonnet 4.5' resolves to the 4.5 model via name", () => {
+      const result = resolveModel("sonnet 4.5", makeRegistry(SIMILAR_MODELS));
+      expect(result).toEqual(SIMILAR_MODELS[1]);
+    });
+
+    it("'4-6' picks the 4.6 model", () => {
+      const result = resolveModel("4-6", makeRegistry(SIMILAR_MODELS));
+      expect(result).toEqual(SIMILAR_MODELS[0]);
+    });
+  });
+
+  describe("empty registry", () => {
+    it("returns error with empty available list", () => {
+      const result = resolveModel("haiku", makeRegistry([]));
+      expect(typeof result).toBe("string");
+      expect(result).toContain("Model not found");
+    });
+  });
+});

--- a/packages/pi-subagents/test/output-file-compaction-e2e.test.ts
+++ b/packages/pi-subagents/test/output-file-compaction-e2e.test.ts
@@ -1,0 +1,151 @@
+/**
+ * output-file-compaction-e2e.test.ts — regression for issue #145: output-file
+ * streaming must survive session compaction.
+ *
+ * Uses a REAL pi AgentSession (faux model backend, in-memory session manager)
+ * and drives a REAL session.compact() — no mocked compaction semantics, so
+ * this breaks if pi changes how compaction rebuilds session.messages.
+ */
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fauxAssistantMessage, fauxText } from "@earendil-works/pi-ai";
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  getAgentDir,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { streamToOutputFile, writeInitialEntry } from "../src/output-file.js";
+import { registerFauxProvider } from "./helpers/pi-ai.js";
+
+const TURNS_BEFORE_COMPACT = 6;
+
+describe("output-file streaming across a real compaction (#145)", () => {
+  let tmp: string;
+  let prevAgentDir: string | undefined;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "issue-145-"));
+    prevAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = tmp; // hermetic: no dev-env extensions/themes
+  });
+
+  afterEach(() => {
+    if (prevAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = prevAgentDir;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("keeps writing post-compaction messages to the output file", async () => {
+    const cwd = tmp;
+    const faux = registerFauxProvider({
+      provider: "faux",
+      models: [{ id: "faux-1", contextWindow: 200_000 }],
+    });
+    const model = faux.getModel();
+    // Context-branching responder: compaction issues a variable number of
+    // model calls (summary, plus a turn-prefix summary when the cut point
+    // splits a turn), so a fixed FIFO would desync. Decide from the request.
+    const respond = (context: { messages: Array<{ role: string; content: unknown }> }) => {
+      const last = context.messages[context.messages.length - 1];
+      const text = typeof last?.content === "string"
+        ? last.content
+        : JSON.stringify(last?.content ?? "");
+      // Compaction requests first — their instruction embeds the transcript,
+      // so the "question N" branch below would otherwise match inside it.
+      // Markers are pi's own prompt texts (SUMMARIZATION_PROMPT and
+      // TURN_PREFIX_SUMMARIZATION_PROMPT in core/compaction).
+      if (text.includes("conversation to summarize") || text.includes("PREFIX of a turn")) {
+        return fauxAssistantMessage([fauxText("summary of everything so far")]);
+      }
+      if (text.includes("final question")) {
+        return fauxAssistantMessage([fauxText("POST-COMPACTION-ANSWER")]);
+      }
+      const q = text.match(/question (\d+)/);
+      if (last?.role === "user" && q) {
+        return fauxAssistantMessage([fauxText(`answer-${q[1]} ${"filler ".repeat(200)}`)]);
+      }
+      throw new Error(`unexpected faux request: ${text.slice(0, 120)}`);
+    };
+    faux.setResponses(Array.from({ length: 16 }, () => respond));
+
+    const agentDir = getAgentDir();
+    const loader = new DefaultResourceLoader({
+      cwd,
+      agentDir,
+      systemPromptOverride: () => "You are a test agent.",
+      appendSystemPromptOverride: () => [],
+      noPromptTemplates: true,
+      noThemes: true,
+      noContextFiles: true,
+    });
+    await loader.reload();
+
+    const { session } = await createAgentSession({
+      cwd,
+      agentDir,
+      model,
+      modelRegistry: {
+        find: () => model,
+        getAll: () => [model],
+        getAvailable: () => [model],
+        hasConfiguredAuth: () => true,
+        isUsingOAuth: () => false,
+        getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "faux", headers: {} }),
+        registerProvider: () => {},
+        unregisterProvider: () => {},
+      } as never,
+      resourceLoader: loader,
+      sessionManager: SessionManager.inMemory(cwd),
+      settingsManager: SettingsManager.inMemory({
+        // Auto-compaction off (deterministic manual compact() below); a small
+        // keep-window so the bulky early turns actually get summarized away.
+        compaction: { enabled: false, keepRecentTokens: 500 },
+        retry: { enabled: false },
+      }),
+    });
+
+    const outPath = join(tmp, "agent.output");
+    writeInitialEntry(outPath, "agent-145", "repro", cwd);
+    const cleanup = streamToOutputFile(session as never, outPath, "agent-145", cwd);
+
+    const readEntries = () =>
+      readFileSync(outPath, "utf-8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    // Build up history, streaming as we go (turn_end fires per prompt).
+    for (let i = 0; i < TURNS_BEFORE_COMPACT; i++) {
+      await session.prompt(`question ${i}`);
+    }
+    const writtenBeforeCompact = readEntries().length;
+    expect(writtenBeforeCompact).toBeGreaterThan(TURNS_BEFORE_COMPACT); // sanity: streaming worked pre-compaction
+
+    const lenBefore = session.messages.length;
+    const result = await session.compact();
+    expect(result?.summary).toContain("summary"); // sanity: real compaction ran
+    // Sanity: compaction actually shrank the array — the exact condition that
+    // used to strand writtenCount past the end and halt streaming (#145).
+    expect(session.messages.length).toBeLessThan(lenBefore);
+
+    // The run continues after compaction...
+    await session.prompt("final question");
+    cleanup();
+
+    // The post-compaction turn reaches the output file...
+    const entries = readEntries();
+    const all = JSON.stringify(entries);
+    expect(all).toContain("final question");
+    expect(all).toContain("POST-COMPACTION-ANSWER");
+    // ...and re-anchoring didn't double-write the compaction-kept tail: every
+    // pre-compaction answer still appears exactly once.
+    for (let i = 0; i < TURNS_BEFORE_COMPACT; i++) {
+      expect(all.split(`answer-${i} `).length - 1).toBe(1);
+    }
+    expect(entries.length).toBe(writtenBeforeCompact + 2); // + final question + its answer
+  }, 30_000);
+});

--- a/packages/pi-subagents/test/output-file.test.ts
+++ b/packages/pi-subagents/test/output-file.test.ts
@@ -1,0 +1,267 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { encodeCwd, streamToOutputFile, writeInitialEntry } from "../src/output-file.js";
+
+describe("encodeCwd", () => {
+  it("encodes a POSIX absolute path by stripping the leading slash and replacing separators", () => {
+    expect(encodeCwd("/home/user/project")).toBe("home-user-project");
+  });
+
+  it("handles a POSIX root path", () => {
+    expect(encodeCwd("/")).toBe("");
+  });
+
+  it("encodes a Windows drive-letter path by stripping the drive prefix", () => {
+    expect(encodeCwd("C:\\Users\\foo\\project")).toBe("Users-foo-project");
+  });
+
+  it("handles lowercase Windows drives", () => {
+    expect(encodeCwd("c:\\foo")).toBe("foo");
+  });
+
+  it("handles a Windows path written with forward slashes", () => {
+    expect(encodeCwd("C:/Users/foo/project")).toBe("Users-foo-project");
+  });
+
+  it("preserves server and share for UNC paths", () => {
+    expect(encodeCwd("\\\\server\\share\\project")).toBe("server-share-project");
+  });
+
+  it("handles mixed separators", () => {
+    expect(encodeCwd("/home\\user/project")).toBe("home-user-project");
+  });
+
+  it("collapses runs of leading dashes after separator replacement", () => {
+    expect(encodeCwd("///foo")).toBe("foo");
+  });
+
+  it("returns an empty string for an empty cwd", () => {
+    expect(encodeCwd("")).toBe("");
+  });
+
+  it("leaves a relative-looking path with no leading separator alone", () => {
+    expect(encodeCwd("foo/bar")).toBe("foo-bar");
+  });
+});
+
+/**
+ * Minimal AgentSession fake. streamToOutputFile only reads `session.messages`
+ * and calls `session.subscribe(cb)`, so we provide just those — plus test-only
+ * helpers to mutate state and fire events deterministically.
+ */
+function makeFakeSession(initialMessages: unknown[] = []) {
+  let messages: unknown[] = [...initialMessages];
+  let cb: ((event: unknown) => void) | null = null;
+  return {
+    get messages() {
+      return messages;
+    },
+    subscribe(fn: (event: unknown) => void) {
+      cb = fn;
+      return () => {
+        cb = null;
+      };
+    },
+    push(...msgs: unknown[]) {
+      messages.push(...msgs);
+    },
+    /** Swap the whole array, like pi's compaction (`agent.state.messages = ...`). */
+    replaceAll(msgs: unknown[]) {
+      messages = msgs;
+    },
+    fire(event: unknown) {
+      cb?.(event);
+    },
+    isSubscribed() {
+      return cb !== null;
+    },
+  };
+}
+
+/** Drain the microtask queue (the compaction re-anchor is deferred one tick). */
+const microtask = () => Promise.resolve();
+
+describe("streamToOutputFile", () => {
+  let tmp: string;
+  let outPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "stream-out-test-"));
+    outPath = join(tmp, "agent.output");
+    writeInitialEntry(outPath, "agent-1", "do the thing", "/work");
+  });
+
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  function readEntries(): Array<Record<string, unknown>> {
+    return readFileSync(outPath, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+  }
+
+  it("writes nothing past the initial entry until turn_end fires", () => {
+    const session = makeFakeSession([{ role: "user", content: "do the thing" }]);
+    streamToOutputFile(session as never, outPath, "agent-1", "/work");
+
+    session.push({ role: "assistant", content: [{ type: "text", text: "ok" }] });
+    expect(readEntries()).toHaveLength(1); // only the initial entry
+
+    session.fire({ type: "turn_end" });
+    expect(readEntries()).toHaveLength(2);
+  });
+
+  it("tags assistant, user, and tool messages with the correct type field", () => {
+    const session = makeFakeSession([{ role: "user", content: "go" }]);
+    streamToOutputFile(session as never, outPath, "agent-1", "/work");
+
+    session.push(
+      { role: "assistant", content: [{ type: "text", text: "thinking" }] },
+      { role: "user", content: "follow-up" },
+      { role: "tool", content: [{ type: "tool_result", content: "x" }] },
+    );
+    session.fire({ type: "turn_end" });
+
+    const entries = readEntries();
+    expect(entries.map((e) => e.type)).toEqual(["user", "assistant", "user", "toolResult"]);
+    expect(entries.every((e) => e.agentId === "agent-1" && e.isSidechain === true)).toBe(true);
+    expect(entries.every((e) => e.cwd === "/work")).toBe(true);
+  });
+
+  it("never re-emits messages already flushed on a previous turn_end", () => {
+    const session = makeFakeSession([{ role: "user", content: "go" }]);
+    streamToOutputFile(session as never, outPath, "agent-1", "/work");
+
+    session.push({ role: "assistant", content: [{ type: "text", text: "one" }] });
+    session.fire({ type: "turn_end" });
+
+    session.push({ role: "assistant", content: [{ type: "text", text: "two" }] });
+    session.fire({ type: "turn_end" });
+
+    // Fire a redundant turn_end with no new messages — must not duplicate
+    session.fire({ type: "turn_end" });
+
+    expect(readEntries()).toHaveLength(3);
+  });
+
+  it("ignores session events other than turn_end", () => {
+    const session = makeFakeSession([{ role: "user", content: "go" }]);
+    streamToOutputFile(session as never, outPath, "agent-1", "/work");
+
+    session.push({ role: "assistant", content: [{ type: "text", text: "x" }] });
+    session.fire({ type: "message_start" });
+    session.fire({ type: "tool_call" });
+    session.fire({ type: "message_end" });
+
+    expect(readEntries()).toHaveLength(1);
+  });
+
+  // ---- Compaction (#145): pi replaces session.messages with a shorter,
+  // summarized array; streaming must survive it. Event sequences below mirror
+  // pi's real order of operations (verified against agent-session 0.80.6).
+
+  it("resumes streaming after compaction shrinks the message array (#145)", async () => {
+    const session = makeFakeSession([{ role: "user", content: "go" }]);
+    streamToOutputFile(session as never, outPath, "agent-1", "/work");
+
+    session.push(
+      { role: "assistant", content: [{ type: "text", text: "one" }] },
+      { role: "user", content: "q2" },
+      { role: "assistant", content: [{ type: "text", text: "two" }] },
+    );
+    session.fire({ type: "turn_end" }); // 4 messages flushed
+
+    // Compaction: summary + kept tail, much shorter than what was written.
+    session.fire({ type: "compaction_start", reason: "manual" });
+    session.replaceAll([
+      { role: "user", content: "summary of earlier turns" },
+      { role: "assistant", content: [{ type: "text", text: "two" }] },
+    ]);
+    session.fire({ type: "compaction_end", reason: "manual", aborted: false, result: { summary: "s" } });
+    await microtask();
+
+    session.push({ role: "assistant", content: [{ type: "text", text: "AFTER" }] });
+    session.fire({ type: "turn_end" });
+
+    const entries = readEntries();
+    // initial + one + q2 + two + AFTER — the kept tail is NOT re-written.
+    expect(entries).toHaveLength(5);
+    expect(JSON.stringify(entries.at(-1))).toContain("AFTER");
+  });
+
+  it("flushes the not-yet-written tail before compaction discards it (#145)", () => {
+    const session = makeFakeSession([{ role: "user", content: "go" }]);
+    streamToOutputFile(session as never, outPath, "agent-1", "/work");
+
+    // A message lands with no turn_end yet (e.g. overflow mid-turn)...
+    session.push({ role: "assistant", content: [{ type: "text", text: "tail-before-compact" }] });
+    expect(readEntries()).toHaveLength(1);
+
+    // ...then compaction starts: the tail must reach the file before the array is replaced.
+    session.fire({ type: "compaction_start", reason: "overflow" });
+    expect(JSON.stringify(readEntries().at(-1))).toContain("tail-before-compact");
+  });
+
+  it("re-anchors after the overflow-retry trim, not at compaction_end (#145)", async () => {
+    const session = makeFakeSession([{ role: "user", content: "go" }]);
+    streamToOutputFile(session as never, outPath, "agent-1", "/work");
+
+    session.push({ role: "assistant", content: [{ type: "text", text: "big" }] });
+    session.fire({ type: "turn_end" });
+
+    // pi's overflow-retry order: compaction_end fires, THEN the trailing error
+    // assistant message is sliced off. A synchronous anchor would sit one past
+    // the trimmed array and skip the first post-compaction message.
+    session.fire({ type: "compaction_start", reason: "overflow" });
+    session.replaceAll([
+      { role: "user", content: "summary" },
+      { role: "assistant", content: [{ type: "text", text: "err" }], stopReason: "error" },
+    ]);
+    session.fire({ type: "compaction_end", reason: "overflow", aborted: false, result: { summary: "s" }, willRetry: true });
+    session.replaceAll([{ role: "user", content: "summary" }]); // the post-emit trim
+    await microtask();
+
+    session.push({ role: "assistant", content: [{ type: "text", text: "RETRY-ANSWER" }] });
+    session.fire({ type: "turn_end" });
+
+    expect(JSON.stringify(readEntries().at(-1))).toContain("RETRY-ANSWER");
+  });
+
+  it("does not re-anchor on aborted or failed compaction (#145)", async () => {
+    const session = makeFakeSession([{ role: "user", content: "go" }]);
+    streamToOutputFile(session as never, outPath, "agent-1", "/work");
+
+    session.fire({ type: "compaction_start", reason: "manual" });
+    // Aborted/failed: session.messages is left untouched by pi.
+    session.fire({ type: "compaction_end", reason: "manual", aborted: true, result: undefined });
+    session.fire({ type: "compaction_end", reason: "manual", aborted: false, result: undefined, errorMessage: "boom" });
+    await microtask();
+
+    session.push({ role: "assistant", content: [{ type: "text", text: "still-streaming" }] });
+    session.fire({ type: "turn_end" });
+
+    const entries = readEntries();
+    expect(entries).toHaveLength(2); // nothing skipped, nothing duplicated
+    expect(JSON.stringify(entries.at(-1))).toContain("still-streaming");
+  });
+
+  it("cleanup() does a final flush and detaches the subscription", () => {
+    const session = makeFakeSession([{ role: "user", content: "go" }]);
+    const cleanup = streamToOutputFile(session as never, outPath, "agent-1", "/work");
+
+    // Trailing message arrives with no turn_end before shutdown
+    session.push({ role: "assistant", content: [{ type: "text", text: "tail" }] });
+    expect(readEntries()).toHaveLength(1);
+
+    cleanup();
+    expect(readEntries()).toHaveLength(2);
+    expect(session.isSubscribed()).toBe(false);
+
+    // Post-cleanup messages must not be written, even if events would otherwise fire
+    session.push({ role: "assistant", content: [{ type: "text", text: "ghost" }] });
+    session.fire({ type: "turn_end" });
+    expect(readEntries()).toHaveLength(2);
+  });
+});

--- a/packages/pi-subagents/test/output-transcript-wiring.test.ts
+++ b/packages/pi-subagents/test/output-transcript-wiring.test.ts
@@ -1,0 +1,188 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+vi.mock("../src/output-file.js", () => ({
+  createOutputFilePath: vi.fn(() => "/tmp/fake-subagent.output"),
+  writeInitialEntry: vi.fn(),
+  streamToOutputFile: vi.fn(() => vi.fn()),
+}));
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+import { createOutputFilePath, streamToOutputFile, writeInitialEntry } from "../src/output-file.js";
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>();
+  const events = new Map<string, any>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((tool: any) => tools.set(tool.name, tool)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: {
+      emit: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        events.set(event, handler);
+        return vi.fn();
+      }),
+    },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  return { pi, tools, lifecycle };
+}
+
+function makeCtx(cwd: string) {
+  return {
+    hasUI: false,
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    cwd,
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: vi.fn(() => "session-1"), getBranch: vi.fn(() => []) },
+    getSystemPrompt: vi.fn(() => "parent"),
+  } as any;
+}
+
+describe("output_transcript agent wiring", () => {
+  let cwd: string;
+  let agentDir: string;
+  let previousCwd: string;
+  let previousAgentDir: string | undefined;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "pi-output-transcript-cwd-"));
+    agentDir = mkdtempSync(join(tmpdir(), "pi-output-transcript-agent-"));
+    previousCwd = process.cwd();
+    previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+    previousHome = process.env.HOME;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.HOME = agentDir;
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(join(cwd, ".pi", "subagents.json"), JSON.stringify({ schedulingEnabled: false }));
+    mkdirSync(join(agentDir, "agents"), { recursive: true });
+    process.chdir(cwd);
+    vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, options) => {
+      await Promise.resolve();
+      const session = { messages: [], subscribe: vi.fn(() => vi.fn()), dispose: vi.fn() } as any;
+      options.onSessionCreated?.(session);
+      return { responseText: "done", session, aborted: false, steered: false };
+    });
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    if (previousAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    if (previousHome == null) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(agentDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("creates no transcript when a custom agent sets output_transcript false", async () => {
+    writeFileSync(join(agentDir, "agents", "sensitive.md"), `---\ndescription: Sensitive in-memory agent\noutput_transcript: false\n---\n\nKeep data in memory.`);
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    await tools.get("Agent").execute(
+      "tool-call",
+      { prompt: "process sensitive data", description: "Process sensitive data", subagent_type: "sensitive" },
+      undefined,
+      undefined,
+      makeCtx(cwd),
+    );
+
+    expect(createOutputFilePath).not.toHaveBeenCalled();
+    expect(writeInitialEntry).not.toHaveBeenCalled();
+    expect(streamToOutputFile).not.toHaveBeenCalled();
+    await lifecycle.get("session_shutdown")?.({}, makeCtx(cwd));
+  });
+
+  it("also suppresses the background transcript", async () => {
+    writeFileSync(join(agentDir, "agents", "sensitive.md"), `---\ndescription: Sensitive in-memory agent\noutput_transcript: false\nrun_in_background: true\n---\n\nKeep data in memory.`);
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    await tools.get("Agent").execute(
+      "tool-call",
+      { prompt: "process sensitive data", description: "Process sensitive data", subagent_type: "sensitive" },
+      undefined,
+      undefined,
+      makeCtx(cwd),
+    );
+
+    expect(createOutputFilePath).not.toHaveBeenCalled();
+    expect(writeInitialEntry).not.toHaveBeenCalled();
+    expect(streamToOutputFile).not.toHaveBeenCalled();
+    await lifecycle.get("session_shutdown")?.({}, makeCtx(cwd));
+  });
+
+  it("keeps transcript creation as the default", async () => {
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    await tools.get("Agent").execute(
+      "tool-call",
+      { prompt: "ordinary work", description: "Do ordinary work", subagent_type: "general-purpose" },
+      undefined,
+      undefined,
+      makeCtx(cwd),
+    );
+
+    expect(createOutputFilePath).toHaveBeenCalledOnce();
+    expect(writeInitialEntry).toHaveBeenCalledOnce();
+    expect(streamToOutputFile).toHaveBeenCalledOnce();
+    await lifecycle.get("session_shutdown")?.({}, makeCtx(cwd));
+  });
+
+  it("suppresses the transcript project-wide when subagents.json sets outputTranscript false", async () => {
+    // A plain default agent (no frontmatter) inherits the project default.
+    writeFileSync(join(cwd, ".pi", "subagents.json"), JSON.stringify({ schedulingEnabled: false, outputTranscript: false }));
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    await tools.get("Agent").execute(
+      "tool-call",
+      { prompt: "ordinary work", description: "Do ordinary work", subagent_type: "general-purpose" },
+      undefined,
+      undefined,
+      makeCtx(cwd),
+    );
+
+    expect(createOutputFilePath).not.toHaveBeenCalled();
+    expect(writeInitialEntry).not.toHaveBeenCalled();
+    expect(streamToOutputFile).not.toHaveBeenCalled();
+    await lifecycle.get("session_shutdown")?.({}, makeCtx(cwd));
+  });
+
+  it("lets agent frontmatter output_transcript true override a project outputTranscript false", async () => {
+    writeFileSync(join(cwd, ".pi", "subagents.json"), JSON.stringify({ schedulingEnabled: false, outputTranscript: false }));
+    writeFileSync(join(agentDir, "agents", "audited.md"), `---\ndescription: Always keeps a transcript\noutput_transcript: true\n---\n\nWrite a transcript regardless of the project default.`);
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    await tools.get("Agent").execute(
+      "tool-call",
+      { prompt: "audited work", description: "Do audited work", subagent_type: "audited" },
+      undefined,
+      undefined,
+      makeCtx(cwd),
+    );
+
+    expect(createOutputFilePath).toHaveBeenCalledOnce();
+    expect(writeInitialEntry).toHaveBeenCalledOnce();
+    expect(streamToOutputFile).toHaveBeenCalledOnce();
+    await lifecycle.get("session_shutdown")?.({}, makeCtx(cwd));
+  });
+});

--- a/packages/pi-subagents/test/print-mode.test.ts
+++ b/packages/pi-subagents/test/print-mode.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return {
+    ...actual,
+    runAgent: vi.fn(),
+  };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const handlers = new Map<string, any>();
+  const eventHandlers = new Map<string, any>();
+
+  return {
+    pi: {
+      registerMessageRenderer: vi.fn(),
+      registerTool: vi.fn((tool: any) => {
+        tools.set(tool.name, tool);
+      }),
+      registerCommand: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        handlers.set(event, handler);
+      }),
+      events: {
+        emit: vi.fn(),
+        on: vi.fn((event: string, handler: any) => {
+          eventHandlers.set(event, handler);
+          return vi.fn();
+        }),
+      },
+      appendEntry: vi.fn(),
+      sendMessage: vi.fn(() => {
+        throw new Error("stale extension context");
+      }),
+    } as any,
+    tools,
+    handlers,
+  };
+}
+
+function makeHeadlessCtx() {
+  return {
+    hasUI: false,
+    ui: {
+      setStatus: vi.fn(),
+      setWidget: vi.fn(),
+    },
+    cwd: "/tmp",
+    model: undefined,
+    modelRegistry: {
+      find: vi.fn(),
+      getAvailable: vi.fn(() => []),
+    },
+    sessionManager: {
+      getSessionId: vi.fn(() => "session-1"),
+      getBranch: vi.fn(() => []),
+    },
+    getSystemPrompt: vi.fn(() => "parent prompt"),
+  } as any;
+}
+
+describe("print mode background notifications", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("ignores stale-context errors from delayed completion nudges", async () => {
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "done",
+      session: { dispose: vi.fn() } as any,
+      aborted: false,
+      steered: false,
+    });
+
+    const { pi, tools, handlers } = makePi();
+    subagentsExtension(pi);
+    vi.useFakeTimers();
+
+    const agentTool = tools.get("Agent");
+    await agentTool.execute(
+      "tool-call-1",
+      {
+        prompt: "reply done",
+        description: "tiny child",
+        subagent_type: "general-purpose",
+        run_in_background: true,
+      },
+      undefined,
+      undefined,
+      makeHeadlessCtx(),
+    );
+
+    await vi.advanceTimersByTimeAsync(100); // smart-join batch debounce
+    await vi.advanceTimersByTimeAsync(200); // notification hold window
+
+    expect(pi.sendMessage).toHaveBeenCalled();
+
+    await handlers.get("session_shutdown")?.({}, makeHeadlessCtx());
+  });
+});

--- a/packages/pi-subagents/test/prompts.test.ts
+++ b/packages/pi-subagents/test/prompts.test.ts
@@ -1,0 +1,391 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getAgentConfig, registerAgents } from "../src/agent-types.js";
+import { buildAgentPrompt } from "../src/prompts.js";
+import type { AgentConfig, EnvInfo } from "../src/types.js";
+
+const env: EnvInfo = {
+  isGitRepo: true,
+  branch: "main",
+  platform: "darwin",
+};
+
+const envNoGit: EnvInfo = {
+  isGitRepo: false,
+  branch: "",
+  platform: "linux",
+};
+
+// Initialize default agents
+beforeEach(() => {
+  registerAgents(new Map());
+});
+
+function getDefaultConfig(name: string): AgentConfig {
+  return getAgentConfig(name)!;
+}
+
+describe("buildAgentPrompt", () => {
+  it("includes cwd and git info", () => {
+    const config = getDefaultConfig("general-purpose");
+    const prompt = buildAgentPrompt(config, "/workspace", env);
+    expect(prompt).toContain("/workspace");
+    expect(prompt).toContain("Branch: main");
+    expect(prompt).toContain("darwin");
+  });
+
+  it("handles non-git repos", () => {
+    const config = getDefaultConfig("Explore");
+    const prompt = buildAgentPrompt(config, "/workspace", envNoGit);
+    expect(prompt).toContain("Not a git repository");
+    expect(prompt).not.toContain("Branch:");
+  });
+
+  it("Explore prompt is read-only", () => {
+    const config = getDefaultConfig("Explore");
+    const prompt = buildAgentPrompt(config, "/workspace", env);
+    expect(prompt).toContain("READ-ONLY");
+    expect(prompt).toContain("file search specialist");
+  });
+
+  it("Plan prompt is read-only", () => {
+    const config = getDefaultConfig("Plan");
+    const prompt = buildAgentPrompt(config, "/workspace", env);
+    expect(prompt).toContain("READ-ONLY");
+    expect(prompt).toContain("software architect");
+  });
+
+  it("general-purpose uses append mode (parent twin)", () => {
+    const config = getDefaultConfig("general-purpose");
+    const parentPrompt = "You are a parent coding agent with full powers.";
+    const prompt = buildAgentPrompt(config, "/workspace", env, parentPrompt);
+    expect(prompt).toContain("parent coding agent with full powers");
+    expect(prompt).toContain("<sub_agent_context>");
+    expect(prompt).not.toContain("<inherited_system_prompt>");
+    expect(prompt).not.toContain("READ-ONLY");
+    // Empty systemPrompt means no <agent_instructions> section
+    expect(prompt).not.toContain("<agent_instructions>");
+  });
+
+  it("general-purpose without parent prompt falls back to generic base", () => {
+    const config = getDefaultConfig("general-purpose");
+    const prompt = buildAgentPrompt(config, "/workspace", env);
+    expect(prompt).toContain("general-purpose coding agent");
+    expect(prompt).not.toContain("READ-ONLY");
+  });
+
+  it("append mode with parent prompt includes parent + custom instructions", () => {
+    const config: AgentConfig = {
+      name: "appender",
+      description: "Appender",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "Extra custom instructions here.",
+      promptMode: "append",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const parentPrompt = "You are a parent coding agent with special powers.";
+    const prompt = buildAgentPrompt(config, "/workspace", env, parentPrompt);
+    expect(prompt).toContain("/workspace");
+    expect(prompt).toContain("parent coding agent with special powers");
+    expect(prompt).toContain("<sub_agent_context>");
+    expect(prompt).not.toContain("<inherited_system_prompt>");
+    expect(prompt).toContain("<agent_instructions>");
+    expect(prompt).toContain("Extra custom instructions here.");
+  });
+
+  it("append mode without parent prompt falls back to generic base", () => {
+    const config: AgentConfig = {
+      name: "appender",
+      description: "Appender",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "Extra custom instructions here.",
+      promptMode: "append",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const prompt = buildAgentPrompt(config, "/workspace", env);
+    expect(prompt).toContain("/workspace");
+    expect(prompt).toContain("general-purpose coding agent");
+    expect(prompt).toContain("Extra custom instructions here.");
+  });
+
+  it("append mode with empty systemPrompt is a pure parent clone", () => {
+    const config: AgentConfig = {
+      name: "clone",
+      description: "Clone",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "",
+      promptMode: "append",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const parentPrompt = "You are a parent coding agent.";
+    const prompt = buildAgentPrompt(config, "/workspace", env, parentPrompt);
+    expect(prompt).toContain("parent coding agent");
+    expect(prompt).toContain("<sub_agent_context>");
+    expect(prompt).not.toContain("<inherited_system_prompt>");
+    expect(prompt).not.toContain("<agent_instructions>");
+  });
+
+  it("replace mode uses config systemPrompt directly", () => {
+    const config: AgentConfig = {
+      name: "custom",
+      description: "Custom",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "You are a specialized agent.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const prompt = buildAgentPrompt(config, "/workspace", env);
+    expect(prompt).toContain("You are a specialized agent.");
+    expect(prompt).toContain("/workspace");
+    expect(prompt).toContain("You are a pi coding agent sub-agent");
+  });
+
+  it("replace mode ignores parent prompt", () => {
+    const config: AgentConfig = {
+      name: "standalone",
+      description: "Standalone",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "You are a standalone agent.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const prompt = buildAgentPrompt(config, "/workspace", env, "SECRET parent prompt content");
+    expect(prompt).toContain("You are a standalone agent.");
+    expect(prompt).not.toContain("SECRET parent prompt content");
+    expect(prompt).not.toContain("<sub_agent_context>");
+  });
+
+  it("append mode bridge contains tool reminders", () => {
+    const config = getDefaultConfig("general-purpose");
+    const prompt = buildAgentPrompt(config, "/workspace", env, "Parent prompt.");
+    expect(prompt).toContain("Use the read tool instead of cat");
+    expect(prompt).toContain("Use the edit tool instead of sed");
+    expect(prompt).toContain("Use the grep tool instead of");
+  });
+
+  it("append mode without parent prompt still has bridge", () => {
+    const config: AgentConfig = {
+      name: "no-parent",
+      description: "No parent",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "Extra stuff.",
+      promptMode: "append",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const prompt = buildAgentPrompt(config, "/workspace", env);
+    expect(prompt).toContain("<sub_agent_context>");
+    expect(prompt).not.toContain("<inherited_system_prompt>");
+    expect(prompt).toContain("Use the read tool instead of cat");
+    expect(prompt).toContain("general-purpose coding agent");
+    expect(prompt).toContain("Extra stuff.");
+  });
+
+  it("injects memory block in replace mode", () => {
+    const config: AgentConfig = {
+      name: "mem-agent",
+      description: "Memory Agent",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "You are a memory agent.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const extras = { memoryBlock: "# Agent Memory\nYou have persistent memory at /tmp/mem/" };
+    const prompt = buildAgentPrompt(config, "/workspace", env, undefined, extras);
+    expect(prompt).toContain("You are a memory agent.");
+    expect(prompt).toContain("Agent Memory");
+    expect(prompt).toContain("persistent memory");
+  });
+
+  it("injects memory block in append mode", () => {
+    const config: AgentConfig = {
+      name: "mem-append",
+      description: "Memory Append",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "Custom instructions.",
+      promptMode: "append",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const extras = { memoryBlock: "# Agent Memory\nPersistent memory here." };
+    const prompt = buildAgentPrompt(config, "/workspace", env, "Parent prompt.", extras);
+    expect(prompt).toContain("<sub_agent_context>");
+    expect(prompt).toContain("Agent Memory");
+    expect(prompt).toContain("Custom instructions.");
+  });
+
+  it("injects preloaded skill blocks", () => {
+    const config: AgentConfig = {
+      name: "skill-agent",
+      description: "Skill Agent",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "You are a skill agent.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const extras = {
+      skillBlocks: [
+        { name: "api-conventions", content: "Use REST endpoints." },
+        { name: "error-handling", content: "Handle errors gracefully." },
+      ],
+    };
+    const prompt = buildAgentPrompt(config, "/workspace", env, undefined, extras);
+    expect(prompt).toContain("Preloaded Skill: api-conventions");
+    expect(prompt).toContain("Use REST endpoints.");
+    expect(prompt).toContain("Preloaded Skill: error-handling");
+    expect(prompt).toContain("Handle errors gracefully.");
+  });
+
+  it("injects both memory and skills", () => {
+    const config: AgentConfig = {
+      name: "full-agent",
+      description: "Full Agent",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "Full agent.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const extras = {
+      memoryBlock: "# Memory\nRemember this.",
+      skillBlocks: [{ name: "skill1", content: "Skill content." }],
+    };
+    const prompt = buildAgentPrompt(config, "/workspace", env, undefined, extras);
+    expect(prompt).toContain("# Memory");
+    expect(prompt).toContain("Preloaded Skill: skill1");
+  });
+
+  it("no extras means no extra sections", () => {
+    const config: AgentConfig = {
+      name: "plain",
+      description: "Plain",
+      builtinToolNames: [],
+      extensions: true,
+      skills: true,
+      systemPrompt: "Plain agent.",
+      promptMode: "replace",
+      inheritContext: false,
+      runInBackground: false,
+      isolated: false,
+    };
+    const prompt = buildAgentPrompt(config, "/workspace", env);
+    expect(prompt).not.toContain("Agent Memory");
+    expect(prompt).not.toContain("Preloaded Skill");
+  });
+
+  describe("active_agent tag", () => {
+    it("tag is present at start of prompt in replace mode", () => {
+      const config: AgentConfig = {
+        name: "my-agent",
+        description: "Test",
+        builtinToolNames: [],
+        extensions: true,
+        skills: true,
+        systemPrompt: "You are a test agent.",
+        promptMode: "replace",
+        inheritContext: false,
+        runInBackground: false,
+        isolated: false,
+      };
+      const prompt = buildAgentPrompt(config, "/workspace", env);
+      expect(prompt).toMatch(/^<active_agent name="my-agent"\/>/);
+    });
+
+    it("tag follows the cacheable inherited prefix in append mode", () => {
+      const config: AgentConfig = {
+        name: "my-agent",
+        description: "Test",
+        builtinToolNames: [],
+        extensions: true,
+        skills: true,
+        systemPrompt: "Custom instructions.",
+        promptMode: "append",
+        inheritContext: false,
+        runInBackground: false,
+        isolated: false,
+      };
+      const prompt = buildAgentPrompt(config, "/workspace", env, "Parent prompt.");
+      // Parent prompt must form the verbatim, cacheable byte prefix.
+      expect(prompt.startsWith("Parent prompt.")).toBe(true);
+      // The varying tag follows the static <sub_agent_context> bridge.
+      const ctxIdx = prompt.indexOf("<sub_agent_context>");
+      const tagIdx = prompt.indexOf('<active_agent name="my-agent"/>');
+      expect(ctxIdx).toBeGreaterThan(-1);
+      expect(tagIdx).toBeGreaterThan(ctxIdx);
+    });
+
+    it("tag uses agent name verbatim", () => {
+      const config: AgentConfig = {
+        name: "Some Agent With Spaces",
+        description: "Test",
+        builtinToolNames: [],
+        extensions: true,
+        skills: true,
+        systemPrompt: "Test.",
+        promptMode: "replace",
+        inheritContext: false,
+        runInBackground: false,
+        isolated: false,
+      };
+      const prompt = buildAgentPrompt(config, "/workspace", env);
+      expect(prompt).toContain('<active_agent name="Some Agent With Spaces"/>');
+    });
+
+    it("tag appears before the env block in both modes", () => {
+      for (const promptMode of ["replace", "append"] as const) {
+        const config: AgentConfig = {
+          name: "test-agent",
+          description: "Test",
+          builtinToolNames: [],
+          extensions: true,
+          skills: true,
+          systemPrompt: "Test.",
+          promptMode,
+          inheritContext: false,
+          runInBackground: false,
+          isolated: false,
+        };
+        const prompt = buildAgentPrompt(config, "/workspace", env, "Parent.");
+        const tagIndex = prompt.indexOf('<active_agent name="test-agent"/>');
+        const envIndex = prompt.indexOf("# Environment");
+        expect(tagIndex).toBeLessThan(envIndex);
+      }
+    });
+  });
+});

--- a/packages/pi-subagents/test/rpc-lifecycle-gating.test.ts
+++ b/packages/pi-subagents/test/rpc-lifecycle-gating.test.ts
@@ -1,0 +1,161 @@
+/**
+ * rpc-lifecycle-gating.test.ts — issue #142.
+ *
+ * pi runs every extension factory BEFORE applying an agent's `extensions:`
+ * filter, and only delivers lifecycle events (session_start, …) to the
+ * survivors — but the `pi.events` bus is shared with the filtered-out
+ * activations. The old code registered the RPC handlers and emitted
+ * `subagents:ready` at factory time, so a child session that excluded
+ * pi-subagents still saw `subagents:ready` + a working `subagents:rpc:ping`,
+ * yet every spawn failed with "No active session" (its session_start never
+ * fired, so currentCtx stayed undefined).
+ *
+ * The fix defers BOTH the RPC registration and the readiness broadcast to the
+ * first bound session_start. These tests drive the real extension factory with
+ * a mock ExtensionAPI and assert the timing: nothing is wired at factory time;
+ * everything is wired (once) on session_start.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+const RPC_CHANNELS = ["subagents:rpc:ping", "subagents:rpc:spawn", "subagents:rpc:stop"] as const;
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>(); // pi.on(...) — session_start, session_shutdown, …
+  const busHandlers = new Map<string, (raw: any) => unknown>(); // pi.events.on(...) — rpc channels
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((t: any) => tools.set(t.name, t)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: {
+      emit: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        busHandlers.set(event, handler);
+        return vi.fn();
+      }),
+    },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  return { pi, tools, lifecycle, busHandlers };
+}
+
+function ctx() {
+  return {
+    hasUI: false,
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    cwd: process.cwd(),
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: vi.fn(() => "s1"), getBranch: vi.fn(() => []) },
+    getSystemPrompt: vi.fn(() => "parent"),
+  } as any;
+}
+
+const readyEmits = (pi: any): unknown[] =>
+  pi.events.emit.mock.calls.filter((c: any[]) => c[0] === "subagents:ready");
+const onCallsFor = (pi: any, channel: string): unknown[] =>
+  pi.events.on.mock.calls.filter((c: any[]) => c[0] === channel);
+
+describe("issue #142: RPC handlers + subagents:ready are gated on session_start", () => {
+  let tmpDir: string;
+  let agentDir: string;
+  let prevCwd: string;
+  let prevAgentDir: string | undefined;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    // Hermetic cwd + global dir with scheduling off, so session_start doesn't
+    // spin a scheduler or touch the dev's filesystem — isolates the RPC wiring.
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-142-"));
+    agentDir = mkdtempSync(join(tmpdir(), "pi-142-agentdir-"));
+    prevAgentDir = process.env.PI_CODING_AGENT_DIR;
+    prevHome = process.env.HOME;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.HOME = agentDir;
+    prevCwd = process.cwd();
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(join(tmpDir, ".pi", "subagents.json"), JSON.stringify({ schedulingEnabled: false }));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    if (prevAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = prevAgentDir;
+    if (prevHome == null) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(agentDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("does NOT advertise or register RPC at factory time (the filtered-out case)", () => {
+    const { pi, busHandlers } = makePi();
+
+    // A filtered-out activation only ever gets the factory run — its
+    // session_start never fires. So after the factory alone, nothing should
+    // be on the shared bus.
+    subagentsExtension(pi);
+
+    expect(readyEmits(pi), "no subagents:ready before session_start").toHaveLength(0);
+    for (const channel of RPC_CHANNELS) {
+      expect(busHandlers.has(channel), `${channel} must not be registered at factory time`).toBe(false);
+    }
+  });
+
+  it("advertises and registers RPC on session_start, and spawn works once bound", async () => {
+    const { pi, lifecycle, busHandlers } = makePi();
+    subagentsExtension(pi);
+
+    await lifecycle.get("session_start")({}, ctx());
+
+    // Readiness broadcast once, all three channels now live.
+    expect(readyEmits(pi), "subagents:ready fires once bound").toHaveLength(1);
+    for (const channel of RPC_CHANNELS) {
+      expect(busHandlers.has(channel), `${channel} registered on session_start`).toBe(true);
+    }
+
+    // spawn no longer hits the "No active session" trap — currentCtx is set.
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}) as any); // never resolves
+    const requestId = "req-142";
+    await busHandlers.get("subagents:rpc:spawn")!({
+      requestId,
+      type: "general-purpose",
+      prompt: "go",
+      options: { description: "rpc gating test" },
+    });
+
+    const reply = pi.events.emit.mock.calls.find(
+      (c: any[]) => c[0] === `subagents:rpc:spawn:reply:${requestId}`,
+    );
+    expect(reply, "spawn emitted a reply").toBeTruthy();
+    expect(reply![1].success, `spawn succeeded, got: ${JSON.stringify(reply![1])}`).toBe(true);
+    expect(reply![1].data.id).toBeTruthy();
+  });
+
+  it("is idempotent — a second session_start does not re-advertise or double-register", async () => {
+    const { pi, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    await lifecycle.get("session_start")({}, ctx());
+    await lifecycle.get("session_start")({}, ctx());
+
+    expect(readyEmits(pi), "subagents:ready emitted exactly once across two session_starts").toHaveLength(1);
+    for (const channel of RPC_CHANNELS) {
+      expect(onCallsFor(pi, channel), `${channel} registered exactly once`).toHaveLength(1);
+    }
+  });
+});

--- a/packages/pi-subagents/test/schedule-e2e.test.ts
+++ b/packages/pi-subagents/test/schedule-e2e.test.ts
@@ -1,0 +1,237 @@
+/**
+ * schedule-e2e.test.ts — End-to-end integration test for the scheduler.
+ *
+ * Unlike `schedule.test.ts` (which uses vi.useFakeTimers), this exercises
+ * the full real-timer firing path: real `setTimeout` triggers `executeJob`,
+ * a faithful `AgentManager` mock (promise resolves with the right semantics)
+ * runs through to `finalize`, and the on-disk `ScheduleStore` reflects the
+ * outcome. Catches integration bugs that fake-timer microtask scheduling
+ * can hide.
+ *
+ * Uses very short timings (100–300ms) so the test stays fast.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SubagentScheduler } from "../src/schedule.js";
+import { ScheduleStore } from "../src/schedule-store.js";
+
+type FakeRecord = { status: string; promise: Promise<string>; resolve: () => void };
+
+/**
+ * Faithful AgentManager mock: spawn returns an id, getRecord returns a
+ * record whose promise can be resolved at test time, status is mutable so
+ * the test can assert success vs error inference.
+ */
+function makeFaithfulManager(initialStatus = "completed") {
+  const records = new Map<string, FakeRecord>();
+  return {
+    records,
+    initialStatus,
+    spawn: vi.fn(function (this: any) {
+      const id = "agent-" + Math.random().toString(36).slice(2, 10);
+      let resolve!: () => void;
+      const promise = new Promise<string>(r => { resolve = () => r(""); });
+      records.set(id, { status: initialStatus, promise, resolve });
+      // Auto-resolve on next tick — mimics a fast-finishing real agent.
+      queueMicrotask(() => records.get(id)?.resolve());
+      return id;
+    }),
+    getRecord: vi.fn(function (this: any, id: string) {
+      return records.get(id);
+    }),
+  } as any;
+}
+
+function makePi() {
+  return { events: { emit: vi.fn() } } as any;
+}
+
+function makeCtx() {
+  return {
+    cwd: "/tmp",
+    modelRegistry: { find: vi.fn(), getAll: () => [], getAvailable: () => [] },
+    sessionManager: { getSessionId: () => "sess-e2e" },
+  } as any;
+}
+
+/** Wait for a predicate, polling at 5ms intervals, with a deadline. */
+async function waitFor(predicate: () => boolean, timeoutMs = 1500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+    }
+    await new Promise(r => setTimeout(r, 5));
+  }
+}
+
+describe("SubagentScheduler — end-to-end with real timers", () => {
+  let tmp: string;
+  let store: ScheduleStore;
+  let scheduler: SubagentScheduler;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "schedule-e2e-"));
+    store = new ScheduleStore(join(tmp, "schedules.json"));
+    scheduler = new SubagentScheduler();
+  });
+
+  afterEach(() => {
+    scheduler.stop();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("one-shot job: real setTimeout fires, agent runs, store reflects success", async () => {
+    const manager = makeFaithfulManager("completed");
+    const pi = makePi();
+    scheduler.start(pi, makeCtx(), manager, store);
+
+    // Fire ~100ms in the future. detectSchedule normalizes "+100ms" — but our
+    // parser only accepts s/m/h/d, so use a near-future ISO timestamp instead.
+    const future = new Date(Date.now() + 100).toISOString();
+    const job = scheduler.addJob({
+      name: "e2e-once",
+      description: "test",
+      schedule: future,
+      subagent_type: "general-purpose",
+      prompt: "hello",
+    });
+    expect(job.scheduleType).toBe("once");
+
+    // Wait for the spawn to occur (real timer fires) and the finalize promise
+    // chain to settle. Polling, no fake timers.
+    await waitFor(() => manager.spawn.mock.calls.length === 1);
+    await waitFor(() => scheduler.list().find(j => j.id === job.id)?.lastStatus === "success");
+
+    const final = scheduler.list().find(j => j.id === job.id)!;
+    expect(final.lastStatus).toBe("success");
+    expect(final.runCount).toBe(1);
+    expect(final.enabled).toBe(false);  // one-shot auto-disabled
+    expect(final.lastRun).toBeDefined();
+  });
+
+  it("one-shot job that errors: store records lastStatus error (regression — bug #1)", async () => {
+    const manager = makeFaithfulManager("error");  // Agent terminates with error status
+    const pi = makePi();
+    scheduler.start(pi, makeCtx(), manager, store);
+
+    const future = new Date(Date.now() + 100).toISOString();
+    const job = scheduler.addJob({
+      name: "e2e-fail",
+      description: "test",
+      schedule: future,
+      subagent_type: "general-purpose",
+      prompt: "fail",
+    });
+
+    await waitFor(() => manager.spawn.mock.calls.length === 1);
+    await waitFor(() => scheduler.list().find(j => j.id === job.id)?.lastStatus !== "running");
+
+    expect(scheduler.list().find(j => j.id === job.id)?.lastStatus).toBe("error");
+    expect(scheduler.list().find(j => j.id === job.id)?.runCount).toBe(1);
+  });
+
+  it("interval job: fires repeatedly, runCount grows", async () => {
+    const manager = makeFaithfulManager("completed");
+    const pi = makePi();
+    scheduler.start(pi, makeCtx(), manager, store);
+
+    // 100ms interval — wait for ~3 fires
+    const job = scheduler.addJob({
+      name: "e2e-interval",
+      description: "test",
+      schedule: "100s",  // Will be too long; override below.
+      subagent_type: "general-purpose",
+      prompt: "tick",
+    });
+    // Replace with a literal 100ms interval — easier than crafting a parseable shorthand for ms.
+    // (parseInterval doesn't accept "ms"; we patch the persisted job and re-arm.)
+    scheduler.updateJob(job.id, { intervalMs: 100, schedule: "100ms" });
+
+    await waitFor(() => manager.spawn.mock.calls.length >= 3, 2000);
+
+    const final = scheduler.list().find(j => j.id === job.id)!;
+    expect(final.runCount).toBeGreaterThanOrEqual(3);
+    expect(final.lastStatus).toBe("success");
+    expect(final.enabled).toBe(true);  // intervals don't auto-disable
+
+    scheduler.removeJob(job.id);
+  });
+
+  it("persistence: schedules survive re-instantiating the store on the same file", async () => {
+    const manager = makeFaithfulManager("completed");
+    const pi = makePi();
+    scheduler.start(pi, makeCtx(), manager, store);
+
+    const future = new Date(Date.now() + 60_000).toISOString();  // far enough not to fire
+    const job = scheduler.addJob({
+      name: "persistent",
+      description: "x",
+      schedule: future,
+      subagent_type: "general-purpose",
+      prompt: "x",
+    });
+
+    // Tear down the live scheduler; re-load from disk
+    scheduler.stop();
+    const reloadedStore = new ScheduleStore(join(tmp, "schedules.json"));
+    expect(reloadedStore.list()).toHaveLength(1);
+    expect(reloadedStore.list()[0].id).toBe(job.id);
+    expect(reloadedStore.list()[0].name).toBe("persistent");
+  });
+
+  it("on-disk file shape: version=1 plus jobs array", async () => {
+    const manager = makeFaithfulManager("completed");
+    const pi = makePi();
+    scheduler.start(pi, makeCtx(), manager, store);
+
+    scheduler.addJob({
+      name: "shape-test",
+      description: "x",
+      schedule: "1h",
+      subagent_type: "general-purpose",
+      prompt: "x",
+    });
+
+    const onDisk = JSON.parse(readFileSync(join(tmp, "schedules.json"), "utf-8"));
+    expect(onDisk.version).toBe(1);
+    expect(onDisk.jobs).toHaveLength(1);
+    expect(onDisk.jobs[0]).toMatchObject({
+      name: "shape-test",
+      schedule: "1h",
+      scheduleType: "interval",
+      enabled: true,
+      runCount: 0,
+    });
+  });
+
+  it("subagents:scheduled events fire across the lifecycle", async () => {
+    const manager = makeFaithfulManager("completed");
+    const pi = makePi();
+    scheduler.start(pi, makeCtx(), manager, store);
+
+    const future = new Date(Date.now() + 100).toISOString();
+    const job = scheduler.addJob({
+      name: "events", description: "x", schedule: future,
+      subagent_type: "general-purpose", prompt: "x",
+    });
+
+    await waitFor(() => manager.spawn.mock.calls.length === 1);
+
+    const eventTypes = pi.events.emit.mock.calls
+      .filter((c: any[]) => c[0] === "subagents:scheduled")
+      .map((c: any[]) => c[1].type);
+
+    expect(eventTypes).toContain("added");
+    expect(eventTypes).toContain("fired");
+
+    scheduler.removeJob(job.id);
+    const after = pi.events.emit.mock.calls
+      .filter((c: any[]) => c[0] === "subagents:scheduled")
+      .map((c: any[]) => c[1].type);
+    expect(after).toContain("removed");
+  });
+});

--- a/packages/pi-subagents/test/schedule-store.test.ts
+++ b/packages/pi-subagents/test/schedule-store.test.ts
@@ -1,0 +1,179 @@
+/**
+ * schedule-store.test.ts — Persistence + concurrency for ScheduleStore.
+ *
+ * Mirrors the patterns from pi-chonky-tasks's task-store testing: round-trip
+ * load/save, parse-error self-heal, stale-lock recovery.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveStorePath, ScheduleStore } from "../src/schedule-store.js";
+import type { ScheduledSubagent } from "../src/types.js";
+
+function makeJob(overrides: Partial<ScheduledSubagent> = {}): ScheduledSubagent {
+  return {
+    id: "job-" + Math.random().toString(36).slice(2, 10),
+    name: "test-job",
+    description: "test",
+    schedule: "5m",
+    scheduleType: "interval",
+    intervalMs: 5 * 60_000,
+    subagent_type: "general-purpose",
+    prompt: "hello",
+    enabled: true,
+    createdAt: new Date().toISOString(),
+    runCount: 0,
+    ...overrides,
+  };
+}
+
+describe("ScheduleStore", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "schedule-store-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("resolveStorePath produces session-scoped path under .pi/subagent-schedules/", () => {
+    const p = resolveStorePath("/repo", "abc123");
+    expect(p).toBe("/repo/.pi/subagent-schedules/abc123.json");
+  });
+
+  it("starts empty and round-trips a job through add/list", () => {
+    const store = new ScheduleStore(join(tmp, "s.json"));
+    expect(store.list()).toEqual([]);
+    const job = makeJob();
+    store.add(job);
+    expect(store.list()).toEqual([job]);
+
+    // New instance on same file — verifies persistence
+    const fresh = new ScheduleStore(join(tmp, "s.json"));
+    expect(fresh.list()).toEqual([job]);
+  });
+
+  it("update returns merged record and persists the patch", () => {
+    const store = new ScheduleStore(join(tmp, "s.json"));
+    const job = makeJob({ name: "before" });
+    store.add(job);
+
+    const updated = store.update(job.id, { name: "after", runCount: 3 });
+    expect(updated).toMatchObject({ id: job.id, name: "after", runCount: 3 });
+
+    const fresh = new ScheduleStore(join(tmp, "s.json"));
+    expect(fresh.list()[0]).toMatchObject({ name: "after", runCount: 3 });
+  });
+
+  it("update returns undefined for unknown id and does not create a record", () => {
+    const store = new ScheduleStore(join(tmp, "s.json"));
+    const r = store.update("nonexistent", { name: "x" });
+    expect(r).toBeUndefined();
+    expect(store.list()).toEqual([]);
+  });
+
+  it("remove returns true on existing job and false on missing", () => {
+    const store = new ScheduleStore(join(tmp, "s.json"));
+    const job = makeJob();
+    store.add(job);
+    expect(store.remove(job.id)).toBe(true);
+    expect(store.list()).toEqual([]);
+    expect(store.remove(job.id)).toBe(false);
+  });
+
+  it("hasName excludes a given id (for rename safety)", () => {
+    const store = new ScheduleStore(join(tmp, "s.json"));
+    const job = makeJob({ name: "alpha" });
+    store.add(job);
+    expect(store.hasName("alpha")).toBe(true);
+    expect(store.hasName("alpha", job.id)).toBe(false);  // excluded — own record
+    expect(store.hasName("beta")).toBe(false);
+  });
+
+  it("uses atomic temp+rename — write produces final file, no .tmp leftover", () => {
+    const file = join(tmp, "s.json");
+    const store = new ScheduleStore(file);
+    store.add(makeJob());
+    expect(existsSync(file)).toBe(true);
+    expect(existsSync(file + ".tmp")).toBe(false);
+  });
+
+  it("self-heals from a corrupt JSON file — load silently empties, next save rewrites", () => {
+    const file = join(tmp, "s.json");
+    writeFileSync(file, "{ this is not valid JSON");
+    const store = new ScheduleStore(file);
+    expect(store.list()).toEqual([]);
+
+    // Next mutation overwrites the broken file with healthy JSON
+    store.add(makeJob({ id: "fresh" }));
+    const data = JSON.parse(readFileSync(file, "utf-8"));
+    expect(data.version).toBe(1);
+    expect(data.jobs).toHaveLength(1);
+    expect(data.jobs[0].id).toBe("fresh");
+  });
+
+  it("recovers from a stale lock left by a dead process", () => {
+    const file = join(tmp, "s.json");
+    const lockFile = file + ".lock";
+    // Simulate a stale lock file containing a non-existent PID.
+    // PID 999_999_999 is virtually never a live process — kill -0 returns ESRCH.
+    writeFileSync(lockFile, "999999999");
+
+    const store = new ScheduleStore(file);
+    // The mutation will detect the stale lock, unlink it, and proceed.
+    expect(() => store.add(makeJob())).not.toThrow();
+    expect(store.list()).toHaveLength(1);
+    expect(existsSync(lockFile)).toBe(false);
+  });
+
+  it("releases the lock after a successful mutation so subsequent ones don't deadlock", () => {
+    const store = new ScheduleStore(join(tmp, "s.json"));
+    const a = makeJob({ id: "a" });
+    const b = makeJob({ id: "b" });
+    store.add(a);
+    store.add(b);  // would hang if the lock from the first add wasn't released
+    expect(store.list().map(j => j.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("does not create the backing directory until a mutation persists", () => {
+    const dir = join(tmp, ".pi", "subagent-schedules");
+    const file = join(dir, "sess.json");
+
+    // Constructing + read-only use must not touch the filesystem.
+    const store = new ScheduleStore(file);
+    expect(store.list()).toEqual([]);
+    expect(existsSync(dir)).toBe(false);
+
+    // First mutation lazily creates the directory.
+    store.add(makeJob());
+    expect(existsSync(dir)).toBe(true);
+    expect(existsSync(file)).toBe(true);
+  });
+
+  it("no-op update/remove of an unknown id never creates the backing directory", () => {
+    const dir = join(tmp, ".pi", "subagent-schedules");
+    const file = join(dir, "sess.json");
+    const store = new ScheduleStore(file);
+
+    expect(store.update("nonexistent", { name: "x" })).toBeUndefined();
+    expect(store.remove("nonexistent")).toBe(false);
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it("deleteFileIfEmpty unlinks file only when no jobs remain", () => {
+    const file = join(tmp, "s.json");
+    const store = new ScheduleStore(file);
+    const job = makeJob();
+    store.add(job);
+    store.deleteFileIfEmpty();  // not empty — should be a no-op
+    expect(existsSync(file)).toBe(true);
+
+    store.remove(job.id);
+    store.deleteFileIfEmpty();
+    expect(existsSync(file)).toBe(false);
+  });
+});

--- a/packages/pi-subagents/test/schedule.test.ts
+++ b/packages/pi-subagents/test/schedule.test.ts
@@ -1,0 +1,429 @@
+/**
+ * schedule.test.ts — SubagentScheduler engine.
+ *
+ * Tests:
+ *   - Static format parsers (cron / relative / interval / detection)
+ *   - Job lifecycle (add / update / remove / cleanup)
+ *   - Fire path (interval, one-shot) with mocked AgentManager + fake timers
+ *   - Past-timestamp rejection
+ *   - One-shot auto-disable
+ *   - Concurrency-bypass option flows through to manager.spawn
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SubagentScheduler } from "../src/schedule.js";
+import { ScheduleStore } from "../src/schedule-store.js";
+
+function makeMockManager() {
+  const spawnFn = vi.fn(() => "agent-" + Math.random().toString(36).slice(2, 10));
+  return {
+    spawn: spawnFn,
+    getRecord: vi.fn(() => ({ promise: Promise.resolve("done") })),
+  } as any;
+}
+
+function makeMockPi() {
+  return {
+    events: { emit: vi.fn() },
+  } as any;
+}
+
+function makeMockCtx() {
+  return {
+    cwd: "/tmp",
+    modelRegistry: { find: vi.fn(), getAll: () => [], getAvailable: () => [] },
+    sessionManager: { getSessionId: () => "sess-1" },
+  } as any;
+}
+
+describe("SubagentScheduler — static format parsers", () => {
+  it("parseRelativeTime accepts +Ns/Nm/Nh/Nd and rejects bare numbers", () => {
+    const before = Date.now();
+    const iso = SubagentScheduler.parseRelativeTime("+10s");
+    expect(iso).not.toBeNull();
+    const t = new Date(iso!).getTime();
+    expect(t - before).toBeGreaterThanOrEqual(9_000);
+    expect(t - before).toBeLessThanOrEqual(11_000);
+
+    expect(SubagentScheduler.parseRelativeTime("+5m")).not.toBeNull();
+    expect(SubagentScheduler.parseRelativeTime("+1h")).not.toBeNull();
+    expect(SubagentScheduler.parseRelativeTime("+2d")).not.toBeNull();
+
+    // Bare digits / wrong unit / no plus → null
+    expect(SubagentScheduler.parseRelativeTime("10s")).toBeNull();
+    expect(SubagentScheduler.parseRelativeTime("+5x")).toBeNull();
+    expect(SubagentScheduler.parseRelativeTime("hello")).toBeNull();
+  });
+
+  it("parseInterval converts unit-suffixed strings to milliseconds", () => {
+    expect(SubagentScheduler.parseInterval("10s")).toBe(10_000);
+    expect(SubagentScheduler.parseInterval("5m")).toBe(300_000);
+    expect(SubagentScheduler.parseInterval("1h")).toBe(3_600_000);
+    expect(SubagentScheduler.parseInterval("2d")).toBe(172_800_000);
+
+    expect(SubagentScheduler.parseInterval("+5m")).toBeNull();   // relative isn't an interval
+    expect(SubagentScheduler.parseInterval("5x")).toBeNull();
+    expect(SubagentScheduler.parseInterval("five-minutes")).toBeNull();
+  });
+
+  it("validateCronExpression rejects non-6-field expressions", () => {
+    expect(SubagentScheduler.validateCronExpression("* * * * *").valid).toBe(false);  // 5 fields
+    expect(SubagentScheduler.validateCronExpression("0 0 9 * * 1").valid).toBe(true);
+    expect(SubagentScheduler.validateCronExpression("0 0 9 * * *").valid).toBe(true);
+    expect(SubagentScheduler.validateCronExpression("not-a-cron").valid).toBe(false);
+  });
+
+  it("detectSchedule tags type and normalizes input", () => {
+    expect(SubagentScheduler.detectSchedule("+10m").type).toBe("once");
+    expect(SubagentScheduler.detectSchedule("5m").type).toBe("interval");
+    expect(SubagentScheduler.detectSchedule("5m").intervalMs).toBe(300_000);
+    expect(SubagentScheduler.detectSchedule("0 0 9 * * 1").type).toBe("cron");
+
+    const iso = "2099-01-01T00:00:00.000Z";
+    const r = SubagentScheduler.detectSchedule(iso);
+    expect(r.type).toBe("once");
+    expect(r.normalized).toBe(iso);
+
+    expect(() => SubagentScheduler.detectSchedule("garbage")).toThrow(/Invalid schedule/);
+  });
+});
+
+describe("SubagentScheduler — lifecycle", () => {
+  let tmp: string;
+  let store: ScheduleStore;
+  let scheduler: SubagentScheduler;
+  let manager: any;
+  let pi: any;
+  let ctx: any;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "scheduler-test-"));
+    store = new ScheduleStore(join(tmp, "s.json"));
+    scheduler = new SubagentScheduler();
+    manager = makeMockManager();
+    pi = makeMockPi();
+    ctx = makeMockCtx();
+    scheduler.start(pi, ctx, manager, store);
+  });
+
+  afterEach(() => {
+    scheduler.stop();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("isActive() reports start/stop state", () => {
+    expect(scheduler.isActive()).toBe(true);
+    scheduler.stop();
+    expect(scheduler.isActive()).toBe(false);
+  });
+
+  it("addJob persists, arms, and emits added event", () => {
+    const job = scheduler.addJob({
+      name: "j1",
+      description: "test",
+      schedule: "1h",
+      subagent_type: "general-purpose",
+      prompt: "hi",
+    });
+    expect(job.scheduleType).toBe("interval");
+    expect(scheduler.list()).toHaveLength(1);
+    expect(pi.events.emit).toHaveBeenCalledWith("subagents:scheduled", expect.objectContaining({ type: "added" }));
+  });
+
+  it("addJob rejects duplicate names", () => {
+    scheduler.addJob({ name: "j1", description: "x", schedule: "1h", subagent_type: "general-purpose", prompt: "p" });
+    expect(() => scheduler.addJob({
+      name: "j1", description: "y", schedule: "2h", subagent_type: "general-purpose", prompt: "p2",
+    })).toThrow(/already exists/);
+  });
+
+  it("removeJob clears the job and emits removed", () => {
+    const job = scheduler.addJob({ name: "j1", description: "x", schedule: "1h", subagent_type: "general-purpose", prompt: "p" });
+    expect(scheduler.removeJob(job.id)).toBe(true);
+    expect(scheduler.list()).toEqual([]);
+    expect(pi.events.emit).toHaveBeenCalledWith("subagents:scheduled", expect.objectContaining({ type: "removed", jobId: job.id }));
+  });
+
+  it("updateJob({enabled: false}) unschedules but keeps the record", () => {
+    const job = scheduler.addJob({ name: "j1", description: "x", schedule: "1h", subagent_type: "general-purpose", prompt: "p" });
+    scheduler.updateJob(job.id, { enabled: false });
+    expect(scheduler.list()[0].enabled).toBe(false);
+    expect(scheduler.getNextRun(job.id)).toBeUndefined();
+  });
+
+  // Regression: getNextRun on a freshly-created interval used to return undefined
+  // (the lastRun-based branch needs lastRun, which is undefined before first fire),
+  // surfacing as "Next run: (unknown)" in the agent's create-response.
+  it("getNextRun returns an approximate future time for a fresh interval (no lastRun yet)", () => {
+    const before = Date.now();
+    const job = scheduler.addJob({
+      name: "fresh-interval", description: "x", schedule: "1h",
+      subagent_type: "general-purpose", prompt: "p",
+    });
+    const next = scheduler.getNextRun(job.id);
+    expect(next).toBeDefined();
+    const t = new Date(next!).getTime();
+    // Should be ~now + 1h, with a small tolerance for the time spent in the call
+    expect(t - before).toBeGreaterThanOrEqual(3_600_000 - 1_000);
+    expect(t - before).toBeLessThanOrEqual(3_600_000 + 1_000);
+  });
+
+  // Once a fire happens and `lastRun` is set, getNextRun should pivot to it.
+  it("getNextRun uses lastRun when present for interval jobs", () => {
+    const job = scheduler.addJob({
+      name: "ran-once", description: "x", schedule: "1h",
+      subagent_type: "general-purpose", prompt: "p",
+    });
+    const lastRun = new Date(Date.now() - 30 * 60_000).toISOString(); // 30m ago
+    scheduler.updateJob(job.id, { lastRun });
+    const next = scheduler.getNextRun(job.id);
+    expect(next).toBe(new Date(new Date(lastRun).getTime() + 3_600_000).toISOString());
+  });
+
+  it("rejects past one-shot timestamps upfront — no record created", () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    expect(() => scheduler.addJob({
+      name: "past", description: "x", schedule: past, subagent_type: "general-purpose", prompt: "p",
+    })).toThrow(/in the past/);
+    // No dead-on-arrival record left behind
+    expect(scheduler.list()).toEqual([]);
+  });
+
+  // The safety net in scheduleJob's past-branch only fires on store reload —
+  // a once-job persisted with a future ISO whose time has now passed (process
+  // restart after the trigger window). detectSchedule rejects past timestamps
+  // at create time, so this is the only remaining production path.
+  it("disables a previously-enabled one-shot reloaded from disk past its time", () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    // Direct store insert bypasses addJob's upfront validation, mimicking a
+    // record that was valid when written but is now stale on reload.
+    store.add({
+      id: "reload-test",
+      name: "reload",
+      description: "reload",
+      schedule: past,
+      scheduleType: "once",
+      subagent_type: "general-purpose",
+      prompt: "x",
+      enabled: true,
+      createdAt: past,
+      runCount: 0,
+    });
+    // Re-arm: stop drops timers, start re-reads store.list() and calls scheduleJob
+    // for every enabled job → the past-branch fires for our seeded record.
+    scheduler.stop();
+    scheduler.start(pi, ctx, manager, store);
+
+    const reloaded = scheduler.list().find(j => j.id === "reload-test");
+    expect(reloaded?.enabled).toBe(false);
+    expect(reloaded?.lastStatus).toBe("error");
+    expect(pi.events.emit).toHaveBeenCalledWith("subagents:scheduled", expect.objectContaining({
+      type: "error", jobId: "reload-test", error: expect.stringMatching(/in the past/),
+    }));
+  });
+});
+
+describe("SubagentScheduler — fire path", () => {
+  let tmp: string;
+  let store: ScheduleStore;
+  let scheduler: SubagentScheduler;
+  let manager: any;
+  let pi: any;
+  let ctx: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    tmp = mkdtempSync(join(tmpdir(), "scheduler-fire-"));
+    store = new ScheduleStore(join(tmp, "s.json"));
+    scheduler = new SubagentScheduler();
+    manager = makeMockManager();
+    pi = makeMockPi();
+    ctx = makeMockCtx();
+    scheduler.start(pi, ctx, manager, store);
+  });
+
+  afterEach(() => {
+    scheduler.stop();
+    vi.useRealTimers();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("interval jobs fire repeatedly via setInterval", () => {
+    scheduler.addJob({
+      name: "every-10s", description: "tick", schedule: "10s",
+      subagent_type: "general-purpose", prompt: "tick",
+    });
+
+    expect(manager.spawn).toHaveBeenCalledTimes(0);
+    vi.advanceTimersByTime(10_000);
+    expect(manager.spawn).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(20_000);
+    expect(manager.spawn).toHaveBeenCalledTimes(3);
+  });
+
+  it("one-shot fires once and auto-disables", async () => {
+    const job = scheduler.addJob({
+      name: "soon", description: "once", schedule: "+1s",
+      subagent_type: "general-purpose", prompt: "once",
+    });
+
+    vi.advanceTimersByTime(2_000);
+    expect(manager.spawn).toHaveBeenCalledTimes(1);
+
+    // The auto-disable update happens synchronously inside the timer callback
+    expect(scheduler.list().find(j => j.id === job.id)?.enabled).toBe(false);
+
+    // Subsequent ticks shouldn't fire again
+    vi.advanceTimersByTime(60_000);
+    expect(manager.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("fire passes bypassQueue: true to manager.spawn", () => {
+    scheduler.addJob({
+      name: "every-1s", description: "x", schedule: "1s",
+      subagent_type: "general-purpose", prompt: "x",
+    });
+
+    vi.advanceTimersByTime(1_000);
+    expect(manager.spawn).toHaveBeenCalledTimes(1);
+    const optsArg = manager.spawn.mock.calls[0][4];
+    expect(optsArg.bypassQueue).toBe(true);
+    expect(optsArg.isBackground).toBe(true);
+  });
+
+  it("disabled jobs do not fire", () => {
+    const job = scheduler.addJob({
+      name: "off", description: "x", schedule: "1s",
+      subagent_type: "general-purpose", prompt: "x",
+    });
+    scheduler.updateJob(job.id, { enabled: false });
+    vi.advanceTimersByTime(5_000);
+    expect(manager.spawn).toHaveBeenCalledTimes(0);
+  });
+
+  it("emits fired event with agentId on successful spawn", () => {
+    scheduler.addJob({
+      name: "fire-once", description: "x", schedule: "+1s",
+      subagent_type: "general-purpose", prompt: "x",
+    });
+    vi.advanceTimersByTime(2_000);
+    expect(pi.events.emit).toHaveBeenCalledWith("subagents:scheduled", expect.objectContaining({
+      type: "fired", name: "fire-once", agentId: expect.stringMatching(/^agent-/),
+    }));
+  });
+
+  it("records lastStatus error and emits when manager.spawn throws", async () => {
+    manager.spawn.mockImplementationOnce(() => { throw new Error("no slots"); });
+    const job = scheduler.addJob({
+      name: "boom", description: "x", schedule: "+1s",
+      subagent_type: "general-purpose", prompt: "x",
+    });
+    vi.advanceTimersByTime(2_000);
+
+    // Update is synchronous in the spawn-throw path
+    expect(scheduler.list().find(j => j.id === job.id)?.lastStatus).toBe("error");
+    expect(pi.events.emit).toHaveBeenCalledWith("subagents:scheduled", expect.objectContaining({
+      type: "error", jobId: job.id, error: "no slots",
+    }));
+  });
+
+  // ── Status reflection from record.status (regression for bug #1) ────
+  // The real AgentManager's promise *always* resolves (its .catch returns ""),
+  // so the schedule's success/error must be inferred from `record.status`,
+  // not from promise resolution. These two tests model that contract.
+  describe("infers success vs error from record.status, not promise resolution", () => {
+    type FakeRecord = { status: string; promise: Promise<string>; resolve: () => void };
+
+    function installFaithfulMock(): Map<string, FakeRecord> {
+      const records = new Map<string, FakeRecord>();
+      manager.spawn.mockImplementation(() => {
+        const id = "agent-" + Math.random().toString(36).slice(2, 10);
+        let resolve!: () => void;
+        const promise = new Promise<string>(r => { resolve = () => r(""); });
+        records.set(id, { status: "running", promise, resolve });
+        return id;
+      });
+      manager.getRecord.mockImplementation((id: string) => records.get(id));
+      return records;
+    }
+
+    it("records lastStatus 'error' when the agent terminates with status='error'", async () => {
+      const records = installFaithfulMock();
+      const job = scheduler.addJob({
+        name: "fail-job", description: "x", schedule: "+1s",
+        subagent_type: "general-purpose", prompt: "x",
+      });
+
+      vi.advanceTimersByTime(2_000);
+      expect(manager.spawn).toHaveBeenCalledTimes(1);
+
+      // The agent ran and ended in error — same shape the real AgentManager produces.
+      const r = [...records.values()][0];
+      r.status = "error";
+      r.resolve();
+
+      // Flush microtasks so .then(finalize) runs.
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(scheduler.list().find(j => j.id === job.id)?.lastStatus).toBe("error");
+    });
+
+    it("records lastStatus 'success' when the agent terminates with status='completed'", async () => {
+      const records = installFaithfulMock();
+      const job = scheduler.addJob({
+        name: "ok-job", description: "x", schedule: "+1s",
+        subagent_type: "general-purpose", prompt: "x",
+      });
+
+      vi.advanceTimersByTime(2_000);
+      const r = [...records.values()][0];
+      r.status = "completed";
+      r.resolve();
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(scheduler.list().find(j => j.id === job.id)?.lastStatus).toBe("success");
+    });
+
+    it("treats aborted and stopped as errors (terminal failure states)", async () => {
+      const records = installFaithfulMock();
+      const a = scheduler.addJob({
+        name: "abort-job", description: "x", schedule: "+1s",
+        subagent_type: "general-purpose", prompt: "x",
+      });
+      const b = scheduler.addJob({
+        name: "stop-job", description: "x", schedule: "+2s",
+        subagent_type: "general-purpose", prompt: "x",
+      });
+
+      vi.advanceTimersByTime(3_000);
+      const recs = [...records.values()];
+      recs[0].status = "aborted";
+      recs[0].resolve();
+      recs[1].status = "stopped";
+      recs[1].resolve();
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(scheduler.list().find(j => j.id === a.id)?.lastStatus).toBe("error");
+      expect(scheduler.list().find(j => j.id === b.id)?.lastStatus).toBe("error");
+    });
+  });
+});
+
+describe("SubagentScheduler — stopped state", () => {
+  it("throws on mutation when not started", () => {
+    const scheduler = new SubagentScheduler();
+    expect(() => scheduler.addJob({
+      name: "x", description: "x", schedule: "1h", subagent_type: "general-purpose", prompt: "p",
+    })).toThrow(/not started/);
+  });
+
+  it("list() returns empty array when not started", () => {
+    const scheduler = new SubagentScheduler();
+    expect(scheduler.list()).toEqual([]);
+  });
+});

--- a/packages/pi-subagents/test/settings.test.ts
+++ b/packages/pi-subagents/test/settings.test.ts
@@ -1,0 +1,606 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyAndEmitLoaded,
+  applySettings,
+  loadSettings,
+  persistToastFor,
+  type SettingsAppliers,
+  saveAndEmitChanged,
+  saveSettings,
+} from "../src/settings.js";
+
+/**
+ * Tests for persistent settings. Uses two tmp directories:
+ * - `globalDir`: redirected via PI_CODING_AGENT_DIR so getAgentDir() returns it.
+ *   Simulates `~/.pi/agent/` — the global scope.
+ * - `projectDir`: passed explicitly as cwd to load/save.
+ *   Simulates the user's project root. Settings live at `<projectDir>/.pi/subagents.json`.
+ */
+describe("settings persistence", () => {
+  let globalDir: string;
+  let projectDir: string;
+  let originalAgentDirEnv: string | undefined;
+
+  const globalFile = () => join(globalDir, "subagents.json");
+  const projectFile = () => join(projectDir, ".pi", "subagents.json");
+
+  beforeEach(() => {
+    globalDir = mkdtempSync(join(tmpdir(), "pi-settings-global-"));
+    projectDir = mkdtempSync(join(tmpdir(), "pi-settings-project-"));
+    originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = globalDir;
+  });
+
+  afterEach(() => {
+    if (originalAgentDirEnv == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
+    rmSync(globalDir, { recursive: true, force: true });
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function writeGlobal(obj: unknown) {
+    writeFileSync(globalFile(), JSON.stringify(obj));
+  }
+
+  function writeProject(obj: unknown) {
+    mkdirSync(join(projectDir, ".pi"), { recursive: true });
+    writeFileSync(projectFile(), JSON.stringify(obj));
+  }
+
+  it("returns {} when both files are missing", () => {
+    expect(loadSettings(projectDir)).toEqual({});
+  });
+
+  it("returns {} when both files are malformed JSON", () => {
+    writeFileSync(globalFile(), "not json {{");
+    mkdirSync(join(projectDir, ".pi"), { recursive: true });
+    writeFileSync(projectFile(), "also not json");
+    expect(loadSettings(projectDir)).toEqual({});
+  });
+
+  it("loads from global when no project file", () => {
+    writeGlobal({ maxConcurrent: 16, graceTurns: 10 });
+    expect(loadSettings(projectDir)).toEqual({ maxConcurrent: 16, graceTurns: 10 });
+  });
+
+  it("loads from project when no global file", () => {
+    writeProject({ maxConcurrent: 8, defaultJoinMode: "group" });
+    expect(loadSettings(projectDir)).toEqual({ maxConcurrent: 8, defaultJoinMode: "group" });
+  });
+
+  it("merges global + project with project winning on conflicts", () => {
+    writeGlobal({ maxConcurrent: 16, graceTurns: 10, defaultJoinMode: "async" });
+    writeProject({ maxConcurrent: 4, defaultMaxTurns: 50 });
+    expect(loadSettings(projectDir)).toEqual({
+      maxConcurrent: 4, // project wins
+      graceTurns: 10, // from global
+      defaultJoinMode: "async", // from global
+      defaultMaxTurns: 50, // from project only
+    });
+  });
+
+  it("round-trips values: saveSettings then loadSettings", () => {
+    const settings = {
+      maxConcurrent: 7,
+      defaultMaxTurns: 30,
+      graceTurns: 3,
+      defaultJoinMode: "smart" as const,
+      schedulingEnabled: false,
+      toolDescriptionMode: "compact" as const,
+    };
+    saveSettings(settings, projectDir);
+    expect(loadSettings(projectDir)).toEqual(settings);
+  });
+
+  it("round-trips schedulingEnabled (true and false), and absence stays absent", () => {
+    saveSettings({ schedulingEnabled: false }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ schedulingEnabled: false });
+
+    saveSettings({ schedulingEnabled: true }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ schedulingEnabled: true });
+
+    // Absence — caller's "use default" signal — must not become a stored false.
+    saveSettings({}, projectDir);
+    expect(loadSettings(projectDir)).toEqual({});
+  });
+
+  it("round-trips fleetView (true and false); keeps boolean, drops non-boolean", () => {
+    saveSettings({ fleetView: false }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ fleetView: false });
+    saveSettings({ fleetView: true }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ fleetView: true });
+    writeProject({ fleetView: "on" } as any);
+    expect(loadSettings(projectDir)).toEqual({}); // non-boolean dropped
+  });
+
+  it("round-trips widgetMode; keeps valid values, drops invalid", () => {
+    saveSettings({ widgetMode: "off" }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ widgetMode: "off" });
+    saveSettings({ widgetMode: "background" }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ widgetMode: "background" });
+    writeProject({ widgetMode: "sideways" } as any);
+    expect(loadSettings(projectDir)).toEqual({}); // invalid value dropped
+  });
+
+  it("round-trips outputTranscript; drops non-boolean", () => {
+    saveSettings({ outputTranscript: false }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ outputTranscript: false });
+    saveSettings({ outputTranscript: true }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ outputTranscript: true });
+    writeProject({ outputTranscript: "no" } as any);
+    expect(loadSettings(projectDir)).toEqual({}); // non-boolean dropped
+  });
+
+  it("sanitize drops non-boolean schedulingEnabled silently", async () => {
+    writeProject({ schedulingEnabled: "yes" } as any);
+    expect(loadSettings(projectDir)).toEqual({});
+    writeProject({ schedulingEnabled: 1 } as any);
+    expect(loadSettings(projectDir)).toEqual({});
+  });
+
+  it("saveSettings writes only to the project file; global is untouched", () => {
+    writeGlobal({ maxConcurrent: 16 });
+    saveSettings({ maxConcurrent: 2 }, projectDir);
+
+    // Project file contains the new value
+    expect(JSON.parse(readFileSync(projectFile(), "utf-8"))).toEqual({ maxConcurrent: 2 });
+    // Global file unchanged
+    expect(JSON.parse(readFileSync(globalFile(), "utf-8"))).toEqual({ maxConcurrent: 16 });
+  });
+
+  it("saveSettings creates <cwd>/.pi/ when missing", () => {
+    expect(existsSync(join(projectDir, ".pi"))).toBe(false);
+    saveSettings({ maxConcurrent: 4 }, projectDir);
+    expect(existsSync(projectFile())).toBe(true);
+  });
+
+  it("round-trips defaultMaxTurns: 0 (unlimited marker)", () => {
+    saveSettings({ defaultMaxTurns: 0 }, projectDir);
+    expect(loadSettings(projectDir)).toEqual({ defaultMaxTurns: 0 });
+  });
+
+  it("ignores unknown extra fields on load (forward-compat)", () => {
+    writeProject({ maxConcurrent: 2, futureField: "ignored" });
+    const loaded = loadSettings(projectDir);
+    expect(loaded.maxConcurrent).toBe(2);
+    // Unknown fields are stripped by the sanitizer — old versions won't persist garbage
+    expect((loaded as Record<string, unknown>).futureField).toBeUndefined();
+  });
+
+  it("composes partial global + partial project correctly", () => {
+    writeGlobal({ graceTurns: 10 });
+    writeProject({ maxConcurrent: 2 });
+    expect(loadSettings(projectDir)).toEqual({ graceTurns: 10, maxConcurrent: 2 });
+  });
+
+  describe("sanitizer", () => {
+    it("drops maxConcurrent < 1", () => {
+      writeProject({ maxConcurrent: 0, graceTurns: 5 });
+      expect(loadSettings(projectDir)).toEqual({ graceTurns: 5 });
+    });
+
+    it("drops negative maxConcurrent", () => {
+      writeProject({ maxConcurrent: -3 });
+      expect(loadSettings(projectDir)).toEqual({});
+    });
+
+    it("drops non-integer maxConcurrent (floats, NaN, strings)", () => {
+      writeProject({ maxConcurrent: 3.5 });
+      expect(loadSettings(projectDir).maxConcurrent).toBeUndefined();
+      writeProject({ maxConcurrent: "four" });
+      expect(loadSettings(projectDir).maxConcurrent).toBeUndefined();
+      writeProject({ maxConcurrent: null });
+      expect(loadSettings(projectDir).maxConcurrent).toBeUndefined();
+    });
+
+    it("accepts defaultMaxTurns: 0 (explicit unlimited)", () => {
+      writeProject({ defaultMaxTurns: 0 });
+      expect(loadSettings(projectDir)).toEqual({ defaultMaxTurns: 0 });
+    });
+
+    it("drops negative defaultMaxTurns", () => {
+      writeProject({ defaultMaxTurns: -1 });
+      expect(loadSettings(projectDir)).toEqual({});
+    });
+
+    it("drops graceTurns < 1", () => {
+      writeProject({ graceTurns: 0 });
+      expect(loadSettings(projectDir)).toEqual({});
+    });
+
+    it("drops invalid defaultJoinMode values", () => {
+      writeProject({ defaultJoinMode: "invalid" });
+      expect(loadSettings(projectDir)).toEqual({});
+      writeProject({ defaultJoinMode: 42 });
+      expect(loadSettings(projectDir)).toEqual({});
+      writeProject({ defaultJoinMode: "" });
+      expect(loadSettings(projectDir)).toEqual({});
+    });
+
+    it("accepts all three valid join modes", () => {
+      for (const mode of ["async", "group", "smart"] as const) {
+        writeProject({ defaultJoinMode: mode });
+        expect(loadSettings(projectDir)).toEqual({ defaultJoinMode: mode });
+      }
+    });
+
+    it("accepts scopeModels boolean (true and false)", () => {
+      writeProject({ scopeModels: true });
+      expect(loadSettings(projectDir)).toEqual({ scopeModels: true });
+      writeProject({ scopeModels: false });
+      expect(loadSettings(projectDir)).toEqual({ scopeModels: false });
+    });
+
+    it("drops non-boolean scopeModels", () => {
+      writeProject({ scopeModels: "yes" });
+      expect(loadSettings(projectDir).scopeModels).toBeUndefined();
+      writeProject({ scopeModels: 1 });
+      expect(loadSettings(projectDir).scopeModels).toBeUndefined();
+      writeProject({ scopeModels: null });
+      expect(loadSettings(projectDir).scopeModels).toBeUndefined();
+    });
+
+    it("accepts disableDefaultAgents boolean (true and false)", () => {
+      writeProject({ disableDefaultAgents: true });
+      expect(loadSettings(projectDir)).toEqual({ disableDefaultAgents: true });
+      writeProject({ disableDefaultAgents: false });
+      expect(loadSettings(projectDir)).toEqual({ disableDefaultAgents: false });
+    });
+
+    it("drops non-boolean disableDefaultAgents", () => {
+      writeProject({ disableDefaultAgents: "yes" });
+      expect(loadSettings(projectDir).disableDefaultAgents).toBeUndefined();
+      writeProject({ disableDefaultAgents: 1 });
+      expect(loadSettings(projectDir).disableDefaultAgents).toBeUndefined();
+      writeProject({ disableDefaultAgents: null });
+      expect(loadSettings(projectDir).disableDefaultAgents).toBeUndefined();
+    });
+
+    it("accepts all valid toolDescriptionMode values", () => {
+      for (const mode of ["full", "compact", "custom"] as const) {
+        writeProject({ toolDescriptionMode: mode });
+        expect(loadSettings(projectDir)).toEqual({ toolDescriptionMode: mode });
+      }
+    });
+
+    it("drops invalid toolDescriptionMode", () => {
+      writeProject({ toolDescriptionMode: "tiny" });
+      expect(loadSettings(projectDir).toolDescriptionMode).toBeUndefined();
+      writeProject({ toolDescriptionMode: true });
+      expect(loadSettings(projectDir).toolDescriptionMode).toBeUndefined();
+      writeProject({ toolDescriptionMode: null });
+      expect(loadSettings(projectDir).toolDescriptionMode).toBeUndefined();
+    });
+
+    it("returns {} when the JSON root is not an object (array, string, null)", () => {
+      mkdirSync(join(projectDir, ".pi"), { recursive: true });
+      writeFileSync(projectFile(), '["not", "an", "object"]');
+      expect(loadSettings(projectDir)).toEqual({});
+      writeFileSync(projectFile(), '"just a string"');
+      expect(loadSettings(projectDir)).toEqual({});
+      writeFileSync(projectFile(), "null");
+      expect(loadSettings(projectDir)).toEqual({});
+    });
+
+    it("keeps valid fields while dropping invalid siblings", () => {
+      writeProject({
+        maxConcurrent: 4, // ok
+        defaultMaxTurns: -5, // dropped
+        graceTurns: 3, // ok
+        defaultJoinMode: "nope", // dropped
+      });
+      expect(loadSettings(projectDir)).toEqual({ maxConcurrent: 4, graceTurns: 3 });
+    });
+
+    it("accepts values at the ceiling (maxConcurrent=1024, defaultMaxTurns=10000, graceTurns=1000)", () => {
+      writeProject({ maxConcurrent: 1024, defaultMaxTurns: 10_000, graceTurns: 1_000 });
+      expect(loadSettings(projectDir)).toEqual({
+        maxConcurrent: 1024,
+        defaultMaxTurns: 10_000,
+        graceTurns: 1_000,
+      });
+    });
+
+    it("drops values above the ceiling", () => {
+      writeProject({ maxConcurrent: 1025 });
+      expect(loadSettings(projectDir).maxConcurrent).toBeUndefined();
+      writeProject({ defaultMaxTurns: 10_001 });
+      expect(loadSettings(projectDir).defaultMaxTurns).toBeUndefined();
+      writeProject({ graceTurns: 1_001 });
+      expect(loadSettings(projectDir).graceTurns).toBeUndefined();
+    });
+
+    it("drops absurdly large values (e.g. 1e6)", () => {
+      writeProject({ maxConcurrent: 1_000_000, defaultMaxTurns: 1_000_000, graceTurns: 1_000_000 });
+      expect(loadSettings(projectDir)).toEqual({});
+    });
+  });
+
+  describe("save result + corrupt-file warning", () => {
+    it("saveSettings returns true on success", () => {
+      expect(saveSettings({ maxConcurrent: 2 }, projectDir)).toBe(true);
+      expect(JSON.parse(readFileSync(projectFile(), "utf-8"))).toEqual({ maxConcurrent: 2 });
+    });
+
+    it("saveSettings returns false when the target dir cannot be created", () => {
+      // Place a regular file where the parent of the settings file would go —
+      // mkdirSync + writeFileSync both fail with ENOTDIR / EEXIST.
+      const filePosingAsCwd = join(tmpdir(), `pi-settings-notdir-${Date.now()}`);
+      writeFileSync(filePosingAsCwd, "");
+      try {
+        expect(saveSettings({ maxConcurrent: 1 }, filePosingAsCwd)).toBe(false);
+      } finally {
+        rmSync(filePosingAsCwd, { force: true });
+      }
+    });
+
+    it("warns to console.warn when an existing file is malformed", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mkdirSync(join(projectDir, ".pi"), { recursive: true });
+      writeFileSync(projectFile(), "not valid json {{{");
+      try {
+        expect(loadSettings(projectDir)).toEqual({});
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(String(spy.mock.calls[0][0])).toMatch(/Ignoring malformed settings/);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("does NOT warn when a file is simply missing", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        expect(loadSettings(projectDir)).toEqual({});
+        expect(spy).not.toHaveBeenCalled();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  describe("applySettings", () => {
+    let appliers: SettingsAppliers;
+
+    beforeEach(() => {
+      appliers = {
+        setMaxConcurrent: vi.fn(),
+        setDefaultMaxTurns: vi.fn(),
+        setGraceTurns: vi.fn(),
+        setDefaultJoinMode: vi.fn(),
+        setSchedulingEnabled: vi.fn(),
+        setScopeModels: vi.fn(),
+        setDisableDefaultAgents: vi.fn(),
+        setToolDescriptionMode: vi.fn(),
+        setFleetView: vi.fn(),
+        setWidgetMode: vi.fn(),
+        setOutputTranscript: vi.fn(),
+      };
+    });
+
+    it("is a no-op on an empty settings object", () => {
+      applySettings({}, appliers);
+      expect(appliers.setMaxConcurrent).not.toHaveBeenCalled();
+      expect(appliers.setDefaultMaxTurns).not.toHaveBeenCalled();
+      expect(appliers.setGraceTurns).not.toHaveBeenCalled();
+      expect(appliers.setDefaultJoinMode).not.toHaveBeenCalled();
+      expect(appliers.setSchedulingEnabled).not.toHaveBeenCalled();
+      expect(appliers.setScopeModels).not.toHaveBeenCalled();
+      expect(appliers.setDisableDefaultAgents).not.toHaveBeenCalled();
+      expect(appliers.setToolDescriptionMode).not.toHaveBeenCalled();
+    });
+
+    it("applies only the fields that are present", () => {
+      applySettings({ maxConcurrent: 4, graceTurns: 3 }, appliers);
+      expect(appliers.setMaxConcurrent).toHaveBeenCalledWith(4);
+      expect(appliers.setGraceTurns).toHaveBeenCalledWith(3);
+      expect(appliers.setDefaultMaxTurns).not.toHaveBeenCalled();
+      expect(appliers.setDefaultJoinMode).not.toHaveBeenCalled();
+      expect(appliers.setSchedulingEnabled).not.toHaveBeenCalled();
+      expect(appliers.setScopeModels).not.toHaveBeenCalled();
+    });
+
+    it("applies all fields when all are present", () => {
+      applySettings(
+        {
+          maxConcurrent: 8,
+          defaultMaxTurns: 50,
+          graceTurns: 7,
+          defaultJoinMode: "group",
+          schedulingEnabled: false,
+          scopeModels: true,
+          disableDefaultAgents: true,
+          toolDescriptionMode: "compact",
+          fleetView: false,
+          widgetMode: "off",
+        },
+        appliers,
+      );
+      expect(appliers.setMaxConcurrent).toHaveBeenCalledWith(8);
+      expect(appliers.setDefaultMaxTurns).toHaveBeenCalledWith(50);
+      expect(appliers.setGraceTurns).toHaveBeenCalledWith(7);
+      expect(appliers.setDefaultJoinMode).toHaveBeenCalledWith("group");
+      expect(appliers.setSchedulingEnabled).toHaveBeenCalledWith(false);
+      expect(appliers.setScopeModels).toHaveBeenCalledWith(true);
+      expect(appliers.setDisableDefaultAgents).toHaveBeenCalledWith(true);
+      expect(appliers.setToolDescriptionMode).toHaveBeenCalledWith("compact");
+      expect(appliers.setFleetView).toHaveBeenCalledWith(false);
+      expect(appliers.setWidgetMode).toHaveBeenCalledWith("off");
+    });
+
+    it("applies widgetMode; skips it when absent", () => {
+      applySettings({ widgetMode: "off" }, appliers);
+      expect(appliers.setWidgetMode).toHaveBeenCalledWith("off");
+      applySettings({}, appliers);
+      expect(appliers.setWidgetMode).toHaveBeenCalledTimes(1); // absence is "use default"
+    });
+
+    it("applies fleetView (true and false); skips it when absent", () => {
+      applySettings({ fleetView: true }, appliers);
+      expect(appliers.setFleetView).toHaveBeenCalledWith(true);
+      applySettings({}, appliers);
+      expect(appliers.setFleetView).toHaveBeenCalledTimes(1); // absence is "use default"
+    });
+
+    it("applies scopeModels: false", () => {
+      applySettings({ scopeModels: false }, appliers);
+      expect(appliers.setScopeModels).toHaveBeenCalledWith(false);
+    });
+
+    it("applies disableDefaultAgents: false", () => {
+      applySettings({ disableDefaultAgents: false }, appliers);
+      expect(appliers.setDisableDefaultAgents).toHaveBeenCalledWith(false);
+    });
+
+    it("applies toolDescriptionMode", () => {
+      applySettings({ toolDescriptionMode: "full" }, appliers);
+      expect(appliers.setToolDescriptionMode).toHaveBeenCalledWith("full");
+    });
+
+    it("applies outputTranscript (both true and false)", () => {
+      applySettings({ outputTranscript: false }, appliers);
+      expect(appliers.setOutputTranscript).toHaveBeenCalledWith(false);
+      applySettings({ outputTranscript: true }, appliers);
+      expect(appliers.setOutputTranscript).toHaveBeenCalledWith(true);
+    });
+
+    it("applies defaultMaxTurns: 0 as the explicit unlimited marker", () => {
+      applySettings({ defaultMaxTurns: 0 }, appliers);
+      expect(appliers.setDefaultMaxTurns).toHaveBeenCalledWith(0);
+    });
+
+    // Wiring tests for the master switch — ensures the schedulingEnabled
+    // field flows from the parsed settings into the applier callback that
+    // sets the in-memory flag in index.ts.
+    it("calls setSchedulingEnabled(true) when schedulingEnabled is true", () => {
+      applySettings({ schedulingEnabled: true }, appliers);
+      expect(appliers.setSchedulingEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it("calls setSchedulingEnabled(false) when schedulingEnabled is false", () => {
+      applySettings({ schedulingEnabled: false }, appliers);
+      expect(appliers.setSchedulingEnabled).toHaveBeenCalledWith(false);
+    });
+
+    // Absence preserves the in-memory default — the applier must NOT be
+    // called, otherwise loading a settings file without the field would
+    // overwrite the runtime default with `undefined`.
+    it("does not call setSchedulingEnabled when the field is absent", () => {
+      applySettings({ maxConcurrent: 4 }, appliers);
+      expect(appliers.setSchedulingEnabled).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("persistToastFor", () => {
+    it("returns info-level toast with the plain message on success", () => {
+      expect(persistToastFor("Max concurrency set to 7", true)).toEqual({
+        message: "Max concurrency set to 7",
+        level: "info",
+      });
+    });
+
+    it("returns warning-level toast with session-only suffix on failure", () => {
+      expect(persistToastFor("Max concurrency set to 7", false)).toEqual({
+        message: "Max concurrency set to 7 (session only; failed to persist)",
+        level: "warning",
+      });
+    });
+  });
+
+  describe("applyAndEmitLoaded", () => {
+    let appliers: SettingsAppliers;
+
+    beforeEach(() => {
+      appliers = {
+        setMaxConcurrent: vi.fn(),
+        setDefaultMaxTurns: vi.fn(),
+        setGraceTurns: vi.fn(),
+        setDefaultJoinMode: vi.fn(),
+        setSchedulingEnabled: vi.fn(),
+        setScopeModels: vi.fn(),
+        setDisableDefaultAgents: vi.fn(),
+        setToolDescriptionMode: vi.fn(),
+        setFleetView: vi.fn(),
+        setWidgetMode: vi.fn(),
+        setOutputTranscript: vi.fn(),
+      };
+    });
+
+    it("loads, applies, and emits subagents:settings_loaded with merged settings", () => {
+      writeGlobal({ maxConcurrent: 16 });
+      writeProject({ graceTurns: 7 });
+      const emit = vi.fn();
+
+      const result = applyAndEmitLoaded(appliers, emit, projectDir);
+
+      expect(appliers.setMaxConcurrent).toHaveBeenCalledWith(16);
+      expect(appliers.setGraceTurns).toHaveBeenCalledWith(7);
+      expect(appliers.setDefaultMaxTurns).not.toHaveBeenCalled();
+      expect(appliers.setDefaultJoinMode).not.toHaveBeenCalled();
+
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(emit).toHaveBeenCalledWith("subagents:settings_loaded", {
+        settings: { maxConcurrent: 16, graceTurns: 7 },
+      });
+      expect(result).toEqual({ maxConcurrent: 16, graceTurns: 7 });
+    });
+
+    it("still emits the event when both files are missing (payload carries {})", () => {
+      const emit = vi.fn();
+
+      const result = applyAndEmitLoaded(appliers, emit, projectDir);
+
+      expect(emit).toHaveBeenCalledWith("subagents:settings_loaded", { settings: {} });
+      expect(result).toEqual({});
+      // No setters fired — defaults preserved
+      expect(appliers.setMaxConcurrent).not.toHaveBeenCalled();
+      expect(appliers.setDefaultMaxTurns).not.toHaveBeenCalled();
+      expect(appliers.setGraceTurns).not.toHaveBeenCalled();
+      expect(appliers.setDefaultJoinMode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("saveAndEmitChanged", () => {
+    it("persists, emits with persisted=true, and returns info toast on success", () => {
+      const emit = vi.fn();
+      const snapshot = { maxConcurrent: 5, graceTurns: 2 };
+
+      const toast = saveAndEmitChanged(snapshot, "Max concurrency set to 5", emit, projectDir);
+
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(emit).toHaveBeenCalledWith("subagents:settings_changed", {
+        settings: snapshot,
+        persisted: true,
+      });
+      expect(toast).toEqual({ message: "Max concurrency set to 5", level: "info" });
+      // File actually written
+      expect(JSON.parse(readFileSync(projectFile(), "utf-8"))).toEqual(snapshot);
+    });
+
+    it("emits with persisted=false and returns warning toast on save failure", () => {
+      const filePosingAsCwd = join(tmpdir(), `pi-settings-notdir-${Date.now()}`);
+      writeFileSync(filePosingAsCwd, "");
+      const emit = vi.fn();
+      try {
+        const toast = saveAndEmitChanged(
+          { maxConcurrent: 5 },
+          "Max concurrency set to 5",
+          emit,
+          filePosingAsCwd,
+        );
+        expect(emit).toHaveBeenCalledWith("subagents:settings_changed", {
+          settings: { maxConcurrent: 5 },
+          persisted: false,
+        });
+        expect(toast).toEqual({
+          message: "Max concurrency set to 5 (session only; failed to persist)",
+          level: "warning",
+        });
+      } finally {
+        rmSync(filePosingAsCwd, { force: true });
+      }
+    });
+  });
+});

--- a/packages/pi-subagents/test/skill-loader.test.ts
+++ b/packages/pi-subagents/test/skill-loader.test.ts
@@ -1,0 +1,237 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { preloadSkills } from "../src/skill-loader.js";
+
+describe("preloadSkills", () => {
+  let tmpDir: string;
+  let originalAgentDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-skill-test-"));
+    originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(tmpDir, "user-agent-dir");
+  });
+
+  afterEach(() => {
+    if (originalAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const projectRoot = () => join(tmpDir, ".pi", "skills");
+  const globalRoot = () => join(process.env.PI_CODING_AGENT_DIR!, "skills");
+
+  function writeFlat(root: string, name: string, content: string, ext = ".md") {
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, name + ext), content);
+  }
+
+  function writeSkillDir(root: string, name: string, content: string) {
+    const dir = join(root, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "SKILL.md"), content);
+  }
+
+  it("returns empty array for empty skill list", () => {
+    expect(preloadSkills([], tmpDir)).toEqual([]);
+  });
+
+  it("loads a top-level flat .md skill from project", () => {
+    writeFlat(projectRoot(), "api-conventions", "# API Conventions");
+    const result = preloadSkills(["api-conventions"], tmpDir);
+    expect(result[0].content).toContain("API Conventions");
+  });
+
+  it("ignores .txt files (only .md is supported)", () => {
+    writeFlat(projectRoot(), "error-handling", "should not load", ".txt");
+    expect(preloadSkills(["error-handling"], tmpDir)[0].content).toContain("not found");
+  });
+
+  it("ignores extensionless files (only .md is supported)", () => {
+    writeFlat(projectRoot(), "bare-skill", "should not load", "");
+    expect(preloadSkills(["bare-skill"], tmpDir)[0].content).toContain("not found");
+  });
+
+  it("loads a top-level <name>/SKILL.md from project", () => {
+    writeSkillDir(projectRoot(), "writing-go", "# Writing Go");
+    expect(preloadSkills(["writing-go"], tmpDir)[0].content).toContain("Writing Go");
+  });
+
+  it("loads a top-level <name>/SKILL.md from getAgentDir()/skills", () => {
+    writeSkillDir(globalRoot(), "writing-python", "# Writing Python");
+    expect(preloadSkills(["writing-python"], tmpDir)[0].content).toContain("Writing Python");
+  });
+
+  it("loads a flat .md from getAgentDir()/skills", () => {
+    writeFlat(globalRoot(), "shell-tips", "use rg");
+    expect(preloadSkills(["shell-tips"], tmpDir)[0].content).toBe("use rg");
+  });
+
+  it("finds nested <subdir>/<name>/SKILL.md in getAgentDir()/skills", () => {
+    writeSkillDir(join(globalRoot(), "dev-tools"), "using-modern-cli", "# Modern CLI");
+    expect(preloadSkills(["using-modern-cli"], tmpDir)[0].content).toContain("Modern CLI");
+  });
+
+  it("loads <name>/SKILL.md from project .agents/skills (Agent Skills spec)", () => {
+    writeSkillDir(join(tmpDir, ".agents", "skills"), "writing-rust", "# Writing Rust");
+    expect(preloadSkills(["writing-rust"], tmpDir)[0].content).toContain("Writing Rust");
+  });
+
+  it("prefers .pi/skills over .agents/skills in the same project", () => {
+    writeSkillDir(projectRoot(), "shared", "from-pi");
+    writeSkillDir(join(tmpDir, ".agents", "skills"), "shared", "from-agents");
+    expect(preloadSkills(["shared"], tmpDir)[0].content).toBe("from-pi");
+  });
+
+  it("finds nested <subdir>/<name>/SKILL.md", () => {
+    writeSkillDir(join(projectRoot(), "dev-tools"), "using-modern-cli", "# Modern CLI");
+    expect(preloadSkills(["using-modern-cli"], tmpDir)[0].content).toContain("Modern CLI");
+  });
+
+  it("prefers project over global", () => {
+    writeSkillDir(projectRoot(), "shared", "from-project");
+    writeSkillDir(globalRoot(), "shared", "from-global");
+    expect(preloadSkills(["shared"], tmpDir)[0].content).toBe("from-project");
+  });
+
+  it("prefers shallower match (lex tie-break)", () => {
+    // Different depths — shallower wins.
+    writeSkillDir(join(projectRoot(), "z-deep", "nested"), "collide", "deep");
+    writeSkillDir(join(projectRoot(), "a-shallow"), "collide", "shallow");
+    expect(preloadSkills(["collide"], tmpDir)[0].content).toBe("shallow");
+
+    // Same depth — alphabetical wins.
+    writeSkillDir(join(projectRoot(), "b-sibling"), "tie", "b");
+    writeSkillDir(join(projectRoot(), "a-sibling"), "tie", "a");
+    expect(preloadSkills(["tie"], tmpDir)[0].content).toBe("a");
+  });
+
+  it("descends past a same-named dir that lacks SKILL.md to find a deeper match", () => {
+    // .pi/skills/foo exists empty; .pi/skills/foo/inner/foo/SKILL.md is the real skill.
+    mkdirSync(join(projectRoot(), "foo"), { recursive: true });
+    writeSkillDir(join(projectRoot(), "foo", "inner"), "foo", "deeper");
+    expect(preloadSkills(["foo"], tmpDir)[0].content).toBe("deeper");
+  });
+
+  it("does not descend into a sibling skill directory (skills don't nest)", () => {
+    // .pi/skills/outer is itself a skill; .pi/skills/outer/target/SKILL.md must NOT be found.
+    writeSkillDir(projectRoot(), "outer", "outer-skill");
+    writeSkillDir(join(projectRoot(), "outer"), "target", "hidden");
+    expect(preloadSkills(["target"], tmpDir)[0].content).toContain("not found");
+  });
+
+  it("skips node_modules during recursion", () => {
+    writeSkillDir(join(projectRoot(), "node_modules", "some-pkg"), "leaked", "should not load");
+    expect(preloadSkills(["leaked"], tmpDir)[0].content).toContain("not found");
+  });
+
+  it("skips dotfile directories during recursion", () => {
+    writeSkillDir(join(projectRoot(), ".hidden-tree"), "buried", "should not load");
+    expect(preloadSkills(["buried"], tmpDir)[0].content).toContain("not found");
+  });
+
+  it("returns fallback for missing skills", () => {
+    const result = preloadSkills(["nonexistent"], tmpDir);
+    expect(result[0].name).toBe("nonexistent");
+    expect(result[0].content).toContain("not found");
+  });
+
+  it("loads multiple skills", () => {
+    writeFlat(projectRoot(), "a", "Content A");
+    writeSkillDir(projectRoot(), "b", "Content B");
+    const result = preloadSkills(["a", "b"], tmpDir);
+    expect(result.map((r) => r.content)).toEqual(["Content A", expect.stringContaining("Content B")]);
+  });
+
+  it("skips skill names with path traversal (..)", () => {
+    expect(preloadSkills(["../../etc/passwd"], tmpDir)[0].content).toContain("path traversal");
+  });
+
+  it("skips skill names with forward slash", () => {
+    expect(preloadSkills(["sub/dir"], tmpDir)[0].content).toContain("path traversal");
+  });
+
+  it("skips skill names with backslash", () => {
+    expect(preloadSkills(["sub\\dir"], tmpDir)[0].content).toContain("path traversal");
+  });
+
+  it("skips skill names with spaces", () => {
+    expect(preloadSkills(["my skill"], tmpDir)[0].content).toContain("path traversal");
+  });
+
+  it("skips skill names starting with a dot", () => {
+    expect(preloadSkills([".hidden"], tmpDir)[0].content).toContain("path traversal");
+  });
+
+  it("skips empty skill names", () => {
+    expect(preloadSkills([""], tmpDir)[0].content).toContain("path traversal");
+  });
+
+  it("skips skill names exceeding 128 characters", () => {
+    const longName = "a".repeat(129);
+    expect(preloadSkills([longName], tmpDir)[0].content).toContain("path traversal");
+  });
+
+  it("loads valid skills alongside skipped unsafe ones", () => {
+    writeFlat(projectRoot(), "legit", "Good content");
+    const result = preloadSkills(["../evil", "legit"], tmpDir);
+    expect(result[0].content).toContain("path traversal");
+    expect(result[1].content).toBe("Good content");
+  });
+
+  it("rejects symlinked flat .md files", () => {
+    mkdirSync(projectRoot(), { recursive: true });
+    const secret = join(tmpDir, "secret.md");
+    writeFileSync(secret, "TOP SECRET");
+    symlinkSync(secret, join(projectRoot(), "evil.md"));
+    const result = preloadSkills(["evil"], tmpDir);
+    expect(result[0].content).toContain("not found");
+    expect(result[0].content).not.toContain("TOP SECRET");
+  });
+
+  it("rejects symlinked skill directories", () => {
+    mkdirSync(projectRoot(), { recursive: true });
+    const realDir = join(tmpDir, "real-skill");
+    mkdirSync(realDir, { recursive: true });
+    writeFileSync(join(realDir, "SKILL.md"), "TOP SECRET");
+    symlinkSync(realDir, join(projectRoot(), "evil-dir"));
+    const result = preloadSkills(["evil-dir"], tmpDir);
+    expect(result[0].content).toContain("not found");
+    expect(result[0].content).not.toContain("TOP SECRET");
+  });
+
+  it("rejects symlinked skill root", () => {
+    // <cwd>/.pi/skills → symlink to a directory that holds real-looking skills.
+    const realRoot = join(tmpDir, "elsewhere");
+    mkdirSync(realRoot, { recursive: true });
+    writeFileSync(join(realRoot, "leaked-flat.md"), "TOP SECRET FLAT");
+    mkdirSync(join(realRoot, "leaked-dir"), { recursive: true });
+    writeFileSync(join(realRoot, "leaked-dir", "SKILL.md"), "TOP SECRET DIR");
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    symlinkSync(realRoot, projectRoot());
+
+    const flatResult = preloadSkills(["leaked-flat"], tmpDir)[0].content;
+    expect(flatResult).toContain("not found");
+    expect(flatResult).not.toContain("TOP SECRET");
+
+    const dirResult = preloadSkills(["leaked-dir"], tmpDir)[0].content;
+    expect(dirResult).toContain("not found");
+    expect(dirResult).not.toContain("TOP SECRET");
+  });
+
+  it("rejects symlinked SKILL.md inside a real skill directory", () => {
+    const skillDir = join(projectRoot(), "evil-inner");
+    mkdirSync(skillDir, { recursive: true });
+    const secret = join(tmpDir, "secret.md");
+    writeFileSync(secret, "TOP SECRET");
+    symlinkSync(secret, join(skillDir, "SKILL.md"));
+    const result = preloadSkills(["evil-inner"], tmpDir);
+    expect(result[0].content).toContain("not found");
+    expect(result[0].content).not.toContain("TOP SECRET");
+  });
+});

--- a/packages/pi-subagents/test/status-note-wiring.test.ts
+++ b/packages/pi-subagents/test/status-note-wiring.test.ts
@@ -1,0 +1,114 @@
+/**
+ * status-note-wiring.test.ts — proves the status note actually reaches the
+ * PARENT through the real tool handlers, not just that getStatusNote() returns
+ * a string. Drives the registered `Agent` / `get_subagent_result` tools and
+ * inspects the text delivered back, for a turn-limit abort and a user stop.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const eventHandlers = new Map<string, any>();
+  const lifecycle = new Map<string, any>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((t: any) => tools.set(t.name, t)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: {
+      emit: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        eventHandlers.set(event, handler);
+        return vi.fn();
+      }),
+    },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  return { pi, tools, eventHandlers, lifecycle };
+}
+
+// The RPC channels are registered on the first bound session_start (#142), so a
+// test that drives them must fire it first — as a real session always does. A
+// sessionId-less ctx makes startScheduler short-circuit (no filesystem touch).
+async function bind(lifecycle: Map<string, any>) {
+  const bindCtx = ctx();
+  bindCtx.sessionManager.getSessionId = vi.fn(() => undefined);
+  await lifecycle.get("session_start")({}, bindCtx);
+}
+
+function ctx() {
+  return {
+    hasUI: false,
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    cwd: "/tmp",
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: vi.fn(() => "s1"), getBranch: vi.fn(() => []) },
+    getSystemPrompt: vi.fn(() => "parent"),
+  } as any;
+}
+
+const textOf = (r: any): string => r.content[0].text;
+
+describe("status note reaches the parent through the real handlers", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("foreground turn-limit abort → the Agent result flags an incomplete outcome", async () => {
+    vi.mocked(runAgent).mockResolvedValue({
+      responseText: "partial work so far",
+      session: { dispose: vi.fn() } as any,
+      aborted: true, // hard turn-limit abort
+      steered: false,
+    });
+    const { pi, tools } = makePi();
+    subagentsExtension(pi);
+
+    const res = await tools.get("Agent").execute(
+      "tc1",
+      { prompt: "go", description: "d", subagent_type: "general-purpose" },
+      undefined, undefined, ctx(),
+    );
+
+    const out = textOf(res);
+    expect(out).toContain("hit the turn limit");      // getStatusNote("aborted") is wired in
+    expect(out).toContain("partial work so far");     // partial result still delivered
+    expect(out).not.toContain("STOPPED BY THE USER"); // not mislabelled as a user stop
+  });
+
+  it("background user-stop → get_subagent_result flags STOPPED BY THE USER (not completed)", async () => {
+    // A background agent that never settles on its own — only a stop ends it.
+    vi.mocked(runAgent).mockReturnValue(new Promise(() => {}) as any);
+    const { pi, tools, eventHandlers, lifecycle } = makePi();
+    subagentsExtension(pi);
+    await bind(lifecycle); // register RPC channels via session_start (#142)
+
+    const spawn = await tools.get("Agent").execute(
+      "tc2",
+      { prompt: "go", description: "d", subagent_type: "general-purpose", run_in_background: true },
+      undefined, undefined, ctx(),
+    );
+    const id = textOf(spawn).match(/Agent ID: (\S+)/)?.[1];
+    expect(id, "background spawn should surface an agent id").toBeTruthy();
+
+    // The user stops it — same path the viewer's stop key uses (manager.abort).
+    eventHandlers.get("subagents:rpc:stop")?.({ requestId: "r1", agentId: id });
+
+    const res = await tools.get("get_subagent_result").execute(
+      "tc3", { agent_id: id }, undefined, undefined, ctx(),
+    );
+
+    const out = textOf(res);
+    expect(out).toContain("STOPPED BY THE USER");
+    expect(out).toContain("the task was NOT finished");
+    expect(out).not.toContain("Done"); // not surfaced as a normal completion
+  });
+});

--- a/packages/pi-subagents/test/subagent-error-status-e2e.test.ts
+++ b/packages/pi-subagents/test/subagent-error-status-e2e.test.ts
@@ -1,0 +1,102 @@
+/**
+ * subagent-error-status-e2e.test.ts — regression for issue #144: a subagent
+ * whose final assistant turn is a provider error must be reported as a
+ * failure, not as "completed" with an empty (or stale) result.
+ *
+ * Full-stack: real pi loader + real extension + real runAgent + real child
+ * sessions on a faux model.
+ */
+import { fauxAssistantMessage, fauxText, fauxToolCall } from "@earendil-works/pi-ai";
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  agentCall,
+  type PrintModeRun,
+  routeBySession,
+  runPrintMode,
+} from "./helpers/print-mode-runner.js";
+
+/** Text of the parent's Agent tool result — what the orchestrator LLM sees. */
+function agentToolResult(session: AgentSession): string {
+  const msg = [...session.messages].reverse().find(
+    (m) => m.role === "toolResult" && (m as { toolName?: string }).toolName === "Agent",
+  );
+  return ((msg?.content ?? []) as Array<{ text?: string }>).map((b) => b.text ?? "").join("");
+}
+
+vi.setConfig({ testTimeout: 30_000 });
+
+// Not matched by pi's transient-error patterns → no auto-retry, deterministic.
+const FATAL = "invalid request: provider rejected the prompt";
+
+describe("issue #144 — empty-error final turns must not be 'completed'", () => {
+  let run: PrintModeRun | undefined;
+  afterEach(async () => {
+    await run?.dispose();
+    run = undefined;
+  });
+
+  it("a run whose ONLY turn errors with no output is a failure, not an empty success", async () => {
+    run = await runPrintMode({
+      prompt: "Delegate.",
+      respond: routeBySession({
+        parentInitial: agentCall({ description: "doomed", prompt: "Do work." }),
+        parentFinal: "parent done",
+        // The child's one and only turn: provider error, zero content.
+        subagent: () => fauxAssistantMessage([], { stopReason: "error", errorMessage: FATAL }),
+      }),
+    });
+
+    // DESIRED: the orchestrator sees a failure naming the provider error —
+    // not a clean success reading "No output.".
+    const toolResult = agentToolResult(run.parentSession);
+    expect(toolResult).toContain(FATAL);
+    expect(toolResult).not.toContain("No output.");
+  });
+
+  it("an earlier turn's text must not mask a failed final turn as a fresh success", async () => {
+    run = await runPrintMode({
+      prompt: "Delegate.",
+      respond: routeBySession({
+        parentInitial: agentCall({ description: "masked", prompt: "Do work." }),
+        parentFinal: "parent done",
+        subagent: (ctx) => {
+          const hasToolResult = ctx.messages.some((m) => m.role === "toolResult");
+          // Turn 1: real text + a tool call. Turn 2 (after the tool result):
+          // provider error with zero content.
+          return hasToolResult
+            ? fauxAssistantMessage([], { stopReason: "error", errorMessage: FATAL })
+            : fauxAssistantMessage([
+                fauxText("EARLIER-PARTIAL-TEXT"),
+                fauxToolCall("bash", { command: "echo hi" }),
+              ]);
+        },
+      }),
+    });
+
+    // The orchestrator sees the failure (not the earlier text as a clean
+    // answer), AND the partial output is salvaged, clearly labeled as
+    // pre-failure so it can't be mistaken for the final answer.
+    const toolResult = agentToolResult(run.parentSession);
+    expect(toolResult).toContain(FATAL);
+    expect(toolResult).toContain("Partial output before the failure:");
+    expect(toolResult).toContain("EARLIER-PARTIAL-TEXT");
+    // The failure headline comes before the salvaged partial output.
+    expect(toolResult.indexOf(FATAL)).toBeLessThan(toolResult.indexOf("EARLIER-PARTIAL-TEXT"));
+  });
+
+  it("a pure empty-error run shows no 'partial output' section", async () => {
+    run = await runPrintMode({
+      prompt: "Delegate.",
+      respond: routeBySession({
+        parentInitial: agentCall({ description: "empty", prompt: "Do work." }),
+        parentFinal: "parent done",
+        subagent: () => fauxAssistantMessage([], { stopReason: "error", errorMessage: FATAL }),
+      }),
+    });
+
+    const toolResult = agentToolResult(run.parentSession);
+    expect(toolResult).toContain(FATAL);
+    expect(toolResult).not.toContain("Partial output before the failure:");
+  });
+});

--- a/packages/pi-subagents/test/subagents-print-mode-e2e.test.ts
+++ b/packages/pi-subagents/test/subagents-print-mode-e2e.test.ts
@@ -1,0 +1,349 @@
+/**
+ * subagents-print-mode-e2e.test.ts — REAL end-to-end subagent runs through the
+ * headless print-mode host (`test/helpers/print-mode-runner.ts`).
+ *
+ * Unlike agent-runner-e2e / ext-templates-e2e (which assert on the gated tool
+ * set captured at construction and never drive a turn), these tests drive a real
+ * parent turn that calls the `Agent` tool, lets the extension spawn a real child
+ * session via the real `runAgent`, and waits for it through the real subagent
+ * hold condition — then asserts on what actually flowed back.
+ *
+ * Deterministic by default: a scripted faux model drives both parent and child
+ * (no network). The same runner also drives a real LLM when PI_E2E_LIVE=1 — the
+ * `live` describe below is a smoke test for that opt-in path.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Context } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  agentCall,
+  agentToolCalls,
+  agentToolResults,
+  conversationText,
+  invokedToolNames,
+  type PrintModeRun,
+  routeBySession,
+  runPrintMode,
+} from "./helpers/print-mode-runner.js";
+
+// Real pi-mono (loader + dynamic extension import + two live sessions) — a cold
+// run under full-suite CPU contention can exceed vitest's 5s default.
+vi.setConfig({ testTimeout: 30_000 });
+
+const LIVE = /^(1|true|yes)$/i.test(process.env.PI_E2E_LIVE ?? "");
+
+describe.skipIf(LIVE)("subagents print-mode e2e (scripted faux, real pi-mono)", () => {
+  let run: PrintModeRun | undefined;
+  const tmpDirs: string[] = [];
+
+  afterEach(async () => {
+    await run?.dispose();
+    run = undefined;
+    for (const d of tmpDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  it("spawns a FOREGROUND subagent and routes its real output back to the parent", async () => {
+    run = await runPrintMode({
+      prompt: "Delegate the greeting to a subagent.",
+      respond: routeBySession({
+        parentInitial: agentCall({
+          subagent_type: "general-purpose",
+          description: "greet",
+          prompt: "Say hello.",
+          run_in_background: false,
+        }),
+        // NON-circular: the parent's final answer echoes whatever the child's
+        // result actually was in context. If the child output didn't reach the
+        // parent, this returns CHILD_MISSING and the responseText assertion fails.
+        parentFinal: (ctx: Context) => {
+          const childOut = [...ctx.messages]
+            .reverse()
+            .find((m) => m.role === "toolResult" && (m as { toolName?: string }).toolName === "Agent");
+          const text = ((childOut?.content ?? []) as Array<{ text?: string }>)
+            .map((b) => b.text ?? "")
+            .join("");
+          return `Parent relays: ${text.includes("CHILD_GREETING_OK") ? "CHILD_GREETING_OK" : "CHILD_MISSING"}`;
+        },
+        subagent: "CHILD_GREETING_OK",
+      }),
+    });
+
+    // The child actually ran: its output reached the parent via the Agent tool
+    // result (real record.result), and the parent's final answer was derived
+    // from that result — not a value the test hard-coded into the parent.
+    const toolResults = agentToolResults(run.parentSession);
+    expect(toolResults.length).toBe(1);
+    expect(toolResults[0]).toContain("CHILD_GREETING_OK");
+    expect(run.responseText).toContain("CHILD_GREETING_OK");
+    expect(run.responseText).not.toContain("CHILD_MISSING");
+    // Parent t1 (Agent call) + child t1 (reply) + parent t2 (final) = 3 calls.
+    expect(run.modelCalls).toBeGreaterThanOrEqual(3);
+  });
+
+  it("the hold condition is load-bearing: it keeps a BACKGROUND child alive (vs abandoned without it)", async () => {
+    // The child takes a beat to "think" (a real delay in its faux turn). That
+    // delay is what makes the contrast causal and deterministic:
+    //   - WITHOUT the hold, the parent's turn ends and the runner tears down
+    //     before the child ever streams → the child is abandoned (2 model calls:
+    //     parent's tool-call turn + its summary turn; the child never runs).
+    //   - WITH the hold, the parent loop blocks in waitForAll() until the child
+    //     finishes → the child's own model turn actually runs (≥3 calls).
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    const respond = async (ctx: Context) => {
+      const isParent = (ctx.tools ?? []).some((t) => t.name === "Agent");
+      if (!isParent) {
+        await sleep(80); // child takes long enough that a non-held parent exits first
+        return "CHILD_BG_RAN";
+      }
+      const spawned = ctx.messages.some(
+        (m) => m.role === "toolResult" && (m as { toolName?: string }).toolName === "Agent",
+      );
+      return spawned
+        ? "summarized"
+        : agentCall({ description: "bg work", prompt: "Do background work.", run_in_background: true });
+    };
+
+    // Control: no hold → the child hasn't run by the time the parent turn ends.
+    // `modelCalls` is snapshotted at that moment (it's a plain number on the
+    // result), so draining afterwards to tear down cleanly doesn't change it.
+    const noHold = await runPrintMode({ prompt: "go", hold: false, respond });
+    const abandonedCalls = noHold.modelCalls;
+    await noHold.manager?.waitForAll(); // let the orphan finish before dispose (avoids stale-ctx)
+    await noHold.dispose();
+
+    // Subject: hold on → child runs to completion before the parent finishes.
+    run = await runPrintMode({ prompt: "go", hold: true, respond });
+
+    // Background spawn returns its envelope synchronously either way.
+    expect(agentToolResults(run.parentSession)[0]).toMatch(/background/i);
+    // The hold is load-bearing: only with it does the child's turn actually run.
+    expect(abandonedCalls).toBe(2); // parent tool-call + summary; child never streamed
+    expect(run.modelCalls).toBeGreaterThan(abandonedCalls);
+    expect(run.modelCalls).toBeGreaterThanOrEqual(3);
+  });
+
+  it("spawns a FRONTMATTER-defined (.pi/agents/*.md) agent and its prompt reaches the child", async () => {
+    // A project agent whose body is a distinctive system prompt. Proving the
+    // child SAW it proves the full chain: the extension discovers the .md from
+    // process.cwd(), parses its frontmatter, and runAgent's buildAgentPrompt
+    // feeds the body into the real child session.
+    const MARKER = "SPYMARKER_FRONTMATTER_REACHED_CHILD";
+    const cwd = mkdtempSync(join(tmpdir(), "subagents-fm-"));
+    tmpDirs.push(cwd);
+    mkdirSync(join(cwd, ".pi", "agents"), { recursive: true });
+    writeFileSync(
+      join(cwd, ".pi", "agents", "echo-spy.md"),
+      `---\ndescription: "Echoes a marker proving its frontmatter prompt reached the child."\n---\n${MARKER}\n`,
+    );
+
+    run = await runPrintMode({
+      prompt: "Delegate to the echo-spy agent.",
+      cwd, // runner chdir's here so the extension discovers echo-spy.md
+      respond: routeBySession({
+        parentInitial: agentCall({
+          subagent_type: "echo-spy",
+          description: "echo",
+          prompt: "Report what you were told.",
+          run_in_background: false,
+        }),
+        parentFinal: "Reported.",
+        // The child reflects whether the frontmatter body reached its own prompt.
+        subagent: (ctx: Context) =>
+          `child saw: ${ctx.systemPrompt?.includes(MARKER) ? MARKER : "MISSING"}`,
+      }),
+    });
+
+    const toolResults = agentToolResults(run.parentSession);
+    expect(toolResults.length).toBe(1);
+    expect(toolResults[0]).toContain(MARKER);
+    expect(toolResults[0]).not.toContain("MISSING");
+    // The custom type resolved — it did NOT silently fall back to general-purpose.
+    expect(toolResults[0]).not.toMatch(/Unknown agent type/i);
+  });
+
+  it("spawns a FRONTMATTER-defined (.agents/agents/*.md) agent and its prompt reaches the child", async () => {
+    const MARKER = "SPYMARKER_AGENTS_FRONTMATTER_REACHED_CHILD";
+    const cwd = mkdtempSync(join(tmpdir(), "subagents-agents-fm-"));
+    tmpDirs.push(cwd);
+    mkdirSync(join(cwd, ".agents", "agents"), { recursive: true });
+    writeFileSync(
+      join(cwd, ".agents", "agents", "agents-spy.md"),
+      `---\ndescription: "Echoes a marker from the .agents/agents workspace dir."\n---\n${MARKER}\n`,
+    );
+
+    run = await runPrintMode({
+      prompt: "Delegate to the agents-spy agent.",
+      cwd,
+      respond: routeBySession({
+        parentInitial: agentCall({
+          subagent_type: "agents-spy",
+          description: "echo workspace",
+          prompt: "Report what you were told.",
+          run_in_background: false,
+        }),
+        parentFinal: "Reported.",
+        subagent: (ctx: Context) =>
+          `child saw: ${ctx.systemPrompt?.includes(MARKER) ? MARKER : "MISSING"}`,
+      }),
+    });
+
+    const toolResults = agentToolResults(run.parentSession);
+    expect(toolResults.length).toBe(1);
+    expect(toolResults[0]).toContain(MARKER);
+    expect(toolResults[0]).not.toContain("MISSING");
+    expect(toolResults[0]).not.toMatch(/Unknown agent type/i);
+  });
+
+  it("errors clearly when faux mode is given no script", async () => {
+    await expect(runPrintMode({ prompt: "x" })).rejects.toThrow(/provide `respond` or `steps`/);
+  });
+
+  it("times out with the runner's own descriptive error and restores the environment", async () => {
+    const prevCwd = process.cwd();
+    // A responder that never resolves — the turn stalls until the wall-clock guard fires.
+    await expect(
+      runPrintMode({ prompt: "stall", respond: () => new Promise(() => {}), timeoutMs: 300 }),
+    ).rejects.toThrow(/print-mode runner timed out after 300ms/);
+    // The failure path ran dispose(): cwd and global isolation were restored even
+    // though the caller never received a dispose handle.
+    expect(process.cwd()).toBe(prevCwd);
+    expect((globalThis as Record<symbol, unknown>)[Symbol.for("pi-subagents:manager")]).toBeUndefined();
+  });
+});
+
+// Opt-in real-LLM smoke tests — exercise the SAME runner against a live model
+// (auto-resolved from the local `pi` login). Skipped unless PI_E2E_LIVE=1.
+//
+// These are SMOKE tests, not strict assertions: a live model decides whether and
+// how to call the tool, so we cover the subset it can be reliably steered into
+// (foreground spawn, background spawn + get_subagent_result, an Explore spawn)
+// and assert robust invariants (a real spawn happened and produced output).
+// Per-feature determinism lives in the faux suite above, which scripts exact calls.
+const LIVE_TIMEOUT = 150_000;
+// SELF-SMOKE chains three live spawns in one session; passing runs land ~145s,
+// but live variance (slow turns, provider retries, extra polling) has blown past
+// 2× that — give it 4× so the smoke doesn't flake on latency alone.
+const SELF_SMOKE_TIMEOUT = 600_000;
+// The vitest per-test timer starts before runPrintMode and should not fire
+// first: the runner's own timeoutMs guard produces a descriptive error and
+// aborts the live session + subagents, while a vitest timeout is generic and
+// leaks them. The slack covers live setup/teardown outside the runner's guard.
+const VITEST_SLACK = 30_000;
+const LIVE_VITEST_TIMEOUT = LIVE_TIMEOUT + VITEST_SLACK;
+const SELF_SMOKE_VITEST_TIMEOUT = SELF_SMOKE_TIMEOUT + VITEST_SLACK;
+
+describe.runIf(LIVE)("subagents print-mode e2e (live LLM, opt-in)", () => {
+  let run: PrintModeRun | undefined;
+  afterEach(async () => {
+    await run?.dispose();
+    run = undefined;
+  });
+
+  it(
+    "FOREGROUND spawn — real model spawns a subagent and reports its output",
+    async () => {
+      run = await runPrintMode({
+        prompt:
+          "Use the Agent tool to spawn a general-purpose subagent (run_in_background: false) " +
+          "whose only task is to reply with the exact word PONG, then tell me what it replied.",
+        timeoutMs: LIVE_TIMEOUT,
+      });
+      expect(run.modelCalls).toBe(0); // live mode doesn't use the faux counter
+      expect(invokedToolNames(run.parentSession)).toContain("Agent");
+      // The child actually ran and its output came back through the tool result.
+      expect(agentToolResults(run.parentSession).join("\n")).toMatch(/PONG/i);
+      expect(run.responseText).toMatch(/PONG/i);
+    },
+    LIVE_VITEST_TIMEOUT,
+  );
+
+  it(
+    "BACKGROUND spawn + get_subagent_result — model backgrounds work then retrieves it",
+    async () => {
+      run = await runPrintMode({
+        prompt:
+          "Spawn a general-purpose subagent IN THE BACKGROUND (run_in_background: true) whose " +
+          "only task is to reply with the exact word BGPONG. After it finishes, use the " +
+          "get_subagent_result tool to fetch its result, then tell me exactly what it said.",
+        timeoutMs: LIVE_TIMEOUT,
+      });
+      const calls = agentToolCalls(run.parentSession);
+      // The model used the background feature…
+      expect(calls.some((c) => c.run_in_background === true)).toBe(true);
+      // …and the spawn returned the "started in background" envelope…
+      expect(agentToolResults(run.parentSession).join("\n")).toMatch(/background/i);
+      // …and the background child genuinely ran (its result surfaced somewhere:
+      // via get_subagent_result and/or the held final answer).
+      expect(run.responseText).toMatch(/BGPONG/i);
+    },
+    LIVE_VITEST_TIMEOUT,
+  );
+
+  it(
+    "Explore subagent_type — model dispatches a non-default agent type",
+    async () => {
+      run = await runPrintMode({
+        prompt:
+          "Use the Agent tool with subagent_type 'Explore' to look at the current working " +
+          "directory and report a one-line summary of what's there.",
+        timeoutMs: LIVE_TIMEOUT,
+      });
+      const calls = agentToolCalls(run.parentSession);
+      // The non-default type was actually selected (case-insensitive per README).
+      expect(
+        calls.some((c) => String(c.subagent_type ?? "").toLowerCase() === "explore"),
+      ).toBe(true);
+      expect(run.responseText.length).toBeGreaterThan(0);
+    },
+    LIVE_VITEST_TIMEOUT,
+  );
+
+  it(
+    "SELF-SMOKE — the agent drives a multi-feature smoke of its own Agent toolset",
+    async () => {
+      // Agent-driven (not puppeted): one prompt, the model itself exercises three
+      // Agent capabilities in a single session and self-reports. We then assert it
+      // genuinely invoked each feature (not just that it claimed to in prose).
+      run = await runPrintMode({
+        prompt: [
+          "You are smoke-testing your own Agent toolset. Do these steps IN ORDER, then print a",
+          "final report with one PASS/FAIL line per step:",
+          "1) FOREGROUND: spawn a general-purpose subagent (run_in_background: false) whose only",
+          "   task is to reply with the exact token FG_OK. Confirm you got FG_OK back.",
+          "2) BACKGROUND: spawn a general-purpose subagent with run_in_background: true whose only",
+          "   task is to reply with the exact token BG_OK. After it finishes, call get_subagent_result",
+          "   to retrieve its output. Confirm you got BG_OK.",
+          "3) EXPLORE: spawn a subagent with subagent_type 'Explore' to summarize the current",
+          "   working directory in one line.",
+          "Finish with: 'SELF-SMOKE COMPLETE' followed by the PASS/FAIL lines.",
+        ].join("\n"),
+        timeoutMs: SELF_SMOKE_TIMEOUT,
+      });
+
+      const calls = agentToolCalls(run.parentSession);
+      const tools = invokedToolNames(run.parentSession);
+
+      // Each capability was actually exercised at the tool layer (not just narrated):
+      // — a foreground spawn (run_in_background not true on at least one Agent call)
+      expect(calls.some((c) => c.run_in_background !== true)).toBe(true);
+      // — a background spawn
+      expect(calls.some((c) => c.run_in_background === true)).toBe(true);
+      // — the result-retrieval tool was called
+      expect(tools).toContain("get_subagent_result");
+      // — the Explore type was dispatched
+      expect(calls.some((c) => String(c.subagent_type ?? "").toLowerCase() === "explore")).toBe(true);
+      // — and the real child outputs materialized in the conversation (the
+      //   foreground tool result + the get_subagent_result result). We check the
+      //   whole transcript, not the final message: the agent's closing report
+      //   tends to summarize ("Step 1 PASS") rather than re-echo the raw tokens.
+      const transcript = conversationText(run.parentSession);
+      expect(transcript).toMatch(/FG_OK/i);
+      expect(transcript).toMatch(/BG_OK/i);
+      // The agent ran the whole script to completion and self-reported.
+      expect(run.responseText).toMatch(/SELF-SMOKE COMPLETE/i);
+    },
+    SELF_SMOKE_VITEST_TIMEOUT,
+  );
+});

--- a/packages/pi-subagents/test/tool-description-mode.test.ts
+++ b/packages/pi-subagents/test/tool-description-mode.test.ts
@@ -1,0 +1,218 @@
+// End-to-end test for `toolDescriptionMode` (#91): settings file → sanitize →
+// applier → registration-time description pick. Instantiates the real extension
+// with a mock pi (same pattern as print-mode.test.ts) inside a temp cwd, then
+// inspects the registered Agent tool's description.
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import subagentsExtension from "../src/index.js";
+
+const EXAMPLE_TEMPLATE = fileURLToPath(new URL("../examples/agent-tool-description.md", import.meta.url));
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const handlers = new Map<string, any>();
+
+  return {
+    pi: {
+      registerMessageRenderer: vi.fn(),
+      registerTool: vi.fn((tool: any) => {
+        tools.set(tool.name, tool);
+      }),
+      registerCommand: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        handlers.set(event, handler);
+      }),
+      events: {
+        emit: vi.fn(),
+        on: vi.fn(() => vi.fn()),
+      },
+      appendEntry: vi.fn(),
+      sendMessage: vi.fn(),
+    } as any,
+    tools,
+    handlers,
+  };
+}
+
+describe("toolDescriptionMode", () => {
+  let tmpDir: string;
+  let hermeticAgentDir: string;
+  let prevCwd: string;
+  let prevAgentDir: string | undefined;
+  let prevHome: string | undefined;
+  let shutdown: (() => Promise<void>) | undefined;
+
+  function setup(settings?: Record<string, unknown>, beforeInstantiate?: () => void) {
+    tmpDir = mkdtempSync(join(tmpdir(), "pi-tooldesc-"));
+    // Isolate global settings (getAgentDir / ~/.pi) so the dev's real
+    // subagents.json can't leak into the "default is full" assertion.
+    hermeticAgentDir = mkdtempSync(join(tmpdir(), "pi-tooldesc-agentdir-"));
+    prevAgentDir = process.env.PI_CODING_AGENT_DIR;
+    prevHome = process.env.HOME;
+    process.env.PI_CODING_AGENT_DIR = hermeticAgentDir;
+    process.env.HOME = hermeticAgentDir;
+    prevCwd = process.cwd();
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    if (settings) {
+      writeFileSync(join(tmpDir, ".pi", "subagents.json"), JSON.stringify(settings));
+    }
+    beforeInstantiate?.();
+    process.chdir(tmpDir);
+
+    const { pi, tools, handlers } = makePi();
+    subagentsExtension(pi);
+    shutdown = async () => {
+      await handlers.get("session_shutdown")?.({}, { hasUI: false, ui: {} } as any);
+    };
+    return tools;
+  }
+
+  afterEach(async () => {
+    await shutdown?.();
+    shutdown = undefined;
+    process.chdir(prevCwd);
+    if (prevAgentDir == null) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = prevAgentDir;
+    if (prevHome == null) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(hermeticAgentDir, { recursive: true, force: true });
+  });
+
+  it("defaults to the full description", () => {
+    const tools = setup();
+    const desc: string = tools.get("Agent").description;
+    expect(desc).toContain("## Usage notes");
+    expect(desc).toContain("## Writing the prompt");
+    // Full agent descriptions are embedded (a late Explore sentence survives).
+    expect(desc).toContain("very thorough");
+  });
+
+  it("compact mode swaps in the short description with one-line type list", () => {
+    const tools = setup({ toolDescriptionMode: "compact" });
+    const desc: string = tools.get("Agent").description;
+    expect(desc).toContain("Launch an autonomous agent");
+    expect(desc).not.toContain("## Usage notes");
+    expect(desc).not.toContain("## Writing the prompt");
+    // Type list keeps every agent but only the first sentence of each description.
+    expect(desc).toContain("- general-purpose:");
+    expect(desc).toContain("- Explore: Fast read-only search agent for locating code. (Tools:");
+    expect(desc).not.toContain("very thorough");
+    // The point of the feature: materially smaller than the full version.
+    expect(desc.length).toBeLessThan(1600);
+  });
+
+  it("invalid mode in the settings file is dropped — full description", () => {
+    const tools = setup({ toolDescriptionMode: "tiny" });
+    const desc: string = tools.get("Agent").description;
+    expect(desc).toContain("## Usage notes");
+  });
+
+  it("compact keeps every load-bearing contract — fails when a behavior change forgets compact", () => {
+    const tools = setup({ toolDescriptionMode: "compact" });
+    const desc: string = tools.get("Agent").description;
+    // One keyword per behavioral contract the orchestrator must know about.
+    // If you change one of these behaviors, update BOTH descriptions.
+    for (const contract of [
+      "run_in_background",
+      "resume",
+      "steer_subagent",
+      'isolation: "worktree"',
+      ".pi/agents/",
+      "self-contained",
+    ]) {
+      expect(desc).toContain(contract);
+    }
+  });
+
+  it("custom mode renders the project template with placeholders substituted", () => {
+    const tools = setup({ toolDescriptionMode: "custom" }, () => {
+      writeFileSync(
+        join(tmpDir, ".pi", "agent-tool-description.md"),
+        "My agents:\n{{typeList}}\n\nGlobal dir: {{agentDir}}\nUnknown: {{nope}}\nCost: $& stays literal",
+      );
+    });
+    const desc: string = tools.get("Agent").description;
+    expect(desc).toContain("My agents:");
+    expect(desc).toContain("- general-purpose:"); // {{typeList}} expanded
+    expect(desc).toContain(`Global dir: ${hermeticAgentDir}`); // {{agentDir}} expanded
+    expect(desc).toContain("Unknown: {{nope}}"); // unknown placeholder left verbatim
+    expect(desc).toContain("Cost: $& stays literal"); // no $-pattern expansion
+    expect(desc).not.toContain("## Usage notes");
+  });
+
+  it("custom mode falls back to the global file when no project file exists", () => {
+    const tools = setup({ toolDescriptionMode: "custom" }, () => {
+      writeFileSync(join(hermeticAgentDir, "agent-tool-description.md"), "GLOBAL CUSTOM\n{{compactTypeList}}");
+    });
+    const desc: string = tools.get("Agent").description;
+    expect(desc).toContain("GLOBAL CUSTOM");
+    expect(desc).toContain("- Explore: Fast read-only search agent for locating code. (Tools:");
+  });
+
+  it("{{scheduleGuideline}} expands to the schedule bullet when scheduling is on (default)", () => {
+    const tools = setup({ toolDescriptionMode: "custom" }, () => {
+      writeFileSync(join(tmpDir, ".pi", "agent-tool-description.md"), "RULES:{{scheduleGuideline}}\nEND");
+    });
+    const desc: string = tools.get("Agent").description;
+    // The expansion carries its own leading "\n- " bullet.
+    expect(desc).toContain("RULES:\n- Use `schedule` only when");
+  });
+
+  it("{{scheduleGuideline}} expands to the empty string when scheduling is disabled", () => {
+    const tools = setup({ toolDescriptionMode: "custom", schedulingEnabled: false }, () => {
+      writeFileSync(join(tmpDir, ".pi", "agent-tool-description.md"), "RULES:{{scheduleGuideline}}\nEND");
+    });
+    const desc: string = tools.get("Agent").description;
+    expect(desc).toContain("RULES:\nEND");
+    expect(desc).not.toContain("schedule");
+  });
+
+  it("every documented placeholder is replaced — no {{ }} residue", () => {
+    const tools = setup({ toolDescriptionMode: "custom" }, () => {
+      writeFileSync(
+        join(tmpDir, ".pi", "agent-tool-description.md"),
+        "A {{typeList}} B {{compactTypeList}} C {{agentDir}} D {{scheduleGuideline}} E",
+      );
+    });
+    const desc: string = tools.get("Agent").description;
+    expect(desc).not.toContain("{{");
+    expect(desc).not.toContain("}}");
+  });
+
+  it("the shipped example template renders byte-identical to the full description", async () => {
+    // Guards examples/agent-tool-description.md against going stale: it must
+    // reproduce the full description exactly. If you edit one, edit the other.
+    const example = readFileSync(EXAMPLE_TEMPLATE, "utf-8");
+    const tools = setup({ toolDescriptionMode: "custom" }, () => {
+      writeFileSync(join(tmpDir, ".pi", "agent-tool-description.md"), example);
+    });
+    const customDesc: string = tools.get("Agent").description;
+
+    // Second instance in the same hermetic cwd, flipped to full mode.
+    writeFileSync(join(tmpDir, ".pi", "subagents.json"), JSON.stringify({ toolDescriptionMode: "full" }));
+    const second = makePi();
+    subagentsExtension(second.pi);
+    try {
+      expect(customDesc).toBe(second.tools.get("Agent").description);
+    } finally {
+      await second.handlers.get("session_shutdown")?.({}, { hasUI: false, ui: {} } as any);
+    }
+  });
+
+  it("custom mode without a file falls back to the full description with a warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const tools = setup({ toolDescriptionMode: "custom" });
+      const desc: string = tools.get("Agent").description;
+      expect(desc).toContain("## Usage notes");
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("no agent-tool-description.md found"));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/pi-subagents/test/tool-render.test.ts
+++ b/packages/pi-subagents/test/tool-render.test.ts
@@ -127,3 +127,32 @@ describe("renderAgentLikeResult", () => {
     expect(out.split("\n").length).toBeLessThan(6);
   });
 });
+
+describe("resultBodyText header peel", () => {
+  it("keeps multi-paragraph errors intact (does not drop first segment)", () => {
+    const text =
+      'Model not in scope: "foo".\n\nAllowed models (from enabledModels):\n  anthropic/claude';
+    expect(resultBodyText(text)).toContain("Model not in scope");
+    expect(resultBodyText(text)).toContain("Allowed models");
+    expect(firstLinePreview(resultBodyText(text))).toMatch(/Model not in scope/);
+  });
+
+  it("still peels Agent completed status headers", () => {
+    const text = "Agent completed in 1.2s (3 tool uses).\n\n## Findings\n\nok";
+    expect(resultBodyText(text)).toContain("## Findings");
+    expect(resultBodyText(text)).not.toMatch(/^Agent completed/);
+  });
+});
+
+describe("renderUndetailedResult", () => {
+  it("does not paint success for plain validation failures", async () => {
+    const { renderUndetailedResult } = await import("../src/ui/tool-render.js");
+    const text =
+      'Model not in scope: "foo".\n\nAllowed models (from enabledModels):\n  anthropic/claude';
+    const component = renderUndetailedResult(text, { expanded: false }, theme());
+    const out = plain(component);
+    expect(out).toMatch(/✗/);
+    expect(out).not.toMatch(/✓/);
+    expect(out).toMatch(/Model not in scope/);
+  });
+});

--- a/packages/pi-subagents/test/tool-render.test.ts
+++ b/packages/pi-subagents/test/tool-render.test.ts
@@ -156,3 +156,49 @@ describe("renderUndetailedResult", () => {
     expect(out).toMatch(/Model not in scope/);
   });
 });
+
+describe("formatAgentCallMeta / formatAgentDetailsStats", () => {
+  it("call meta always shows model chip (inherit when unset)", async () => {
+    const { formatAgentCallMeta } = await import("../src/ui/tool-render.js");
+    expect(formatAgentCallMeta({})).toBe("model: inherit");
+    expect(formatAgentCallMeta({ model: "haiku", effort: "high", background: true })).toBe(
+      "haiku · effort: high · bg",
+    );
+    expect(formatAgentCallMeta({ model: "haiku", modelInherited: true })).toBe("haiku (inherit)");
+  });
+
+  it("result stats include model (inherit) and effort", async () => {
+    const { formatAgentDetailsStats } = await import("../src/ui/tool-render.js");
+    const s = formatAgentDetailsStats(
+      {
+        displayName: "Explore",
+        description: "x",
+        subagentType: "Explore",
+        toolUses: 2,
+        tokens: "1.0k token",
+        durationMs: 1000,
+        status: "completed",
+        modelName: "haiku",
+        modelInherited: true,
+        effort: "high",
+        tags: ["effort: high", "background"],
+      },
+      theme(),
+    );
+    expect(s).toContain("haiku (inherit)");
+    expect(s).toContain("effort: high");
+    expect(s).toContain("background");
+    expect(s).toContain("2 tool uses");
+    // effort not duplicated from tags
+    expect(s.match(/effort: high/g)?.length).toBe(1);
+  });
+});
+
+describe("shortModelLabel", () => {
+  it("strips Claude prefix and lowercases", async () => {
+    const { shortModelLabel } = await import("../src/ui/agent-widget.js");
+    expect(shortModelLabel({ name: "Claude Sonnet 4", id: "claude-sonnet-4" })).toBe("sonnet 4");
+    expect(shortModelLabel({ id: "haiku" })).toBe("haiku");
+    expect(shortModelLabel(undefined)).toBeUndefined();
+  });
+});

--- a/packages/pi-subagents/test/tool-render.test.ts
+++ b/packages/pi-subagents/test/tool-render.test.ts
@@ -227,3 +227,75 @@ describe("shortModelLabel", () => {
     expect(shortModelLabel(undefined)).toBeUndefined();
   });
 });
+
+describe("Agent → invocation → get_subagent_result inherit contract", () => {
+  it("detailsFromInvocation preserves modelInherited for result stats", async () => {
+    const { detailsFromInvocation } = await import("../src/ui/agent-widget.js");
+    const { formatAgentDetailsStats, formatAgentCallMeta, renderAgentLikeResult } = await import(
+      "../src/ui/tool-render.js"
+    );
+
+    // What Agent tool stores on record.invocation at spawn time.
+    const invocation = {
+      modelName: "sonnet",
+      modelInherited: true,
+      thinking: "high" as const,
+      runInBackground: true,
+    };
+
+    // What get_subagent_result rebuilds into AgentDetails.
+    const fromInv = detailsFromInvocation(invocation);
+    expect(fromInv.modelName).toBe("sonnet");
+    expect(fromInv.modelInherited).toBe(true);
+    expect(fromInv.effort).toBe("high");
+
+    const stats = formatAgentDetailsStats(
+      {
+        displayName: "Explore",
+        description: "x",
+        subagentType: "Explore",
+        toolUses: 1,
+        tokens: "1k token",
+        durationMs: 1000,
+        status: "completed",
+        ...fromInv,
+      },
+      theme(),
+    );
+    expect(stats).toContain("sonnet (inherit)");
+    expect(stats).toContain("effort: high");
+
+    // Call-line chips when record is still live.
+    expect(
+      formatAgentCallMeta({
+        model: invocation.modelName,
+        modelInherited: invocation.modelInherited,
+        effort: invocation.thinking,
+      }),
+    ).toBe("sonnet (inherit) · effort: high");
+
+    // Missing record/invocation must not invent inherit.
+    expect(formatAgentCallMeta({ extra: ["wait"] })).toBe("wait");
+    expect(formatAgentCallMeta({})).toBe("");
+
+    const out = plain(
+      renderAgentLikeResult(
+        {
+          displayName: "Explore",
+          description: "x",
+          subagentType: "Explore",
+          toolUses: 1,
+          tokens: "1k token",
+          durationMs: 1200,
+          status: "completed",
+          ...fromInv,
+        },
+        "Agent completed in 1.2s.\n\nall good",
+        { expanded: false },
+        theme(),
+      ),
+    );
+    expect(out).toContain("sonnet (inherit)");
+    expect(out).toMatch(/⎿\s+Done/);
+  });
+});

--- a/packages/pi-subagents/test/tool-render.test.ts
+++ b/packages/pi-subagents/test/tool-render.test.ts
@@ -165,6 +165,87 @@ describe("renderUndetailedResult", () => {
     expect(out).toMatch(/⎿/);
     expect(out).toMatch(/Model not in scope/);
   });
+
+  it("explicit isError=false never paints ✗ even when text mentions failed/invalid", async () => {
+    const { renderUndetailedResult } = await import("../src/ui/tool-render.js");
+    const text =
+      'Scheduled "Investigate failed tests" (id: job1, type: cron). Next run: tomorrow.';
+    const component = renderUndetailedResult(text, { expanded: false, isError: false }, theme());
+    const out = plain(component);
+    expect(out).not.toMatch(/✗/);
+    expect(out).toContain("Investigate failed tests");
+  });
+
+  it("explicit isError=true paints ✗ without relying on keywords", async () => {
+    const { renderUndetailedResult } = await import("../src/ui/tool-render.js");
+    const component = renderUndetailedResult("all good actually", { expanded: false, isError: true }, theme());
+    expect(plain(component)).toMatch(/✗/);
+  });
+});
+
+describe("looksLikeStatusHeader / isFailureDetailsStatus", () => {
+  it("does not peel unknown-agent notes or bare Agent:/Type: reports", async () => {
+    const { looksLikeStatusHeader, resultBodyText, isFailureDetailsStatus } = await import(
+      "../src/ui/tool-render.js",
+    );
+    expect(looksLikeStatusHeader("Note: Unknown agent type 'x'. Falling back to general-purpose.")).toBe(false);
+    const agentReport = "Agent: foo\nType: bar\n\n## Findings\n\nok";
+    expect(looksLikeStatusHeader(agentReport.split("\n\n")[0]!)).toBe(false);
+    expect(resultBodyText(agentReport)).toContain("Agent: foo");
+    expect(resultBodyText(agentReport)).toContain("## Findings");
+
+    const realMeta =
+      "Agent: abc\nType: Explore | Status: completed | Tool uses: 1\nDescription: x\n\nbody";
+    expect(resultBodyText(realMeta)).toBe("body");
+
+    expect(isFailureDetailsStatus("error")).toBe(true);
+    expect(isFailureDetailsStatus("aborted")).toBe(true);
+    expect(isFailureDetailsStatus("stopped")).toBe(true);
+    expect(isFailureDetailsStatus("completed")).toBe(false);
+    expect(isFailureDetailsStatus("queued")).toBe(false);
+  });
+});
+
+describe("terminal chrome variants", () => {
+  it("queued forces queued… not thinking…", () => {
+    const out = plain(
+      renderAgentLikeResult(
+        completedDetails({ status: "queued", durationMs: 0, activity: "thinking…", toolUses: 0, tokens: "" }),
+        "",
+        { expanded: false },
+        theme(),
+      ),
+    );
+    expect(out).toMatch(/queued/);
+    expect(out).not.toMatch(/thinking/);
+  });
+
+  it("steered shows warning ✓ + Wrapped up (turn limit)", () => {
+    const out = plain(
+      renderAgentLikeResult(
+        completedDetails({ status: "steered", durationMs: 1500 }),
+        "partial answer",
+        { expanded: false },
+        theme(),
+      ),
+    );
+    expect(out).toMatch(/✓/);
+    expect(out).toMatch(/Wrapped up \(turn limit\)/);
+  });
+
+  it("stopped shows ■ Stopped; aborted shows ✗ Aborted", () => {
+    const stopped = plain(
+      renderAgentLikeResult(completedDetails({ status: "stopped", durationMs: 900 }), "", { expanded: false }, theme()),
+    );
+    expect(stopped).toMatch(/■/);
+    expect(stopped).toMatch(/Stopped/);
+
+    const aborted = plain(
+      renderAgentLikeResult(completedDetails({ status: "aborted", durationMs: 900 }), "", { expanded: false }, theme()),
+    );
+    expect(aborted).toMatch(/✗/);
+    expect(aborted).toMatch(/Aborted/);
+  });
 });
 
 describe("background launch chrome", () => {

--- a/packages/pi-subagents/test/tool-render.test.ts
+++ b/packages/pi-subagents/test/tool-render.test.ts
@@ -78,14 +78,21 @@ describe("renderAgentLikeResult", () => {
     ...Array.from({ length: 40 }, (_, i) => `detail line ${i}`),
   ].join("\n");
 
-  it("collapsed completed result is a short Text preview without dumping the body wall", () => {
-    const component = renderAgentLikeResult(completedDetails(), hugeBody, { expanded: false }, theme());
+  it("collapsed completed result is Claude Code chrome (✓ stats / ⎿ Done), no body wall", () => {
+    const component = renderAgentLikeResult(
+      completedDetails({ modelName: "haiku", effort: "high", turnCount: 3 }),
+      hugeBody,
+      { expanded: false },
+      theme(),
+    );
     expect(component).toBeInstanceOf(Text);
     const out = plain(component);
-    expect(out).toMatch(/✓/);
-    expect(out).toMatch(/Report|# Report/);
+    expect(out).toMatch(/^✓/m);
+    expect(out).toContain("haiku");
+    expect(out).toContain("effort: high");
+    expect(out).toMatch(/⎿\s+Done/);
+    expect(out).not.toContain("LINE_SHOULD_STAY_COLLAPSED");
     expect(out).not.toContain("detail line 20");
-    expect(out).toMatch(/expand/i);
   });
 
   it("expanded completed result uses Markdown under a status header", () => {
@@ -101,16 +108,18 @@ describe("renderAgentLikeResult", () => {
     expect(out).toContain("Report");
   });
 
-  it("running status stays compact", () => {
+  it("running status is spinner + ⎿ activity (Claude Code shape)", () => {
     const component = renderAgentLikeResult(
-      completedDetails({ status: "running", durationMs: 0, activity: "reading src/a.ts" }),
+      completedDetails({ status: "running", durationMs: 0, activity: "reading src/a.ts", toolUses: 2 }),
       "",
       { expanded: false },
       theme(),
     );
     const out = plain(component, 100);
-    expect(out).toMatch(/running|reading/i);
-    expect(out).toContain("abc123");
+    expect(out).toMatch(/reading src\/a\.ts/);
+    expect(out).toMatch(/⎿/);
+    expect(out).toContain("2 tool uses");
+    expect(out).not.toContain("abc123"); // id stays off the running chrome (CC)
   });
 
   it("error collapsed shows error line without full dump", () => {
@@ -153,14 +162,30 @@ describe("renderUndetailedResult", () => {
     const out = plain(component);
     expect(out).toMatch(/✗/);
     expect(out).not.toMatch(/✓/);
+    expect(out).toMatch(/⎿/);
     expect(out).toMatch(/Model not in scope/);
   });
 });
 
+describe("background launch chrome", () => {
+  it("renders single ⎿ Running in background line", () => {
+    const component = renderAgentLikeResult(
+      completedDetails({ status: "background", agentId: "abc", durationMs: 0, toolUses: 0, tokens: "" }),
+      "",
+      { expanded: false },
+      theme(),
+    );
+    const out = plain(component);
+    expect(out).toMatch(/Running in background \(ID: abc\)/);
+    expect(out).toMatch(/⎿/);
+    expect(out).not.toMatch(/✓/);
+  });
+});
+
 describe("formatAgentCallMeta / formatAgentDetailsStats", () => {
-  it("call meta always shows model chip (inherit when unset)", async () => {
+  it("call meta is empty unless model/effort/bg explicitly set (clean CC title)", async () => {
     const { formatAgentCallMeta } = await import("../src/ui/tool-render.js");
-    expect(formatAgentCallMeta({})).toBe("model: inherit");
+    expect(formatAgentCallMeta({})).toBe("");
     expect(formatAgentCallMeta({ model: "haiku", effort: "high", background: true })).toBe(
       "haiku · effort: high · bg",
     );

--- a/packages/pi-subagents/test/tool-render.test.ts
+++ b/packages/pi-subagents/test/tool-render.test.ts
@@ -1,0 +1,129 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { Container, Markdown, Text, type Component } from "@earendil-works/pi-tui";
+import type { AgentDetails } from "../src/ui/agent-widget.js";
+import {
+  firstLinePreview,
+  renderAgentLikeResult,
+  resultBodyText,
+  toolResultText,
+} from "../src/ui/tool-render.js";
+
+beforeAll(() => {
+  initTheme("dark", false);
+});
+
+function plain(component: Component, width = 120): string {
+  return component
+    .render(width)
+    .map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd())
+    .join("\n");
+}
+
+function containerChildren(component: Component): Component[] {
+  return ((component as unknown as { children?: Component[] }).children ?? []) as Component[];
+}
+
+function theme() {
+  return {
+    fg: (_c: string, t: string) => t,
+    bold: (t: string) => t,
+  } as any;
+}
+
+function completedDetails(overrides: Partial<AgentDetails> = {}): AgentDetails {
+  return {
+    displayName: "Explore",
+    description: "find auth",
+    subagentType: "Explore",
+    toolUses: 3,
+    tokens: "1.2k token",
+    durationMs: 4200,
+    status: "completed",
+    agentId: "abc123",
+    ...overrides,
+  };
+}
+
+describe("toolResultText / previews", () => {
+  it("joins text content blocks", () => {
+    expect(
+      toolResultText({
+        content: [
+          { type: "text", text: "a" },
+          { type: "text", text: "b" },
+        ],
+      }),
+    ).toBe("a\nb");
+  });
+
+  it("strips status header for body preview", () => {
+    const full =
+      "Agent: abc\nType: Explore | Status: completed | Tool uses: 3\nDescription: x\n\n## Findings\n\n- auth.ts";
+    expect(resultBodyText(full)).toContain("## Findings");
+    expect(resultBodyText(full)).not.toMatch(/^Agent:/);
+    expect(firstLinePreview(resultBodyText(full))).toBe("## Findings");
+  });
+});
+
+describe("renderAgentLikeResult", () => {
+  const hugeBody = [
+    "Agent: abc123",
+    "Type: Explore | Status: completed | Tool uses: 3",
+    "Description: find auth",
+    "",
+    "# Report",
+    "",
+    "LINE_SHOULD_STAY_COLLAPSED",
+    ...Array.from({ length: 40 }, (_, i) => `detail line ${i}`),
+  ].join("\n");
+
+  it("collapsed completed result is a short Text preview without dumping the body wall", () => {
+    const component = renderAgentLikeResult(completedDetails(), hugeBody, { expanded: false }, theme());
+    expect(component).toBeInstanceOf(Text);
+    const out = plain(component);
+    expect(out).toMatch(/✓/);
+    expect(out).toMatch(/Report|# Report/);
+    expect(out).not.toContain("detail line 20");
+    expect(out).toMatch(/expand/i);
+  });
+
+  it("expanded completed result uses Markdown under a status header", () => {
+    const component = renderAgentLikeResult(completedDetails(), hugeBody, { expanded: true }, theme());
+    expect(component).toBeInstanceOf(Container);
+    const kids = containerChildren(component);
+    expect(kids.some((c) => c instanceof Text)).toBe(true);
+    expect(kids.some((c) => c instanceof Markdown)).toBe(true);
+
+    const out = plain(component, 100);
+    expect(out).toMatch(/✓/);
+    expect(out).toContain("detail line 20");
+    expect(out).toContain("Report");
+  });
+
+  it("running status stays compact", () => {
+    const component = renderAgentLikeResult(
+      completedDetails({ status: "running", durationMs: 0, activity: "reading src/a.ts" }),
+      "",
+      { expanded: false },
+      theme(),
+    );
+    const out = plain(component, 100);
+    expect(out).toMatch(/running|reading/i);
+    expect(out).toContain("abc123");
+  });
+
+  it("error collapsed shows error line without full dump", () => {
+    const text = "Agent: x\n\nError: boom\n" + "stack\n".repeat(30);
+    const component = renderAgentLikeResult(
+      completedDetails({ status: "error", error: "boom" }),
+      text,
+      { expanded: false },
+      theme(),
+    );
+    const out = plain(component, 100);
+    expect(out).toMatch(/✗/);
+    expect(out).toContain("boom");
+    expect(out.split("\n").length).toBeLessThan(6);
+  });
+});

--- a/packages/pi-subagents/test/usage.test.ts
+++ b/packages/pi-subagents/test/usage.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { getLifetimeTotal, getSessionContextPercent, getSessionTokens } from "../src/usage.js";
+
+// Regression for issue #38 — token semantics + context indicator
+describe("usage", () => {
+  describe("getSessionTokens", () => {
+    it("uses billed-token semantics (input + output + cacheWrite), not inflated total", () => {
+      const session = {
+        getSessionStats: () => ({
+          tokens: { input: 100, output: 200, cacheRead: 500_000, cacheWrite: 50, total: 500_350 } as any,
+          contextUsage: { tokens: 50_300, contextWindow: 200_000, percent: 25 },
+        }),
+      };
+      expect(getSessionTokens(session)).toBe(350);
+    });
+
+    it("returns 0 when session is undefined or stats throw", () => {
+      expect(getSessionTokens(undefined)).toBe(0);
+      const broken = { getSessionStats: () => { throw new Error("nope"); } } as any;
+      expect(getSessionTokens(broken)).toBe(0);
+    });
+  });
+
+  describe("getSessionContextPercent", () => {
+    it("returns null when contextUsage is unavailable", () => {
+      const session = {
+        getSessionStats: () => ({ tokens: { input: 10, output: 20, cacheWrite: 5 } }),
+      };
+      expect(getSessionContextPercent(session)).toBeNull();
+    });
+
+    it("returns null when percent is null (post-compaction)", () => {
+      const session = {
+        getSessionStats: () => ({
+          tokens: { input: 10, output: 20, cacheWrite: 5 },
+          contextUsage: { tokens: null, contextWindow: 200_000, percent: null },
+        }),
+      };
+      expect(getSessionContextPercent(session)).toBeNull();
+    });
+
+    it("returns the upstream percent when available", () => {
+      const session = {
+        getSessionStats: () => ({
+          tokens: { input: 10, output: 20, cacheWrite: 5 },
+          contextUsage: { tokens: 50_000, contextWindow: 200_000, percent: 25 },
+        }),
+      };
+      expect(getSessionContextPercent(session)).toBe(25);
+    });
+  });
+
+  describe("getLifetimeTotal", () => {
+    it("sums components and handles undefined", () => {
+      expect(getLifetimeTotal(undefined)).toBe(0);
+      expect(getLifetimeTotal({ input: 100, output: 200, cacheWrite: 50 })).toBe(350);
+    });
+
+    // getSessionTokens reads upstream session stats (resets at compaction);
+    // getLifetimeTotal reads our independent accumulator (survives compaction).
+    // They agree pre-compaction, diverge after — both legitimate signals.
+    it("agrees with getSessionTokens pre-compaction, diverges after", () => {
+      let sessionStatsTokens = { input: 100, output: 200, cacheWrite: 50 };
+      const session = {
+        getSessionStats: () => ({ tokens: sessionStatsTokens }),
+      };
+      const lifetime = { input: 100, output: 200, cacheWrite: 50 };
+
+      expect(getSessionTokens(session)).toBe(350);
+      expect(getLifetimeTotal(lifetime)).toBe(350);
+
+      // Compaction: upstream replaces session.state.messages, so stats reset.
+      // Our accumulator is independent — it keeps growing.
+      sessionStatsTokens = { input: 0, output: 0, cacheWrite: 0 };
+
+      expect(getSessionTokens(session)).toBe(0);            // reset
+      expect(getLifetimeTotal(lifetime)).toBe(350);          // preserved
+
+      // Subsequent message_end events feed both: session re-fills, accumulator continues
+      sessionStatsTokens = { input: 80, output: 150, cacheWrite: 30 };
+      lifetime.input += 80; lifetime.output += 150; lifetime.cacheWrite += 30;
+
+      expect(getSessionTokens(session)).toBe(260);           // post-compaction window
+      expect(getLifetimeTotal(lifetime)).toBe(610);          // 350 + 260, monotone
+    });
+
+    // The accumulator survives compaction because it lives on AgentActivity /
+    // AgentRecord, not on session.state.messages (which compaction replaces).
+    it("stays monotone across simulated compaction when fed via addUsage-style accumulation", () => {
+      const usage = { input: 0, output: 0, cacheWrite: 0 };
+      const onUsage = (u: { input: number; output: number; cacheWrite: number }) => {
+        usage.input += u.input;
+        usage.output += u.output;
+        usage.cacheWrite += u.cacheWrite;
+      };
+
+      // 5 normal turns
+      for (let i = 0; i < 5; i++) onUsage({ input: 1000, output: 200, cacheWrite: 50 });
+      expect(getLifetimeTotal(usage)).toBe(5 * 1250);
+
+      // Compaction would replace session.state.messages, dropping any sum
+      // re-derived from it. Our accumulator is independent — no reset.
+      const beforeCompaction = getLifetimeTotal(usage);
+
+      // 3 more turns post-"compaction"
+      for (let i = 0; i < 3; i++) onUsage({ input: 800, output: 150, cacheWrite: 30 });
+      expect(getLifetimeTotal(usage)).toBe(beforeCompaction + 3 * 980);
+      expect(getLifetimeTotal(usage)).toBeGreaterThan(beforeCompaction); // monotone
+
+      // input + output + cacheWrite = total — by construction, no drift
+      expect(usage.input + usage.output + usage.cacheWrite).toBe(getLifetimeTotal(usage));
+    });
+  });
+});

--- a/packages/pi-subagents/test/wait-queued.test.ts
+++ b/packages/pi-subagents/test/wait-queued.test.ts
@@ -1,0 +1,228 @@
+/**
+ * wait-queued.test.ts — get_subagent_result(wait: true) lifecycle behavior.
+ *
+ * Queued records have no promise yet (it's created when the queue starts
+ * them), so the old `status === "running" && record.promise` condition
+ * skipped the wait entirely and returned "still running" — forcing the
+ * caller into a poll loop against the concurrency queue.
+ *
+ * Wiring test through the REAL extension: spawn background agents until one
+ * queues, call the real tool with wait:true, drain the queue, and assert the
+ * call returns the final result.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+function makePi() {
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((t: any) => tools.set(t.name, t)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events: {
+      emit: vi.fn(),
+      on: vi.fn(() => vi.fn()),
+    },
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+  return { pi, tools, lifecycle };
+}
+
+function ctx() {
+  return {
+    hasUI: false,
+    ui: { setStatus: vi.fn(), setWidget: vi.fn(), notify: vi.fn() },
+    cwd: process.cwd(),
+    model: undefined,
+    modelRegistry: { find: vi.fn(), getAvailable: vi.fn(() => []) },
+    sessionManager: { getSessionId: vi.fn(() => "s1"), getBranch: vi.fn(() => []) },
+    getSystemPrompt: vi.fn(() => "parent"),
+  } as any;
+}
+
+const textOf = (r: any): string => r.content[0].text;
+const flush = async () => {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+};
+
+/** runAgent mock where each call blocks until we resolve it manually. */
+function deferredRuns() {
+  const resolvers: Array<(v: any) => void> = [];
+  vi.mocked(runAgent).mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        resolvers.push(() =>
+          resolve({
+            responseText: "THE-RESULT-PAYLOAD",
+            session: { dispose: vi.fn() } as any,
+            aborted: false,
+            steered: false,
+          }),
+        );
+      }) as any,
+  );
+  return resolvers;
+}
+
+async function spawnBackground(tools: Map<string, any>): Promise<{ id: string; queued: boolean }> {
+  const r = await tools.get("Agent").execute(
+    "tc-spawn",
+    { prompt: "go", description: "queued-wait test agent", subagent_type: "general-purpose", run_in_background: true },
+    undefined,
+    undefined,
+    ctx(),
+  );
+  const id = /Agent ID: (\S+)/.exec(textOf(r))![1];
+  return { id, queued: textOf(r).includes("queued in background") };
+}
+
+describe("get_subagent_result wait:true on a queued agent", () => {
+  it("waits through queue start and returns the result (no 'still running')", async () => {
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    const resolvers = deferredRuns();
+
+    // Spawn until one lands in the queue (concurrency limit is config-dependent).
+    let queuedId: string | undefined;
+    for (let i = 0; i < 10 && !queuedId; i++) {
+      const { id, queued } = await spawnBackground(tools);
+      if (queued) queuedId = id;
+    }
+    expect(queuedId, "expected to hit the concurrency limit within 10 spawns").toBeDefined();
+
+    // wait:true on the QUEUED agent — must not return "still running".
+    const waitPromise = tools
+      .get("get_subagent_result")
+      .execute("tc-wait", { agent_id: queuedId, wait: true }, undefined, undefined, ctx());
+
+    // Drain: resolve running agents until the queued one starts and finishes.
+    let settled = false;
+    void waitPromise.then(() => { settled = true; });
+    for (let i = 0; i < 40 && !settled; i++) {
+      while (resolvers.length > 0) resolvers.shift()!();
+      await flush();
+      await new Promise((r) => setTimeout(r, 100)); // outlive one 250ms poll tick
+    }
+
+    const result = await waitPromise;
+    expect(textOf(result)).toContain("THE-RESULT-PAYLOAD");
+    expect(textOf(result)).not.toContain("still running");
+
+    await new Promise((r) => setTimeout(r, 350));
+    expect(JSON.stringify(pi.sendMessage.mock.calls)).not.toContain(queuedId);
+
+    await lifecycle.get("session_shutdown")?.();
+  }, 20_000);
+
+  it("aborts a running result wait without aborting or consuming the child", async () => {
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    let resolveRun: (() => void) | undefined;
+    let childSignal: AbortSignal | undefined;
+    vi.mocked(runAgent).mockImplementation(
+      (_ctx, _type, _prompt, options) =>
+        new Promise((resolve) => {
+          childSignal = options.signal;
+          resolveRun = () => resolve({
+            responseText: "THE-RESULT-PAYLOAD",
+            session: { dispose: vi.fn() } as any,
+            aborted: false,
+            steered: false,
+          });
+        }),
+    );
+
+    const { id } = await spawnBackground(tools);
+    const controller = new AbortController();
+    const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+    const waitOutcome = tools
+      .get("get_subagent_result")
+      .execute("tc-wait-abort", { agent_id: id, wait: true }, controller.signal, undefined, ctx())
+      .then(
+        () => "resolved",
+        (error: unknown) => error instanceof Error ? error.name : String(error),
+      );
+
+    controller.abort();
+    const outcome = await Promise.race([
+      waitOutcome,
+      new Promise<string>((resolve) => setTimeout(() => resolve("timed-out"), 100)),
+    ]);
+    const childWasAborted = childSignal?.aborted;
+
+    resolveRun?.();
+    await flush();
+    await waitOutcome;
+    await new Promise((r) => setTimeout(r, 350));
+
+    const completedResult = await tools
+      .get("get_subagent_result")
+      .execute("tc-result", { agent_id: id }, undefined, undefined, ctx());
+
+    await lifecycle.get("session_shutdown")?.();
+
+    expect(outcome).toBe("AbortError");
+    expect(childWasAborted).toBe(false);
+    expect(removeListener).toHaveBeenCalledTimes(1);
+    expect(pi.sendMessage).toHaveBeenCalledTimes(1);
+    expect(textOf(completedResult)).toContain("THE-RESULT-PAYLOAD");
+  });
+
+  it("aborts a queued result wait before the agent starts", async () => {
+    const { pi, tools, lifecycle } = makePi();
+    subagentsExtension(pi);
+
+    const resolvers = deferredRuns();
+    let queuedId: string | undefined;
+    for (let i = 0; i < 10 && !queuedId; i++) {
+      const { id, queued } = await spawnBackground(tools);
+      if (queued) queuedId = id;
+    }
+    expect(queuedId, "expected to hit the concurrency limit within 10 spawns").toBeDefined();
+
+    const controller = new AbortController();
+    const waitOutcome = tools
+      .get("get_subagent_result")
+      .execute("tc-queued-abort", { agent_id: queuedId, wait: true }, controller.signal, undefined, ctx())
+      .then(
+        () => "resolved",
+        (error: unknown) => error instanceof Error ? error.name : String(error),
+      );
+
+    controller.abort();
+    const outcome = await Promise.race([
+      waitOutcome,
+      new Promise<string>((resolve) => setTimeout(() => resolve("timed-out"), 100)),
+    ]);
+
+    let completedResult: any;
+    for (let i = 0; i < 40 && !completedResult; i++) {
+      while (resolvers.length > 0) resolvers.shift()!();
+      await flush();
+      const result = await tools
+        .get("get_subagent_result")
+        .execute("tc-queued-result", { agent_id: queuedId }, undefined, undefined, ctx());
+      if (textOf(result).includes("THE-RESULT-PAYLOAD")) completedResult = result;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+
+    await waitOutcome;
+    await lifecycle.get("session_shutdown")?.();
+
+    expect(outcome).toBe("AbortError");
+    expect(textOf(completedResult)).toContain("THE-RESULT-PAYLOAD");
+  });
+});

--- a/packages/pi-subagents/test/worktree.test.ts
+++ b/packages/pi-subagents/test/worktree.test.ts
@@ -1,0 +1,258 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupWorktree, createWorktree, pruneWorktrees } from "../src/worktree.js";
+
+/**
+ * Helper: create a temporary git repo with an initial commit.
+ */
+function initGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pi-wt-test-"));
+  execFileSync("git", ["init"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "README.md"), "# Test repo");
+  execFileSync("git", ["add", "README.md"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: dir, stdio: "pipe" });
+  return dir;
+}
+
+describe("worktree", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = initGitRepo();
+  });
+
+  afterEach(() => {
+    // Clean up any lingering worktrees first, then remove repo
+    try { pruneWorktrees(repoDir); } catch { /* ignore */ }
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  describe("createWorktree", () => {
+    it("creates a worktree in tmpdir", () => {
+      const wt = createWorktree(repoDir, "test-id-1");
+      expect(wt).toBeDefined();
+      expect(existsSync(wt!.path)).toBe(true);
+      expect(wt!.branch).toBe("pi-agent-test-id-1");
+      expect(wt!.baseSha).toBe(execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: repoDir, stdio: "pipe",
+      }).toString().trim());
+
+      // Verify it's a valid worktree with the repo's files
+      expect(existsSync(join(wt!.path, "README.md"))).toBe(true);
+
+      // Cleanup
+      try { execFileSync("git", ["worktree", "remove", "--force", wt!.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+
+    it("returns undefined for non-git directory", () => {
+      const nonGit = mkdtempSync(join(tmpdir(), "pi-wt-nongit-"));
+      try {
+        const wt = createWorktree(nonGit, "test-id-2");
+        expect(wt).toBeUndefined();
+      } finally {
+        rmSync(nonGit, { recursive: true, force: true });
+      }
+    });
+
+    it("returns undefined for git repo with no commits", () => {
+      const emptyRepo = mkdtempSync(join(tmpdir(), "pi-wt-empty-"));
+      try {
+        execFileSync("git", ["init"], { cwd: emptyRepo, stdio: "pipe" });
+        const wt = createWorktree(emptyRepo, "no-commits");
+        expect(wt).toBeUndefined();
+      } finally {
+        rmSync(emptyRepo, { recursive: true, force: true });
+      }
+    });
+
+    it("workPath equals path when created from the repo root", () => {
+      const wt = createWorktree(repoDir, "root-wp")!;
+      expect(wt.workPath).toBe(wt.path);
+      try { execFileSync("git", ["worktree", "remove", "--force", wt.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+
+    it("workPath preserves subdirectory scoping (monorepo package cwd)", () => {
+      mkdirSync(join(repoDir, "packages", "api"), { recursive: true });
+      writeFileSync(join(repoDir, "packages", "api", "index.ts"), "export {}");
+      execFileSync("git", ["add", "-A"], { cwd: repoDir, stdio: "pipe" });
+      execFileSync("git", ["commit", "-m", "add package"], { cwd: repoDir, stdio: "pipe" });
+
+      const wt = createWorktree(join(repoDir, "packages", "api"), "subdir-wp")!;
+      expect(wt).toBeDefined();
+      expect(wt.workPath).toBe(join(wt.path, "packages", "api"));
+      expect(existsSync(wt.workPath)).toBe(true);
+      try { execFileSync("git", ["worktree", "remove", "--force", wt.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+
+    it("uses unique paths for multiple worktrees", () => {
+      const wt1 = createWorktree(repoDir, "multi-1");
+      const wt2 = createWorktree(repoDir, "multi-2");
+      expect(wt1).toBeDefined();
+      expect(wt2).toBeDefined();
+      expect(wt1!.path).not.toBe(wt2!.path);
+
+      // Cleanup
+      try { execFileSync("git", ["worktree", "remove", "--force", wt1!.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+      try { execFileSync("git", ["worktree", "remove", "--force", wt2!.path], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+  });
+
+  describe("cleanupWorktree", () => {
+    it("removes worktree when no changes made", () => {
+      const wt = createWorktree(repoDir, "clean-1")!;
+      expect(wt).toBeDefined();
+
+      const result = cleanupWorktree(repoDir, wt, "test cleanup");
+      expect(result.hasChanges).toBe(false);
+      expect(result.branch).toBeUndefined();
+    });
+
+    it("commits changes and creates branch when changes exist", () => {
+      const wt = createWorktree(repoDir, "dirty-1")!;
+      expect(wt).toBeDefined();
+
+      // Make a change in the worktree
+      writeFileSync(join(wt.path, "new-file.txt"), "agent wrote this");
+
+      const result = cleanupWorktree(repoDir, wt, "added new file");
+      expect(result.hasChanges).toBe(true);
+      expect(result.branch).toBeDefined();
+      expect(result.branch).toContain("pi-agent-dirty-1");
+
+      // Verify the branch exists in the main repo
+      const branches = execFileSync("git", ["branch", "--list", result.branch!], {
+        cwd: repoDir, stdio: "pipe",
+      }).toString().trim();
+      expect(branches).toContain(result.branch!);
+
+      // Verify the commit message
+      const log = execFileSync("git", ["log", "--oneline", "-1", result.branch!], {
+        cwd: repoDir, stdio: "pipe",
+      }).toString().trim();
+      expect(log).toContain("pi-agent: added new file");
+
+      // Cleanup branch
+      try { execFileSync("git", ["branch", "-D", result.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+
+    it("commits changes even when a pre-commit hook rejects (--no-verify)", () => {
+      // A failing pre-commit hook in the main repo also applies to its
+      // worktrees — without --no-verify it would abort the preservation commit.
+      const hookPath = join(repoDir, ".git", "hooks", "pre-commit");
+      writeFileSync(hookPath, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+
+      const wt = createWorktree(repoDir, "hooked-1")!;
+      expect(wt).toBeDefined();
+      writeFileSync(join(wt.path, "hooked-file.txt"), "agent wrote this");
+
+      const result = cleanupWorktree(repoDir, wt, "hook should not block");
+      expect(result.hasChanges).toBe(true);
+      expect(result.branch).toBe("pi-agent-hooked-1");
+
+      // Cleanup branch
+      try { execFileSync("git", ["branch", "-D", result.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+
+    it("creates branch when worktree is clean but HEAD moved", () => {
+      const wt = createWorktree(repoDir, "committed-1")!;
+      expect(wt).toBeDefined();
+
+      writeFileSync(join(wt.path, "committed-file.txt"), "agent committed this");
+      execFileSync("git", ["add", "committed-file.txt"], { cwd: wt.path, stdio: "pipe" });
+      execFileSync("git", ["commit", "-m", "agent commit"], { cwd: wt.path, stdio: "pipe" });
+      const agentCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: wt.path, stdio: "pipe",
+      }).toString().trim();
+
+      const result = cleanupWorktree(repoDir, wt, "already committed");
+      expect(result.hasChanges).toBe(true);
+      expect(result.branch).toBeDefined();
+      expect(result.branch).toBe("pi-agent-committed-1");
+
+      const branchCommit = execFileSync("git", ["rev-parse", result.branch!], {
+        cwd: repoDir, stdio: "pipe",
+      }).toString().trim();
+      expect(branchCommit).toBe(agentCommit);
+      expect(existsSync(wt.path)).toBe(false);
+
+      // Cleanup branch
+      try { execFileSync("git", ["branch", "-D", result.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+
+    it("does not force-overwrite existing branch", () => {
+      // Create first worktree, make changes, cleanup → creates branch
+      const wt1 = createWorktree(repoDir, "conflict-1")!;
+      writeFileSync(join(wt1.path, "file1.txt"), "first run");
+      const result1 = cleanupWorktree(repoDir, wt1, "first");
+      expect(result1.branch).toBe("pi-agent-conflict-1");
+
+      // Create second worktree with same agent ID, make changes
+      const wt2 = createWorktree(repoDir, "conflict-1")!;
+      writeFileSync(join(wt2.path, "file2.txt"), "second run");
+      const result2 = cleanupWorktree(repoDir, wt2, "second");
+
+      // Should use a different branch name (timestamp suffix)
+      expect(result2.hasChanges).toBe(true);
+      expect(result2.branch).toBeDefined();
+      expect(result2.branch).not.toBe("pi-agent-conflict-1");
+      expect(result2.branch).toContain("pi-agent-conflict-1-");
+
+      // Both branches should exist
+      const branches = execFileSync("git", ["branch", "--list", "pi-agent-conflict-1*"], {
+        cwd: repoDir, stdio: "pipe",
+      }).toString().trim();
+      expect(branches).toContain("pi-agent-conflict-1");
+      expect(branches).toContain(result2.branch!);
+
+      // Cleanup
+      try { execFileSync("git", ["branch", "-D", result1.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+      try { execFileSync("git", ["branch", "-D", result2.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+
+    it("handles already-deleted worktree gracefully", () => {
+      const wt = createWorktree(repoDir, "gone-1")!;
+      // Manually delete the worktree directory
+      rmSync(wt.path, { recursive: true, force: true });
+
+      const result = cleanupWorktree(repoDir, wt, "already gone");
+      expect(result.hasChanges).toBe(false);
+    });
+
+    it("truncates commit message at 200 chars", () => {
+      const wt = createWorktree(repoDir, "long-msg")!;
+      writeFileSync(join(wt.path, "change.txt"), "something");
+      const longDesc = "x".repeat(300);
+      const result = cleanupWorktree(repoDir, wt, longDesc);
+      expect(result.hasChanges).toBe(true);
+
+      const log = execFileSync("git", ["log", "--oneline", "-1", result.branch!], {
+        cwd: repoDir, stdio: "pipe",
+      }).toString().trim();
+      // "pi-agent: " prefix (10 chars) + 200 chars of x = 210 total max
+      expect(log.length).toBeLessThanOrEqual(220); // some slack for hash prefix
+
+      // Cleanup
+      try { execFileSync("git", ["branch", "-D", result.branch!], { cwd: repoDir, stdio: "pipe" }); } catch { /* ignore */ }
+    });
+  });
+
+  describe("pruneWorktrees", () => {
+    it("does not throw on a clean repo", () => {
+      expect(() => pruneWorktrees(repoDir)).not.toThrow();
+    });
+
+    it("does not throw on non-git directory", () => {
+      const nonGit = mkdtempSync(join(tmpdir(), "pi-wt-nongit-"));
+      try {
+        expect(() => pruneWorktrees(nonGit)).not.toThrow();
+      } finally {
+        rmSync(nonGit, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/packages/pi-subagents/tsconfig.json
+++ b/packages/pi-subagents/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "test", "dist"]
+}

--- a/packages/pi-subagents/tsconfig.test.json
+++ b/packages/pi-subagents/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/pi-subagents/vitest.config.ts
+++ b/packages/pi-subagents/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // The print-mode e2e suite (test/subagents-print-mode-e2e.test.ts) drives REAL
+  // faux-model turns through pi-coding-agent + pi-agent-core. That requires ONE
+  // shared @earendil-works/pi-ai instance so the faux provider the test registers
+  // lands in the same api-registry the session streams through. npm physically
+  // duplicates pi-ai (a top-level copy and one nested under pi-coding-agent), which
+  // otherwise yields two registries and "No API provider registered" errors.
+  // Inlining the @earendil-works packages routes them through Vite's resolver so
+  // dedupe can collapse pi-ai to a single instance — for the parent AND for every
+  // subagent session the extension spawns. dedupe alone is insufficient (it only
+  // affects modules Vite resolves; without inline the runtime stays externalized).
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    // Skip heavy e2e suites in the monorepo default path; run with
+    // `pnpm test -- test/e2e` or the upstream `test:e2e` script when needed.
+    exclude: ["**/node_modules/**", "**/dist/**", "test/e2e/**", "test/**/*-e2e.test.ts", "test/subagents-print-mode-e2e.test.ts"],
+    server: { deps: { inline: [/@earendil-works\/pi-/] } },
+  },
+  resolve: { dedupe: ["@earendil-works/pi-ai"] },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,15 @@ importers:
       '@juicesharp/rpiv-config':
         specifier: 2.4.0
         version: 2.4.0
+      '@sinclair/typebox':
+        specifier: ^0.34.49
+        version: 0.34.52
+      croner:
+        specifier: ^10.0.1
+        version: 10.0.1
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.16
       typebox:
         specifier: 1.1.24
         version: 1.1.24

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,37 @@ importers:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/pi-subagents:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: ^0.34.49
+        version: 0.34.52
+      croner:
+        specifier: ^10.0.1
+        version: 10.0.1
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.16
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: 0.81.1
+        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.81.1
+        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.81.1
+        version: 0.81.1
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/pi-todo:
     dependencies:
       '@earendil-works/pi-ai':
@@ -909,6 +940,9 @@ packages:
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
 
+  '@sinclair/typebox@0.34.52':
+    resolution: {integrity: sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==}
+
   '@smithy/core@3.29.2':
     resolution: {integrity: sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==}
     engines: {node: '>=18.0.0'}
@@ -1072,6 +1106,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  croner@10.0.1:
+    resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
+    engines: {node: '>=18.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1423,6 +1461,11 @@ packages:
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   node-domexception@1.0.0:
@@ -2695,6 +2738,8 @@ snapshots:
 
   '@silvia-odwyer/photon-node@0.3.4': {}
 
+  '@sinclair/typebox@0.34.52': {}
+
   '@smithy/core@3.29.2':
     dependencies:
       '@smithy/types': 4.16.0
@@ -2863,6 +2908,8 @@ snapshots:
   chardet@2.2.0: {}
 
   convert-source-map@2.0.0: {}
+
+  croner@10.0.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3203,6 +3250,8 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.16: {}
+
+  nanoid@5.1.16: {}
 
   node-domexception@1.0.0: {}
 

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -15,6 +15,7 @@ const packagePaths = [
 	"./packages/pi-search-hub",
 	"./packages/pi-context7",
 	"./packages/pi-ask-user-question",
+	"./packages/pi-subagents",
 	"./providers/pi-provider-volcengine-agent-plan",
 ];
 
@@ -48,6 +49,13 @@ const requiredPackFiles = new Map([
 		"packages/pi-ask-user-question/locales/zh.json",
 		"packages/pi-ask-user-question/README.md",
 		"packages/pi-ask-user-question/UPSTREAM_SOURCE.md",
+		"packages/pi-subagents/src/index.ts",
+		"packages/pi-subagents/src/ui/conversation-brief.ts",
+		"packages/pi-subagents/src/ui/tool-render.ts",
+		"packages/pi-subagents/package.json",
+		"packages/pi-subagents/README.md",
+		"packages/pi-subagents/README.zh-CN.md",
+		"packages/pi-subagents/UPSTREAM_SOURCE.md",
 	]],
 	["./packages/pi-recap", [
 		"extensions/recap.ts",
@@ -104,6 +112,19 @@ const requiredPackFiles = new Map([
 		"UPSTREAM_LICENSE",
 		"UPSTREAM_SOURCE.md",
 	]],
+	["./packages/pi-subagents", [
+		"src/index.ts",
+		"src/ui/conversation-brief.ts",
+		"src/ui/conversation-viewer.ts",
+		"src/ui/tool-render.ts",
+		"src/ui/agent-widget.ts",
+		"README.md",
+		"README.zh-CN.md",
+		"CHANGELOG.md",
+		"LICENSE",
+		"UPSTREAM_LICENSE",
+		"UPSTREAM_SOURCE.md",
+	]],
 	["./providers/pi-provider-volcengine-agent-plan", [
 		"index.ts",
 		"README.md",
@@ -126,6 +147,8 @@ const maintainedReadmes = [
 	"packages/pi-context7/README.md",
 	"packages/pi-context7/README.zh-CN.md",
 	"packages/pi-ask-user-question/README.md",
+	"packages/pi-subagents/README.md",
+	"packages/pi-subagents/README.zh-CN.md",
 	"providers/pi-provider-volcengine-agent-plan/README.md",
 	"providers/pi-provider-volcengine-agent-plan/README.zh-CN.md",
 	"packages/pi-todo/README.md",
@@ -168,6 +191,10 @@ await assertBilingualPair(
 await assertBilingualPair(
 	"packages/pi-context7/README.md",
 	"packages/pi-context7/README.zh-CN.md",
+);
+await assertBilingualPair(
+	"packages/pi-subagents/README.md",
+	"packages/pi-subagents/README.zh-CN.md",
 );
 await assertBilingualPair(
 	"providers/pi-provider-volcengine-agent-plan/README.md",

--- a/scripts/check-smoke.mjs
+++ b/scripts/check-smoke.mjs
@@ -14,6 +14,7 @@ const packagePaths = [
 	"./packages/pi-search-hub",
 	"./packages/pi-context7",
 	"./packages/pi-ask-user-question",
+	"./packages/pi-subagents",
 	"./providers/pi-provider-volcengine-agent-plan",
 ];
 

--- a/scripts/reconcile-release.sh
+++ b/scripts/reconcile-release.sh
@@ -10,6 +10,7 @@ PACKAGES=(
   "@zhcsyncer/pi-plan-mode|packages/pi-plan-mode/package.json|packages/pi-plan-mode/CHANGELOG.md|pi-plan-mode|child"
   "@zhcsyncer/pi-context7|packages/pi-context7/package.json|packages/pi-context7/CHANGELOG.md|pi-context7|child"
   "@zhcsyncer/pi-ask-user-question|packages/pi-ask-user-question/package.json|packages/pi-ask-user-question/CHANGELOG.md|pi-ask-user-question|child"
+  "@zhcsyncer/pi-subagents|packages/pi-subagents/package.json|packages/pi-subagents/CHANGELOG.md|pi-subagents|child"
   "pi-provider-volcengine-agent-plan|providers/pi-provider-volcengine-agent-plan/package.json|providers/pi-provider-volcengine-agent-plan/CHANGELOG.md|pi-provider-volcengine-agent-plan|child"
 )
 

--- a/scripts/release-policy.mjs
+++ b/scripts/release-policy.mjs
@@ -13,6 +13,7 @@ export const CHILD_PACKAGES = Object.freeze([
 	"@zhcsyncer/pi-plan-mode",
 	"@zhcsyncer/pi-context7",
 	"@zhcsyncer/pi-ask-user-question",
+	"@zhcsyncer/pi-subagents",
 ]);
 
 /**

--- a/scripts/release-policy.test.mjs
+++ b/scripts/release-policy.test.mjs
@@ -12,6 +12,7 @@ const GLANCE = "@zhcsyncer/pi-glance";
 const PLAN_MODE = "@zhcsyncer/pi-plan-mode";
 const CONTEXT7 = "@zhcsyncer/pi-context7";
 const ASK_USER_QUESTION = "@zhcsyncer/pi-ask-user-question";
+const SUBAGENTS = "@zhcsyncer/pi-subagents";
 const AGENT_PLAN = "pi-provider-volcengine-agent-plan";
 
 function releases(...entries) {
@@ -78,6 +79,12 @@ test("requires the root package when Context7 releases", () => {
 test("requires the root package when Ask User Question releases", () => {
 	assert.deepEqual(validateReleasePolicy(releases([ASK_USER_QUESTION, "minor"])), [
 		`${ASK_USER_QUESTION} has a minor release, but ${ROOT} is missing from the release plan.`,
+	]);
+});
+
+test("requires the root package when Subagents releases", () => {
+	assert.deepEqual(validateReleasePolicy(releases([SUBAGENTS, "minor"])), [
+		`${SUBAGENTS} has a minor release, but ${ROOT} is missing from the release plan.`,
 	]);
 });
 


### PR DESCRIPTION
## Summary

- Fork `@tintinweb/pi-subagents@0.14.3` into `packages/pi-subagents` as `@zhcsyncer/pi-subagents` (pre-release `0.0.0` + minor changeset).
- **ConversationViewer scheme A**: Prompt · one-line Steps · Result (no default toolResult walls); `o` expands step detail; failures prefer `record.error`.
- **Main-transcript tool TUI** (Agent / get_subagent_result / steer): Claude Code chrome (`▸` / `✓|⠹|✗` + `⎿`); Ctrl+O expands Markdown; model + effort on result stats; `modelInherited` persisted through get_result.
- Widget: current tool step on activity line; status bar cleared while widget is on (compact count only when `widgetMode: off`).
- Docs: EN-default package README with upstream-diff table; root bilingual README lists the package (**not** registered on root `pi.extensions` yet).

## Local trial (not release)

```bash
pnpm install
pi -e ./packages/pi-subagents/src/index.ts
```

If `~/.pi/agent/settings.json` already loads `@tintinweb/pi-subagents`, disable that entry for the trial session.

## Release note

**Not shipping yet.** Package is independent (not in root bundle). First publish will need Changesets version PR + npm bootstrap for `@zhcsyncer/pi-subagents@0.1.0` after soak. Do not merge version/publish from this PR alone without an explicit release gate.

## Test plan

- [x] `pnpm --filter @zhcsyncer/pi-subagents check` (typecheck + vitest)
- [ ] Manual: spawn foreground/background Agent; confirm overlay brief view + tool chrome
- [ ] Manual: widget activity shows current step; no duplicate `1 running agent` status while widget is on
- [ ] Manual: get_subagent_result keeps `model (inherit)` when applicable
- [ ] Confirm no dual-load with `@tintinweb/pi-subagents`