### PR TITLE
feat: support Pi 0.84 across extensions

### DIFF
--- a/.changeset/bilingual-question-docs.md
+++ b/.changeset/bilingual-question-docs.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-ask-user-question": patch
+"@zhcsyncer/pi-extensions": patch
+---
+
+Publish an English default README and a structurally aligned Simplified Chinese README for Ask User Question in both standalone and bundle artifacts.

--- a/.changeset/fresh-pi-084-compat.md
+++ b/.changeset/fresh-pi-084-compat.md
@@ -1,0 +1,9 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-context7": patch
+"@zhcsyncer/pi-plan-mode": patch
+"@zhcsyncer/pi-todo": patch
+"@zhcsyncer/pi-tool-display-intent": patch
+---
+
+Declare and verify compatibility with Pi 0.84 across the bundled extensions.

--- a/.changeset/safe-subagent-display.md
+++ b/.changeset/safe-subagent-display.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-subagents": patch
+---
+
+Strip ANSI and terminal control sequences from child-agent text before rendering it in the parent TUI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,7 @@
+# Documentation
+
+- 维护中的用户可见包文档必须提供双语版本：英文使用默认 `README.md`，简体中文使用 `README.zh-CN.md`；只有仓库中明确记录的例外可以省略该规则。
+
 # Release
 
 - 发版必须走 Changesets 的 version PR 流程：用户可见变更先附带 changeset 合入 `main`，等待 `.github/workflows/release.yml` 创建或更新 `chore: version packages` PR，审核并合并该 PR 后再由 GitHub Actions 发布。

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,7 +22,7 @@ Repository-level follow-up work that should remain discoverable across sessions.
   - Package file lists and pack checks include both language versions where applicable.
   - Add an appropriate changeset if the documentation update accompanies user-visible behavior changes.
 
-- [ ] Make `@zhcsyncer/pi-ask-user-question` documentation bilingual with English as the default before the next root bundle release.
+- [x] Make `@zhcsyncer/pi-ask-user-question` documentation bilingual with English as the default before the next root bundle release.
 
   Acceptance criteria:
 
@@ -51,7 +51,7 @@ Fork display work and adversarial-review P1/P2 honesty fixes are on the branch; 
   - Full args remain available only behind explicit expand (`o` / Ctrl+O), with no regression to false ✓/✗ status chrome.
   - Unit coverage for at least one bash command containing a token-like value.
 
-- [ ] **Strip ANSI / terminal control sequences from child-sourced display text**
+- [x] **Strip ANSI / terminal control sequences from child-sourced display text**
 
   Tool args and outputs can carry ESC/OSC sequences into parent widget lines and step notes; pi-tui may pass them through.
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "packages/pi-ask-user-question/locales/*.json",
     "packages/pi-ask-user-question/docs/*.md",
     "packages/pi-ask-user-question/README.md",
+    "packages/pi-ask-user-question/README.zh-CN.md",
     "packages/pi-ask-user-question/CHANGELOG.md",
     "packages/pi-ask-user-question/LICENSE",
     "packages/pi-ask-user-question/UPSTREAM_LICENSE",
@@ -137,7 +138,10 @@
     "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
-    "@changesets/cli": "2.31.0"
+    "@changesets/cli": "2.31.0",
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
+    "@earendil-works/pi-tui": "0.84.0"
   },
   "packageManager": "pnpm@11.11.0"
 }

--- a/packages/pi-ask-user-question/README.md
+++ b/packages/pi-ask-user-question/README.md
@@ -1,45 +1,47 @@
 # pi-ask-user-question
 
-面向 Pi 的结构化问答扩展，维护自 `@juicesharp/rpiv-ask-user-question`。它注册 `ask_user_question` 工具，让模型在需求不明确时一次提出 1–4 个带说明的单选或多选问题。
+[简体中文](./README.zh-CN.md)
 
-该 fork 将问卷放入 Pi 的正常自定义组件布局，而不是覆盖底部区域的全屏 overlay；同时支持上下文感知的数字键直选，并在交互结束后提供可审计结果渲染。
+A structured questionnaire extension for Pi, maintained from `@juicesharp/rpiv-ask-user-question`. It registers the `ask_user_question` tool so the model can ask 1–4 documented single-select or multi-select questions at once when requirements are ambiguous.
 
-## 安装
+This fork renders the questionnaire in Pi's normal custom-component layout instead of a full-screen overlay over the bottom area. It also adds context-aware numeric selection and an auditable result view after the interaction finishes.
 
-只安装问答扩展：
+## Install
+
+Install only the questionnaire extension:
 
 ```bash
 pi install npm:@zhcsyncer/pi-ask-user-question
 ```
 
-也可以安装完整扩展集合：
+Or install the complete extension bundle:
 
 ```bash
 pi install npm:@zhcsyncer/pi-extensions
 ```
 
-## 交互
+## Interaction
 
-- `1`–`5`：焦点不在 `Type something.` 时，`1`–`N` 直接选择或切换正式选项，`N+1` 聚焦 `Type something.`。
-- `↑` / `↓`：移动焦点。
-- `Enter`：确认当前单选项；多选中切换当前项，聚焦 `Next` 时提交该题。
-- `Space`：切换当前多选项。
-- `Tab` / `Shift+Tab`：在多题问卷的题目与提交页之间切换。
-- `n`：为当前题添加备注。
-- `Esc`：取消整个问卷。
-- `Ctrl+]`：把问卷缩成一行或恢复；可通过配置修改或关闭。
+- `1`–`5`: when `Type something.` is not focused, `1`–`N` selects or toggles a defined option directly, while `N+1` focuses `Type something.`.
+- `↑` / `↓`: move focus.
+- `Enter`: confirm the focused single-select option; in multi-select questions, toggle the focused option or submit the question when `Next` is focused.
+- `Space`: toggle the focused multi-select option.
+- `Tab` / `Shift+Tab`: move between questions and the submit page in a multi-question questionnaire.
+- `n`: add a note to the current question.
+- `Esc`: cancel the entire questionnaire.
+- `Ctrl+]`: collapse the questionnaire to one line or restore it; the shortcut can be changed or disabled in configuration.
 
-每道题会自动追加 `Type something.`，用于输入选项之外的回答。未进入输入状态时，可按紧随正式选项的编号直接聚焦该行；聚焦后所有数字都作为普通文本输入。多选题的 `Next` 仍只能通过导航与 Enter 触发，避免数字误提交。
+Every question automatically includes a `Type something.` row for answers outside the authored options. Before text entry begins, press the number immediately following the defined options to focus that row. Once focused, every digit is entered as ordinary text. A multi-select question's `Next` row still requires navigation and `Enter`, preventing accidental submission through numeric shortcuts.
 
-## TUI 布局与工具展示
+## TUI Layout and Tool Rendering
 
-问卷通过非 overlay 的 `ctx.ui.custom()` 渲染：交互期间临时替换底部 editor、保留并在结束后恢复 editor 草稿，同时参与 Pi 正常布局计算，使 transcript 重排且 footer 始终单独可见。
+The questionnaire uses non-overlay `ctx.ui.custom()` rendering. During the interaction it temporarily replaces the bottom editor, preserves and later restores its draft, and participates in Pi's normal layout calculation so the transcript reflows while the footer remains separately visible.
 
-交互进行时不额外显示 pending tool call；结束后结果节点展示每道题的答案、回答类型和备注，展开后可阅读受长度限制的已选 preview。取消时仍保留可审计的部分回答，校验与运行错误始终可见。宽屏左右分栏时，内容宽度的 preview 框会在右侧剩余列中居中。
+No additional pending tool call is shown while the questionnaire is active. After completion, the result node shows each answer, its answer type, and any note; expanding it reveals length-limited previews for selected options. Cancellation retains partial answers for auditing, and validation or runtime errors remain visible. In a wide side-by-side layout, the content-width preview box is centered within the remaining columns on the right.
 
-## 配置
+## Configuration
 
