### PR TITLE
fix(pi-subagents): improve runtime metrics UI

### DIFF
--- a/.changeset/honest-subagent-metrics.md
+++ b/.changeset/honest-subagent-metrics.md
@@ -3,4 +3,4 @@
 "@zhcsyncer/pi-subagents": patch
 ---
 
-Improve subagent runtime UI with an honest `working…` fallback, readable accented durations, and lifetime input/output/cache/cost breakdowns that keep current-context utilization and the existing compact total semantics distinct.
+Improve subagent runtime UI with an honest `working…` fallback, delayed coarse activity phases that do not flicker through exact steps, readable accented durations, and lifetime input/output/cache/cost breakdowns that keep current-context utilization and the existing compact total semantics distinct.

--- a/.changeset/honest-subagent-metrics.md
+++ b/.changeset/honest-subagent-metrics.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-subagents": patch
+---
+
+Improve subagent runtime UI with an honest `working…` fallback, readable accented durations, and lifetime input/output/cache/cost breakdowns that keep current-context utilization and the existing compact total semantics distinct.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -17,7 +17,8 @@ This fork keeps upstream **runtime** behavior (spawn, steer, resume, FleetView w
 
 | Area | Upstream (`@tintinweb/pi-subagents`) | This fork (`@zhcsyncer/pi-subagents`) |
 | --- | --- | --- |
-| **Conversation overlay** (FleetView / agent list → Enter) | Full conversation dump: user / assistant / toolResult walls (tool bodies truncated ~500 chars but still large) | **Scheme A brief view**: **Prompt** → **Steps** (one line per tool) → **Result**; tool bodies folded by default |
+| **Conversation overlay** (FleetView / agent list → Enter) | Full conversation dump: user / assistant / toolResult walls (tool bodies truncated ~500 chars but still large) | **Scheme A brief view**: **Prompt** → **Usage** → **Steps** (one line per tool) → **Result**; tool bodies folded by default |
+| Runtime status / metrics | Idle progress falls back to `thinking…`; long runs remain long second counts; compact tokens and context can look like one metric | Honest `working…` fallback; friendly minute/hour durations with only the duration fragment highlighted; compact **lifetime** total is distinct from **current context**, with a full usage breakdown in the overlay |
 | Overlay step detail | N/A (everything dumped) | Press **`o`** to expand/fold tool args + results |
 | Overlay on agent **error / aborted / stopped / steered** | Last messages still dominate the dump | **Result** prefers `record.error`; `steered` shows turn-limit; header icons match chrome; terminal records settle dangling running steps |
 | Overlay **bashExecution** | Shown as command + output dump | One step line; **`exitCode` / `cancelled`** → `✗` (not a false `✓`) |
@@ -67,10 +68,11 @@ pi -e .
 
 Open FleetView / agent list, select a subagent, press Enter:
 
-1. **Header** — name / status / duration / tools / tokens (upstream)
+1. **Header** — name / status / highlighted duration / tools / compact **lifetime** tokens and **current ctx** percentage
 2. **Prompt** — first meaningful user (dispatch) message
-3. **Steps** — one line per tool (`✓ read path`, `⠹ bash …`, `✗ grep …`); results folded
-4. **Result** — final assistant text, running indicator, or **error** on terminal failure
+3. **Usage** — lifetime `input` / `output` / `cache read` / `cache write`, optional cost, and current context as a separate metric
+4. **Steps** — one line per tool (`✓ read path`, `⠹ bash …`, `✗ grep …`); results folded
+5. **Result** — final assistant text, `working…` fallback, or **error** on terminal failure
 
 | Key | Action |
 | --- | --- |
@@ -86,20 +88,22 @@ Matches upstream’s documented shape ([UPSTREAM_README](./UPSTREAM_README.md) �
 
 ```text
 ▸ Explore  Find auth files
-⠹ haiku · effort: high · ↻3 · 3 tool uses · 12.4k token
-  ⎿  searching…
-✓ haiku · effort: high · ↻8 · 5 tool uses · 33.8k token · 12.3s
+⠹ haiku · effort: high · ↻3 · 3 tool uses · lifetime 12.4k token
+  ⎿  working…
+✓ haiku · effort: high · ↻8 · 5 tool uses · lifetime 33.8k token · 10 min 13s
   ⎿  Done
 ```
 
 | State | What you see |
 | --- | --- |
 | **Call** | `▸ Type  description` (+ dim chips only if call args set `model` / `thinking` / `bg`) |
-| **Running** | `⠹` + stats / `⎿` activity |
-| **Completed** | `✓` + stats · duration / `⎿ Done` (or Wrapped up / Stopped / Error) |
+| **Running** | `⠹` + stats / `⎿` tool or body activity; otherwise `working…` |
+| **Completed** | `✓` + stats · friendly duration / `⎿ Done` (or Wrapped up / Stopped / Error) |
 | **Expanded** (`Ctrl+O`) | Same chrome + **Markdown** body (no default dump) |
 
 `effort` is display wording for the existing `thinking` parameter/frontmatter field. Effective **model** (including parent inherit) is always on the **result** stats line when known.
+
+The compact **lifetime** token figure deliberately keeps its existing `input + output + cache write` meaning; `cache read` is retained and shown in the Usage breakdown but is not silently added back into that total ([upstream issue #38](https://github.com/tintinweb/pi-subagents/issues/38)). **Current ctx** is current context-window utilization, not a percentage of the lifetime total. Durations remain seconds below one minute, then switch to readable minute/hour forms such as `10 min 13s` and `1 hr 2 min 3s`.
 
 ## Configuration storage
 

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -18,7 +18,7 @@ This fork keeps upstream **runtime** behavior (spawn, steer, resume, FleetView w
 | Area | Upstream (`@tintinweb/pi-subagents`) | This fork (`@zhcsyncer/pi-subagents`) |
 | --- | --- | --- |
 | **Conversation overlay** (FleetView / agent list → Enter) | Full conversation dump: user / assistant / toolResult walls (tool bodies truncated ~500 chars but still large) | **Scheme A brief view**: **Prompt** → **Usage** → **Steps** (one line per tool) → **Result**; tool bodies folded by default |
-| Runtime status / metrics | Idle progress falls back to `thinking…`; long runs remain long second counts; compact tokens and context can look like one metric | Honest `working…` fallback; friendly minute/hour durations with only the duration fragment highlighted; compact **lifetime** total is distinct from **current context**, with a full usage breakdown in the overlay |
+| Runtime status / metrics | Idle progress falls back to `thinking…`; long runs remain long second counts; compact tokens and context can look like one metric | Honest `working…` fallback with delayed, stable coarse phases; friendly minute/hour durations with only the duration fragment highlighted; compact **lifetime** total is distinct from **current context**, with a full usage breakdown in the overlay |
 | Overlay step detail | N/A (everything dumped) | Press **`o`** to expand/fold tool args + results |
 | Overlay on agent **error / aborted / stopped / steered** | Last messages still dominate the dump | **Result** prefers `record.error`; `steered` shows turn-limit; header icons match chrome; terminal records settle dangling running steps |
 | Overlay **bashExecution** | Shown as command + output dump | One step line; **`exitCode` / `cancelled`** → `✗` (not a false `✓`) |
@@ -89,7 +89,7 @@ Matches upstream’s documented shape ([UPSTREAM_README](./UPSTREAM_README.md) �
 ```text
 ▸ Explore  Find auth files
 ⠹ haiku · effort: high · ↻3 · 3 tool uses · lifetime 12.4k token
-  ⎿  working…
+  ⎿  exploring…
 ✓ haiku · effort: high · ↻8 · 5 tool uses · lifetime 33.8k token · 10 min 13s
   ⎿  Done
 ```
@@ -97,11 +97,13 @@ Matches upstream’s documented shape ([UPSTREAM_README](./UPSTREAM_README.md) �
 | State | What you see |
 | --- | --- |
 | **Call** | `▸ Type  description` (+ dim chips only if call args set `model` / `thinking` / `bg`) |
-| **Running** | `⠹` + stats / `⎿` tool or body activity; otherwise `working…` |
+| **Running** | `⠹` + stats / `⎿` stable coarse phase (`exploring…`, `editing…`, `running commands…`, or `delegating…`); otherwise `working…` |
 | **Completed** | `✓` + stats · friendly duration / `⎿ Done` (or Wrapped up / Stopped / Error) |
 | **Expanded** (`Ctrl+O`) | Same chrome + **Markdown** body (no default dump) |
 
 `effort` is display wording for the existing `thinking` parameter/frontmatter field. Effective **model** (including parent inherit) is always on the **result** stats line when known.
+
+Compact running surfaces do not stream file paths, commands, or assistant body text. Fast and unknown work stays `working…`; a known coarse phase appears only after about 0.8 seconds and then remains visible for at least 1.5 seconds to avoid flicker. Exact per-tool steps remain available in the conversation overlay.
 
 The compact **lifetime** token figure deliberately keeps its existing `input + output + cache write` meaning; `cache read` is retained and shown in the Usage breakdown but is not silently added back into that total ([upstream issue #38](https://github.com/tintinweb/pi-subagents/issues/38)). **Current ctx** is current context-window utilization, not a percentage of the lifetime total. Durations remain seconds below one minute, then switch to readable minute/hour forms such as `10 min 13s` and `1 hr 2 min 3s`.
 

--- a/packages/pi-subagents/README.zh-CN.md
+++ b/packages/pi-subagents/README.zh-CN.md
@@ -18,7 +18,7 @@
 | 区域 | 上游 `@tintinweb/pi-subagents` | 本 fork `@zhcsyncer/pi-subagents` |
 | --- | --- | --- |
 | **对话 overlay**（FleetView / 列表 → Enter） | 全文 dump：user / assistant / toolResult 墙（tool 体约 500 字截断仍很大） | **方案 A 摘要视图**：**Prompt** → **Usage** → **Steps**（一行一步）→ **Result**；tool 体默认折叠 |
-| 运行状态 / 指标 | 空闲进度 fallback 为 `thinking…`；长任务一直显示大秒数；紧凑 token 与 context 容易被看成同一指标 | 语义诚实的 `working…` fallback；分钟/小时友好时长且只高亮时长片段；紧凑 **lifetime** 总量与 **current context** 明确分开，overlay 提供完整 usage breakdown |
+| 运行状态 / 指标 | 空闲进度 fallback 为 `thinking…`；长任务一直显示大秒数；紧凑 token 与 context 容易被看成同一指标 | 语义诚实的 `working…` fallback，并仅延迟展示稳定的粗粒度阶段；分钟/小时友好时长且只高亮时长片段；紧凑 **lifetime** 总量与 **current context** 明确分开，overlay 提供完整 usage breakdown |
 | Overlay 步骤详情 | 无（全摊开） | **`o`** 展开/折叠 tool 参数与结果 |
 | Overlay 在 agent **error / aborted / stopped / steered** | 仍以消息流为主 | **Result 优先 `record.error`**；`steered` 标明 turn-limit；头部图标对齐 chrome；终态收敛悬空 running step |
 | Overlay **bashExecution** | 命令 + 输出 dump | 一步一行；**`exitCode` / `cancelled`** → `✗`（不会误标 ✓） |
@@ -89,7 +89,7 @@ FleetView / agent 列表选中子 agent 后回车：
 ```text
 ▸ Explore  Find auth files
 ⠹ haiku · effort: high · ↻3 · 3 tool uses · lifetime 12.4k token
-  ⎿  working…
+  ⎿  exploring…
 ✓ haiku · effort: high · ↻8 · 5 tool uses · lifetime 33.8k token · 10 min 13s
   ⎿  Done
 ```
@@ -97,11 +97,13 @@ FleetView / agent 列表选中子 agent 后回车：
 | 状态 | 呈现 |
 | --- | --- |
 | **调用行** | `▸ Type  description`（仅当 args 显式带 model/thinking/bg 时附加 dim 芯片） |
-| **运行中** | `⠹` + stats / `⎿` tool 或正文 activity；两者都没有时显示 `working…` |
+| **运行中** | `⠹` + stats / `⎿` 稳定的粗粒度阶段（`exploring…`、`editing…`、`running commands…` 或 `delegating…`）；否则显示 `working…` |
 | **完成** | `✓` + stats · 友好时长 / `⎿ Done`（或 Wrapped up / Stopped / Error） |
 | **展开**（`Ctrl+O`） | 同上 chrome + **Markdown** 正文 |
 
 `effort` 对应 `thinking`。有效 **model**（含继承）在**结果** stats 中展示。
+
+紧凑运行界面不会流式展示文件路径、命令或 assistant 正文。快速步骤与未知工作保持 `working…`；已知粗粒度阶段持续约 0.8 秒后才出现，并至少保持 1.5 秒以避免闪烁。逐 tool 的精确步骤仍可在 conversation overlay 中查看。
 
 紧凑 **lifetime** token 数刻意保留原有的 `input + output + cache write` 语义；`cache read` 会被保留并显示在 Usage breakdown 中，但不会悄悄加回这个总量（见[上游 issue #38](https://github.com/tintinweb/pi-subagents/issues/38)）。**Current ctx** 表示当前 context window 的占用率，不是 lifetime 总量的百分比。时长不足一分钟时仍显示秒数，之后切换为 `10 min 13s`、`1 hr 2 min 3s` 等易读的分钟/小时格式。
 

--- a/packages/pi-subagents/README.zh-CN.md
+++ b/packages/pi-subagents/README.zh-CN.md
@@ -17,7 +17,8 @@
 
 | 区域 | 上游 `@tintinweb/pi-subagents` | 本 fork `@zhcsyncer/pi-subagents` |
 | --- | --- | --- |
-| **对话 overlay**（FleetView / 列表 → Enter） | 全文 dump：user / assistant / toolResult 墙（tool 体约 500 字截断仍很大） | **方案 A 摘要视图**：**Prompt** → **Steps**（一行一步）→ **Result**；tool 体默认折叠 |
+| **对话 overlay**（FleetView / 列表 → Enter） | 全文 dump：user / assistant / toolResult 墙（tool 体约 500 字截断仍很大） | **方案 A 摘要视图**：**Prompt** → **Usage** → **Steps**（一行一步）→ **Result**；tool 体默认折叠 |
+| 运行状态 / 指标 | 空闲进度 fallback 为 `thinking…`；长任务一直显示大秒数；紧凑 token 与 context 容易被看成同一指标 | 语义诚实的 `working…` fallback；分钟/小时友好时长且只高亮时长片段；紧凑 **lifetime** 总量与 **current context** 明确分开，overlay 提供完整 usage breakdown |
 | Overlay 步骤详情 | 无（全摊开） | **`o`** 展开/折叠 tool 参数与结果 |
 | Overlay 在 agent **error / aborted / stopped / steered** | 仍以消息流为主 | **Result 优先 `record.error`**；`steered` 标明 turn-limit；头部图标对齐 chrome；终态收敛悬空 running step |
 | Overlay **bashExecution** | 命令 + 输出 dump | 一步一行；**`exitCode` / `cancelled`** → `✗`（不会误标 ✓） |
@@ -67,10 +68,11 @@ pi -e .
 
 FleetView / agent 列表选中子 agent 后回车：
 
-1. **Header** — 名称 / 状态 / 时长 / tools / tokens（上游）
+1. **Header** — 名称 / 状态 / 高亮时长 / tools / 紧凑 **lifetime** tokens 与 **current ctx** 百分比
 2. **Prompt** — 第一条有意义的 user（派发）消息
-3. **Steps** — 每个 tool 一行摘要；结果默认折叠
-4. **Result** — 最终 assistant 文本、运行中指示，或终态 **error**
+3. **Usage** — lifetime `input` / `output` / `cache read` / `cache write`、可用时的 cost，以及单独列出的当前 context
+4. **Steps** — 每个 tool 一行摘要；结果默认折叠
+5. **Result** — 最终 assistant 文本、`working…` fallback，或终态 **error**
 
 | 键 | 行为 |
 | --- | --- |
@@ -86,20 +88,22 @@ FleetView / agent 列表选中子 agent 后回车：
 
 ```text
 ▸ Explore  Find auth files
-⠹ haiku · effort: high · ↻3 · 3 tool uses · 12.4k token
-  ⎿  searching…
-✓ haiku · effort: high · ↻8 · 5 tool uses · 33.8k token · 12.3s
+⠹ haiku · effort: high · ↻3 · 3 tool uses · lifetime 12.4k token
+  ⎿  working…
+✓ haiku · effort: high · ↻8 · 5 tool uses · lifetime 33.8k token · 10 min 13s
   ⎿  Done
 ```
 
 | 状态 | 呈现 |
 | --- | --- |
 | **调用行** | `▸ Type  description`（仅当 args 显式带 model/thinking/bg 时附加 dim 芯片） |
-| **运行中** | `⠹` + stats / `⎿` activity |
-| **完成** | `✓` + stats · duration / `⎿ Done`（或 Wrapped up / Stopped / Error） |
+| **运行中** | `⠹` + stats / `⎿` tool 或正文 activity；两者都没有时显示 `working…` |
+| **完成** | `✓` + stats · 友好时长 / `⎿ Done`（或 Wrapped up / Stopped / Error） |
 | **展开**（`Ctrl+O`） | 同上 chrome + **Markdown** 正文 |
 
 `effort` 对应 `thinking`。有效 **model**（含继承）在**结果** stats 中展示。
+
+紧凑 **lifetime** token 数刻意保留原有的 `input + output + cache write` 语义；`cache read` 会被保留并显示在 Usage breakdown 中，但不会悄悄加回这个总量（见[上游 issue #38](https://github.com/tintinweb/pi-subagents/issues/38)）。**Current ctx** 表示当前 context window 的占用率，不是 lifetime 总量的百分比。时长不足一分钟时仍显示秒数，之后切换为 `10 min 13s`、`1 hr 2 min 3s` 等易读的分钟/小时格式。
 
 ## 配置存储
 

--- a/packages/pi-subagents/src/agent-manager.ts
+++ b/packages/pi-subagents/src/agent-manager.ts
@@ -13,7 +13,7 @@ import type { Model } from "@earendil-works/pi-ai";
 import type { AgentSession, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { resumeAgent, runAgent, type ToolActivity } from "./agent-runner.js";
 import type { AgentInvocation, AgentRecord, IsolationMode, SubagentType, ThinkingLevel } from "./types.js";
-import { addUsage } from "./usage.js";
+import { addUsage, createLifetimeUsage, type LifetimeUsage } from "./usage.js";
 import { cleanupWorktree, createWorktree, pruneWorktrees, } from "./worktree.js";
 
 export type OnAgentComplete = (record: AgentRecord) => void;
@@ -92,7 +92,7 @@ interface SpawnOptions {
   /** Called at the end of each agentic turn with the cumulative count. */
   onTurnEnd?: (turnCount: number) => void;
   /** Called once per assistant message_end with that message's usage delta. */
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+  onAssistantUsage?: (usage: LifetimeUsage) => void;
   /** Called when the session successfully compacts. */
   onCompaction?: (info: CompactionInfo) => void;
 }
@@ -165,7 +165,7 @@ export class AgentManager {
       toolUses: 0,
       startedAt: Date.now(),
       abortController,
-      lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+      lifetimeUsage: createLifetimeUsage(),
       compactionCount: 0,
       // Raw tri-state (not coerced to a boolean): true = background, false =
       // foreground (has an inline tool-result surface), undefined = caller never

--- a/packages/pi-subagents/src/agent-runner.ts
+++ b/packages/pi-subagents/src/agent-runner.ts
@@ -348,7 +348,7 @@ export interface ToolActivity {
   toolName: string;
   /** Stable id for pairing start/end (preferred over toolName). */
   toolCallId?: string;
-  /** Tool-call arguments at start — used for widget step summaries. */
+  /** Tool-call arguments at start — retained for detailed conversation step summaries. */
   args?: unknown;
 }
 

--- a/packages/pi-subagents/src/agent-runner.ts
+++ b/packages/pi-subagents/src/agent-runner.ts
@@ -25,6 +25,7 @@ import { buildMemoryBlock, buildReadOnlyMemoryBlock } from "./memory.js";
 import { buildAgentPrompt, type PromptExtras } from "./prompts.js";
 import { preloadSkills } from "./skill-loader.js";
 import type { SubagentType, ThinkingLevel } from "./types.js";
+import { toLifetimeUsage, type LifetimeUsage } from "./usage.js";
 
 /**
  * Tool names registered by THIS extension. Single source of truth so the
@@ -390,7 +391,7 @@ export interface RunOptions {
    * Lets callers maintain a lifetime accumulator that survives compaction
    * (which replaces session.state.messages and resets stats-derived sums).
    */
-  onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+  onAssistantUsage?: (usage: LifetimeUsage) => void;
   /**
    * Called when the session successfully compacts. `tokensBefore` is upstream's
    * pre-compaction context size estimate. Aborted compactions don't fire.
@@ -894,12 +895,8 @@ export async function runAgent(
       });
     }
     if (event.type === "message_end" && event.message.role === "assistant") {
-      const u = (event.message as any).usage;
-      if (u) options.onAssistantUsage?.({
-        input: u.input ?? 0,
-        output: u.output ?? 0,
-        cacheWrite: u.cacheWrite ?? 0,
-      });
+      const usage = event.message.usage;
+      if (usage) options.onAssistantUsage?.(toLifetimeUsage(usage));
     }
     if (event.type === "compaction_end" && !event.aborted && event.result) {
       options.onCompaction?.({ reason: event.reason, tokensBefore: event.result.tokensBefore });
@@ -941,7 +938,7 @@ export async function resumeAgent(
   prompt: string,
   options: {
     onToolActivity?: (activity: ToolActivity) => void;
-    onAssistantUsage?: (usage: { input: number; output: number; cacheWrite: number }) => void;
+    onAssistantUsage?: (usage: LifetimeUsage) => void;
     onCompaction?: (info: { reason: "manual" | "threshold" | "overflow"; tokensBefore: number }) => void;
     signal?: AbortSignal;
   } = {},
@@ -971,12 +968,8 @@ export async function resumeAgent(
           });
         }
         if (event.type === "message_end" && event.message.role === "assistant") {
-          const u = (event.message as any).usage;
-          if (u) options.onAssistantUsage?.({
-            input: u.input ?? 0,
-            output: u.output ?? 0,
-            cacheWrite: u.cacheWrite ?? 0,
-          });
+          const usage = event.message.usage;
+          if (usage) options.onAssistantUsage?.(toLifetimeUsage(usage));
         }
         if (event.type === "compaction_end" && !event.aborted && event.result) {
           options.onCompaction?.({ reason: event.reason, tokensBefore: event.result.tokensBefore });

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -47,6 +47,7 @@ import {
   getPromptModeLabel,
   shortModelLabel,
   SPINNER,
+  styleDuration,
   type Theme,
   type UICtx,
 } from "./ui/agent-widget.js";
@@ -63,7 +64,7 @@ import {
   renderUndetailedResult,
   toolResultText,
 } from "./ui/tool-render.js";
-import { addUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsage } from "./usage.js";
+import { addUsage, createLifetimeUsage, getLifetimeTotal, getSessionContextPercent, type LifetimeUsage } from "./usage.js";
 
 // ---- Shared helpers ----
 
@@ -161,10 +162,10 @@ export function renderRunningAgentStatus(
   return container;
 }
 
-/** Format an agent's lifetime token total, or "" when zero. */
+/** Format the legacy compact lifetime total, or "" when zero. */
 function formatLifetimeTokens(o: { lifetimeUsage: LifetimeUsage }): string {
   const t = getLifetimeTotal(o.lifetimeUsage);
-  return t > 0 ? formatTokens(t) : "";
+  return t > 0 ? `lifetime ${formatTokens(t)}` : "";
 }
 
 /**
@@ -179,7 +180,7 @@ function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
     maxTurns,
     responseText: "",
     session: undefined,
-    lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+    lifetimeUsage: createLifetimeUsage(),
   };
 
   const callbacks = {
@@ -192,7 +193,7 @@ function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
       if (activity.type === "start") {
         const id = activity.toolCallId ?? `${activity.toolName}_${Date.now()}`;
         // Store a one-line step summary (not bare tool name) so the widget
-        // last line shows e.g. "reading src/a.ts" instead of only "thinking…".
+        // last line shows e.g. "reading src/a.ts" instead of only "working…".
         state.activeTools.set(id, formatActiveToolSummary(activity.toolName, activity.args));
       } else {
         if (activity.toolCallId && state.activeTools.has(activity.toolCallId)) {
@@ -222,7 +223,7 @@ function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
     onSessionCreated: (session: any) => {
       state.session = session;
     },
-    onAssistantUsage: (usage: { input: number; output: number; cacheWrite: number }) => {
+    onAssistantUsage: (usage: LifetimeUsage) => {
       addUsage(state.lifetimeUsage, usage);
       onStreamUpdate?.();
     },
@@ -379,12 +380,14 @@ export default function (pi: ExtensionAPI) {
 
         // Line 2: stats
         const parts: string[] = [];
-        if (d.turnCount > 0) parts.push(formatTurns(d.turnCount, d.maxTurns));
-        if (d.toolUses > 0) parts.push(`${d.toolUses} tool use${d.toolUses === 1 ? "" : "s"}`);
-        if (d.totalTokens > 0) parts.push(formatTokens(d.totalTokens));
-        if (d.durationMs > 0) parts.push(formatMs(d.durationMs));
+        if (d.turnCount > 0) parts.push(theme.fg("dim", formatTurns(d.turnCount, d.maxTurns)));
+        if (d.toolUses > 0) {
+          parts.push(theme.fg("dim", `${d.toolUses} tool use${d.toolUses === 1 ? "" : "s"}`));
+        }
+        if (d.totalTokens > 0) parts.push(theme.fg("dim", `lifetime ${formatTokens(d.totalTokens)}`));
+        if (d.durationMs > 0) parts.push(styleDuration(theme, formatMs(d.durationMs)));
         if (parts.length) {
-          line += "\n  " + parts.map(p => theme.fg("dim", p)).join(" " + theme.fg("dim", "·") + " ");
+          line += "\n  " + parts.join(" " + theme.fg("dim", "·") + " ");
         }
 
         // Line 3: result preview (collapsed) or full (expanded)
@@ -1083,7 +1086,7 @@ Terse command-style prompts produce shallow, generic work.
       if (isPartial || details.status === "running") {
         const frame = SPINNER[details.spinnerFrame ?? 0];
         const s = formatAgentDetailsStats(details, theme);
-        return renderRunningAgentStatus(frame, s, details.activity ?? "thinking…", theme);
+        return renderRunningAgentStatus(frame, s, details.activity ?? "working…", theme);
       }
 
       return renderAgentLikeResult(details, text, { expanded, isPartial }, theme);
@@ -1570,7 +1573,7 @@ Terse command-style prompts produce shallow, generic work.
       const contextPercent = getSessionContextPercent(record.session);
       const statsParts = [`Tool uses: ${record.toolUses}`];
       if (tokens) statsParts.push(tokens);
-      if (contextPercent !== null) statsParts.push(`Context: ${Math.round(contextPercent)}%`);
+      if (contextPercent !== null) statsParts.push(`Current context: ${Math.round(contextPercent)}%`);
       if (record.compactionCount) statsParts.push(`Compactions: ${record.compactionCount}`);
       statsParts.push(`Duration: ${duration}`);
 
@@ -1605,7 +1608,7 @@ Terse command-style prompts produce shallow, generic work.
 
       const activity = agentActivity.get(record.id);
       const invMeta = detailsFromInvocation(record.invocation);
-      // Queued must force "queued…" — never let an empty activity map become thinking…
+      // Queued must force "queued…" — never let an empty activity map become working…
       const activityText =
         record.status === "queued"
           ? "queued…"
@@ -1695,7 +1698,7 @@ Terse command-style prompts produce shallow, generic work.
         const stateParts: string[] = [];
         if (tokens) stateParts.push(tokens);
         stateParts.push(`${record.toolUses} tool ${record.toolUses === 1 ? "use" : "uses"}`);
-        if (contextPercent !== null) stateParts.push(`context ${Math.round(contextPercent)}% full`);
+        if (contextPercent !== null) stateParts.push(`current context ${Math.round(contextPercent)}% full`);
         if (record.compactionCount) stateParts.push(`${record.compactionCount} compaction${record.compactionCount === 1 ? "" : "s"}`);
         return textResult(
           `Steering message sent to agent ${record.id}. The agent will process it after its current tool execution.\n` +

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -36,7 +36,7 @@ import {
   type AgentDetails,
   AgentWidget,
   buildInvocationTags,
-  describeActivity,
+  describeCompactActivity,
   detailsFromInvocation,
   formatActiveToolSummary,
   formatDuration,
@@ -49,6 +49,8 @@ import {
   SPINNER,
   styleDuration,
   type Theme,
+  trackActivityPhaseEnd,
+  trackActivityPhaseStart,
   type UICtx,
 } from "./ui/agent-widget.js";
 import { sanitizeDisplayText } from "./ui/display-safety.js";
@@ -175,6 +177,8 @@ function formatLifetimeTokens(o: { lifetimeUsage: LifetimeUsage }): string {
 function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
   const state: AgentActivity = {
     activeTools: new Map(),
+    activeToolPhases: new Map(),
+    phaseSummary: {},
     toolUses: 0,
     turnCount: 1,
     maxTurns,
@@ -190,23 +194,30 @@ function createActivityTracker(maxTurns?: number, onStreamUpdate?: () => void) {
       toolCallId?: string;
       args?: unknown;
     }) => {
+      const now = Date.now();
       if (activity.type === "start") {
-        const id = activity.toolCallId ?? `${activity.toolName}_${Date.now()}`;
-        // Store a one-line step summary (not bare tool name) so the widget
-        // last line shows e.g. "reading src/a.ts" instead of only "working…".
+        const id = activity.toolCallId ?? `${activity.toolName}_${now}`;
+        // Exact step detail remains available to the conversation overlay; the
+        // compact widget derives only a delayed coarse phase from the tool name.
         state.activeTools.set(id, formatActiveToolSummary(activity.toolName, activity.args));
+        trackActivityPhaseStart(state, id, activity.toolName, now);
       } else {
+        let endedId: string | undefined;
         if (activity.toolCallId && state.activeTools.has(activity.toolCallId)) {
-          state.activeTools.delete(activity.toolCallId);
+          endedId = activity.toolCallId;
         } else {
-          // Fallback: drop one entry whose summary starts with this tool's action/name.
+          // Fallback: find one entry whose summary starts with this tool's action/name.
           const action = formatActiveToolSummary(activity.toolName);
           for (const [key, summary] of state.activeTools) {
             if (summary === action || summary.startsWith(`${action} `) || summary.startsWith(activity.toolName)) {
-              state.activeTools.delete(key);
+              endedId = key;
               break;
             }
           }
+        }
+        if (endedId) {
+          state.activeTools.delete(endedId);
+          trackActivityPhaseEnd(state, endedId, now);
         }
         state.toolUses++;
       }
@@ -1385,7 +1396,7 @@ Terse command-style prompts produce shallow, generic work.
           maxTurns: fgState.maxTurns,
           durationMs: Date.now() - startedAt,
           status: "running",
-          activity: describeActivity(fgState.activeTools, fgState.responseText),
+          activity: describeCompactActivity(fgState),
           spinnerFrame: spinnerFrame % SPINNER.length,
         };
         onUpdate?.({
@@ -1613,7 +1624,7 @@ Terse command-style prompts produce shallow, generic work.
         record.status === "queued"
           ? "queued…"
           : activity
-            ? describeActivity(activity.activeTools, activity.responseText)
+            ? describeCompactActivity(activity)
             : undefined;
       const details: AgentDetails = {
         displayName,

--- a/packages/pi-subagents/src/types.ts
+++ b/packages/pi-subagents/src/types.ts
@@ -108,9 +108,10 @@ export interface AgentRecord {
   /** Cleanup function for the output file stream subscription. */
   outputCleanup?: () => void;
   /**
-   * Lifetime usage breakdown, accumulated via `message_end` events. Survives
-   * compaction. Total = input + output + cacheWrite (cacheRead deliberately
-   * excluded — see issue #38). Initialized to zeros at spawn.
+   * Lifetime usage breakdown, accumulated via assistant `message_end` events.
+   * Survives compaction and retains input/output/cacheRead/cacheWrite plus cost
+   * when available. The legacy compact total remains input + output +
+   * cacheWrite; cacheRead is breakdown-only (issue #38).
    */
   lifetimeUsage: LifetimeUsage;
   /** Number of times this agent's session has compacted. Initialized to 0 at spawn. */

--- a/packages/pi-subagents/src/ui/agent-widget.ts
+++ b/packages/pi-subagents/src/ui/agent-widget.ts
@@ -92,6 +92,12 @@ export interface ActivityPhaseSummaryState {
   visibleSince?: number;
 }
 
+/** Coarse phase metadata for one in-flight tool. */
+export interface ActiveToolPhase {
+  phase?: ActivityPhase;
+  startedAt: number;
+}
+
 /** Per-agent live activity state. */
 export interface AgentActivity {
   /**
@@ -99,8 +105,8 @@ export interface AgentActivity {
    * e.g. "reading src/a.ts", "running rg auth". Kept for the detailed overlay.
    */
   activeTools: Map<string, string>;
-  /** Matching coarse phase for each in-flight tool; undefined means generic work. */
-  activeToolPhases: Map<string, ActivityPhase | undefined>;
+  /** Matching coarse phase and start time for each in-flight tool. */
+  activeToolPhases: Map<string, ActiveToolPhase>;
   /** Debounce/minimum-hold state used only by compact running surfaces. */
   phaseSummary: ActivityPhaseSummaryState;
   toolUses: number;
@@ -111,7 +117,7 @@ export interface AgentActivity {
   turnCount: number;
   /** Effective max turns for this agent (undefined = unlimited). */
   maxTurns?: number;
-  /** Lifetime usage breakdown — see LifetimeUsage docs. */
+  /** Ephemeral live usage mirror for foreground streaming; AgentRecord is authoritative when available. */
   lifetimeUsage: LifetimeUsage;
 }
 
@@ -387,7 +393,12 @@ export function getToolActivityPhase(toolName: string): ActivityPhase | undefine
   return TOOL_ACTIVITY_PHASE[normalized];
 }
 
-function observeActivePhase(state: ActivityPhaseSummaryState, phase: ActivityPhase | undefined, now: number): void {
+function observeActivePhase(
+  state: ActivityPhaseSummaryState,
+  phase: ActivityPhase | undefined,
+  now: number,
+  phaseSince = now,
+): void {
   if (phase === undefined) {
     state.candidate = undefined;
     state.candidateSince = undefined;
@@ -398,10 +409,37 @@ function observeActivePhase(state: ActivityPhaseSummaryState, phase: ActivityPha
   const continuesCandidate = state.candidate === phase
     && (state.inactiveSince === undefined || now - state.inactiveSince <= ACTIVITY_PHASE_GAP_MS);
   if (!continuesCandidate || state.candidateSince === undefined) {
-    state.candidateSince = now;
+    state.candidateSince = phaseSince;
   }
   state.candidate = phase;
   state.inactiveSince = undefined;
+}
+
+/**
+ * Pick one truthful phase without letting a short parallel tool displace stable
+ * work. Keep the visible/candidate phase while any matching tool remains;
+ * otherwise choose the oldest known in-flight phase. Unknown tools are ignored
+ * when a known phase is still active.
+ */
+function selectActivePhase(activity: AgentActivity): { phase?: ActivityPhase; since?: number } {
+  const known = [...activity.activeToolPhases.values()]
+    .filter((entry): entry is ActiveToolPhase & { phase: ActivityPhase } => entry.phase !== undefined);
+  if (known.length === 0) return {};
+
+  for (const preferred of [activity.phaseSummary.visible, activity.phaseSummary.candidate]) {
+    if (preferred === undefined) continue;
+    const matching = known.filter((entry) => entry.phase === preferred);
+    if (matching.length > 0) {
+      return {
+        phase: preferred,
+        since: Math.min(...matching.map((entry) => entry.startedAt)),
+      };
+    }
+  }
+
+  const oldest = known.reduce((selected, entry) =>
+    entry.startedAt < selected.startedAt ? entry : selected);
+  return { phase: oldest.phase, since: oldest.startedAt };
 }
 
 /** Record a tool start for compact phase debouncing; detailed args never enter this state. */
@@ -411,9 +449,12 @@ export function trackActivityPhaseStart(
   toolName: string,
   now = Date.now(),
 ): void {
-  const phase = getToolActivityPhase(toolName);
-  activity.activeToolPhases.set(toolCallId, phase);
-  observeActivePhase(activity.phaseSummary, phase, now);
+  activity.activeToolPhases.set(toolCallId, {
+    phase: getToolActivityPhase(toolName),
+    startedAt: now,
+  });
+  const selected = selectActivePhase(activity);
+  observeActivePhase(activity.phaseSummary, selected.phase, now, selected.since);
 }
 
 /** Record a tool end while allowing a very short same-phase gap to remain continuous. */
@@ -427,8 +468,8 @@ export function trackActivityPhaseEnd(
     activity.phaseSummary.inactiveSince = now;
     return;
   }
-  const remainingPhase = [...activity.activeToolPhases.values()].at(-1);
-  observeActivePhase(activity.phaseSummary, remainingPhase, now);
+  const selected = selectActivePhase(activity);
+  observeActivePhase(activity.phaseSummary, selected.phase, now, selected.since);
 }
 
 function phaseLabel(phase: ActivityPhase): string {
@@ -447,7 +488,8 @@ function phaseLabel(phase: ActivityPhase): string {
 export function describeCompactActivity(activity: AgentActivity, now = Date.now()): string {
   const state = activity.phaseSummary;
   const hasActiveTools = activity.activeToolPhases.size > 0;
-  const activePhase = hasActiveTools ? [...activity.activeToolPhases.values()].at(-1) : undefined;
+  const selected = selectActivePhase(activity);
+  const activePhase = selected.phase;
 
   if (!hasActiveTools || activePhase === undefined) {
     if (hasActiveTools) {
@@ -485,7 +527,7 @@ export function describeCompactActivity(activity: AgentActivity, now = Date.now(
     || state.candidateSince === undefined
     || state.inactiveSince !== undefined
   ) {
-    observeActivePhase(state, activePhase, now);
+    observeActivePhase(state, activePhase, now, selected.since);
   }
 
   // A same-named phase is immediately reusable only when it is the same
@@ -715,8 +757,11 @@ export class AgentWidget {
       const elapsed = formatMs(Date.now() - a.startedAt);
 
       const bg = this.agentActivity.get(a.id);
-      const toolUses = bg?.toolUses ?? a.toolUses;
-      const tokens = getLifetimeTotal(bg?.lifetimeUsage ?? a.lifetimeUsage);
+      // AgentRecord is the lifetime source of truth. The live tracker is an
+      // ephemeral mirror and can outlive a completed run during group hold,
+      // while resume updates only the record.
+      const toolUses = a.toolUses;
+      const tokens = getLifetimeTotal(a.lifetimeUsage);
       const contextPercent = getSessionContextPercent(bg?.session ?? a.session);
       const tokenText = tokens > 0 ? formatSessionTokens(tokens, contextPercent, theme, a.compactionCount) : "";
 

--- a/packages/pi-subagents/src/ui/agent-widget.ts
+++ b/packages/pi-subagents/src/ui/agent-widget.ts
@@ -112,22 +112,46 @@ export function fgPreservingNestedStyles(theme: Theme, color: string, text: stri
   return theme.fg(color, text.replace(/\u001b\[(?:0|39)m/g, reset => `${reset}${styleStart}`));
 }
 
+/** Format a token count magnitude without a unit: "33.8k", "1.2M". */
+export function formatTokenCount(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+  return `${count}`;
+}
+
 /** Format a token count compactly: "33.8k token", "1.2M token". */
 export function formatTokens(count: number): string {
-  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M token`;
-  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k token`;
-  return `${count} token`;
+  return `${formatTokenCount(count)} token`;
+}
+
+/** Format provider-reported USD cost with the same precision policy as pi-glance. */
+export function formatUsageCost(cost: number): string {
+  if (!Number.isFinite(cost) || cost <= 0) return "$0.000";
+  if (cost < 0.001) return "<$0.001";
+  if (cost < 1) return `$${cost.toFixed(3)}`;
+  if (cost < 10) return `$${cost.toFixed(2)}`;
+  return `$${cost.toFixed(1)}`;
+}
+
+/** Clear, fully additive lifetime breakdown for the conversation detail overlay. */
+export function formatLifetimeUsageBreakdown(usage: LifetimeUsage): string {
+  const parts = [
+    `input ${formatTokenCount(usage.input ?? 0)}`,
+    `output ${formatTokenCount(usage.output ?? 0)}`,
+    `cache read ${formatTokenCount(usage.cacheRead ?? 0)}`,
+    `cache write ${formatTokenCount(usage.cacheWrite ?? 0)}`,
+  ];
+  if (usage.cost !== undefined && Number.isFinite(usage.cost)) {
+    parts.push(`cost ${formatUsageCost(usage.cost)}`);
+  }
+  return `Lifetime usage: ${parts.join(" · ")}`;
 }
 
 /**
- * Token count with optional context-fill % and compaction-count annotations.
+ * Compact lifetime total with optional *current* context-fill % and compaction
+ * annotations. The labels deliberately make the two windows explicit: lifetime
+ * usage is cumulative, while context % describes only the current context.
  * Thresholds for percent: <70% dim, 70–85% warning, ≥85% error.
- * Compaction count rendered as `⇊N` in dim.
- *
- *   "12.3k token"               — no annotations
- *   "12.3k token (45%)"         — percent only
- *   "12.3k token (⇊2)"          — compactions only (e.g. right after compact)
- *   "12.3k token (45% · ⇊2)"    — both
  */
 export function formatSessionTokens(
   tokens: number,
@@ -135,11 +159,11 @@ export function formatSessionTokens(
   theme: Theme,
   compactions = 0,
 ): string {
-  const tokenStr = formatTokens(tokens);
+  const tokenStr = `lifetime ${formatTokens(tokens)}`;
   const annot: string[] = [];
   if (percent !== null) {
     const color = percent >= 85 ? "error" : percent >= 70 ? "warning" : "dim";
-    annot.push(theme.fg(color, `${Math.round(percent)}%`));
+    annot.push(theme.fg(color, `current ctx ${Math.round(percent)}%`));
   }
   if (compactions > 0) {
     annot.push(theme.fg("dim", `⇊${compactions}`));
@@ -153,15 +177,44 @@ export function formatTurns(turnCount: number, maxTurns?: number | null): string
   return maxTurns != null ? `↻${turnCount}≤${maxTurns}` : `↻${turnCount}`;
 }
 
-/** Format milliseconds as human-readable duration. */
+/**
+ * Format milliseconds as a stable human duration.
+ * Sub-minute values retain tenths; longer values use minute/hour units instead
+ * of growing into unreadable long-second counts.
+ */
 export function formatMs(ms: number): string {
-  return `${(ms / 1000).toFixed(1)}s`;
+  const safeMs = Number.isFinite(ms) ? Math.max(0, ms) : 0;
+  if (safeMs < 60_000) {
+    const seconds = Math.floor(safeMs / 100) / 10;
+    return `${Number.isInteger(seconds) ? seconds.toFixed(0) : seconds.toFixed(1)}s`;
+  }
+
+  const totalSeconds = Math.floor(safeMs / 1000);
+  const seconds = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes} min ${seconds}s`;
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours} hr ${minutes} min ${seconds}s`;
+}
+
+/** Apply the shared semantic duration color without brightening surrounding stats. */
+export function styleDuration(theme: Pick<Theme, "fg">, duration: string): string {
+  return theme.fg("accent", duration);
 }
 
 /** Format duration from start/completed timestamps. */
 export function formatDuration(startedAt: number, completedAt?: number): string {
-  if (completedAt) return formatMs(completedAt - startedAt);
+  if (completedAt !== undefined) return formatMs(completedAt - startedAt);
   return `${formatMs(Date.now() - startedAt)} (running)`;
+}
+
+function styleStatsWithDuration(parts: string[], duration: string, theme: Theme): string {
+  return [
+    ...parts.map((part) => fgPreservingNestedStyles(theme, "dim", part)),
+    styleDuration(theme, duration),
+  ].join(" " + theme.fg("dim", "·") + " ");
 }
 
 /** Get display name for any agent type (built-in or custom). */
@@ -286,7 +339,7 @@ export function formatActiveToolSummary(toolName: string, args?: unknown): strin
 
 /**
  * Build the widget's last-line activity string.
- * Prefer in-flight tool step summaries; else streaming assistant text; else "thinking…".
+ * Prefer in-flight tool step summaries; else streaming assistant text; else "working…".
  */
 export function describeActivity(activeTools: Map<string, string>, responseText?: string): string {
   if (activeTools.size > 0) {
@@ -309,7 +362,7 @@ export function describeActivity(activeTools: Map<string, string>, responseText?
     return truncateLine(responseText);
   }
 
-  return "thinking…";
+  return "working…";
 }
 
 // ---- Widget manager ----
@@ -438,10 +491,10 @@ export class AgentWidget {
     const activity = this.agentActivity.get(a.id);
     if (activity) parts.push(formatTurns(activity.turnCount, activity.maxTurns));
     if (a.toolUses > 0) parts.push(`${a.toolUses} tool use${a.toolUses === 1 ? "" : "s"}`);
-    parts.push(duration);
+    const statsText = styleStatsWithDuration(parts, duration, theme);
 
     const modeTag = modeLabel ? ` ${theme.fg("dim", `(${modeLabel})`)}` : "";
-    return `${icon} ${theme.fg("dim", name)}${modeTag}  ${theme.fg("dim", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", parts.join(" · "))}${statusText}`;
+    return `${icon} ${theme.fg("dim", name)}${modeTag}  ${theme.fg("dim", a.description)} ${theme.fg("dim", "·")} ${statsText}${statusText}`;
   }
 
   /**
@@ -486,21 +539,20 @@ export class AgentWidget {
 
       const bg = this.agentActivity.get(a.id);
       const toolUses = bg?.toolUses ?? a.toolUses;
-      const tokens = getLifetimeTotal(bg?.lifetimeUsage);
-      const contextPercent = getSessionContextPercent(bg?.session);
+      const tokens = getLifetimeTotal(bg?.lifetimeUsage ?? a.lifetimeUsage);
+      const contextPercent = getSessionContextPercent(bg?.session ?? a.session);
       const tokenText = tokens > 0 ? formatSessionTokens(tokens, contextPercent, theme, a.compactionCount) : "";
 
       const parts: string[] = [];
       if (bg) parts.push(formatTurns(bg.turnCount, bg.maxTurns));
       if (toolUses > 0) parts.push(`${toolUses} tool use${toolUses === 1 ? "" : "s"}`);
       if (tokenText) parts.push(tokenText);
-      parts.push(elapsed);
-      const statsText = parts.join(" · ");
+      const statsText = styleStatsWithDuration(parts, elapsed, theme);
 
-      const activity = bg ? describeActivity(bg.activeTools, bg.responseText) : "thinking…";
+      const activity = bg ? describeActivity(bg.activeTools, bg.responseText) : "working…";
 
       runningLines.push([
-        truncate(theme.fg("dim", "├─") + ` ${theme.fg("accent", frame)} ${theme.bold(name)}${modeTag}  ${theme.fg("muted", a.description)} ${theme.fg("dim", "·")} ${fgPreservingNestedStyles(theme, "dim", statsText)}`),
+        truncate(theme.fg("dim", "├─") + ` ${theme.fg("accent", frame)} ${theme.bold(name)}${modeTag}  ${theme.fg("muted", a.description)} ${theme.fg("dim", "·")} ${statsText}`),
         truncate(theme.fg("dim", "│  ") + theme.fg("dim", `  ⎿  ${activity}`)),
       ]);
     }

--- a/packages/pi-subagents/src/ui/agent-widget.ts
+++ b/packages/pi-subagents/src/ui/agent-widget.ts
@@ -23,7 +23,17 @@ export const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", 
 /** Statuses that indicate an error/non-success outcome (used for linger behavior and icon rendering). */
 export const ERROR_STATUSES = new Set(["error", "aborted", "steered", "stopped"]);
 
-/** Tool name → human-readable action for activity descriptions. */
+/** Stable, coarse phases allowed on compact running surfaces. */
+export type ActivityPhase = "exploring" | "editing" | "runningCommands" | "delegating";
+
+/** A phase must remain active this long before compact UI promotes it above `working…`. */
+export const ACTIVITY_PHASE_PROMOTION_MS = 800;
+/** Once promoted, keep a phase visible long enough to avoid flashing between labels. */
+export const ACTIVITY_PHASE_MIN_HOLD_MS = 1500;
+/** Same-phase tools separated by only this gap count as one continuous phase. */
+export const ACTIVITY_PHASE_GAP_MS = 200;
+
+/** Tool name → human-readable action for detailed activity descriptions. */
 const TOOL_DISPLAY: Record<string, string> = {
   read: "reading",
   bash: "running",
@@ -35,6 +45,26 @@ const TOOL_DISPLAY: Record<string, string> = {
   Agent: "spawning",
   get_subagent_result: "awaiting",
   steer_subagent: "steering",
+};
+
+/** Conservative classification: unknown/custom tools stay on the honest generic fallback. */
+const TOOL_ACTIVITY_PHASE: Readonly<Record<string, ActivityPhase>> = {
+  read: "exploring",
+  grep: "exploring",
+  find: "exploring",
+  ls: "exploring",
+  web_search: "exploring",
+  web_read: "exploring",
+  ollama_web_search: "exploring",
+  ollama_web_fetch: "exploring",
+  "resolve-library-id": "exploring",
+  "query-docs": "exploring",
+  edit: "editing",
+  write: "editing",
+  bash: "runningCommands",
+  agent: "delegating",
+  get_subagent_result: "delegating",
+  steer_subagent: "delegating",
 };
 
 // ---- Types ----
@@ -53,14 +83,28 @@ export type UICtx = {
   ): void;
 };
 
+/** Mutable debounce state for the compact phase summary. */
+export interface ActivityPhaseSummaryState {
+  candidate?: ActivityPhase;
+  candidateSince?: number;
+  inactiveSince?: number;
+  visible?: ActivityPhase;
+  visibleSince?: number;
+}
+
 /** Per-agent live activity state. */
 export interface AgentActivity {
   /**
    * In-flight tools: key = toolCallId (or synthetic), value = one-line step summary
-   * e.g. "reading src/a.ts", "running rg auth".
+   * e.g. "reading src/a.ts", "running rg auth". Kept for the detailed overlay.
    */
   activeTools: Map<string, string>;
+  /** Matching coarse phase for each in-flight tool; undefined means generic work. */
+  activeToolPhases: Map<string, ActivityPhase | undefined>;
+  /** Debounce/minimum-hold state used only by compact running surfaces. */
+  phaseSummary: ActivityPhaseSummaryState;
   toolUses: number;
+  /** Streaming assistant body retained for the detailed conversation overlay only. */
   responseText: string;
   session?: SessionLike;
   /** Current turn count. */
@@ -80,7 +124,7 @@ export interface AgentDetails {
   tokens: string;
   durationMs: number;
   status: "queued" | "running" | "completed" | "steered" | "aborted" | "stopped" | "error" | "background";
-  /** Human-readable description of what the agent is currently doing. */
+  /** Compact activity label: a stable coarse phase, `working…`, or queued status. */
   activity?: string;
   /** Current spinner frame index (for animated running indicator). */
   spinnerFrame?: number;
@@ -294,7 +338,7 @@ export function formatSubagentsStatusText(runningCount: number, queuedCount: num
 }
 
 /**
- * One-line summary for an in-flight tool (widget / tool-result activity row).
+ * One-line summary for an in-flight tool in the detailed conversation overlay.
  * Prefers path/command/pattern from args when present.
  */
 export function formatActiveToolSummary(toolName: string, args?: unknown): string {
@@ -337,9 +381,142 @@ export function formatActiveToolSummary(toolName: string, args?: unknown): strin
   return action;
 }
 
+/** Map a known tool onto a deliberately coarse compact-UI phase. */
+export function getToolActivityPhase(toolName: string): ActivityPhase | undefined {
+  const normalized = sanitizeDisplayText(toolName).trim().toLowerCase();
+  return TOOL_ACTIVITY_PHASE[normalized];
+}
+
+function observeActivePhase(state: ActivityPhaseSummaryState, phase: ActivityPhase | undefined, now: number): void {
+  if (phase === undefined) {
+    state.candidate = undefined;
+    state.candidateSince = undefined;
+    state.inactiveSince = undefined;
+    return;
+  }
+
+  const continuesCandidate = state.candidate === phase
+    && (state.inactiveSince === undefined || now - state.inactiveSince <= ACTIVITY_PHASE_GAP_MS);
+  if (!continuesCandidate || state.candidateSince === undefined) {
+    state.candidateSince = now;
+  }
+  state.candidate = phase;
+  state.inactiveSince = undefined;
+}
+
+/** Record a tool start for compact phase debouncing; detailed args never enter this state. */
+export function trackActivityPhaseStart(
+  activity: AgentActivity,
+  toolCallId: string,
+  toolName: string,
+  now = Date.now(),
+): void {
+  const phase = getToolActivityPhase(toolName);
+  activity.activeToolPhases.set(toolCallId, phase);
+  observeActivePhase(activity.phaseSummary, phase, now);
+}
+
+/** Record a tool end while allowing a very short same-phase gap to remain continuous. */
+export function trackActivityPhaseEnd(
+  activity: AgentActivity,
+  toolCallId: string,
+  now = Date.now(),
+): void {
+  activity.activeToolPhases.delete(toolCallId);
+  if (activity.activeToolPhases.size === 0) {
+    activity.phaseSummary.inactiveSince = now;
+    return;
+  }
+  const remainingPhase = [...activity.activeToolPhases.values()].at(-1);
+  observeActivePhase(activity.phaseSummary, remainingPhase, now);
+}
+
+function phaseLabel(phase: ActivityPhase): string {
+  switch (phase) {
+    case "exploring": return "exploring…";
+    case "editing": return "editing…";
+    case "runningCommands": return "running commands…";
+    case "delegating": return "delegating…";
+  }
+}
+
 /**
- * Build the widget's last-line activity string.
- * Prefer in-flight tool step summaries; else streaming assistant text; else "working…".
+ * Stable activity for compact surfaces. Fast/unknown tools and streaming body
+ * text deliberately stay `working…`; only a durable coarse phase is promoted.
+ */
+export function describeCompactActivity(activity: AgentActivity, now = Date.now()): string {
+  const state = activity.phaseSummary;
+  const hasActiveTools = activity.activeToolPhases.size > 0;
+  const activePhase = hasActiveTools ? [...activity.activeToolPhases.values()].at(-1) : undefined;
+
+  if (!hasActiveTools || activePhase === undefined) {
+    if (hasActiveTools) {
+      // An unknown/custom tool is real work, but not a phase we can label honestly.
+      state.candidate = undefined;
+      state.candidateSince = undefined;
+      state.inactiveSince = undefined;
+    } else if (state.inactiveSince === undefined) {
+      state.inactiveSince = now;
+    }
+
+    if (
+      state.visible !== undefined
+      && state.visibleSince !== undefined
+      && now - state.visibleSince < ACTIVITY_PHASE_MIN_HOLD_MS
+    ) {
+      return phaseLabel(state.visible);
+    }
+
+    state.visible = undefined;
+    state.visibleSince = undefined;
+    if (
+      !hasActiveTools
+      && state.inactiveSince !== undefined
+      && now - state.inactiveSince >= ACTIVITY_PHASE_GAP_MS
+    ) {
+      state.candidate = undefined;
+      state.candidateSince = undefined;
+    }
+    return "working…";
+  }
+
+  if (
+    state.candidate !== activePhase
+    || state.candidateSince === undefined
+    || state.inactiveSince !== undefined
+  ) {
+    observeActivePhase(state, activePhase, now);
+  }
+
+  // A same-named phase is immediately reusable only when it is the same
+  // continuous candidate that originally promoted the visible label. After a
+  // long unrendered idle gap, candidateSince is newer and must earn 800ms again.
+  const visibleBelongsToCandidate = state.visible === activePhase
+    && state.visibleSince !== undefined
+    && state.candidateSince !== undefined
+    && state.candidateSince <= state.visibleSince;
+  if (visibleBelongsToCandidate) return phaseLabel(activePhase);
+  if (
+    state.visible !== undefined
+    && state.visibleSince !== undefined
+    && now - state.visibleSince < ACTIVITY_PHASE_MIN_HOLD_MS
+  ) {
+    return phaseLabel(state.visible);
+  }
+
+  state.visible = undefined;
+  state.visibleSince = undefined;
+  if (state.candidateSince !== undefined && now - state.candidateSince >= ACTIVITY_PHASE_PROMOTION_MS) {
+    state.visible = activePhase;
+    state.visibleSince = now;
+    return phaseLabel(activePhase);
+  }
+  return "working…";
+}
+
+/**
+ * Detailed live activity for the conversation overlay.
+ * Prefer exact in-flight tool steps; else streaming assistant text; else `working…`.
  */
 export function describeActivity(activeTools: Map<string, string>, responseText?: string): string {
   if (activeTools.size > 0) {
@@ -549,7 +726,7 @@ export class AgentWidget {
       if (tokenText) parts.push(tokenText);
       const statsText = styleStatsWithDuration(parts, elapsed, theme);
 
-      const activity = bg ? describeActivity(bg.activeTools, bg.responseText) : "working…";
+      const activity = bg ? describeCompactActivity(bg) : "working…";
 
       runningLines.push([
         truncate(theme.fg("dim", "├─") + ` ${theme.fg("accent", frame)} ${theme.bold(name)}${modeTag}  ${theme.fg("muted", a.description)} ${theme.fg("dim", "·")} ${statsText}`),

--- a/packages/pi-subagents/src/ui/conversation-viewer.ts
+++ b/packages/pi-subagents/src/ui/conversation-viewer.ts
@@ -10,7 +10,7 @@ import { type Component, Input, matchesKey, type TUI, truncateToWidth, visibleWi
 import type { AgentRecord } from "../types.js";
 import { createLifetimeUsage, getLifetimeTotal, getSessionContextPercent } from "../usage.js";
 import type { Theme } from "./agent-widget.js";
-import { type AgentActivity, buildInvocationTags, describeActivity, fgPreservingNestedStyles, formatDuration, formatLifetimeUsageBreakdown, formatSessionTokens, getDisplayName, getPromptModeLabel, styleDuration } from "./agent-widget.js";
+import { type AgentActivity, buildInvocationTags, describeActivity, fgPreservingNestedStyles, formatLifetimeUsageBreakdown, formatMs, formatSessionTokens, getDisplayName, getPromptModeLabel, styleDuration } from "./agent-widget.js";
 import {
   buildConversationBrief,
   formatStepLine,
@@ -160,12 +160,18 @@ export class ConversationViewer implements Component {
     const modeLabel = getPromptModeLabel(this.record.type);
     const modeTag = modeLabel ? ` ${th.fg("dim", `(${modeLabel})`)}` : "";
     const statusIcon = headerStatusIcon(this.record.status, th);
-    const duration = styleDuration(th, formatDuration(this.record.startedAt, this.record.completedAt));
+    const duration = styleDuration(
+      th,
+      formatMs((this.record.completedAt ?? Date.now()) - this.record.startedAt),
+    );
+    const durationText = this.record.completedAt === undefined
+      ? `${duration}${th.fg("dim", " (running)")}`
+      : duration;
 
-    const headerParts: string[] = [duration];
-    const toolUses = this.activity?.toolUses ?? this.record.toolUses;
+    const headerParts: string[] = [durationText];
+    const toolUses = this.record.toolUses;
     if (toolUses > 0) headerParts.unshift(`${toolUses} tool${toolUses === 1 ? "" : "s"}`);
-    const lifetimeUsage = this.activity?.lifetimeUsage ?? this.record.lifetimeUsage ?? createLifetimeUsage();
+    const lifetimeUsage = this.record.lifetimeUsage ?? this.activity?.lifetimeUsage ?? createLifetimeUsage();
     const tokens = getLifetimeTotal(lifetimeUsage);
     if (tokens > 0) {
       const percent = getSessionContextPercent(this.activity?.session ?? this.record.session ?? this.session);
@@ -338,7 +344,7 @@ export class ConversationViewer implements Component {
     // ── Usage ───────────────────────────────────────────────────────────
     lines.push("");
     section("Usage");
-    const lifetimeUsage = this.activity?.lifetimeUsage ?? this.record.lifetimeUsage ?? createLifetimeUsage();
+    const lifetimeUsage = this.record.lifetimeUsage ?? this.activity?.lifetimeUsage ?? createLifetimeUsage();
     for (const line of wrapTextWithAnsi(formatLifetimeUsageBreakdown(lifetimeUsage), width)) {
       lines.push(line);
     }

--- a/packages/pi-subagents/src/ui/conversation-viewer.ts
+++ b/packages/pi-subagents/src/ui/conversation-viewer.ts
@@ -8,9 +8,9 @@
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import { type Component, Input, matchesKey, type TUI, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AgentRecord } from "../types.js";
-import { getLifetimeTotal, getSessionContextPercent } from "../usage.js";
+import { createLifetimeUsage, getLifetimeTotal, getSessionContextPercent } from "../usage.js";
 import type { Theme } from "./agent-widget.js";
-import { type AgentActivity, buildInvocationTags, describeActivity, fgPreservingNestedStyles, formatDuration, formatSessionTokens, getDisplayName, getPromptModeLabel } from "./agent-widget.js";
+import { type AgentActivity, buildInvocationTags, describeActivity, fgPreservingNestedStyles, formatDuration, formatLifetimeUsageBreakdown, formatSessionTokens, getDisplayName, getPromptModeLabel, styleDuration } from "./agent-widget.js";
 import {
   buildConversationBrief,
   formatStepLine,
@@ -160,14 +160,15 @@ export class ConversationViewer implements Component {
     const modeLabel = getPromptModeLabel(this.record.type);
     const modeTag = modeLabel ? ` ${th.fg("dim", `(${modeLabel})`)}` : "";
     const statusIcon = headerStatusIcon(this.record.status, th);
-    const duration = formatDuration(this.record.startedAt, this.record.completedAt);
+    const duration = styleDuration(th, formatDuration(this.record.startedAt, this.record.completedAt));
 
     const headerParts: string[] = [duration];
     const toolUses = this.activity?.toolUses ?? this.record.toolUses;
     if (toolUses > 0) headerParts.unshift(`${toolUses} tool${toolUses === 1 ? "" : "s"}`);
-    const tokens = getLifetimeTotal(this.activity?.lifetimeUsage);
+    const lifetimeUsage = this.activity?.lifetimeUsage ?? this.record.lifetimeUsage ?? createLifetimeUsage();
+    const tokens = getLifetimeTotal(lifetimeUsage);
     if (tokens > 0) {
-      const percent = getSessionContextPercent(this.activity?.session);
+      const percent = getSessionContextPercent(this.activity?.session ?? this.record.session ?? this.session);
       headerParts.push(formatSessionTokens(tokens, percent, th, this.record.compactionCount));
     }
 
@@ -334,6 +335,24 @@ export class ConversationViewer implements Component {
       }
     }
 
+    // ── Usage ───────────────────────────────────────────────────────────
+    lines.push("");
+    section("Usage");
+    const lifetimeUsage = this.activity?.lifetimeUsage ?? this.record.lifetimeUsage ?? createLifetimeUsage();
+    for (const line of wrapTextWithAnsi(formatLifetimeUsageBreakdown(lifetimeUsage), width)) {
+      lines.push(line);
+    }
+    const contextPercent = getSessionContextPercent(this.activity?.session ?? this.record.session ?? this.session);
+    const contextParts = [
+      contextPercent === null
+        ? "Current context: unavailable"
+        : `Current context: ${Math.round(contextPercent)}%`,
+    ];
+    if (this.record.compactionCount > 0) {
+      contextParts.push(`${this.record.compactionCount} compaction${this.record.compactionCount === 1 ? "" : "s"}`);
+    }
+    lines.push(th.fg("dim", contextParts.join(" · ")));
+
     // ── Steps ───────────────────────────────────────────────────────────
     lines.push("");
     section("Steps");
@@ -386,11 +405,13 @@ export class ConversationViewer implements Component {
         lines.push(line);
       }
     } else if (this.record.status === "running" || this.record.status === "queued") {
-      if (this.activity) {
+      if (this.record.status === "queued") {
+        lines.push(th.fg("dim", "queued…"));
+      } else if (this.activity) {
         const act = describeActivity(this.activity.activeTools, this.activity.responseText);
-        lines.push(truncateToWidth(th.fg("accent", "⠹ ") + th.fg("dim", act || "running…"), width));
+        lines.push(truncateToWidth(th.fg("accent", "⠹ ") + th.fg("dim", act || "working…"), width));
       } else {
-        lines.push(th.fg("dim", "(running…)"));
+        lines.push(th.fg("dim", "working…"));
       }
     } else {
       lines.push(th.fg("dim", "(no final result text)"));

--- a/packages/pi-subagents/src/ui/fleet-list.ts
+++ b/packages/pi-subagents/src/ui/fleet-list.ts
@@ -15,7 +15,7 @@ import { Editor, isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } 
 import type { AgentManager } from "../agent-manager.js";
 import type { AgentRecord } from "../types.js";
 import { getLifetimeTotal } from "../usage.js";
-import { type AgentActivity, getDisplayName, type Theme } from "./agent-widget.js";
+import { type AgentActivity, formatMs, getDisplayName, styleDuration, type Theme } from "./agent-widget.js";
 import { ConversationViewer, VIEWPORT_HEIGHT_PCT } from "./conversation-viewer.js";
 
 /** Widget key for the below-editor fleet list. */
@@ -47,18 +47,18 @@ type MainEntry = { kind: "main" };
 type AgentEntry = { kind: "agent"; record: AgentRecord };
 type FleetEntry = MainEntry | AgentEntry;
 
-/** `11s` — integer seconds, no decimal/suffix (matches Claude Code, unlike formatMs). */
+/** Fleet elapsed time uses the same friendly formatter as every other runtime surface. */
 export function formatFleetElapsed(ms: number): string {
-  return `${Math.max(0, Math.round(ms / 1000))}s`;
+  return formatMs(ms);
 }
 
-/** `↓ 13.1k tokens` — down-arrow prefix, compact magnitude, plural "tokens". */
+/** `↓ lifetime 13.1k tokens` — compact total with explicit cumulative scope. */
 export function formatFleetTokens(count: number): string {
   let compact: string;
   if (count >= 1_000_000) compact = `${(count / 1_000_000).toFixed(1)}M`;
   else if (count >= 1_000) compact = `${(count / 1_000).toFixed(1)}k`;
   else compact = `${count}`;
-  return `↓ ${compact} tokens`;
+  return `↓ lifetime ${compact} tokens`;
 }
 
 /**
@@ -374,7 +374,11 @@ export class FleetList {
     const left = `  ${this.bullet(rosterIndex, sel, theme)} ${theme.fg("muted", getDisplayName(record.type))}  ${record.description}`;
     const tokens = getLifetimeTotal(this.agentActivity.get(record.id)?.lifetimeUsage ?? record.lifetimeUsage);
     const elapsedMs = (record.completedAt ?? Date.now()) - record.startedAt; // freezes once finished
-    const right = theme.fg("dim", `${formatFleetElapsed(elapsedMs)} · ${formatFleetTokens(tokens)}`);
+    const right = [
+      styleDuration(theme, formatFleetElapsed(elapsedMs)),
+      theme.fg("dim", "·"),
+      theme.fg("dim", formatFleetTokens(tokens)),
+    ].join(" ");
     return rightAlign(left, right, width);
   }
 }

--- a/packages/pi-subagents/src/ui/fleet-list.ts
+++ b/packages/pi-subagents/src/ui/fleet-list.ts
@@ -372,7 +372,8 @@ export class FleetList {
 
   private renderAgentRow(rosterIndex: number, sel: number, record: AgentRecord, width: number, theme: Theme): string {
     const left = `  ${this.bullet(rosterIndex, sel, theme)} ${theme.fg("muted", getDisplayName(record.type))}  ${record.description}`;
-    const tokens = getLifetimeTotal(this.agentActivity.get(record.id)?.lifetimeUsage ?? record.lifetimeUsage);
+    // Record remains authoritative across resume; activity is only live UI state.
+    const tokens = getLifetimeTotal(record.lifetimeUsage);
     const elapsedMs = (record.completedAt ?? Date.now()) - record.startedAt; // freezes once finished
     const right = [
       styleDuration(theme, formatFleetElapsed(elapsedMs)),

--- a/packages/pi-subagents/src/ui/tool-render.ts
+++ b/packages/pi-subagents/src/ui/tool-render.ts
@@ -11,7 +11,7 @@
 import { getMarkdownTheme, keyHint } from "@earendil-works/pi-coding-agent";
 import { Container, Markdown, Text, type Component } from "@earendil-works/pi-tui";
 import type { AgentDetails, Theme } from "./agent-widget.js";
-import { fgPreservingNestedStyles, formatMs, formatTurns, SPINNER } from "./agent-widget.js";
+import { fgPreservingNestedStyles, formatMs, formatTurns, SPINNER, styleDuration } from "./agent-widget.js";
 import { sanitizeDisplayText } from "./display-safety.js";
 
 /** Collapsed preview: first non-empty line, hard-capped. */
@@ -223,7 +223,7 @@ function statusHeaderLine(
   theme: Theme,
 ): string {
   let line = icon + (stats ? " " + stats : "");
-  if (duration) line += " " + theme.fg("dim", "·") + " " + theme.fg("dim", duration);
+  if (duration) line += " " + theme.fg("dim", "·") + " " + styleDuration(theme, duration);
   return line;
 }
 
@@ -256,9 +256,9 @@ export function renderUndetailedResult(
 /**
  * Shared Agent / get_subagent_result result chrome — Claude Code transcript shape:
  *
- *   ⠹ ↻3 · 3 tool uses · 12.4k token
+ *   ⠹ ↻3 · 3 tool uses · lifetime 12.4k token
  *     ⎿  searching…
- *   ✓ ↻8 · 5 tool uses · 33.8k token · 12.3s
+ *   ✓ ↻8 · 5 tool uses · lifetime 33.8k token · 10 min 13s
  *     ⎿  Done
  *
  * Collapsed never dumps the model-facing body; expanded adds Markdown under the chrome.
@@ -279,11 +279,11 @@ export function renderAgentLikeResult(
   if (opts.isPartial || isActiveStatus(details.status)) {
     const frame = SPINNER[details.spinnerFrame ?? 0] ?? SPINNER[0];
     const top = theme.fg("accent", frame!) + (s ? " " + s : "");
-    // Queued must never show thinking… even if a stale activity string was attached.
+    // Queued must never show a generic working fallback, even if stale activity was attached.
     const activity =
       details.status === "queued"
         ? "queued…"
-        : (details.activity ?? "thinking…");
+        : (details.activity ?? "working…");
     return new Text(top + "\n" + formatClerkLine(theme, activity), 0, 0);
   }
 

--- a/packages/pi-subagents/src/usage.ts
+++ b/packages/pi-subagents/src/usage.ts
@@ -1,29 +1,86 @@
 /** usage.ts — Token usage: shapes, accumulator operators, session-stats readers. */
 
 /**
- * Lifetime usage components, accumulated via `message_end` events. Survives
- * compaction (which replaces session.state.messages and would reset any
- * stats-derived sum). cacheRead is excluded because each turn's cacheRead is
- * the cumulative cached prefix re-read on that one call — summing across
- * turns counts the prefix N times. See issue #38.
+ * Lifetime usage components, accumulated via assistant `message_end` events.
+ * Survives compaction (which replaces session.state.messages and would reset
+ * any stats-derived sum). `cacheRead` is retained for an honest breakdown, but
+ * remains excluded from the legacy compact total returned by
+ * `getLifetimeTotal()` — summing each call's cumulative cached prefix into that
+ * total would reintroduce issue #38's inflated semantics.
  */
-export type LifetimeUsage = { input: number; output: number; cacheWrite: number };
+export type LifetimeUsage = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  /** Accumulated provider-reported USD cost when a reliable value was present. */
+  cost?: number;
+};
 
-/** Sum of lifetime usage components, or 0 if undefined. */
+/** Fresh zeroed accumulator. Cost stays unavailable until a message reports it. */
+export function createLifetimeUsage(): LifetimeUsage {
+  return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+}
+
+function nonNegativeFinite(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/** Read a reliable cost total, preferring `cost.total` over component sums. */
+function readUsageCost(value: unknown): number | undefined {
+  const direct = nonNegativeFinite(value);
+  if (direct !== undefined) return direct;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+
+  const cost = value as Record<string, unknown>;
+  const total = nonNegativeFinite(cost.total);
+  if (total !== undefined) return total;
+
+  const components = ["input", "output", "cacheRead", "cacheWrite"]
+    .map((key) => nonNegativeFinite(cost[key]));
+  if (!components.some((part) => part !== undefined)) return undefined;
+  return components.reduce<number>((sum, part) => sum + (part ?? 0), 0);
+}
+
+/** Normalize a Pi assistant-message usage object into one lifetime delta. */
+export function toLifetimeUsage(value: unknown): LifetimeUsage {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return createLifetimeUsage();
+  }
+  const usage = value as Record<string, unknown>;
+  const cost = readUsageCost(usage.cost);
+  return {
+    input: nonNegativeFinite(usage.input) ?? 0,
+    output: nonNegativeFinite(usage.output) ?? 0,
+    cacheRead: nonNegativeFinite(usage.cacheRead) ?? 0,
+    cacheWrite: nonNegativeFinite(usage.cacheWrite) ?? 0,
+    ...(cost !== undefined ? { cost } : {}),
+  };
+}
+
+/**
+ * Legacy compact lifetime total used by existing terse surfaces.
+ * Deliberately remains input + output + cacheWrite; cacheRead is available on
+ * the breakdown but must not silently change this metric's issue #38 semantics.
+ */
 export function getLifetimeTotal(u?: LifetimeUsage): number {
-  return u ? u.input + u.output + u.cacheWrite : 0;
+  return u ? (u.input ?? 0) + (u.output ?? 0) + (u.cacheWrite ?? 0) : 0;
 }
 
 /** Add a usage delta into a target accumulator (mutates target). */
 export function addUsage(into: LifetimeUsage, delta: LifetimeUsage): void {
-  into.input += delta.input;
-  into.output += delta.output;
-  into.cacheWrite += delta.cacheWrite;
+  into.input = (into.input ?? 0) + (delta.input ?? 0);
+  into.output = (into.output ?? 0) + (delta.output ?? 0);
+  into.cacheRead = (into.cacheRead ?? 0) + (delta.cacheRead ?? 0);
+  into.cacheWrite = (into.cacheWrite ?? 0) + (delta.cacheWrite ?? 0);
+  if (delta.cost !== undefined && Number.isFinite(delta.cost)) {
+    into.cost = (into.cost ?? 0) + delta.cost;
+  }
 }
 
 /** Minimal shape we read from upstream `getSessionStats()`. */
 export type SessionStatsLike = {
-  tokens: { input: number; output: number; cacheWrite: number };
+  tokens: { input: number; output: number; cacheRead?: number; cacheWrite: number };
   contextUsage?: { percent: number | null };
 };
 export type SessionLike = { getSessionStats(): SessionStatsLike };

--- a/packages/pi-subagents/test/agent-manager.test.ts
+++ b/packages/pi-subagents/test/agent-manager.test.ts
@@ -380,7 +380,7 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     });
     const record = manager.getRecord(id)!;
 
-    expect(record.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0 });
+    expect(record.lifetimeUsage).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
     expect(record.compactionCount).toBe(0);
 
     manager.abort(id);
@@ -394,8 +394,8 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, opts: any) => {
       captured = opts;
       // Two assistant messages with usage
-      opts.onAssistantUsage?.({ input: 100, output: 50, cacheWrite: 10 });
-      opts.onAssistantUsage?.({ input: 200, output: 80, cacheWrite: 20 });
+      opts.onAssistantUsage?.({ input: 100, output: 50, cacheRead: 1_000, cacheWrite: 10, cost: 0.1 });
+      opts.onAssistantUsage?.({ input: 200, output: 80, cacheRead: 2_000, cacheWrite: 20, cost: 0.2 });
       return { responseText: "done", session: mockSession(), aborted: false, steered: false };
     });
 
@@ -407,7 +407,11 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
 
     expect(captured).toBeDefined();
     expect(manager.getRecord(id)!.lifetimeUsage).toEqual({
-      input: 300, output: 130, cacheWrite: 30,
+      input: 300,
+      output: 130,
+      cacheRead: 3_000,
+      cacheWrite: 30,
+      cost: 0.30000000000000004,
     });
   });
 
@@ -443,13 +447,18 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
   it("resume() also accumulates usage and increments compactions on the same record", async () => {
     manager = new AgentManager();
 
-    // First, spawn with a session that resume can latch onto
+    // First, spawn with a session that resume can latch onto and non-zero usage.
     const session = { ...mockSession() };
-    vi.mocked(runAgent).mockResolvedValue({
-      responseText: "first",
-      session: session as any,
-      aborted: false,
-      steered: false,
+    vi.mocked(runAgent).mockImplementation(async (_ctx, _type, _prompt, opts: any) => {
+      opts.onAssistantUsage?.({
+        input: 40, output: 10, cacheRead: 100, cacheWrite: 2, cost: 0.1,
+      });
+      return {
+        responseText: "first",
+        session: session as any,
+        aborted: false,
+        steered: false,
+      };
     });
 
     const id = manager.spawn(mockPi, mockCtx, "general-purpose", "test", {
@@ -458,21 +467,30 @@ describe("AgentManager — lifetime usage + compaction count are eagerly initial
     });
     await manager.getRecord(id)!.promise;
 
-    // Pre-resume: lifetimeUsage from spawn was zero (mock didn't call onAssistantUsage)
-    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 0, output: 0, cacheWrite: 0 });
+    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({
+      input: 40, output: 10, cacheRead: 100, cacheWrite: 2, cost: 0.1,
+    });
     expect(manager.getRecord(id)!.compactionCount).toBe(0);
 
     // Now resume — drive callbacks via the mocked resumeAgent
     const { resumeAgent: resumeMock } = await import("../src/agent-runner.js");
     vi.mocked(resumeMock).mockImplementation(async (_session, _prompt, opts: any) => {
-      opts.onAssistantUsage?.({ input: 70, output: 30, cacheWrite: 5 });
+      opts.onAssistantUsage?.({
+        input: 70, output: 30, cacheRead: 300, cacheWrite: 5, cost: 0.2,
+      });
       opts.onCompaction?.({ reason: "overflow", tokensBefore: 999 });
       return { text: "second" };
     });
 
     await manager.resume(id, "more");
 
-    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({ input: 70, output: 30, cacheWrite: 5 });
+    expect(manager.getRecord(id)!.lifetimeUsage).toEqual({
+      input: 110,
+      output: 40,
+      cacheRead: 400,
+      cacheWrite: 7,
+      cost: 0.30000000000000004,
+    });
     expect(manager.getRecord(id)!.compactionCount).toBe(1);
   });
 });

--- a/packages/pi-subagents/test/agent-runner.test.ts
+++ b/packages/pi-subagents/test/agent-runner.test.ts
@@ -486,11 +486,15 @@ describe("agent-runner usage callback wiring", () => {
     const { session, listeners } = createSession("OK");
     createAgentSession.mockResolvedValue({ session });
 
-    const seen: Array<{ input: number; output: number; cacheWrite: number }> = [];
+    const seen: any[] = [];
     session.prompt = vi.fn(async () => {
       // Two assistant messages over the run
-      emitMessageEnd(listeners, { input: 100, output: 50, cacheWrite: 10 });
-      emitMessageEnd(listeners, { input: 200, output: 80, cacheWrite: 20 });
+      emitMessageEnd(listeners, {
+        input: 100, output: 50, cacheRead: 1_000, cacheWrite: 10, cost: { total: 0.1 },
+      });
+      emitMessageEnd(listeners, {
+        input: 200, output: 80, cacheRead: 2_000, cacheWrite: 20, cost: { total: 0.2 },
+      });
       session.messages.push({ role: "assistant", content: [{ type: "text", text: "OK" }] });
     });
 
@@ -500,8 +504,8 @@ describe("agent-runner usage callback wiring", () => {
     });
 
     expect(seen).toEqual([
-      { input: 100, output: 50, cacheWrite: 10 },
-      { input: 200, output: 80, cacheWrite: 20 },
+      { input: 100, output: 50, cacheRead: 1_000, cacheWrite: 10, cost: 0.1 },
+      { input: 200, output: 80, cacheRead: 2_000, cacheWrite: 20, cost: 0.2 },
     ]);
   });
 
@@ -511,7 +515,7 @@ describe("agent-runner usage callback wiring", () => {
 
     const seen: any[] = [];
     session.prompt = vi.fn(async () => {
-      emitMessageEnd(listeners, { input: 50 }); // output, cacheWrite missing
+      emitMessageEnd(listeners, { input: 50 }); // output/cache fields and cost missing
       session.messages.push({ role: "assistant", content: [{ type: "text", text: "OK" }] });
     });
 
@@ -520,7 +524,7 @@ describe("agent-runner usage callback wiring", () => {
       onAssistantUsage: (u) => seen.push(u),
     });
 
-    expect(seen).toEqual([{ input: 50, output: 0, cacheWrite: 0 }]);
+    expect(seen).toEqual([{ input: 50, output: 0, cacheRead: 0, cacheWrite: 0 }]);
   });
 
   it("runAgent skips the callback when message_end has no usage field", async () => {
@@ -543,7 +547,10 @@ describe("agent-runner usage callback wiring", () => {
     const seen: any[] = [];
 
     session.prompt = vi.fn(async () => {
-      emitMessageEnd(listeners, { input: 10, output: 20, cacheWrite: 5 });
+      emitMessageEnd(listeners, {
+        input: 10, output: 20, cacheRead: 300, cacheWrite: 5,
+        cost: { input: 0.01, output: 0.02, cacheRead: 0.03, cacheWrite: 0.04 },
+      });
       session.messages.push({ role: "assistant", content: [{ type: "text", text: "RESUMED" }] });
     });
 
@@ -551,7 +558,9 @@ describe("agent-runner usage callback wiring", () => {
       onAssistantUsage: (u) => seen.push(u),
     });
 
-    expect(seen).toEqual([{ input: 10, output: 20, cacheWrite: 5 }]);
+    expect(seen).toEqual([{
+      input: 10, output: 20, cacheRead: 300, cacheWrite: 5, cost: 0.1,
+    }]);
   });
 
   it("forwards compaction_end events to onCompaction (only when not aborted)", async () => {

--- a/packages/pi-subagents/test/agent-widget.test.ts
+++ b/packages/pi-subagents/test/agent-widget.test.ts
@@ -200,6 +200,23 @@ describe("AgentWidget", () => {
     expect(renderLines(manager, "unflagged", () => "background")).toContain("unflagged description");
   });
 
+  it("prefers record lifetime metrics over a stale activity mirror after resume", () => {
+    const record = makeRecord("resumed", { isBackground: true });
+    record.toolUses = 7;
+    record.lifetimeUsage = {
+      input: 1_200,
+      output: 300,
+      cacheRead: 500_000,
+      cacheWrite: 50,
+    };
+    const manager = { listAgents: () => [record] };
+
+    const lines = renderLines(manager, "resumed", () => "background");
+    expect(lines).toContain("7 tool uses");
+    expect(lines).toContain("lifetime 1.6k token");
+    expect(lines).not.toContain("lifetime 501.6k token");
+  });
+
   // "off" hides the widget entirely — even a background agent renders nothing.
   it("renders nothing in 'off' mode", () => {
     const manager = { listAgents: () => [makeRecord("background", { isBackground: true })] };
@@ -349,6 +366,29 @@ describe("describeCompactActivity", () => {
     trackActivityPhaseStart(state, "b1", "bash", 900);
     expect(describeCompactActivity(state, 1600)).toBe("exploring…");
     expect(describeCompactActivity(state, 2300)).toBe("running commands…");
+  });
+
+  it("keeps continuous known work stable through concurrent known and unknown tools", () => {
+    const state = activity();
+    trackActivityPhaseStart(state, "b1", "bash", 0);
+    trackActivityPhaseStart(state, "r1", "read", 100);
+    trackActivityPhaseStart(state, "x1", "custom_private_tool", 200);
+
+    // Later starts do not reset the oldest candidate's promotion clock.
+    expect(describeCompactActivity(state, 799)).toBe("working…");
+    expect(describeCompactActivity(state, 800)).toBe("running commands…");
+
+    // Nor may another known phase displace a still-truthful visible phase.
+    trackActivityPhaseStart(state, "e1", "edit", 900);
+    expect(describeCompactActivity(state, 1000)).toBe("running commands…");
+    trackActivityPhaseEnd(state, "e1", 1050);
+    trackActivityPhaseEnd(state, "x1", 1100);
+
+    // Once bash ends, the continuously active read is already mature. The old
+    // label keeps its minimum hold, then switches without a working flash.
+    trackActivityPhaseEnd(state, "b1", 1200);
+    expect(describeCompactActivity(state, 2200)).toBe("running commands…");
+    expect(describeCompactActivity(state, 2300)).toBe("exploring…");
   });
 
   it("does not reuse a stale same-named phase after rendering was paused", () => {

--- a/packages/pi-subagents/test/agent-widget.test.ts
+++ b/packages/pi-subagents/test/agent-widget.test.ts
@@ -7,8 +7,11 @@ import {
   describeActivity,
   fgPreservingNestedStyles,
   formatActiveToolSummary,
+  formatLifetimeUsageBreakdown,
+  formatMs,
   formatSessionTokens,
   formatSubagentsStatusText,
+  styleDuration,
 } from "../src/ui/agent-widget.js";
 
 describe("formatSessionTokens", () => {
@@ -21,43 +24,95 @@ describe("formatSessionTokens", () => {
     bold: (s: string) => s,
   };
 
-  it("applies threshold colors (<70 dim, 70–85 warning, ≥85 error)", () => {
-    expect(formatSessionTokens(1234, null, theme)).toBe("1.2k token");
-    expect(formatSessionTokens(1234, 50, theme)).toBe("1.2k token (<dim>50%</dim>)");
-    expect(formatSessionTokens(1234, 70, theme)).toBe("1.2k token (<warning>70%</warning>)");
-    expect(formatSessionTokens(1234, 84, theme)).toBe("1.2k token (<warning>84%</warning>)");
-    expect(formatSessionTokens(1234, 85, theme)).toBe("1.2k token (<error>85%</error>)");
-    expect(formatSessionTokens(1234, 99, theme)).toBe("1.2k token (<error>99%</error>)");
+  it("labels lifetime total separately from current context and applies thresholds", () => {
+    expect(formatSessionTokens(1234, null, theme)).toBe("lifetime 1.2k token");
+    expect(formatSessionTokens(1234, 50, theme)).toBe(
+      "lifetime 1.2k token (<dim>current ctx 50%</dim>)",
+    );
+    expect(formatSessionTokens(1234, 70, theme)).toBe(
+      "lifetime 1.2k token (<warning>current ctx 70%</warning>)",
+    );
+    expect(formatSessionTokens(1234, 84, theme)).toBe(
+      "lifetime 1.2k token (<warning>current ctx 84%</warning>)",
+    );
+    expect(formatSessionTokens(1234, 85, theme)).toBe(
+      "lifetime 1.2k token (<error>current ctx 85%</error>)",
+    );
+    expect(formatSessionTokens(1234, 99, theme)).toBe(
+      "lifetime 1.2k token (<error>current ctx 99%</error>)",
+    );
   });
 
   it("annotates compaction count alongside percent", () => {
     // compactions only (e.g. immediately post-compaction, percent null)
-    expect(formatSessionTokens(1234, null, theme, 1)).toBe("1.2k token (<dim>⇊1</dim>)");
-    expect(formatSessionTokens(1234, null, theme, 3)).toBe("1.2k token (<dim>⇊3</dim>)");
+    expect(formatSessionTokens(1234, null, theme, 1)).toBe(
+      "lifetime 1.2k token (<dim>⇊1</dim>)",
+    );
+    expect(formatSessionTokens(1234, null, theme, 3)).toBe(
+      "lifetime 1.2k token (<dim>⇊3</dim>)",
+    );
     // percent + compactions, joined with ` · `
-    expect(formatSessionTokens(1234, 45, theme, 2)).toBe("1.2k token (<dim>45%</dim> · <dim>⇊2</dim>)");
-    expect(formatSessionTokens(1234, 88, theme, 4)).toBe("1.2k token (<error>88%</error> · <dim>⇊4</dim>)");
+    expect(formatSessionTokens(1234, 45, theme, 2)).toBe(
+      "lifetime 1.2k token (<dim>current ctx 45%</dim> · <dim>⇊2</dim>)",
+    );
+    expect(formatSessionTokens(1234, 88, theme, 4)).toBe(
+      "lifetime 1.2k token (<error>current ctx 88%</error> · <dim>⇊4</dim>)",
+    );
     // compactions=0 omitted
-    expect(formatSessionTokens(1234, 45, theme, 0)).toBe("1.2k token (<dim>45%</dim>)");
+    expect(formatSessionTokens(1234, 45, theme, 0)).toBe(
+      "lifetime 1.2k token (<dim>current ctx 45%</dim>)",
+    );
   });
 
   it("preserves the outer style after nested annotation styles reset", () => {
     const tokenText = formatSessionTokens(1234, 70, ansiTheme);
 
     expect(fgPreservingNestedStyles(ansiTheme, "accent", tokenText)).toBe(
-      "\u001b[35m1.2k token (\u001b[33m70%\u001b[39m\u001b[35m)\u001b[39m",
+      "\u001b[35mlifetime 1.2k token (\u001b[33mcurrent ctx 70%\u001b[39m\u001b[35m)\u001b[39m",
     );
+  });
+});
+
+describe("lifetime usage and duration formatters", () => {
+  it("formats the full usage breakdown and optional cost", () => {
+    expect(formatLifetimeUsageBreakdown({
+      input: 1_200,
+      output: 345,
+      cacheRead: 98_700,
+      cacheWrite: 40,
+      cost: 0.042,
+    })).toBe("Lifetime usage: input 1.2k · output 345 · cache read 98.7k · cache write 40 · cost $0.042");
+    expect(formatLifetimeUsageBreakdown({
+      input: 0, output: 0, cacheRead: 0, cacheWrite: 0,
+    })).not.toContain("cost");
+  });
+
+  it("formats sub-minute, minute, and hour boundaries without long-second counts", () => {
+    expect(formatMs(-500)).toBe("0s");
+    expect(formatMs(0)).toBe("0s");
+    expect(formatMs(999)).toBe("0.9s");
+    expect(formatMs(11_000)).toBe("11s");
+    expect(formatMs(59_999)).toBe("59.9s");
+    expect(formatMs(60_000)).toBe("1 min 0s");
+    expect(formatMs(613_000)).toBe("10 min 13s");
+    expect(formatMs(3_600_000)).toBe("1 hr 0 min 0s");
+    expect(formatMs(3_661_000)).toBe("1 hr 1 min 1s");
+  });
+
+  it("uses only the semantic accent color for the duration fragment", () => {
+    const semanticTheme = { fg: (color: string, text: string) => `<${color}>${text}</${color}>` };
+    expect(styleDuration(semanticTheme, "10 min 13s")).toBe("<accent>10 min 13s</accent>");
   });
 });
 
 describe("renderRunningAgentStatus", () => {
   it("renders running status as separate component lines", () => {
     const theme = { fg: (_c: string, s: string) => s };
-    const component = renderRunningAgentStatus("⠋", "effort: xhigh · 4 tool uses", "thinking…", theme);
+    const component = renderRunningAgentStatus("⠋", "effort: xhigh · 4 tool uses", "working…", theme);
 
     expect(component.render(120).map((line) => line.trimEnd())).toEqual([
       "⠋ effort: xhigh · 4 tool uses",
-      "  ⎿  thinking…",
+      "  ⎿  working…",
     ]);
   });
 });
@@ -219,7 +274,7 @@ describe("formatActiveToolSummary / describeActivity", () => {
     expect(summary).not.toContain("evil.invalid");
   });
 
-  it("describeActivity prefers in-flight step summaries over thinking…", () => {
+  it("describeActivity prefers tool/body summaries over the working fallback", () => {
     const tools = new Map<string, string>([
       ["c1", "reading src/a.ts"],
       ["c2", "running rg auth"],
@@ -227,6 +282,6 @@ describe("formatActiveToolSummary / describeActivity", () => {
     expect(describeActivity(tools)).toBe("reading src/a.ts, running rg auth…");
     expect(describeActivity(new Map([["c1", "searching \"x\""]]))).toBe('searching "x"…');
     expect(describeActivity(new Map(), " partial answer ")).toBe("partial answer");
-    expect(describeActivity(new Map())).toBe("thinking…");
+    expect(describeActivity(new Map())).toBe("working…");
   });
 });

--- a/packages/pi-subagents/test/agent-widget.test.ts
+++ b/packages/pi-subagents/test/agent-widget.test.ts
@@ -2,16 +2,22 @@ import { describe, expect, it } from "vitest";
 import { renderRunningAgentStatus } from "../src/index.js";
 import type { WidgetMode } from "../src/types.js";
 import {
+  ACTIVITY_PHASE_MIN_HOLD_MS,
+  ACTIVITY_PHASE_PROMOTION_MS,
   type AgentActivity,
   AgentWidget,
   describeActivity,
+  describeCompactActivity,
   fgPreservingNestedStyles,
   formatActiveToolSummary,
   formatLifetimeUsageBreakdown,
   formatMs,
   formatSessionTokens,
   formatSubagentsStatusText,
+  getToolActivityPhase,
   styleDuration,
+  trackActivityPhaseEnd,
+  trackActivityPhaseStart,
 } from "../src/ui/agent-widget.js";
 
 describe("formatSessionTokens", () => {
@@ -123,6 +129,8 @@ describe("AgentWidget", () => {
   function makeActivity(): AgentActivity {
     return {
       activeTools: new Map(),
+      activeToolPhases: new Map(),
+      phaseSummary: {},
       toolUses: 0,
       responseText: "",
       turnCount: 1,
@@ -257,14 +265,14 @@ describe("AgentWidget status bar policy", () => {
 });
 
 describe("formatActiveToolSummary / describeActivity", () => {
-  it("summarizes read/bash/grep args into a step line", () => {
+  it("summarizes read/bash/grep args into a detailed step line", () => {
     expect(formatActiveToolSummary("read", { path: "src/a.ts" })).toBe("reading src/a.ts");
     expect(formatActiveToolSummary("bash", { command: 'rg "auth" -n' })).toBe('running rg "auth" -n');
     expect(formatActiveToolSummary("grep", { pattern: "foo", glob: "*.ts" })).toBe('searching "foo" *.ts');
     expect(formatActiveToolSummary("edit", {})).toBe("editing");
   });
 
-  it("strips terminal controls from parent widget activity", () => {
+  it("strips terminal controls from detailed overlay activity", () => {
     const summary = formatActiveToolSummary("bash", {
       command: "echo \u001b[31mred\u001b[0m \u001b]8;;https://evil.invalid/?token=x\u0007link\u001b]8;;\u0007 中文",
     });
@@ -274,7 +282,7 @@ describe("formatActiveToolSummary / describeActivity", () => {
     expect(summary).not.toContain("evil.invalid");
   });
 
-  it("describeActivity prefers tool/body summaries over the working fallback", () => {
+  it("keeps exact tool/body summaries available to the conversation overlay", () => {
     const tools = new Map<string, string>([
       ["c1", "reading src/a.ts"],
       ["c2", "running rg auth"],
@@ -283,5 +291,85 @@ describe("formatActiveToolSummary / describeActivity", () => {
     expect(describeActivity(new Map([["c1", "searching \"x\""]]))).toBe('searching "x"…');
     expect(describeActivity(new Map(), " partial answer ")).toBe("partial answer");
     expect(describeActivity(new Map())).toBe("working…");
+  });
+});
+
+describe("describeCompactActivity", () => {
+  function activity(responseText = ""): AgentActivity {
+    return {
+      activeTools: new Map(),
+      activeToolPhases: new Map(),
+      phaseSummary: {},
+      toolUses: 0,
+      responseText,
+      turnCount: 1,
+      lifetimeUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    };
+  }
+
+  it("classifies only known tools into coarse, non-sensitive phases", () => {
+    expect(getToolActivityPhase("read")).toBe("exploring");
+    expect(getToolActivityPhase("web_search")).toBe("exploring");
+    expect(getToolActivityPhase("edit")).toBe("editing");
+    expect(getToolActivityPhase("bash")).toBe("runningCommands");
+    expect(getToolActivityPhase("Agent")).toBe("delegating");
+    expect(getToolActivityPhase("custom_private_tool")).toBeUndefined();
+  });
+
+  it("keeps fast exact steps hidden until a coarse phase is stable", () => {
+    const state = activity();
+    state.activeTools.set("r1", "reading secret/customer-file.ts");
+    trackActivityPhaseStart(state, "r1", "read", 0);
+
+    expect(describeCompactActivity(state, ACTIVITY_PHASE_PROMOTION_MS - 1)).toBe("working…");
+    expect(describeCompactActivity(state, ACTIVITY_PHASE_PROMOTION_MS)).toBe("exploring…");
+    expect(describeCompactActivity(state, ACTIVITY_PHASE_PROMOTION_MS)).not.toContain("customer-file");
+  });
+
+  it("treats short same-phase gaps as continuous and holds a promoted label", () => {
+    const state = activity();
+    trackActivityPhaseStart(state, "r1", "read", 0);
+    trackActivityPhaseEnd(state, "r1", 400);
+    trackActivityPhaseStart(state, "g1", "grep", 550);
+
+    expect(describeCompactActivity(state, ACTIVITY_PHASE_PROMOTION_MS)).toBe("exploring…");
+    trackActivityPhaseEnd(state, "g1", 900);
+    expect(describeCompactActivity(state, ACTIVITY_PHASE_PROMOTION_MS + ACTIVITY_PHASE_MIN_HOLD_MS - 1))
+      .toBe("exploring…");
+    expect(describeCompactActivity(state, ACTIVITY_PHASE_PROMOTION_MS + ACTIVITY_PHASE_MIN_HOLD_MS))
+      .toBe("working…");
+  });
+
+  it("holds the old phase before switching to a stable new phase", () => {
+    const state = activity();
+    trackActivityPhaseStart(state, "r1", "read", 0);
+    expect(describeCompactActivity(state, 800)).toBe("exploring…");
+
+    trackActivityPhaseEnd(state, "r1", 850);
+    trackActivityPhaseStart(state, "b1", "bash", 900);
+    expect(describeCompactActivity(state, 1600)).toBe("exploring…");
+    expect(describeCompactActivity(state, 2300)).toBe("running commands…");
+  });
+
+  it("does not reuse a stale same-named phase after rendering was paused", () => {
+    const state = activity();
+    trackActivityPhaseStart(state, "r1", "read", 0);
+    expect(describeCompactActivity(state, 800)).toBe("exploring…");
+    trackActivityPhaseEnd(state, "r1", 900);
+
+    // No render occurs while compact UI is hidden. A later read is a new phase,
+    // even though the old visible label was never ticked away.
+    trackActivityPhaseStart(state, "r2", "read", 5000);
+    expect(describeCompactActivity(state, 5000)).toBe("working…");
+    expect(describeCompactActivity(state, 5799)).toBe("working…");
+    expect(describeCompactActivity(state, 5800)).toBe("exploring…");
+  });
+
+  it("uses working for unknown tools and streaming body text on compact surfaces", () => {
+    const state = activity("partial answer with implementation details");
+    trackActivityPhaseStart(state, "x1", "custom_private_tool", 0);
+
+    expect(describeCompactActivity(state, 5000)).toBe("working…");
+    expect(describeActivity(new Map(), state.responseText)).toBe("partial answer with implementation details");
   });
 });

--- a/packages/pi-subagents/test/conversation-viewer.test.ts
+++ b/packages/pi-subagents/test/conversation-viewer.test.ts
@@ -595,6 +595,69 @@ describe("ConversationViewer brief layout (scheme A)", () => {
     expect(out).not.toContain("lifetime 501.6k token");
   });
 
+  it("prefers record lifetime metrics over a stale activity mirror after resume", () => {
+    const now = Date.now();
+    const activity = {
+      activeTools: new Map(),
+      activeToolPhases: new Map(),
+      phaseSummary: {},
+      toolUses: 1,
+      turnCount: 1,
+      responseText: "",
+      lifetimeUsage: { input: 100, output: 0, cacheRead: 0, cacheWrite: 0 },
+    };
+    const viewer = new ConversationViewer(
+      mockTui(40, W),
+      mockSession([{ role: "user", content: "continue" }]),
+      mockRecord({
+        status: "completed",
+        toolUses: 7,
+        startedAt: now - 1_000,
+        completedAt: now,
+        lifetimeUsage: { input: 1_200, output: 300, cacheRead: 500_000, cacheWrite: 50 },
+      }),
+      activity as any,
+      ansiTheme(),
+      vi.fn(),
+    );
+
+    const out = viewer.render(W).join("\n");
+    expect(out).toContain("7 tools");
+    expect(out).not.toContain("1 tool ·");
+    expect(out).toContain("input 1.2k");
+    expect(out).not.toContain("input 100 ·");
+    expect(out).toContain("lifetime 1.6k token");
+  });
+
+  it("accents only the elapsed value, not the running status suffix", () => {
+    const calls: Array<{ color: string; text: string }> = [];
+    const semanticTheme = {
+      fg: (color: string, text: string) => {
+        calls.push({ color, text });
+        return text;
+      },
+      bold: (text: string) => text,
+    } as any;
+    const now = vi.spyOn(Date, "now").mockReturnValue(11_000);
+    try {
+      new ConversationViewer(
+        mockTui(40, W),
+        mockSession([{ role: "user", content: "work" }]),
+        mockRecord({ status: "running", startedAt: 0 }),
+        undefined,
+        semanticTheme,
+        vi.fn(),
+      ).render(W);
+    } finally {
+      now.mockRestore();
+    }
+
+    const accentTexts = calls.filter((call) => call.color === "accent").map((call) => call.text);
+    expect(accentTexts).toContain("11s");
+    expect(accentTexts.some((text) => text.includes("(running)"))).toBe(false);
+    expect(calls).toContainEqual({ color: "dim", text: " (running)" });
+  });
+
   it("uses working for an idle run but preserves queued priority", () => {
     const messages = [{ role: "user", content: "wait" }];
     const running = new ConversationViewer(

--- a/packages/pi-subagents/test/conversation-viewer.test.ts
+++ b/packages/pi-subagents/test/conversation-viewer.test.ts
@@ -223,6 +223,12 @@ describe("ConversationViewer", () => {
         );
         assertAllLinesFit(viewer.render(w), w);
       }
+
+      const detailed = new ConversationViewer(
+        mockTui(30, 120), mockSession(messages), mockRecord({ status: "running" }), activity as any, ansiTheme(), vi.fn(),
+      ).render(120).join("\n");
+      expect(detailed).toContain("reading file.ts");
+      expect(detailed).toContain("searching pattern");
     });
 
     it("no line exceeds width with tool calls", () => {

--- a/packages/pi-subagents/test/conversation-viewer.test.ts
+++ b/packages/pi-subagents/test/conversation-viewer.test.ts
@@ -34,12 +34,15 @@ function mockTui(rows = 40, columns = 80) {
   } as any;
 }
 
-function mockSession(messages: any[] = []) {
+function mockSession(
+  messages: any[] = [],
+  stats: any = { tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
+) {
   return {
     messages,
     subscribe: vi.fn(() => vi.fn()),
     dispose: vi.fn(),
-    getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheWrite: 0 } }),
+    getSessionStats: () => stats,
   } as any;
 }
 
@@ -51,6 +54,8 @@ function mockRecord(overrides: Partial<AgentRecord> = {}): AgentRecord {
     status: "running",
     toolUses: 0,
     startedAt: Date.now(),
+    lifetimeUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    compactionCount: 0,
     ...overrides,
   } as AgentRecord;
 }
@@ -197,8 +202,16 @@ describe("ConversationViewer", () => {
     it("no line exceeds width with running activity indicator", () => {
       const activity = {
         activeTools: new Map([["c1", "reading file.ts"], ["c2", "searching pattern"]]),
-        toolUses: 5, tokens: "10k", responseText: "R".repeat(400),
-        session: { getSessionStats: () => ({ tokens: { total: 50000 } }) },
+        toolUses: 5,
+        turnCount: 2,
+        lifetimeUsage: { input: 10_000, output: 500, cacheRead: 50_000, cacheWrite: 100 },
+        responseText: "R".repeat(400),
+        session: {
+          getSessionStats: () => ({
+            tokens: { input: 10_000, output: 500, cacheRead: 50_000, cacheWrite: 100 },
+            contextUsage: { percent: 25 },
+          }),
+        },
       };
       const messages = [
         { role: "user", content: "do the thing" },
@@ -525,12 +538,72 @@ describe("ConversationViewer brief layout (scheme A)", () => {
     const out = viewer.render(W).join("\n");
     expect(out).toContain("Prompt");
     expect(out).toContain("Dispatch me to find auth");
+    expect(out).toContain("Usage");
     expect(out).toContain("Steps");
     expect(out).toMatch(/grep/);
     expect(out).toContain("Result");
     expect(out).toContain("All done with auth search.");
     // Default view must not dump the huge tool body.
     expect(out).not.toContain("LINE_SHOULD_NOT_APPEAR_IN_DEFAULT_VIEW");
+  });
+
+  it("shows a record-backed lifetime usage breakdown and separate current context", () => {
+    const messages = [
+      { role: "user", content: "measure this run" },
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+    ];
+    const session = mockSession(messages, {
+      tokens: { input: 1_200, output: 300, cacheRead: 500_000, cacheWrite: 50 },
+      contextUsage: { percent: 25 },
+    });
+    const viewer = new ConversationViewer(
+      mockTui(40, W),
+      session,
+      mockRecord({
+        status: "completed",
+        lifetimeUsage: {
+          input: 1_200,
+          output: 300,
+          cacheRead: 500_000,
+          cacheWrite: 50,
+          cost: 0.042,
+        },
+        compactionCount: 2,
+      }),
+      undefined,
+      ansiTheme(),
+      vi.fn(),
+    );
+
+    const out = viewer.render(W).join("\n");
+    expect(out).toContain("Lifetime usage:");
+    expect(out).toContain("input 1.2k");
+    expect(out).toContain("output 300");
+    expect(out).toContain("cache read 500.0k");
+    expect(out).toContain("cache write 50");
+    expect(out).toContain("cost $0.042");
+    expect(out).toContain("Current context: 25%");
+    expect(out).toContain("2 compactions");
+    // Compact total remains input + output + cacheWrite; cacheRead is breakdown-only.
+    expect(out).toContain("lifetime 1.6k token");
+    expect(out).not.toContain("lifetime 501.6k token");
+  });
+
+  it("uses working for an idle run but preserves queued priority", () => {
+    const messages = [{ role: "user", content: "wait" }];
+    const running = new ConversationViewer(
+      mockTui(40, W), mockSession(messages), mockRecord({ status: "running" }),
+      undefined, ansiTheme(), vi.fn(),
+    ).render(W).join("\n");
+    expect(running).toContain("working…");
+    expect(running).not.toContain("thinking…");
+
+    const queued = new ConversationViewer(
+      mockTui(40, W), mockSession(messages), mockRecord({ status: "queued" }),
+      undefined, ansiTheme(), vi.fn(),
+    ).render(W).join("\n");
+    expect(queued).toContain("queued…");
+    expect(queued).not.toContain("working…");
   });
 
   it("o toggles expanded tool detail that reveals folded multi-line result text", () => {

--- a/packages/pi-subagents/test/fleet-list.test.ts
+++ b/packages/pi-subagents/test/fleet-list.test.ts
@@ -2,7 +2,7 @@ import { Editor, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentManager } from "../src/agent-manager.js";
 import type { AgentRecord } from "../src/types.js";
-import { getDisplayName } from "../src/ui/agent-widget.js";
+import { type AgentActivity, getDisplayName } from "../src/ui/agent-widget.js";
 import { FleetList, type FleetUICtx, formatFleetElapsed, formatFleetTokens } from "../src/ui/fleet-list.js";
 
 // ---- Key sequences (see node_modules/@earendil-works/pi-tui/dist/keys.js) ----
@@ -71,7 +71,7 @@ interface Harness {
   widgetTui: { requestRender(): void; focusedComponent?: unknown };
 }
 
-function harness(agents: AgentRecord[]): Harness {
+function harness(agents: AgentRecord[], activity = new Map<string, AgentActivity>()): Harness {
   let inputHandler: ((data: string) => { consume?: boolean } | undefined) | undefined;
   let widgetFactory: ((tui: any, theme: any) => { render(w: number): string[] }) | undefined;
   let editorText = "";
@@ -99,7 +99,7 @@ function harness(agents: AgentRecord[]): Harness {
   };
 
   const manager = fakeManager(agents);
-  const fleet = new FleetList(manager, new Map());
+  const fleet = new FleetList(manager, activity);
   fleet.setUICtx(ui);
   fleet.update();
 
@@ -310,6 +310,27 @@ describe("FleetList rendering", () => {
     expect(agentLine).toContain("↓ lifetime 13.1k tokens");
     expect(agentLine).toMatch(/\x1b\[35m[\d.]+s\x1b\[39m/);
     expect(agentLine).toContain("\x1b[2m↓ lifetime 13.1k tokens\x1b[39m");
+  });
+
+  it("prefers record lifetime usage over a stale activity mirror after resume", () => {
+    const record = makeRecord({
+      id: "resumed",
+      lifetimeUsage: { input: 1_200, output: 300, cacheRead: 500_000, cacheWrite: 50 },
+    });
+    const staleActivity: AgentActivity = {
+      activeTools: new Map(),
+      activeToolPhases: new Map(),
+      phaseSummary: {},
+      toolUses: 1,
+      responseText: "",
+      turnCount: 1,
+      lifetimeUsage: { input: 100, output: 0, cacheRead: 0, cacheWrite: 0 },
+    };
+    const h = harness([record], new Map([[record.id, staleActivity]]));
+    const line = h.render(120).find((candidate) => candidate.includes(record.description))!;
+    expect(line).toContain("↓ lifetime 1.6k tokens");
+    expect(line).not.toContain("↓ lifetime 100 tokens");
+    h.fleet.dispose();
   });
 
   it("renders a long elapsed time in accent without brightening the token metric", () => {

--- a/packages/pi-subagents/test/fleet-list.test.ts
+++ b/packages/pi-subagents/test/fleet-list.test.ts
@@ -15,7 +15,13 @@ const ENTER = "\r";
 // Kitty-protocol key-RELEASE for ↓ (event type 3) — listeners receive these too.
 const DOWN_RELEASE = "\x1b[1;1:3B";
 
-const theme = { fg: (c: string, s: string) => `<${c}>${s}</${c}>`, bold: (s: string) => `*${s}*` };
+const theme = {
+  fg: (color: string, text: string) => {
+    const codes: Record<string, string> = { accent: "35", dim: "2", muted: "90" };
+    return `\x1b[${codes[color] ?? "37"}m${text}\x1b[39m`;
+  },
+  bold: (text: string) => `\x1b[1m${text}\x1b[22m`,
+};
 
 /** A no-op session so a record is "openable" by default (the list hides session-less agents). */
 const FAKE_SESSION = { subscribe: () => () => {}, messages: [] };
@@ -29,7 +35,7 @@ function makeRecord(over: Partial<AgentRecord> = {}): AgentRecord {
     toolUses: 0,
     startedAt: Date.now(),
     session: FAKE_SESSION as any,
-    lifetimeUsage: { input: 13100, output: 0, cacheWrite: 0 },
+    lifetimeUsage: { input: 13100, output: 0, cacheRead: 50_000, cacheWrite: 0 },
     compactionCount: 0,
     ...over,
   } as AgentRecord;
@@ -113,22 +119,22 @@ function harness(agents: AgentRecord[]): Harness {
 }
 
 describe("formatFleetElapsed", () => {
-  it("renders integer seconds (no decimal, no suffix)", () => {
+  it("uses the shared friendly duration format at every boundary", () => {
+    expect(formatFleetElapsed(-500)).toBe("0s");
     expect(formatFleetElapsed(0)).toBe("0s");
     expect(formatFleetElapsed(11_000)).toBe("11s");
-    expect(formatFleetElapsed(11_400)).toBe("11s");
-    expect(formatFleetElapsed(11_600)).toBe("12s");
-  });
-  it("floors negatives to 0s", () => {
-    expect(formatFleetElapsed(-500)).toBe("0s");
+    expect(formatFleetElapsed(11_400)).toBe("11.4s");
+    expect(formatFleetElapsed(60_000)).toBe("1 min 0s");
+    expect(formatFleetElapsed(613_000)).toBe("10 min 13s");
+    expect(formatFleetElapsed(3_600_000)).toBe("1 hr 0 min 0s");
   });
 });
 
 describe("formatFleetTokens", () => {
-  it("prefixes a down-arrow and uses plural 'tokens'", () => {
-    expect(formatFleetTokens(13_100)).toBe("↓ 13.1k tokens");
-    expect(formatFleetTokens(950)).toBe("↓ 950 tokens");
-    expect(formatFleetTokens(1_200_000)).toBe("↓ 1.2M tokens");
+  it("labels the compact total as lifetime without including cacheRead", () => {
+    expect(formatFleetTokens(13_100)).toBe("↓ lifetime 13.1k tokens");
+    expect(formatFleetTokens(950)).toBe("↓ lifetime 950 tokens");
+    expect(formatFleetTokens(1_200_000)).toBe("↓ lifetime 1.2M tokens");
   });
 });
 
@@ -301,8 +307,24 @@ describe("FleetList rendering", () => {
     const agentLine = lines.find(l => l.includes("Sleep then report 1"))!;
     expect(agentLine).toContain("○");
     expect(agentLine).toContain(getDisplayName("general-purpose"));
-    expect(agentLine).toContain("↓ 13.1k tokens");
-    expect(agentLine).toMatch(/\d+s · ↓/); // "<seconds>s · ↓ ..." (timing-agnostic)
+    expect(agentLine).toContain("↓ lifetime 13.1k tokens");
+    expect(agentLine).toMatch(/\x1b\[35m[\d.]+s\x1b\[39m/);
+    expect(agentLine).toContain("\x1b[2m↓ lifetime 13.1k tokens\x1b[39m");
+  });
+
+  it("renders a long elapsed time in accent without brightening the token metric", () => {
+    const now = Date.now();
+    const record = makeRecord({
+      status: "completed",
+      startedAt: now - 613_000,
+      completedAt: now,
+    });
+    const h = harness([record]);
+    const line = h.render(120).find((candidate) => candidate.includes(record.description))!;
+    expect(line).toContain("\x1b[35m10 min 13s\x1b[39m");
+    expect(line).toContain("\x1b[2m↓ lifetime 13.1k tokens\x1b[39m");
+    expect(line).not.toContain("\x1b[35m↓ lifetime");
+    h.fleet.dispose();
   });
 
   it("orders agents earliest-launched first (top)", () => {

--- a/packages/pi-subagents/test/group-join.test.ts
+++ b/packages/pi-subagents/test/group-join.test.ts
@@ -18,7 +18,7 @@ function makeRecord(id: string, overrides: Partial<AgentRecord> = {}): AgentReco
     status: "completed",
     toolUses: 0,
     startedAt: 0,
-    lifetimeUsage: { input: 0, output: 0, cacheWrite: 0 },
+    lifetimeUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     ...overrides,
   };
 }

--- a/packages/pi-subagents/test/tool-render.test.ts
+++ b/packages/pi-subagents/test/tool-render.test.ts
@@ -31,13 +31,20 @@ function theme() {
   } as any;
 }
 
+function taggedTheme() {
+  return {
+    fg: (color: string, text: string) => `<${color}>${text}</${color}>`,
+    bold: (text: string) => text,
+  } as any;
+}
+
 function completedDetails(overrides: Partial<AgentDetails> = {}): AgentDetails {
   return {
     displayName: "Explore",
     description: "find auth",
     subagentType: "Explore",
     toolUses: 3,
-    tokens: "1.2k token",
+    tokens: "lifetime 1.2k token",
     durationMs: 4200,
     status: "completed",
     agentId: "abc123",
@@ -120,6 +127,32 @@ describe("renderAgentLikeResult", () => {
     expect(out).toMatch(/⎿/);
     expect(out).toContain("2 tool uses");
     expect(out).not.toContain("abc123"); // id stays off the running chrome (CC)
+  });
+
+  it("uses working when a running result has no tool or body activity", () => {
+    const out = plain(
+      renderAgentLikeResult(
+        completedDetails({ status: "running", durationMs: 0, activity: undefined }),
+        "",
+        { expanded: false },
+        theme(),
+      ),
+    );
+    expect(out).toContain("working…");
+    expect(out).not.toContain("thinking…");
+  });
+
+  it("renders only the terminal duration fragment in semantic accent", () => {
+    const component = renderAgentLikeResult(
+      completedDetails({ durationMs: 613_000 }),
+      "done",
+      { expanded: false },
+      taggedTheme(),
+    );
+    const out = plain(component, 160);
+    expect(out).toContain("<accent>10 min 13s</accent>");
+    expect(out).toContain("<dim>lifetime 1.2k token</dim>");
+    expect(out).not.toContain("<accent>lifetime 1.2k token</accent>");
   });
 
   it("error collapsed shows error line without full dump", () => {

--- a/packages/pi-subagents/test/tool-render.test.ts
+++ b/packages/pi-subagents/test/tool-render.test.ts
@@ -115,15 +115,16 @@ describe("renderAgentLikeResult", () => {
     expect(out).toContain("Report");
   });
 
-  it("running status is spinner + ⎿ activity (Claude Code shape)", () => {
+  it("running status is spinner + ⎿ coarse activity (Claude Code shape)", () => {
     const component = renderAgentLikeResult(
-      completedDetails({ status: "running", durationMs: 0, activity: "reading src/a.ts", toolUses: 2 }),
+      completedDetails({ status: "running", durationMs: 0, activity: "exploring…", toolUses: 2 }),
       "",
       { expanded: false },
       theme(),
     );
     const out = plain(component, 100);
-    expect(out).toMatch(/reading src\/a\.ts/);
+    expect(out).toContain("exploring…");
+    expect(out).not.toContain("src/a.ts");
     expect(out).toMatch(/⎿/);
     expect(out).toContain("2 tool uses");
     expect(out).not.toContain("abc123"); // id stays off the running chrome (CC)

--- a/packages/pi-subagents/test/usage.test.ts
+++ b/packages/pi-subagents/test/usage.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { getLifetimeTotal, getSessionContextPercent, getSessionTokens } from "../src/usage.js";
+import {
+  addUsage,
+  createLifetimeUsage,
+  getLifetimeTotal,
+  getSessionContextPercent,
+  getSessionTokens,
+  toLifetimeUsage,
+} from "../src/usage.js";
 
 // Regression for issue #38 — token semantics + context indicator
 describe("usage", () => {
@@ -50,64 +57,117 @@ describe("usage", () => {
     });
   });
 
+  describe("toLifetimeUsage / addUsage", () => {
+    it("retains every usage component and reliable cost without adding reasoning", () => {
+      expect(toLifetimeUsage({
+        input: 100,
+        output: 200,
+        cacheRead: 500_000,
+        cacheWrite: 50,
+        reasoning: 99,
+        cost: { total: 0.25 },
+      })).toEqual({
+        input: 100,
+        output: 200,
+        cacheRead: 500_000,
+        cacheWrite: 50,
+        cost: 0.25,
+      });
+    });
+
+    it("falls back to finite cost components and omits unavailable cost", () => {
+      expect(toLifetimeUsage({
+        input: 1,
+        cost: { input: 0.1, output: 0.2, cacheRead: 0.3, cacheWrite: 0.4 },
+      })).toEqual({ input: 1, output: 0, cacheRead: 0, cacheWrite: 0, cost: 1 });
+      expect(toLifetimeUsage({ input: 1 })).toEqual({
+        input: 1, output: 0, cacheRead: 0, cacheWrite: 0,
+      });
+    });
+
+    it("accumulates tokens, cache traffic, and available cost in place", () => {
+      const usage = createLifetimeUsage();
+      addUsage(usage, toLifetimeUsage({
+        input: 100, output: 20, cacheRead: 900, cacheWrite: 5, cost: { total: 0.1 },
+      }));
+      addUsage(usage, toLifetimeUsage({
+        input: 50, output: 10, cacheRead: 1_200, cacheWrite: 3, cost: { total: 0.2 },
+      }));
+
+      expect(usage).toEqual({
+        input: 150,
+        output: 30,
+        cacheRead: 2_100,
+        cacheWrite: 8,
+        cost: 0.30000000000000004,
+      });
+    });
+  });
+
   describe("getLifetimeTotal", () => {
-    it("sums components and handles undefined", () => {
+    it("preserves the compact issue #38 total and excludes cacheRead/cost", () => {
       expect(getLifetimeTotal(undefined)).toBe(0);
-      expect(getLifetimeTotal({ input: 100, output: 200, cacheWrite: 50 })).toBe(350);
+      expect(getLifetimeTotal({
+        input: 100,
+        output: 200,
+        cacheRead: 500_000,
+        cacheWrite: 50,
+        cost: 12.34,
+      })).toBe(350);
     });
 
     // getSessionTokens reads upstream session stats (resets at compaction);
     // getLifetimeTotal reads our independent accumulator (survives compaction).
     // They agree pre-compaction, diverge after — both legitimate signals.
     it("agrees with getSessionTokens pre-compaction, diverges after", () => {
-      let sessionStatsTokens = { input: 100, output: 200, cacheWrite: 50 };
+      let sessionStatsTokens = { input: 100, output: 200, cacheRead: 500_000, cacheWrite: 50 };
       const session = {
         getSessionStats: () => ({ tokens: sessionStatsTokens }),
       };
-      const lifetime = { input: 100, output: 200, cacheWrite: 50 };
+      const lifetime = createLifetimeUsage();
+      addUsage(lifetime, toLifetimeUsage(sessionStatsTokens));
 
       expect(getSessionTokens(session)).toBe(350);
       expect(getLifetimeTotal(lifetime)).toBe(350);
+      expect(lifetime.cacheRead).toBe(500_000);
 
       // Compaction: upstream replaces session.state.messages, so stats reset.
       // Our accumulator is independent — it keeps growing.
-      sessionStatsTokens = { input: 0, output: 0, cacheWrite: 0 };
+      sessionStatsTokens = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 
-      expect(getSessionTokens(session)).toBe(0);            // reset
-      expect(getLifetimeTotal(lifetime)).toBe(350);          // preserved
+      expect(getSessionTokens(session)).toBe(0);
+      expect(getLifetimeTotal(lifetime)).toBe(350);
 
-      // Subsequent message_end events feed both: session re-fills, accumulator continues
-      sessionStatsTokens = { input: 80, output: 150, cacheWrite: 30 };
-      lifetime.input += 80; lifetime.output += 150; lifetime.cacheWrite += 30;
+      // Subsequent message_end events feed both: session re-fills, accumulator continues.
+      sessionStatsTokens = { input: 80, output: 150, cacheRead: 400_000, cacheWrite: 30 };
+      addUsage(lifetime, toLifetimeUsage(sessionStatsTokens));
 
-      expect(getSessionTokens(session)).toBe(260);           // post-compaction window
-      expect(getLifetimeTotal(lifetime)).toBe(610);          // 350 + 260, monotone
+      expect(getSessionTokens(session)).toBe(260);
+      expect(getLifetimeTotal(lifetime)).toBe(610);
+      expect(lifetime.cacheRead).toBe(900_000);
     });
 
     // The accumulator survives compaction because it lives on AgentActivity /
     // AgentRecord, not on session.state.messages (which compaction replaces).
-    it("stays monotone across simulated compaction when fed via addUsage-style accumulation", () => {
-      const usage = { input: 0, output: 0, cacheWrite: 0 };
-      const onUsage = (u: { input: number; output: number; cacheWrite: number }) => {
-        usage.input += u.input;
-        usage.output += u.output;
-        usage.cacheWrite += u.cacheWrite;
-      };
+    it("stays monotone across simulated compaction while retaining cacheRead separately", () => {
+      const usage = createLifetimeUsage();
+      const onUsage = (value: unknown) => addUsage(usage, toLifetimeUsage(value));
 
-      // 5 normal turns
-      for (let i = 0; i < 5; i++) onUsage({ input: 1000, output: 200, cacheWrite: 50 });
+      for (let i = 0; i < 5; i++) {
+        onUsage({ input: 1000, output: 200, cacheRead: 10_000, cacheWrite: 50 });
+      }
       expect(getLifetimeTotal(usage)).toBe(5 * 1250);
+      expect(usage.cacheRead).toBe(50_000);
 
-      // Compaction would replace session.state.messages, dropping any sum
-      // re-derived from it. Our accumulator is independent — no reset.
       const beforeCompaction = getLifetimeTotal(usage);
-
-      // 3 more turns post-"compaction"
-      for (let i = 0; i < 3; i++) onUsage({ input: 800, output: 150, cacheWrite: 30 });
+      for (let i = 0; i < 3; i++) {
+        onUsage({ input: 800, output: 150, cacheRead: 8_000, cacheWrite: 30 });
+      }
       expect(getLifetimeTotal(usage)).toBe(beforeCompaction + 3 * 980);
-      expect(getLifetimeTotal(usage)).toBeGreaterThan(beforeCompaction); // monotone
+      expect(getLifetimeTotal(usage)).toBeGreaterThan(beforeCompaction);
+      expect(usage.cacheRead).toBe(74_000);
 
-      // input + output + cacheWrite = total — by construction, no drift
+      // The compact total deliberately retains its historical formula.
       expect(usage.input + usage.output + usage.cacheWrite).toBe(getLifetimeTotal(usage));
     });
   });


### PR DESCRIPTION
## Summary

- replace misleading idle `thinking…` status with stable, coarse `working…` activity phases
- add lifetime input/output/cache/cost breakdowns while preserving issue #38 compact-total semantics
- standardize readable accented durations and keep resumed/concurrent activity metrics truthful

## Validation

- `pnpm --filter @zhcsyncer/pi-subagents check` (39 files, 803 tests)
- `pnpm check`
- `pnpm changeset status`
- three independent adversarial reviews followed by verified fixes

## Release

Includes a patch changeset for:

- `@zhcsyncer/pi-extensions`
- `@zhcsyncer/pi-subagents`
