### PR TITLE
fix(release): reconcile Ask User Question tags

### DIFF
--- a/scripts/reconcile-release.sh
+++ b/scripts/reconcile-release.sh
@@ -9,6 +9,7 @@ PACKAGES=(
   "@zhcsyncer/pi-glance|packages/pi-glance/package.json|packages/pi-glance/CHANGELOG.md|pi-glance|child"
   "@zhcsyncer/pi-plan-mode|packages/pi-plan-mode/package.json|packages/pi-plan-mode/CHANGELOG.md|pi-plan-mode|child"
   "@zhcsyncer/pi-context7|packages/pi-context7/package.json|packages/pi-context7/CHANGELOG.md|pi-context7|child"
+  "@zhcsyncer/pi-ask-user-question|packages/pi-ask-user-question/package.json|packages/pi-ask-user-question/CHANGELOG.md|pi-ask-user-question|child"
   "pi-provider-volcengine-agent-plan|providers/pi-provider-volcengine-agent-plan/package.json|providers/pi-provider-volcengine-agent-plan/CHANGELOG.md|pi-provider-volcengine-agent-plan|child"
 )
 

--- a/scripts/release-policy.test.mjs
+++ b/scripts/release-policy.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
-import { validateReleasePolicy } from "./release-policy.mjs";
+import { CHILD_PACKAGES, validateReleasePolicy } from "./release-policy.mjs";
 
 const ROOT = "@zhcsyncer/pi-extensions";
 const RECAP = "@zhcsyncer/pi-recap";
@@ -18,6 +19,13 @@ function releases(...entries) {
 		releases: entries.map(([name, type]) => ({ name, type })),
 	};
 }
+
+test("release reconciliation covers every bundled child package", () => {
+	const script = readFileSync(new URL("./reconcile-release.sh", import.meta.url), "utf8");
+	for (const childPackage of CHILD_PACKAGES) {
+		assert.match(script, new RegExp(childPackage.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+	}
+});
 
 test("allows an empty release plan", () => {
 	assert.deepEqual(validateReleasePolicy(releases()), []);


### PR DESCRIPTION
## Summary

- include `@zhcsyncer/pi-ask-user-question` in release tag/GitHub Release reconciliation
- assert every bundled child from the release policy is present in the reconciliation script

The package was successfully bootstrap-published at `0.1.0`, and the normal release rerun published the root bundle at `0.14.0`. This follow-up lets the release workflow create the missing package tag and GitHub Release without manually pushing a tag.

## Validation

- `bash -n scripts/reconcile-release.sh`
- `pnpm check:release-policy` (22 tests)