-配置文件沿用上游位置：`$XDG_CONFIG_HOME/rpiv-ask-user-question/config.json`，未设置 `XDG_CONFIG_HOME` 时使用 `~/.config/rpiv-ask-user-question/config.json`。
+The configuration path remains compatible with upstream: `$XDG_CONFIG_HOME/rpiv-ask-user-question/config.json`, or `~/.config/rpiv-ask-user-question/config.json` when `XDG_CONFIG_HOME` is unset.
 
 ```json
 {
@@ -50,22 +52,22 @@ pi install npm:@zhcsyncer/pi-extensions
 }
 ```
 
-`collapseKey` 设为 `"off"` 可关闭折叠快捷键。`guidance.promptSnippet` 和 `guidance.promptGuidelines` 可覆盖默认模型指导。
+Set `collapseKey` to `"off"` to disable the collapse shortcut. Use `guidance.promptSnippet` and `guidance.promptGuidelines` to override the default model guidance.
 
-## 来源
+## Provenance
 
-- 上游：[`juicesharp/rpiv-mono`](https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-ask-user-question)
-- 基线：`@juicesharp/rpiv-ask-user-question@2.4.0` / `a1531ed4207c21a00941c62571bc1bd3e386cfcb`
-- 上游文档：[`UPSTREAM_README.md`](./UPSTREAM_README.md)
-- 上游版本历史：[`UPSTREAM_CHANGELOG.md`](./UPSTREAM_CHANGELOG.md)
+- Upstream: [`juicesharp/rpiv-mono`](https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-ask-user-question)
+- Baseline: `@juicesharp/rpiv-ask-user-question@2.4.0` / `a1531ed4207c21a00941c62571bc1bd3e386cfcb`
+- Preserved upstream documentation: [`UPSTREAM_README.md`](./UPSTREAM_README.md)
+- Preserved upstream history: [`UPSTREAM_CHANGELOG.md`](./UPSTREAM_CHANGELOG.md)
 
-## 开发
+## Development
 
 ```bash
 pnpm --filter @zhcsyncer/pi-ask-user-question check
 pi --no-extensions -e ./packages/pi-ask-user-question --list-models __pi_ask_user_question_check__
 ```
 
-## 许可证
+## License
 
-MIT。参见 [`LICENSE`](./LICENSE) 和 [`UPSTREAM_LICENSE`](./UPSTREAM_LICENSE)。
+MIT. See [`LICENSE`](./LICENSE) and [`UPSTREAM_LICENSE`](./UPSTREAM_LICENSE).

--- a/packages/pi-ask-user-question/README.zh-CN.md
+++ b/packages/pi-ask-user-question/README.zh-CN.md
@@ -1,0 +1,73 @@
+# pi-ask-user-question
+
+[English](./README.md)
+
+面向 Pi 的结构化问答扩展，维护自 `@juicesharp/rpiv-ask-user-question`。它注册 `ask_user_question` 工具，让模型在需求不明确时一次提出 1–4 个带说明的单选或多选问题。
+
+该 fork 将问卷放入 Pi 的正常自定义组件布局，而不是覆盖底部区域的全屏 overlay；同时支持上下文感知的数字键直选，并在交互结束后提供可审计结果渲染。
+
+## 安装
+
+只安装问答扩展：
+
+```bash
+pi install npm:@zhcsyncer/pi-ask-user-question
+```
+
+也可以安装完整扩展集合：
+
+```bash
+pi install npm:@zhcsyncer/pi-extensions
+```
+
+## 交互
+
+- `1`–`5`：焦点不在 `Type something.` 时，`1`–`N` 直接选择或切换正式选项，`N+1` 聚焦 `Type something.`。
+- `↑` / `↓`：移动焦点。
+- `Enter`：确认当前单选项；多选中切换当前项，聚焦 `Next` 时提交该题。
+- `Space`：切换当前多选项。
+- `Tab` / `Shift+Tab`：在多题问卷的题目与提交页之间切换。
+- `n`：为当前题添加备注。
+- `Esc`：取消整个问卷。
+- `Ctrl+]`：把问卷缩成一行或恢复；可通过配置修改或关闭。
+
+每道题会自动追加 `Type something.`，用于输入选项之外的回答。未进入输入状态时，可按紧随正式选项的编号直接聚焦该行；聚焦后所有数字都作为普通文本输入。多选题的 `Next` 仍只能通过导航与 `Enter` 触发，避免数字误提交。
+
+## TUI 布局与工具展示
+
+问卷通过非 overlay 的 `ctx.ui.custom()` 渲染：交互期间临时替换底部 editor、保留并在结束后恢复 editor 草稿，同时参与 Pi 正常布局计算，使 transcript 重排且 footer 始终单独可见。
+
+交互进行时不额外显示 pending tool call；结束后结果节点展示每道题的答案、回答类型和备注，展开后可阅读受长度限制的已选 preview。取消时仍保留可审计的部分回答，校验与运行错误始终可见。宽屏左右分栏时，内容宽度的 preview 框会在右侧剩余列中居中。
+
+## 配置
+
+配置文件沿用上游位置：`$XDG_CONFIG_HOME/rpiv-ask-user-question/config.json`，未设置 `XDG_CONFIG_HOME` 时使用 `~/.config/rpiv-ask-user-question/config.json`。
+
+```json
+{
+  "collapseKey": "alt+o",
+  "guidance": {
+    "promptSnippet": "Ask before guessing when requirements are ambiguous"
+  }
+}
+```
+
+`collapseKey` 设为 `"off"` 可关闭折叠快捷键。`guidance.promptSnippet` 和 `guidance.promptGuidelines` 可覆盖默认模型指导。
+
+## 来源
+
+- 上游：[`juicesharp/rpiv-mono`](https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-ask-user-question)
+- 基线：`@juicesharp/rpiv-ask-user-question@2.4.0` / `a1531ed4207c21a00941c62571bc1bd3e386cfcb`
+- 保留的上游文档：[`UPSTREAM_README.md`](./UPSTREAM_README.md)
+- 保留的上游版本历史：[`UPSTREAM_CHANGELOG.md`](./UPSTREAM_CHANGELOG.md)
+
+## 开发
+
+```bash
+pnpm --filter @zhcsyncer/pi-ask-user-question check
+pi --no-extensions -e ./packages/pi-ask-user-question --list-models __pi_ask_user_question_check__
+```
+
+## 许可证
+
+MIT。参见 [`LICENSE`](./LICENSE) 和 [`UPSTREAM_LICENSE`](./UPSTREAM_LICENSE)。

--- a/packages/pi-ask-user-question/package.json
+++ b/packages/pi-ask-user-question/package.json
@@ -55,6 +55,7 @@
     "locales/",
     "docs/",
     "README.md",
+    "README.zh-CN.md",
     "CHANGELOG.md",
     "UPSTREAM_LICENSE",
     "UPSTREAM_README.md",
@@ -115,9 +116,9 @@
     "@juicesharp/rpiv-config": "2.4.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.80.3",
-    "@earendil-works/pi-coding-agent": "0.80.3",
-    "@earendil-works/pi-tui": "0.80.3",
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
+    "@earendil-works/pi-tui": "0.84.0",
     "@juicesharp/rpiv-i18n": "2.4.0",
     "@types/node": "25.6.0",
     "typebox": "1.1.24",

--- a/packages/pi-context7/package.json
+++ b/packages/pi-context7/package.json
@@ -61,13 +61,13 @@
     ]
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.80.0",
-    "@earendil-works/pi-tui": "^0.80.0",
+    "@earendil-works/pi-coding-agent": ">=0.80.0 <1",
+    "@earendil-works/pi-tui": ">=0.80.0 <1",
     "typebox": "^1.1.24"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "0.82.1",
-    "@earendil-works/pi-tui": "0.81.1",
+    "@earendil-works/pi-coding-agent": "0.84.0",
+    "@earendil-works/pi-tui": "0.84.0",
     "@types/node": "25.6.0",
     "typebox": "1.1.24",
     "typescript": "6.0.3",

--- a/packages/pi-glance/package.json
+++ b/packages/pi-glance/package.json
@@ -59,9 +59,9 @@
     "@earendil-works/pi-tui": ">=0.80.0 <1"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.81.1",
-    "@earendil-works/pi-coding-agent": "0.81.1",
-    "@earendil-works/pi-tui": "0.81.1",
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
+    "@earendil-works/pi-tui": "0.84.0",
     "@types/node": "25.6.0",
     "typescript": "6.0.3"
   },

--- a/packages/pi-plan-mode/package.json
+++ b/packages/pi-plan-mode/package.json
@@ -51,13 +51,13 @@
     ]
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.81.0",
-    "@earendil-works/pi-tui": "^0.80.3",
+    "@earendil-works/pi-coding-agent": ">=0.81.0 <1",
+    "@earendil-works/pi-tui": ">=0.80.3 <1",
     "typebox": "^1.1.24"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "0.81.1",
-    "@earendil-works/pi-tui": "0.80.3",
+    "@earendil-works/pi-coding-agent": "0.84.0",
+    "@earendil-works/pi-tui": "0.84.0",
     "@types/node": "25.6.0",
     "typescript": "6.0.3",
     "vitest": "4.1.7"

--- a/packages/pi-recap/package.json
+++ b/packages/pi-recap/package.json
@@ -49,6 +49,9 @@
     "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
+    "@earendil-works/pi-tui": "0.84.0",
     "@types/node": "25.6.0",
     "tsx": "4.22.4",
     "typescript": "6.0.3"

--- a/packages/pi-search-hub/package.json
+++ b/packages/pi-search-hub/package.json
@@ -52,14 +52,16 @@
     ]
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "^0.80.0",
-    "@earendil-works/pi-coding-agent": "^0.80.0"
+    "@earendil-works/pi-ai": ">=0.80.0 <1",
+    "@earendil-works/pi-coding-agent": ">=0.80.0 <1"
   },
   "dependencies": {
     "typebox": "1.1.24",
     "wreq-js": "2.3.1"
   },
   "devDependencies": {
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
     "@types/node": "25.6.0",
     "typescript": "6.0.3",
     "vitest": "4.1.7"

--- a/packages/pi-subagents/package.json
+++ b/packages/pi-subagents/package.json
@@ -67,9 +67,9 @@
     "nanoid": "^5.0.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.81.1",
-    "@earendil-works/pi-coding-agent": "0.81.1",
-    "@earendil-works/pi-tui": "0.81.1",
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
+    "@earendil-works/pi-tui": "0.84.0",
     "@types/node": "25.6.0",
     "typescript": "6.0.3",
     "vitest": "4.1.7"

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -49,6 +49,7 @@ import {
   type Theme,
   type UICtx,
 } from "./ui/agent-widget.js";
+import { sanitizeDisplayText } from "./ui/display-safety.js";
 import { FleetList, type FleetUICtx } from "./ui/fleet-list.js";
 import { showSchedulesMenu } from "./ui/schedule-menu.js";
 import {
@@ -316,22 +317,23 @@ function buildDetails(
 /** Build notification details for the custom message renderer. */
 function buildNotificationDetails(record: AgentRecord, resultMaxLen: number, activity?: AgentActivity): NotificationDetails {
   const totalTokens = getLifetimeTotal(record.lifetimeUsage);
+  const safeResult = record.result ? sanitizeDisplayText(record.result) : undefined;
 
   return {
-    id: record.id,
-    description: record.description,
+    id: sanitizeDisplayText(record.id),
+    description: sanitizeDisplayText(record.description),
     status: record.status,
     toolUses: record.toolUses,
     turnCount: activity?.turnCount ?? 0,
     maxTurns: activity?.maxTurns,
     totalTokens,
     durationMs: record.completedAt ? record.completedAt - record.startedAt : 0,
-    outputFile: record.outputFile,
-    error: record.error,
-    resultPreview: record.result
-      ? record.result.length > resultMaxLen
-        ? record.result.slice(0, resultMaxLen) + "…"
-        : record.result
+    outputFile: record.outputFile ? sanitizeDisplayText(record.outputFile) : undefined,
+    error: record.error ? sanitizeDisplayText(record.error) : undefined,
+    resultPreview: safeResult
+      ? safeResult.length > resultMaxLen
+        ? safeResult.slice(0, resultMaxLen) + "…"
+        : safeResult
       : "No output.",
   };
 }
@@ -367,9 +369,12 @@ export default function (pi: ExtensionAPI) {
         const statusText = isError ? d.status
           : d.status === "steered" ? "completed (steered)"
           : "completed";
+        const description = sanitizeDisplayText(d.description);
+        const resultPreview = sanitizeDisplayText(d.resultPreview);
+        const outputFile = d.outputFile ? sanitizeDisplayText(d.outputFile) : undefined;
 
         // Line 1: icon + agent description + status
-        let line = `${icon} ${theme.bold(d.description)} ${theme.fg("dim", statusText)}`;
+        let line = `${icon} ${theme.bold(description)} ${theme.fg("dim", statusText)}`;
 
         // Line 2: stats
         const parts: string[] = [];
@@ -383,16 +388,16 @@ export default function (pi: ExtensionAPI) {
 
         // Line 3: result preview (collapsed) or full (expanded)
         if (expanded) {
-          const lines = d.resultPreview.split("\n").slice(0, 30);
+          const lines = resultPreview.split("\n").slice(0, 30);
           for (const l of lines) line += "\n" + theme.fg("dim", `  ${l}`);
         } else {
-          const preview = d.resultPreview.split("\n")[0]?.slice(0, 80) ?? "";
+          const preview = resultPreview.split("\n")[0]?.slice(0, 80) ?? "";
           line += "\n  " + theme.fg("dim", `⎿  ${preview}`);
         }
 
         // Line 4: output file link (if present)
-        if (d.outputFile) {
-          line += "\n  " + theme.fg("muted", `transcript: ${d.outputFile}`);
+        if (outputFile) {
+          line += "\n  " + theme.fg("muted", `transcript: ${outputFile}`);
         }
 
         return line;

--- a/packages/pi-subagents/src/ui/agent-widget.ts
+++ b/packages/pi-subagents/src/ui/agent-widget.ts
@@ -10,6 +10,7 @@ import type { AgentManager } from "../agent-manager.js";
 import { getConfig } from "../agent-types.js";
 import type { AgentInvocation, SubagentType, WidgetMode } from "../types.js";
 import { getLifetimeTotal, getSessionContextPercent, type LifetimeUsage, type SessionLike } from "../usage.js";
+import { sanitizeDisplayText } from "./display-safety.js";
 
 // ---- Constants ----
 
@@ -221,7 +222,7 @@ export function detailsFromInvocation(invocation: AgentInvocation | undefined): 
 
 /** Truncate text to a single line, max `len` chars. */
 function truncateLine(text: string, len = 60): string {
-  const line = text.split("\n").find(l => l.trim())?.trim() ?? "";
+  const line = sanitizeDisplayText(text).split("\n").find(l => l.trim())?.trim() ?? "";
   if (line.length <= len) return line;
   return line.slice(0, len) + "…";
 }
@@ -244,10 +245,11 @@ export function formatSubagentsStatusText(runningCount: number, queuedCount: num
  * Prefers path/command/pattern from args when present.
  */
 export function formatActiveToolSummary(toolName: string, args?: unknown): string {
-  if (toolName.startsWith("tools-error:") || toolName.startsWith("extension-error:")) {
-    return truncateLine(toolName.replace(/^(tools|extension)-error:/, "⚠ "), 70);
+  const safeToolName = sanitizeDisplayText(toolName);
+  if (safeToolName.startsWith("tools-error:") || safeToolName.startsWith("extension-error:")) {
+    return truncateLine(safeToolName.replace(/^(tools|extension)-error:/, "⚠ "), 70);
   }
-  const action = TOOL_DISPLAY[toolName] ?? toolName;
+  const action = TOOL_DISPLAY[safeToolName] ?? safeToolName;
   const record =
     args && typeof args === "object" && !Array.isArray(args)
       ? (args as Record<string, unknown>)
@@ -256,7 +258,9 @@ export function formatActiveToolSummary(toolName: string, args?: unknown): strin
   const firstString = (...keys: string[]): string | undefined => {
     for (const k of keys) {
       const v = record[k];
-      if (typeof v === "string" && v.trim()) return v.trim();
+      if (typeof v !== "string") continue;
+      const safe = sanitizeDisplayText(v).trim();
+      if (safe) return safe;
     }
     return undefined;
   };
@@ -264,13 +268,14 @@ export function formatActiveToolSummary(toolName: string, args?: unknown): strin
   const command = firstString("command", "cmd");
   const pattern = firstString("pattern", "query", "regex", "search");
   const glob = firstString("glob", "include", "glob_pattern", "globPattern");
+  const url = firstString("url");
   let detail: string | undefined;
   if (command) detail = command;
   else if (path) detail = path;
   else if (pattern && (path || glob)) detail = `${JSON.stringify(pattern)} ${path ?? glob}`;
   else if (pattern) detail = JSON.stringify(pattern);
   else if (glob) detail = glob;
-  else if (typeof record.url === "string" && record.url.trim()) detail = record.url.trim();
+  else if (url) detail = url;
   if (detail) {
     const one = detail.replace(/\s+/g, " ");
     const clipped = one.length > 48 ? `${one.slice(0, 47)}…` : one;
@@ -285,7 +290,9 @@ export function formatActiveToolSummary(toolName: string, args?: unknown): strin
  */
 export function describeActivity(activeTools: Map<string, string>, responseText?: string): string {
   if (activeTools.size > 0) {
-    const parts = [...activeTools.values()].filter((p) => p.trim().length > 0);
+    const parts = [...activeTools.values()]
+      .map((part) => sanitizeDisplayText(part))
+      .filter((part) => part.trim().length > 0);
     if (parts.length === 1) {
       const p = parts[0]!;
       return p.endsWith("…") ? p : `${p}…`;

--- a/packages/pi-subagents/src/ui/conversation-brief.ts
+++ b/packages/pi-subagents/src/ui/conversation-brief.ts
@@ -6,6 +6,7 @@
  */
 
 import { extractText } from "../context.js";
+import { sanitizeDisplayText } from "./display-safety.js";
 
 /** Max lines of the dispatch prompt shown before truncation note. */
 export const PROMPT_MAX_LINES = 30;
@@ -61,14 +62,16 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 
 function firstString(args: Record<string, unknown>, keys: string[]): string | undefined {
   for (const key of keys) {
-    const v = args[key];
-    if (typeof v === "string" && v.trim()) return v.trim();
+    const value = args[key];
+    if (typeof value !== "string") continue;
+    const safe = sanitizeDisplayText(value).trim();
+    if (safe) return safe;
   }
   return undefined;
 }
 
 function compactInline(text: string, maxChars: number): string {
-  const oneLine = text.replace(/\s+/g, " ").trim();
+  const oneLine = sanitizeDisplayText(text).replace(/\s+/g, " ").trim();
   if (oneLine.length <= maxChars) return oneLine;
   if (maxChars <= 1) return "…";
   return `${oneLine.slice(0, Math.max(0, maxChars - 1))}…`;
@@ -139,7 +142,7 @@ export function summarizeToolArgs(toolName: string, args: Record<string, unknown
 
 /** Build a folded one-line note for a tool result body. */
 export function summarizeToolResult(text: string, isError: boolean, maxChars = RESULT_PREVIEW_MAX_CHARS): string {
-  const trimmed = text.replace(/\r\n/g, "\n").trim();
+  const trimmed = sanitizeDisplayText(text).trim();
   if (!trimmed) return isError ? "error" : "ok";
 
   const lines = trimmed.split("\n");
@@ -162,8 +165,8 @@ export function summarizeToolResult(text: string, isError: boolean, maxChars = R
 }
 
 function messageText(msg: LooseMessage): string {
-  if (typeof msg.content === "string") return msg.content;
-  if (Array.isArray(msg.content)) return extractText(msg.content);
+  if (typeof msg.content === "string") return sanitizeDisplayText(msg.content);
+  if (Array.isArray(msg.content)) return sanitizeDisplayText(extractText(msg.content));
   return "";
 }
 
@@ -201,18 +204,22 @@ export function buildConversationBrief(messages: readonly LooseMessage[]): Conve
       for (const raw of content) {
         const block = asRecord(raw);
         if (!block) continue;
-        if (block.type === "text" && typeof block.text === "string" && block.text.trim()) {
-          textParts.push(block.text);
+        if (block.type === "text" && typeof block.text === "string") {
+          const safeText = sanitizeDisplayText(block.text);
+          if (safeText.trim()) textParts.push(safeText);
         } else if (block.type === "toolCall") {
-          const toolName =
+          const toolName = sanitizeDisplayText(
             (typeof block.name === "string" && block.name) ||
             (typeof block.toolName === "string" && block.toolName) ||
-            "unknown";
+            "unknown",
+          );
           const id = getToolCallId(block) ?? `anon-${++syntheticSeq}`;
           const args = getToolCallArgs(block);
           let argsText: string | undefined;
           try {
-            argsText = Object.keys(args).length > 0 ? JSON.stringify(args, null, 2) : undefined;
+            argsText = Object.keys(args).length > 0
+              ? sanitizeDisplayText(JSON.stringify(args, null, 2))
+              : undefined;
           } catch {
             argsText = undefined;
           }
@@ -243,10 +250,11 @@ export function buildConversationBrief(messages: readonly LooseMessage[]): Conve
         (typeof msg.toolCallId === "string" && msg.toolCallId) ||
         (typeof msg.toolUseId === "string" && msg.toolUseId) ||
         `result-${++syntheticSeq}`;
-      const toolName =
+      const toolName = sanitizeDisplayText(
         (typeof msg.toolName === "string" && msg.toolName) ||
         byId.get(id)?.toolName ||
-        "tool";
+        "tool",
+      );
       const text = messageText(msg);
       const isError = msg.isError === true;
       const note = summarizeToolResult(text, isError);
@@ -272,8 +280,8 @@ export function buildConversationBrief(messages: readonly LooseMessage[]): Conve
     }
 
     if (role === "bashExecution") {
-      const command = typeof msg.command === "string" ? msg.command : "";
-      const output = typeof msg.output === "string" ? msg.output : "";
+      const command = typeof msg.command === "string" ? sanitizeDisplayText(msg.command) : "";
+      const output = typeof msg.output === "string" ? sanitizeDisplayText(msg.output) : "";
       // Pi records exitCode/cancelled on bashExecution (see recordBashResult).
       const exitCode = typeof msg.exitCode === "number" ? msg.exitCode : undefined;
       const cancelled = msg.cancelled === true;
@@ -312,7 +320,7 @@ export function promptLooksLikeInheritedContext(prompt: string): boolean {
  * dispatch task is not eaten by the parent history wall.
  */
 export function truncatePromptLines(prompt: string, maxLines = PROMPT_MAX_LINES): { lines: string[]; truncated: boolean } {
-  const lines = prompt.replace(/\r\n/g, "\n").split("\n");
+  const lines = sanitizeDisplayText(prompt).split("\n");
   if (lines.length <= maxLines) return { lines, truncated: false };
   const hidden = lines.length - maxLines;
   if (promptLooksLikeInheritedContext(prompt)) {
@@ -376,13 +384,13 @@ export function stepStatusIcon(status: StepStatus): string {
 /** Format one step row without theme colors: `✓ read   path/to/file.ts`. */
 export function formatStepLine(step: BriefStep, opts?: { includeResultNote?: boolean }): string {
   const icon = stepStatusIcon(step.status);
-  const name = step.toolName || "tool";
+  const name = sanitizeDisplayText(step.toolName || "tool");
   const padName = name.length < 6 ? name.padEnd(6) : name;
   const parts = [icon, padName];
-  if (step.summary) parts.push(step.summary);
+  if (step.summary) parts.push(sanitizeDisplayText(step.summary));
   let line = parts.join(" ");
   if (opts?.includeResultNote !== false && step.resultNote) {
-    line += `  · ${step.resultNote}`;
+    line += `  · ${sanitizeDisplayText(step.resultNote)}`;
   }
   return line;
 }

--- a/packages/pi-subagents/src/ui/display-safety.ts
+++ b/packages/pi-subagents/src/ui/display-safety.ts
@@ -1,0 +1,18 @@
+import { stripVTControlCharacters } from "node:util";
+
+const OSC_SEQUENCE = /(?:\u001b\]|\u009d)[\s\S]*?(?:\u0007|\u001b\\|\u009c|$)/g;
+const STRING_CONTROL_SEQUENCE = /(?:\u001b[PX^_]|[\u0090\u0098\u009e\u009f])[\s\S]*?(?:\u001b\\|\u009c|$)/g;
+const UNSAFE_CONTROL_CHARACTERS = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g;
+
+/**
+ * Remove terminal control sequences from child-sourced text before it reaches
+ * the parent TUI. Preserve tabs, line feeds, printable Unicode, and wide text.
+ */
+export function sanitizeDisplayText(text: string): string {
+  const normalized = text.replace(/\r\n?/g, "\n");
+  return stripVTControlCharacters(
+    normalized
+      .replace(OSC_SEQUENCE, "")
+      .replace(STRING_CONTROL_SEQUENCE, ""),
+  ).replace(UNSAFE_CONTROL_CHARACTERS, "");
+}

--- a/packages/pi-subagents/src/ui/tool-render.ts
+++ b/packages/pi-subagents/src/ui/tool-render.ts
@@ -12,6 +12,7 @@ import { getMarkdownTheme, keyHint } from "@earendil-works/pi-coding-agent";
 import { Container, Markdown, Text, type Component } from "@earendil-works/pi-tui";
 import type { AgentDetails, Theme } from "./agent-widget.js";
 import { fgPreservingNestedStyles, formatMs, formatTurns, SPINNER } from "./agent-widget.js";
+import { sanitizeDisplayText } from "./display-safety.js";
 
 /** Collapsed preview: first non-empty line, hard-capped. */
 export const RESULT_COLLAPSED_PREVIEW_CHARS = 100;
@@ -26,15 +27,14 @@ export function toolResultText(result: TextResultLike): string {
   if (!result.content?.length) return "";
   return result.content
     .filter((c) => c.type === "text" && typeof c.text === "string")
-    .map((c) => c.text ?? "")
+    .map((c) => sanitizeDisplayText(c.text ?? ""))
     .join("\n");
 }
 
 /** First non-empty line, collapsed to a single visual line. */
 export function firstLinePreview(text: string, maxChars = RESULT_COLLAPSED_PREVIEW_CHARS): string {
   const line =
-    text
-      .replace(/\r\n/g, "\n")
+    sanitizeDisplayText(text)
       .split("\n")
       .map((l) => l.trim())
       .find((l) => l.length > 0) ?? "";
@@ -54,7 +54,7 @@ export function firstLinePreview(text: string, maxChars = RESULT_COLLAPSED_PREVI
  *   (`Type: … | Status: …`), so agent-authored reports are not eaten.
  */
 export function looksLikeStatusHeader(block: string): boolean {
-  const head = block.replace(/\r\n/g, "\n").trim();
+  const head = sanitizeDisplayText(block).trim();
   if (!head) return false;
   if (/^Agent completed in \d/i.test(head)) return true;
   if (/^Agent failed:/i.test(head)) return true;
@@ -70,7 +70,7 @@ export function looksLikeStatusHeader(block: string): boolean {
  * losing their first (most important) paragraph in previews.
  */
 export function resultBodyText(text: string): string {
-  const normalized = text.replace(/\r\n/g, "\n").trim();
+  const normalized = sanitizeDisplayText(text).trim();
   if (!normalized) return "";
   const parts = normalized.split(/\n\n+/);
   if (parts.length >= 2 && looksLikeStatusHeader(parts[0] ?? "")) {
@@ -93,12 +93,12 @@ export function expandHint(): string {
 }
 
 export function renderExpandedMarkdown(content: string): Component {
-  return new Markdown(content, 0, 0, getMarkdownTheme());
+  return new Markdown(sanitizeDisplayText(content), 0, 0, getMarkdownTheme());
 }
 
 /** Claude Code-style secondary line: `  ⎿  …`. */
 export function formatClerkLine(theme: Pick<Theme, "fg">, text: string, color = "dim"): string {
-  return theme.fg(color, `  ⎿  ${text}`);
+  return theme.fg(color, `  ⎿  ${sanitizeDisplayText(text)}`);
 }
 
 /**
@@ -113,16 +113,16 @@ export function formatAgentCallMeta(opts: {
   extra?: string[];
 }): string {
   const parts: string[] = [];
-  const model = opts.model?.trim();
+  const model = opts.model ? sanitizeDisplayText(opts.model).trim() : "";
   if (model) {
     parts.push(opts.modelInherited ? `${model} (inherit)` : model);
   }
-  const effort = opts.effort?.trim();
+  const effort = opts.effort ? sanitizeDisplayText(opts.effort).trim() : "";
   if (effort) parts.push(`effort: ${effort}`);
   if (opts.background) parts.push("bg");
   if (opts.extra?.length) {
     for (const x of opts.extra) {
-      const t = x.trim();
+      const t = sanitizeDisplayText(x).trim();
       if (t) parts.push(t);
     }
   }
@@ -174,7 +174,7 @@ export function isActiveStatus(status: string | undefined): boolean {
  * content (schedule names like "Investigate failed tests" must not go red).
  */
 export function looksLikeFailureText(text: string): boolean {
-  const head = text.trim().slice(0, 240);
+  const head = sanitizeDisplayText(text).trim().slice(0, 240);
   return (
     /^error\b/i.test(head) ||
     /^failed\b/i.test(head) ||
@@ -198,9 +198,11 @@ export function isFailureDetailsStatus(status: string | undefined): boolean {
  * Optional trailing dim chips only when explicitly set (model / effort / bg).
  */
 export function renderToolCallTitle(label: string, muted: string | undefined, theme: Theme, dimExtra?: string): Text {
-  let line = "▸ " + theme.fg("toolTitle", theme.bold(label));
-  if (muted) line += "  " + theme.fg("muted", muted);
-  if (dimExtra?.trim()) line += "  " + theme.fg("dim", dimExtra.trim());
+  let line = "▸ " + theme.fg("toolTitle", theme.bold(sanitizeDisplayText(label)));
+  const safeMuted = muted ? sanitizeDisplayText(muted) : "";
+  const safeExtra = dimExtra ? sanitizeDisplayText(dimExtra).trim() : "";
+  if (safeMuted) line += "  " + theme.fg("muted", safeMuted);
+  if (safeExtra) line += "  " + theme.fg("dim", safeExtra);
   return new Text(line, 0, 0);
 }
 

--- a/packages/pi-subagents/test/agent-widget.test.ts
+++ b/packages/pi-subagents/test/agent-widget.test.ts
@@ -209,6 +209,16 @@ describe("formatActiveToolSummary / describeActivity", () => {
     expect(formatActiveToolSummary("edit", {})).toBe("editing");
   });
 
+  it("strips terminal controls from parent widget activity", () => {
+    const summary = formatActiveToolSummary("bash", {
+      command: "echo \u001b[31mred\u001b[0m \u001b]8;;https://evil.invalid/?token=x\u0007link\u001b]8;;\u0007 中文",
+    });
+
+    expect(summary).toBe("running echo red link 中文");
+    expect(summary).not.toMatch(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/);
+    expect(summary).not.toContain("evil.invalid");
+  });
+
   it("describeActivity prefers in-flight step summaries over thinking…", () => {
     const tools = new Map<string, string>([
       ["c1", "reading src/a.ts"],

--- a/packages/pi-subagents/test/conversation-brief.test.ts
+++ b/packages/pi-subagents/test/conversation-brief.test.ts
@@ -33,6 +33,15 @@ describe("summarizeToolArgs", () => {
     expect(out.length).toBeLessThanOrEqual(40);
     expect(out.endsWith("…")).toBe(true);
   });
+
+  it("strips terminal controls while preserving printable Unicode", () => {
+    const out = summarizeToolArgs("bash", {
+      command: "printf '\u001b[31m危险\u001b[0m' \u001b]0;owned\u0007",
+    });
+    expect(out).toBe("printf '危险'");
+    expect(out).not.toContain("owned");
+    expect(out).not.toContain("\u001b");
+  });
 });
 
 describe("summarizeToolResult", () => {
@@ -46,6 +55,12 @@ describe("summarizeToolResult", () => {
 
   it("marks errors", () => {
     expect(summarizeToolResult("boom", true)).toBe("error · boom");
+  });
+
+  it("strips terminal controls from folded result notes", () => {
+    const note = summarizeToolResult("\u001b[31mboom\u001b[0m\u001b]2;title\u0007", true);
+    expect(note).toBe("error · boom");
+    expect(note).not.toContain("\u001b");
   });
 });
 
@@ -82,6 +97,22 @@ describe("buildConversationBrief", () => {
     expect(brief.steps[0]?.resultText).toContain("src/a.ts");
     // Intermediate assistant chatter is not the final result.
     expect(brief.result).toBe("Found three files.");
+  });
+
+  it("strips terminal controls from child assistant text", () => {
+    const brief = buildConversationBrief([
+      {
+        role: "assistant",
+        content: [{
+          type: "text",
+          text: "\u001b[32m完成\u001b[0m \u001b]8;;https://evil.invalid\u0007report\u001b]8;;\u0007",
+        }],
+      },
+    ]);
+
+    expect(brief.result).toBe("完成 report");
+    expect(brief.result).not.toContain("evil.invalid");
+    expect(brief.result).not.toContain("\u001b");
   });
 
   it("keeps running steps open until a toolResult arrives", () => {

--- a/packages/pi-subagents/test/display-safety.test.ts
+++ b/packages/pi-subagents/test/display-safety.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeDisplayText } from "../src/ui/display-safety.js";
+
+describe("sanitizeDisplayText", () => {
+  it("strips CSI, OSC, DCS, C0, and C1 terminal controls", () => {
+    const input = [
+      "before",
+      "\u001b[31mred\u001b[0m",
+      "\u001b]8;;https://example.invalid/?token=secret\u0007link\u001b]8;;\u0007",
+      "\u001bPignored payload\u001b\\",
+      "\u009b32mgreen\u009b0m",
+      "\u0000\u0001after",
+    ].join("");
+
+    const output = sanitizeDisplayText(input);
+
+    expect(output).toBe("beforeredlinkgreenafter");
+    expect(output).not.toMatch(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/);
+    expect(output).not.toContain("example.invalid");
+    expect(output).not.toContain("ignored payload");
+  });
+
+  it("preserves printable wide text, tabs, and line feeds", () => {
+    expect(sanitizeDisplayText("中文🙂\talpha\r\nbeta\rgamma")).toBe("中文🙂\talpha\nbeta\ngamma");
+  });
+});

--- a/packages/pi-subagents/test/tool-render.test.ts
+++ b/packages/pi-subagents/test/tool-render.test.ts
@@ -181,6 +181,19 @@ describe("renderUndetailedResult", () => {
     const component = renderUndetailedResult("all good actually", { expanded: false, isError: true }, theme());
     expect(plain(component)).toMatch(/✗/);
   });
+
+  it("strips terminal controls from undetailed previews", async () => {
+    const { renderUndetailedResult } = await import("../src/ui/tool-render.js");
+    const component = renderUndetailedResult(
+      "\u001b[31mfailed\u001b[0m \u001b]8;;https://evil.invalid\u0007details\u001b]8;;\u0007",
+      { expanded: false, isError: true },
+      theme(),
+    );
+    const out = plain(component);
+    expect(out).toContain("failed details");
+    expect(out).not.toContain("evil.invalid");
+    expect(out).not.toContain("\u001b");
+  });
 });
 
 describe("looksLikeStatusHeader / isFailureDetailsStatus", () => {

--- a/packages/pi-todo/package.json
+++ b/packages/pi-todo/package.json
@@ -75,9 +75,9 @@
   },
   "peerDependencies": {
     "@juicesharp/rpiv-i18n": "*",
-    "@earendil-works/pi-ai": "^0.80.0",
-    "@earendil-works/pi-coding-agent": "^0.80.0",
-    "@earendil-works/pi-tui": "^0.80.0",
+    "@earendil-works/pi-ai": ">=0.80.0 <1",
+    "@earendil-works/pi-coding-agent": ">=0.80.0 <1",
+    "@earendil-works/pi-tui": ">=0.80.0 <1",
     "typebox": "^1.1.24"
   },
   "peerDependenciesMeta": {
@@ -89,6 +89,9 @@
     "@juicesharp/rpiv-config": "1.20.0"
   },
   "devDependencies": {
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
+    "@earendil-works/pi-tui": "0.84.0",
     "@types/node": "25.6.0",
     "typescript": "6.0.3",
     "vitest": "4.1.7"

--- a/packages/pi-tool-display-intent/package.json
+++ b/packages/pi-tool-display-intent/package.json
@@ -69,11 +69,12 @@
     ]
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.80.0",
-    "@earendil-works/pi-tui": "^0.80.0"
+    "@earendil-works/pi-coding-agent": ">=0.80.0 <1",
+    "@earendil-works/pi-tui": ">=0.80.0 <1"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.80.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
+    "@earendil-works/pi-tui": "0.84.0",
     "tsx": "4.22.4",
     "typescript": "6.0.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,15 +13,6 @@ importers:
 
   .:
     dependencies:
-      '@earendil-works/pi-ai':
-        specifier: '*'
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-coding-agent':
-        specifier: '*'
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui':
-        specifier: '*'
-        version: 0.80.3
       '@juicesharp/rpiv-config':
         specifier: 2.4.0
         version: 2.4.0
@@ -44,6 +35,15 @@ importers:
       '@changesets/cli':
         specifier: 2.31.0
         version: 2.31.0(@types/node@26.1.1)
+      '@earendil-works/pi-ai':
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.84.0
+        version: 0.84.0
 
   packages/pi-ask-user-question:
     dependencies:
@@ -52,17 +52,17 @@ importers:
         version: 2.4.0
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.80.3
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: 0.80.3
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: 0.80.3
-        version: 0.80.3
+        specifier: 0.84.0
+        version: 0.84.0
       '@juicesharp/rpiv-i18n':
         specifier: 2.4.0
-        version: 2.4.0(@earendil-works/pi-coding-agent@0.80.3(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.80.3)
+        version: 2.4.0(@earendil-works/pi-coding-agent@0.84.0(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.84.0)
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -79,11 +79,11 @@ importers:
   packages/pi-context7:
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: 0.82.1
-        version: 0.82.1(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: 0.81.1
-        version: 0.81.1
+        specifier: 0.84.0
+        version: 0.84.0
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -100,14 +100,14 @@ importers:
   packages/pi-glance:
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.81.1
-        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: 0.81.1
-        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: 0.81.1
-        version: 0.81.1
+        specifier: 0.84.0
+        version: 0.84.0
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -122,11 +122,11 @@ importers:
         version: 1.1.24
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: 0.81.1
-        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: 0.80.3
-        version: 0.80.3
+        specifier: 0.84.0
+        version: 0.84.0
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -138,17 +138,16 @@ importers:
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-recap:
-    dependencies:
-      '@earendil-works/pi-ai':
-        specifier: '*'
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-coding-agent':
-        specifier: '*'
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui':
-        specifier: '*'
-        version: 0.80.3
     devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.84.0
+        version: 0.84.0
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -161,12 +160,6 @@ importers:
 
   packages/pi-search-hub:
     dependencies:
-      '@earendil-works/pi-ai':
-        specifier: ^0.80.0
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-coding-agent':
-        specifier: ^0.80.0
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
       typebox:
         specifier: 1.1.24
         version: 1.1.24
@@ -174,6 +167,12 @@ importers:
         specifier: 2.3.1
         version: 2.3.1
     devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -197,14 +196,14 @@ importers:
         version: 5.1.16
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.81.1
-        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: 0.81.1
-        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: 0.81.1
-        version: 0.81.1
+        specifier: 0.84.0
+        version: 0.84.0
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -217,25 +216,25 @@ importers:
 
   packages/pi-todo:
     dependencies:
-      '@earendil-works/pi-ai':
-        specifier: ^0.80.0
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-coding-agent':
-        specifier: ^0.80.0
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui':
-        specifier: ^0.80.0
-        version: 0.80.3
       '@juicesharp/rpiv-config':
         specifier: 1.20.0
         version: 1.20.0(typebox@1.1.38)
       '@juicesharp/rpiv-i18n':
         specifier: '*'
-        version: 1.20.0(@earendil-works/pi-coding-agent@0.80.3(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.80.3)(typebox@1.1.38)
+        version: 1.20.0(@earendil-works/pi-coding-agent@0.84.0(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.84.0)(typebox@1.1.38)
       typebox:
         specifier: ^1.1.24
         version: 1.1.38
     devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.84.0
+        version: 0.84.0
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -247,14 +246,13 @@ importers:
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-tool-display-intent:
-    dependencies:
-      '@earendil-works/pi-tui':
-        specifier: ^0.80.0
-        version: 0.80.3
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.80.0
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.84.0
+        version: 0.84.0
       tsx:
         specifier: 4.22.4
         version: 4.22.4
@@ -265,11 +263,11 @@ importers:
   providers/pi-provider-volcengine-agent-plan:
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.81.1
-        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: 0.81.1
-        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -450,58 +448,34 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@earendil-works/pi-agent-core@0.80.3':
-    resolution: {integrity: sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==}
+  '@earendil-works/pi-agent-core@0.84.0':
+    resolution: {integrity: sha512-L1lw0lwR5LXCzGEeHD9XNEruU2bg0H8clOA8ySdGMHvxutp8GC+yZL6MZp4tqQRnLKP3gHmY7TrWzQ3YnFdJYQ==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-agent-core@0.81.1':
-    resolution: {integrity: sha512-yqbh68CyhqxMov/jUogFJfMqlu2Gd37GAki+tr59YCmAPHfomiCA5ESzusXtpGzABeiZFC/OrRdQ4GwCCOMIHA==}
-    engines: {node: '>=22.19.0'}
-
-  '@earendil-works/pi-agent-core@0.82.1':
-    resolution: {integrity: sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg==}
-    engines: {node: '>=22.19.0'}
-
-  '@earendil-works/pi-ai@0.80.3':
-    resolution: {integrity: sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==}
+  '@earendil-works/pi-ai@0.84.0':
+    resolution: {integrity: sha512-N9RDk8q0eglGiy+NqTZ3Ev2j+6oFNXSAJa8b0CYhvWB9HGiKZjsoCESXkUvMDLybrn0wXp75sdsoBzEtHxk9kA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-ai@0.81.1':
-    resolution: {integrity: sha512-hzHE7Z8l5mgJk+ke67Lge0rwS2+wbKJrFKl9o5M1R1rh33+cCT7D1AHz1OAtX5wFs90E1/BTGhyJRTUHaMxGvQ==}
+  '@earendil-works/pi-client@0.84.0':
+    resolution: {integrity: sha512-fHXgw1FdLDh+uw42SvTkJRBfgc3nsrslghvbRFEAxdjfcOxJt7hPsTj4HHNK96wMy1f+zvQYL8Y2znvFoZ8JDA==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-coding-agent@0.84.0':
+    resolution: {integrity: sha512-oxEU7BT9xuVT6UKNwUNDzNP5dVGb+DZRGfaEyMyAab8dRlqTSxxyhSlMAxmYsu//YOeasj9E8n2+px1BzIai0g==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-ai@0.82.1':
-    resolution: {integrity: sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.80.3':
-    resolution: {integrity: sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.81.1':
-    resolution: {integrity: sha512-r6ovAsZOgAqbC/aU6s+/dPnv/sGZBuWyZNvi3pXjpbuX5wvp3XvGkQI7/VLvX2o9XpmpFaPUxKNym1WfkN/P8A==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.82.1':
-    resolution: {integrity: sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-tui@0.80.3':
-    resolution: {integrity: sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==}
+  '@earendil-works/pi-protocol@0.84.0':
+    resolution: {integrity: sha512-Fc28cCYGg5+aRnMzbAD7QAi6Xl//kbETyFroLHCs3Zf4oaXH9L2gzBqVLVAwrKIKeS0uffUrmihocGTECfKW6Q==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-tui@0.81.1':
-    resolution: {integrity: sha512-OMEe+Zt8oQYi/rCq3upxsTlIScWL0FPhXwQus34TbQb3EmTx88S7Uzx32JxvQiEeWOw8eDCdJf2PBUBE9r6wIg==}
+  '@earendil-works/pi-telemetry@0.84.0':
+    resolution: {integrity: sha512-g6hLxEfAUk3zJlDmFWhWHJNcYXYiNGeWuJC9YkcHpkdkj0gxD4uaMNNNU3QsAEJXW9Qcxnl21+U8GfhVsc8C5g==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-tui@0.82.1':
-    resolution: {integrity: sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ==}
+  '@earendil-works/pi-tui@0.84.0':
+    resolution: {integrity: sha512-nbs0FeZJ5rWDD6VpKfXXmYbEHnHqb40V9glE2l9f8ftoWpsP8nw0WcXK8jOjfRsDPnT9dJHy3dItOHdn/AFGjA==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.11.1':
@@ -1266,6 +1240,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  grok-mermaid@0.2.2:
+    resolution: {integrity: sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==}
+    engines: {node: '>=18'}
+
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
@@ -1716,6 +1694,9 @@ packages:
   typebox@1.1.38:
     resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
 
+  typebox@1.3.7:
+    resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -1727,8 +1708,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
     engines: {node: '>=22.19.0'}
 
   universalify@0.1.2:
@@ -2230,40 +2211,13 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
-  '@earendil-works/pi-agent-core@0.80.3(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.84.0(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.80.3(ws@8.21.0)(zod@4.4.3)
-      ignore: 7.0.5
-      typebox: 1.1.38
-      yaml: 2.9.0
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-agent-core@0.81.1(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-ai': 0.81.1(ws@8.21.0)(zod@4.4.3)
-      ignore: 7.0.5
-      typebox: 1.1.38
-      yaml: 2.9.0
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-agent-core@0.82.1(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-ai': 0.82.1(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-telemetry': 0.84.0
       diff: 8.0.4
       ignore: 7.0.5
-      typebox: 1.1.38
+      typebox: 1.3.7
       yaml: 2.9.0
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -2273,10 +2227,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.80.3(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.84.0(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@earendil-works/pi-telemetry': 0.84.0
       '@google/genai': 1.52.0
       '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
@@ -2285,7 +2240,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
       partial-json: 0.1.7
-      typebox: 1.1.38
+      typebox: 1.3.7
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -2294,58 +2249,23 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.81.1(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-client@0.84.0':
     dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
-      '@opentelemetry/api': 1.9.0
-      '@smithy/node-http-handler': 4.7.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
-      partial-json: 0.1.7
-      typebox: 1.1.38
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
+      '@earendil-works/pi-protocol': 0.84.0
 
-  '@earendil-works/pi-ai@0.82.1(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.84.0(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
-      '@opentelemetry/api': 1.9.0
-      '@smithy/node-http-handler': 4.7.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
-      partial-json: 0.1.7
-      typebox: 1.1.38
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-coding-agent@0.80.3(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-agent-core': 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.80.3
+      '@earendil-works/pi-agent-core': 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-client': 0.84.0
+      '@earendil-works/pi-protocol': 0.84.0
+      '@earendil-works/pi-tui': 0.84.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
       diff: 8.0.4
       glob: 13.0.6
+      grok-mermaid: 0.2.2
       highlight.js: 10.7.3
       hosted-git-info: 9.0.3
       ignore: 7.0.5
@@ -2353,8 +2273,8 @@ snapshots:
       minimatch: 10.2.5
       proper-lockfile: 4.1.2
       semver: 7.8.0
-      typebox: 1.1.38
-      undici: 8.5.0
+      typebox: 1.3.7
+      undici: 8.9.0
       yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.9
@@ -2366,77 +2286,13 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.81.1(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-protocol@0.84.0':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.81.1(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.81.1(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.81.1
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cross-spawn: 7.0.6
-      diff: 8.0.4
-      glob: 13.0.6
-      highlight.js: 10.7.3
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      semver: 7.8.0
-      typebox: 1.1.38
-      undici: 8.5.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.9
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
+      typebox: 1.3.7
 
-  '@earendil-works/pi-coding-agent@0.82.1(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-agent-core': 0.82.1(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.82.1(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.82.1
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cross-spawn: 7.0.6
-      diff: 8.0.4
-      glob: 13.0.6
-      highlight.js: 10.7.3
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      semver: 7.8.0
-      typebox: 1.1.38
-      undici: 8.5.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.9
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
+  '@earendil-works/pi-telemetry@0.84.0': {}
 
-  '@earendil-works/pi-tui@0.80.3':
-    dependencies:
-      get-east-asian-width: 1.6.0
-      marked: 18.0.5
-
-  '@earendil-works/pi-tui@0.81.1':
-    dependencies:
-      get-east-asian-width: 1.6.0
-      marked: 18.0.5
-
-  '@earendil-works/pi-tui@0.82.1':
+  '@earendil-works/pi-tui@0.84.0':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
@@ -2563,18 +2419,18 @@ snapshots:
     dependencies:
       typebox: 1.1.24
 
-  '@juicesharp/rpiv-i18n@1.20.0(@earendil-works/pi-coding-agent@0.80.3(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.80.3)(typebox@1.1.38)':
+  '@juicesharp/rpiv-i18n@1.20.0(@earendil-works/pi-coding-agent@0.84.0(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.84.0)(typebox@1.1.38)':
     dependencies:
-      '@earendil-works/pi-coding-agent': 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.80.3
+      '@earendil-works/pi-coding-agent': 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.84.0
       '@juicesharp/rpiv-config': 1.20.0(typebox@1.1.38)
     transitivePeerDependencies:
       - typebox
 
-  '@juicesharp/rpiv-i18n@2.4.0(@earendil-works/pi-coding-agent@0.80.3(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.80.3)':
+  '@juicesharp/rpiv-i18n@2.4.0(@earendil-works/pi-coding-agent@0.84.0(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.84.0)':
     dependencies:
-      '@earendil-works/pi-coding-agent': 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.80.3
+      '@earendil-works/pi-coding-agent': 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.84.0
       '@juicesharp/rpiv-config': 2.4.0
 
   '@manypkg/find-root@1.1.0':
@@ -3095,6 +2951,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  grok-mermaid@0.2.2: {}
+
   highlight.js@10.7.3: {}
 
   hosted-git-info@9.0.3:
@@ -3469,6 +3327,8 @@ snapshots:
 
   typebox@1.1.38: {}
 
+  typebox@1.3.7: {}
+
   typescript@6.0.3: {}
 
   undici-types@7.19.2: {}
@@ -3476,7 +3336,7 @@ snapshots:
   undici-types@8.3.0:
     optional: true
 
-  undici@8.5.0: {}
+  undici@8.9.0: {}
 
   universalify@0.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,12 @@ allowBuilds:
   "@google/genai": false
   esbuild: false
   protobufjs: false
+
+minimumReleaseAgeExclude:
+  - '@earendil-works/pi-agent-core@0.84.0'
+  - '@earendil-works/pi-ai@0.84.0'
+  - '@earendil-works/pi-client@0.84.0'
+  - '@earendil-works/pi-coding-agent@0.84.0'
+  - '@earendil-works/pi-protocol@0.84.0'
+  - '@earendil-works/pi-telemetry@0.84.0'
+  - '@earendil-works/pi-tui@0.84.0'

--- a/providers/pi-provider-volcengine-agent-plan/package.json
+++ b/providers/pi-provider-volcengine-agent-plan/package.json
@@ -50,8 +50,8 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.81.1",
-    "@earendil-works/pi-coding-agent": "0.81.1",
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
     "@types/node": "25.6.0",
     "jiti": "2.7.0",
     "tsx": "4.22.4",

--- a/providers/pi-provider-volcengine-agent-plan/test/provider.test.ts
+++ b/providers/pi-provider-volcengine-agent-plan/test/provider.test.ts
@@ -81,6 +81,7 @@ test("re-prompts an invalid key and stores the selected tier", async () => {
 	let secretPrompts = 0;
 	const notifications: string[] = [];
 	const credential = await login({
+		signal: new AbortController().signal,
 		async prompt(prompt) {
 			if (prompt.type === "secret") {
 				secretPrompts += 1;
@@ -113,6 +114,7 @@ test("allows an explicit save when validation is temporarily unavailable", async
 
 	const prompts: string[] = [];
 	const credential = await login({
+		signal: new AbortController().signal,
 		async prompt(prompt) {
 			prompts.push(prompt.type);
 			if (prompt.type === "secret") return "unchecked-key";
@@ -155,11 +157,12 @@ test("filters the static catalog by tier and resolves standard auth", async () =
 		async env() { return undefined; },
 		async fileExists() { return false; },
 	};
-	const auth = await provider.auth.apiKey?.resolve({ ctx, credential: mediumCredential });
+	const signal = new AbortController().signal;
+	const auth = await provider.auth.apiKey?.resolve({ ctx, credential: mediumCredential, signal });
 	assert.equal(auth?.auth.apiKey, "stored-key");
 	assert.equal(auth?.env?.ARK_AGENT_PLAN_TIER, "medium");
 	assert.equal(auth?.source, "Pi auth.json");
-	assert.equal(await provider.auth.apiKey?.check?.({ ctx }), undefined);
+	assert.equal(await provider.auth.apiKey?.check?.({ ctx, signal }), undefined);
 });
 
 test("provides public API cost estimates for every model", () => {

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -48,6 +48,7 @@ const requiredPackFiles = new Map([
 		"packages/pi-ask-user-question/view/tool-renderer.ts",
 		"packages/pi-ask-user-question/locales/zh.json",
 		"packages/pi-ask-user-question/README.md",
+		"packages/pi-ask-user-question/README.zh-CN.md",
 		"packages/pi-ask-user-question/UPSTREAM_SOURCE.md",
 		"packages/pi-subagents/src/index.ts",
 		"packages/pi-subagents/src/ui/conversation-brief.ts",
@@ -107,6 +108,7 @@ const requiredPackFiles = new Map([
 		"locales/en.json",
 		"locales/zh.json",
 		"README.md",
+		"README.zh-CN.md",
 		"CHANGELOG.md",
 		"LICENSE",
 		"UPSTREAM_LICENSE",
@@ -147,6 +149,7 @@ const maintainedReadmes = [
 	"packages/pi-context7/README.md",
 	"packages/pi-context7/README.zh-CN.md",
 	"packages/pi-ask-user-question/README.md",
+	"packages/pi-ask-user-question/README.zh-CN.md",
 	"packages/pi-subagents/README.md",
 	"packages/pi-subagents/README.zh-CN.md",
 	"providers/pi-provider-volcengine-agent-plan/README.md",
@@ -191,6 +194,10 @@ await assertBilingualPair(
 await assertBilingualPair(
 	"packages/pi-context7/README.md",
 	"packages/pi-context7/README.zh-CN.md",
+);
+await assertBilingualPair(
+	"packages/pi-ask-user-question/README.md",
+	"packages/pi-ask-user-question/README.zh-CN.md",
 );
 await assertBilingualPair(
 	"packages/pi-subagents/README.md",


### PR DESCRIPTION
## Summary

- upgrade the repository's Pi development and smoke-test baseline to 0.84.0, widen affected peer ranges, and update the Agent Plan provider auth tests for the required `AbortSignal`
- strip ANSI and terminal control sequences from child-agent text before it reaches parent TUI summaries, previews, Markdown, and notifications
- publish Ask User Question with an English default README and aligned Simplified Chinese README, enforce bilingual parity and package contents, and document the repository-wide bilingual rule

## Release plan

- `@zhcsyncer/pi-extensions`: 0.15.0 → 0.15.1
- `@zhcsyncer/pi-ask-user-question`: 0.1.0 → 0.1.1
- `@zhcsyncer/pi-context7`: 0.1.0 → 0.1.1
- `@zhcsyncer/pi-plan-mode`: 0.3.0 → 0.3.1
- `@zhcsyncer/pi-todo`: 0.3.1 → 0.3.2
- `@zhcsyncer/pi-tool-display-intent`: 0.7.0 → 0.7.1
- `@zhcsyncer/pi-subagents`: 0.1.0 → 0.1.1

## Validation

- all workspace package/provider type checks and test suites passed against Pi 0.84.0
- `@zhcsyncer/pi-subagents`: 38 files / 765 tests passed
- `@zhcsyncer/pi-ask-user-question`: 32 files / 595 tests passed
- `pnpm check` passed, including release policy, smoke loading, bilingual parity, and npm pack dry runs
- `git diff --check` passed

## Follow-up

Full-screen Pi 0.84 TUI behavior should still receive a real-terminal visual QA pass; no API or automated compatibility failures were found.
