### PR TITLE
fix(pi-subagents): deliver manual background results promptly

### DIFF
--- a/.changeset/fair-subagent-delivery.md
+++ b/.changeset/fair-subagent-delivery.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-subagents": patch
+---
+
+Deliver manually launched background Agent completions as `steer` messages so current-task results reach the parent before its next model call instead of starving behind a long tool loop. Scheduled and cross-extension RPC completions retain detached `followUp` delivery, foreground results remain inline, and the Agent contract now requires foreground for prerequisite results plus genuinely disjoint background work without repeating delegated evidence collection.

--- a/packages/pi-subagents/CHANGELOG.md
+++ b/packages/pi-subagents/CHANGELOG.md
@@ -26,4 +26,8 @@
 
 ## Unreleased
 
+### Fixed
+
+- Manual Agent-tool background completions now use `steer` delivery, including custom agents whose frontmatter resolves to background, so results reach the parent before its next model call instead of starving behind a long tool loop. Scheduled and RPC completions retain detached `followUp` delivery, foreground results remain inline, and the Agent guidance now requires foreground for prerequisite results plus non-overlapping background work with targeted verification rather than repeated evidence collection.
+
 Initial public release will be cut by Changesets from `0.0.0`.

--- a/packages/pi-subagents/README.md
+++ b/packages/pi-subagents/README.md
@@ -13,7 +13,7 @@ This package publishes on its own and is also embedded in the aggregate `@zhcsyn
 
 ## Differences from upstream (read this first)
 
-This fork keeps upstream **runtime** behavior (spawn, steer, resume, FleetView wiring, notifications, schedules). The changes are almost entirely **how progress and tool results are shown** in the TUI — so you can scan subagent work without drowning in dumps.
+This fork keeps upstream spawn, steer, resume, FleetView, schedule, and RPC behavior, but it now changes how manually launched background completion is delivered so current-task results cannot be starved behind a long parent tool loop. Most other differences remain focused on **how progress and tool results are shown** in the TUI.
 
 | Area | Upstream (`@tintinweb/pi-subagents`) | This fork (`@zhcsyncer/pi-subagents`) |
 | --- | --- | --- |
@@ -25,16 +25,30 @@ This fork keeps upstream **runtime** behavior (spawn, steer, resume, FleetView w
 | **Main transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` has Claude Code chrome; **`get_subagent_result` has no custom `renderResult`** → Pi dumps full payload | Same **Claude Code chrome** for all three; queued is honest (`queued…`); **Ctrl+O** expands Markdown without dumping by default |
 | Tool **model / effort** | Model often omitted when same as parent; thinking only in tags if set | **Result stats** always include effective model (`haiku (inherit)` when inherited) + `effort:`; resume chips come from stored invocation |
 | Validation / not-found tool failures | Plain text result (with custom Agent renderer missing details → easy to misread after collapse work) | `error` details + `tool_result` → Pi `isError` (error shell); undetailed success paths never heuristic-red |
+| Background completion delivery | Manual Agent-tool, scheduled, and RPC completions all use `followUp`, which can starve current-task results during a long parent tool loop | Manual Agent-tool background completion uses `steer`; scheduled/RPC detached completion remains `followUp`; `triggerTurn: true` is retained |
+| Orchestration guidance | Foreground/background ownership is easy to blur | Prerequisite results must run foreground; background is only for genuinely disjoint work; the parent synthesizes and uses targeted verification without repeating delegated evidence collection |
 | Packaging | Standalone npm package | Standalone `@zhcsyncer/pi-subagents` **and** embedded/registered in root `@zhcsyncer/pi-extensions` |
 
 ### What did *not* change
 
-- Tool names and contracts: `Agent`, `get_subagent_result`, `steer_subagent`
-- Background completion **followUp** notifications (`triggerTurn`)
+- Tool names and public parameters: `Agent`, `get_subagent_result`, `steer_subagent`
+- `triggerTurn: true` completion notifications; scheduled/RPC detached completion still uses `followUp`
 - FleetView list navigation, Enter steer, `x` `x` stop, Esc/q close
 - Custom agents, worktrees, schedules, settings menus, RPC
 
 Upstream remains the source of truth for those behaviors — start from [`UPSTREAM_README.md`](./UPSTREAM_README.md).
+
+### Foreground vs background contract
+
+Use foreground when the subagent result is a prerequisite for the parent's next read, edit, or decision. Use background only when the parent has genuinely disjoint work to do. Background completion is delivered automatically; do not poll, sleep, or repeat the delegated grep/find/read evidence collection while waiting.
+
+The parent still owns synthesis, decisions, user-facing reporting, and final verification. After a report arrives, verify only high-risk claims with targeted checks instead of rerunning the full investigation. A `steer` completion can enter context before the parent's next model call, but it cannot retract sibling tools already issued in the same assistant turn.
+
+Delivery policy is fixed at spawn time:
+
+- Manual Agent-tool background runs, including custom agents whose frontmatter resolves to `run_in_background: true`: `steer`
+- Scheduled and cross-extension RPC runs: `followUp`
+- Foreground runs: result returned inline; no background completion nudge
 
 ---
 

--- a/packages/pi-subagents/README.zh-CN.md
+++ b/packages/pi-subagents/README.zh-CN.md
@@ -13,7 +13,7 @@
 
 ## 与上游的差异（先看这里）
 
-本 fork **保留上游运行时行为**（spawn / steer / resume、FleetView 接线、完成通知、调度等）。改动几乎都在 **TUI 如何呈现进展与 tool 结果**，避免大段 dump 淹没主会话。
+本 fork 保留上游 spawn / steer / resume、FleetView、调度与 RPC 行为，但现在会改变“手动启动的后台任务”如何投递完成结果，避免当前任务所需结果被主 agent 的长工具循环饿死。其余差异仍主要集中在 **TUI 如何呈现进展与 tool 结果**。
 
 | 区域 | 上游 `@tintinweb/pi-subagents` | 本 fork `@zhcsyncer/pi-subagents` |
 | --- | --- | --- |
@@ -25,16 +25,30 @@
 | **主 transcript** `Agent` / `get_subagent_result` / `steer_subagent` | `Agent` 有 Claude Code 样式；**`get_subagent_result` 无自定义 `renderResult`** → 整段 dump | 三者统一 **Claude Code chrome**；queued 真话；**Ctrl+O** 展开 Markdown，默认不 dump |
 | Tool **model / effort** | 与父模型相同时常不显示；thinking 只在 tags | **结果 stats** 始终含有效模型（继承则 `haiku (inherit)`）与 `effort:`；resume 用存储的 invocation |
 | 校验失败 / 找不到 agent 等 | 纯文本 result（折叠改造后易误读成成功） | `error` details + `tool_result`→`isError`（错误外壳）；undetailed 成功路径不启发式染红 |
+| 后台完成投递 | 手动 Agent-tool、schedule 与 RPC 都使用 `followUp`；主 agent 长工具循环可能饿死当前任务结果 | 手动 Agent-tool 后台完成使用 `steer`；schedule / RPC 等脱离当前推理链的任务保留 `followUp`；继续使用 `triggerTurn: true` |
+| 编排合同 | foreground / background 的工作所有权容易混淆 | 后续步骤依赖结果时必须 foreground；background 只用于真正互不重叠的工作；主 agent 负责综合和定向验证，但不得重复已委派的证据收集 |
 | 发包 | 独立 npm 包 | 独立包 `@zhcsyncer/pi-subagents`，**并**嵌入/注册进根包 `@zhcsyncer/pi-extensions` |
 
 ### 未改动的部分
 
-- 工具名与契约：`Agent`、`get_subagent_result`、`steer_subagent`
-- 后台完成 **followUp** 通知（`triggerTurn`）
+- 工具名与公开参数：`Agent`、`get_subagent_result`、`steer_subagent`
+- 完成通知继续使用 `triggerTurn: true`；schedule / RPC 等 detached 任务仍使用 `followUp`
 - FleetView 导航、Enter steer、`x` `x` stop、Esc/q 关闭
 - 自定义 agent、worktree、调度、设置菜单、RPC
 
 行为细节仍以上游文档为准：[`UPSTREAM_README.md`](./UPSTREAM_README.md)。
+
+### Foreground / background 合同
+
+如果 subagent 结果是主 agent 下一次 read、edit 或 decision 的前置条件，应使用 foreground。只有主 agent 确实有互不重叠的并行工作时才使用 background。后台完成会自动投递；等待期间不要轮询、sleep，也不要重复 subagent 已承担的 grep / find / read 证据收集。
+
+主 agent 仍负责综合、决策、面向用户的报告与最终验证。报告到达后，只对高风险结论做定向抽查，不要重跑整轮调查。`steer` 完成通知能在主 agent 下一次模型调用前进入上下文，但无法撤回同一 assistant turn 已发出的 sibling tools。
+
+投递策略在 spawn 时固定：
+
+- 手动 Agent-tool background（包括 frontmatter 最终解析为 `run_in_background: true` 的自定义 agent）：`steer`
+- schedule 与跨扩展 RPC：`followUp`
+- foreground：结果 inline 返回，不发送后台完成 nudge
 
 ---
 

--- a/packages/pi-subagents/UPSTREAM_SOURCE.md
+++ b/packages/pi-subagents/UPSTREAM_SOURCE.md
@@ -58,7 +58,15 @@ Stable “why” only — implementation detail lives in code/tests.
 - Root tarball carries subagents sources plus runtime deps (`@sinclair/typebox`, `croner`, `nanoid`).
 - `agent-runner`: skip null parent `modelRuntime` for stricter Pi `ModelRuntime` typings.
 
+### Background completion delivery and orchestration contract
+
+- Manual Agent-tool background runs, including custom-agent frontmatter that resolves to background, fix `completionDelivery: "steer"` at spawn. Their completion reaches the parent before its next model call instead of waiting behind a long tool loop.
+- Scheduled and cross-extension RPC runs omit that field and retain AgentManager's detached `followUp` default. Foreground runs still return inline and suppress completion nudges.
+- Smart/group batches currently contain only background Agent-tool calls from one assistant turn, so they are homogeneous and use the first record's delivery policy. Scheduler/RPC do not enter those batches.
+- Full/compact tool descriptions, prompt guidelines, the launch envelope, and the shipped example require foreground for prerequisite results, background only for genuinely disjoint work, no repeated evidence collection, and targeted verification after the report.
+- `steer` cannot retract sibling tools already issued in the same assistant turn. This fork intentionally adds no origin state machine, path locks, natural-language overlap inference, or telemetry.
+
 ### Intentionally unchanged vs upstream
 
-- Tool contracts (names/params), background followUp notifications, FleetView navigation/steer/stop, custom agents, worktrees, schedules, settings, RPC.
-- Note: queued `get_subagent_result` copy and failure `isError` flag are model-visible deltas kept for honesty; runtime spawn/steer/resume behavior is otherwise upstream-aligned.
+- Tool names/params, FleetView navigation/steer/stop, custom agents, worktrees, schedules, settings, and RPC contracts.
+- Note: queued `get_subagent_result` copy, failure `isError`, completion delivery, and orchestration guidance are model-visible deltas kept for honesty and timely result consumption; spawn/steer/resume behavior is otherwise upstream-aligned.

--- a/packages/pi-subagents/examples/agent-tool-description.md
+++ b/packages/pi-subagents/examples/agent-tool-description.md
@@ -14,11 +14,11 @@ If the target is already known, use a direct tool — `read` for a known path, `
 ## Usage notes
 
 - Always include a short (3-5 word) description summarizing what the agent will do (shown in UI).
-- When you launch multiple agents for independent work, send them in a single message with multiple tool uses, with run_in_background: true on each, so they run concurrently. If the user specifies that they want agents run "in parallel", you MUST send a single message with multiple tool calls. Foreground calls run sequentially — only one executes at a time.
+- When you launch multiple agents for genuinely disjoint work, send them in a single message with multiple tool uses, with run_in_background: true on each, so they run concurrently. If the user specifies that they want agents run "in parallel", you MUST send a single message with multiple tool calls. Foreground calls run sequentially — only one executes at a time.
 - When the agent is done, it returns a single message back to you. The result is not visible to the user — to show the user, send a text message with a concise summary.
-- Trust but verify: an agent's summary describes what it intended to do, not necessarily what it did. When an agent writes or edits code, check the actual changes before reporting work as done.
-- Use run_in_background for work you don't need immediately. You will be notified when it completes — do NOT poll or sleep waiting for it. Continue with other work or respond to the user instead.
-- Foreground vs background: use foreground (default) when you need the agent's results before you can proceed. Use background when you have genuinely independent work to do in parallel.
+- Foreground vs background: if the result is a prerequisite for your next read, edit, or decision, use foreground (default). Use background only when you have genuinely disjoint work to do in parallel.
+- Background completion is delivered automatically — do NOT poll or sleep waiting for it. While it runs, do not repeat the agent's evidence collection or otherwise duplicate its work. A completion notice cannot retract sibling tools already issued in the same assistant turn.
+- You retain responsibility for synthesis, decisions, and final verification. After the report arrives, verify only high-risk claims with targeted checks; do not rerun the agent's full grep/find/read evidence collection.
 - Use resume with an agent ID to continue a previous agent's work. A new (non-resume) Agent call starts a fresh agent with no memory of prior runs, so the prompt must be self-contained.
 - Use steer_subagent to send mid-run messages to a running background agent.
 - Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, etc.), since it is not aware of the user's intent.
@@ -39,4 +39,4 @@ Provide clear, detailed prompts so the agent can work autonomously. Brief it lik
 
 Terse command-style prompts produce shallow, generic work.
 
-**Never delegate understanding.** Don't write "based on your findings, fix the bug" or "based on the research, implement it." Those phrases push synthesis onto the agent instead of doing it yourself. Write prompts that prove you understood: include file paths, line numbers, what specifically to change.
+**Never delegate understanding.** Don't write "based on your findings, fix the bug" or "based on the research, implement it." Those phrases push synthesis onto the agent instead of doing it yourself. Write prompts that prove you understood: include file paths, line numbers, what specifically to change. Retaining understanding does not mean repeating evidence collection; synthesize the report and use only targeted verification.

--- a/packages/pi-subagents/src/agent-manager.ts
+++ b/packages/pi-subagents/src/agent-manager.ts
@@ -12,7 +12,7 @@ import { isAbsolute } from "node:path";
 import type { Model } from "@earendil-works/pi-ai";
 import type { AgentSession, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { resumeAgent, runAgent, type ToolActivity } from "./agent-runner.js";
-import type { AgentInvocation, AgentRecord, IsolationMode, SubagentType, ThinkingLevel } from "./types.js";
+import type { AgentInvocation, AgentRecord, CompletionDelivery, IsolationMode, SubagentType, ThinkingLevel } from "./types.js";
 import { addUsage, createLifetimeUsage, type LifetimeUsage } from "./usage.js";
 import { cleanupWorktree, createWorktree, pruneWorktrees, } from "./worktree.js";
 
@@ -62,6 +62,8 @@ interface SpawnOptions {
   inheritContext?: boolean;
   thinkingLevel?: ThinkingLevel;
   isBackground?: boolean;
+  /** How completion is delivered to the parent. Defaults to detached follow-up delivery. */
+  completionDelivery?: CompletionDelivery;
   /**
    * Skip the maxConcurrent queue check for this spawn — start immediately even
    * if the configured concurrency limit would otherwise queue it. Used by the
@@ -167,6 +169,7 @@ export class AgentManager {
       abortController,
       lifetimeUsage: createLifetimeUsage(),
       compactionCount: 0,
+      completionDelivery: options.completionDelivery ?? "followUp",
       // Raw tri-state (not coerced to a boolean): true = background, false =
       // foreground (has an inline tool-result surface), undefined = caller never
       // declared it (e.g. a cross-extension RPC spawn). The widget's background-

--- a/packages/pi-subagents/src/cross-extension-rpc.ts
+++ b/packages/pi-subagents/src/cross-extension-rpc.ts
@@ -90,7 +90,12 @@ export function registerRpcHandlers(deps: RpcDeps): RpcHandle {
       // — same pattern the scheduler path already uses — so the spawned
       // agent's auth lookup doesn't crash with "No API key found for
       // undefined".
-      let normalizedOptions = options ?? {};
+      // Completion delivery is an internal spawn policy, not part of the RPC
+      // contract. Detached RPC work always relies on AgentManager's followUp
+      // default even if an untyped caller sends the field.
+      const rpcOptions = { ...(options ?? {}) };
+      delete rpcOptions.completionDelivery;
+      let normalizedOptions = rpcOptions;
       if (typeof normalizedOptions.model === "string") {
         const registry = (ctx as { modelRegistry?: ModelRegistry }).modelRegistry;
         if (!registry) {

--- a/packages/pi-subagents/src/index.ts
+++ b/packages/pi-subagents/src/index.ts
@@ -472,7 +472,7 @@ export default function (pi: ExtensionAPI) {
       content: notification + footer,
       display: true,
       details: buildNotificationDetails(record, 500, agentActivity.get(record.id)),
-    }, { deliverAs: "followUp", triggerTurn: true });
+    }, { deliverAs: record.completionDelivery, triggerTurn: true });
   }
 
   function sendIndividualNudge(record: AgentRecord) {
@@ -488,6 +488,11 @@ export default function (pi: ExtensionAPI) {
     (records, partial) => {
       for (const r of records) { agentActivity.delete(r.id); widget.markFinished(r.id); fleet.onAgentFinished(r.id); }
 
+      // Smart/group batches contain only Agent-tool background spawns resolved
+      // in one assistant turn. Scheduler and RPC spawns never enter
+      // currentBatchAgents, so the records are homogeneous and the first record
+      // fixes completion delivery for the whole notification.
+      const completionDelivery = records[0]?.completionDelivery ?? "followUp";
       const groupKey = `group:${records.map(r => r.id).join(",")}`;
       scheduleNudge(groupKey, () => {
         // Re-check at send time
@@ -510,7 +515,7 @@ export default function (pi: ExtensionAPI) {
           content: `Background agent group completed: ${label}\n\n${notifications}\n\nUse get_subagent_result for full output.`,
           display: true,
           details,
-        }, { deliverAs: "followUp", triggerTurn: true });
+        }, { deliverAs: completionDelivery, triggerTurn: true });
       });
       widget.update();
     },
@@ -775,7 +780,8 @@ export default function (pi: ExtensionAPI) {
   function setToolDescriptionMode(mode: ToolDescriptionMode): void { toolDescriptionMode = mode; }
 
   // ---- Batch tracking for smart join mode ----
-  // Collects background agent IDs spawned in the current turn for smart grouping.
+  // Collects only Agent-tool background IDs spawned in the current assistant
+  // turn for smart grouping. Scheduler/RPC spawns do not pass through this path.
   // Uses a debounced timer: each new agent resets the 100ms window so that all
   // parallel tool calls (which may be dispatched across multiple microtasks by the
   // framework) are captured in the same batch.
@@ -920,11 +926,11 @@ ${buildCompactTypeListText()}
 Custom agents: .pi/agents/<name>.md (project) or ${getAgentDir()}/agents/<name>.md (global).
 
 Notes:
-- description: 3-5 words (shown in UI). Prompts must be self-contained — the agent has not seen this conversation.
-- Parallel work: one message, multiple Agent calls, run_in_background: true on each. You are notified when background agents finish — never poll or sleep.
-- The result is not shown to the user — summarize it for them. Verify an agent's claimed code changes before reporting work done.
-- resume continues a previous agent by ID; steer_subagent messages a running one.
-- isolation: "worktree" runs the agent in an isolated git worktree; changes land on a branch.`;
+- description: 3-5 words. Prompts must be self-contained — the agent has not seen this conversation.
+- Use foreground if the result gates your next read, edit, or decision. Use run_in_background only for genuinely disjoint work; launch parallel calls in one message.
+- Background completion notifies you automatically. Never poll/sleep or repeat its evidence collection while waiting; completion cannot retract sibling tools already issued in this turn.
+- You own synthesis, decisions, and final verification. After the report, use targeted verification only for high-risk claims; summarize results for the user.
+- resume continues an agent; steer_subagent redirects a running one; isolation: "worktree" isolates changes on a branch.`;
 
   const fullAgentToolDescription = `Launch a new agent to handle complex, multi-step tasks autonomously. Each agent type has specific capabilities and tools available to it.
 
@@ -942,11 +948,11 @@ If the target is already known, use a direct tool — \`read\` for a known path,
 ## Usage notes
 
 - Always include a short (3-5 word) description summarizing what the agent will do (shown in UI).
-- When you launch multiple agents for independent work, send them in a single message with multiple tool uses, with run_in_background: true on each, so they run concurrently. If the user specifies that they want agents run "in parallel", you MUST send a single message with multiple tool calls. Foreground calls run sequentially — only one executes at a time.
+- When you launch multiple agents for genuinely disjoint work, send them in a single message with multiple tool uses, with run_in_background: true on each, so they run concurrently. If the user specifies that they want agents run "in parallel", you MUST send a single message with multiple tool calls. Foreground calls run sequentially — only one executes at a time.
 - When the agent is done, it returns a single message back to you. The result is not visible to the user — to show the user, send a text message with a concise summary.
-- Trust but verify: an agent's summary describes what it intended to do, not necessarily what it did. When an agent writes or edits code, check the actual changes before reporting work as done.
-- Use run_in_background for work you don't need immediately. You will be notified when it completes — do NOT poll or sleep waiting for it. Continue with other work or respond to the user instead.
-- Foreground vs background: use foreground (default) when you need the agent's results before you can proceed. Use background when you have genuinely independent work to do in parallel.
+- Foreground vs background: if the result is a prerequisite for your next read, edit, or decision, use foreground (default). Use background only when you have genuinely disjoint work to do in parallel.
+- Background completion is delivered automatically — do NOT poll or sleep waiting for it. While it runs, do not repeat the agent's evidence collection or otherwise duplicate its work. A completion notice cannot retract sibling tools already issued in the same assistant turn.
+- You retain responsibility for synthesis, decisions, and final verification. After the report arrives, verify only high-risk claims with targeted checks; do not rerun the agent's full grep/find/read evidence collection.
 - Use resume with an agent ID to continue a previous agent's work. A new (non-resume) Agent call starts a fresh agent with no memory of prior runs, so the prompt must be self-contained.
 - Use steer_subagent to send mid-run messages to a running background agent.
 - Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, etc.), since it is not aware of the user's intent.
@@ -967,7 +973,7 @@ Provide clear, detailed prompts so the agent can work autonomously. Brief it lik
 
 Terse command-style prompts produce shallow, generic work.
 
-**Never delegate understanding.** Don't write "based on your findings, fix the bug" or "based on the research, implement it." Those phrases push synthesis onto the agent instead of doing it yourself. Write prompts that prove you understood: include file paths, line numbers, what specifically to change.`;
+**Never delegate understanding.** Don't write "based on your findings, fix the bug" or "based on the research, implement it." Those phrases push synthesis onto the agent instead of doing it yourself. Write prompts that prove you understood: include file paths, line numbers, what specifically to change. Retaining understanding does not mean repeating evidence collection; synthesize the report and use only targeted verification.`;
 
   // `toolDescriptionMode: "custom"` — user-authored description with live
   // dynamic parts. Project file wins over global; missing/empty falls back to
@@ -1010,10 +1016,10 @@ Terse command-style prompts produce shallow, generic work.
     description: agentToolDescription,
     promptSnippet: "Launch autonomous sub-agents for complex multi-step tasks",
     promptGuidelines: [
-      "Use Agent with specialized agents when the task matches an agent type's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing — if you delegate research to a subagent, do not also perform the same searches yourself.",
+      "Use Agent with specialized agents when the task matches an agent type's description. If its result is a prerequisite for your next read, edit, or decision, run it in the foreground. Use background only for genuinely disjoint work.",
       "For broad codebase exploration or research, spawn Agent with an appropriate subagent_type (e.g. Explore). Otherwise use direct tools (read, grep, find) when the target is already known.",
-      "When an agent runs in the background, you will be notified on completion — do not poll or sleep waiting for it. Continue with other work instead.",
-      "Trust but verify: an agent's summary describes intent, not outcome. When an agent writes or edits code, check the actual changes before reporting work as done.",
+      "When an Agent runs in the background, completion is delivered automatically — never poll or sleep, and do not repeat its evidence collection while waiting. A completion notice cannot retract sibling tools already issued in the same assistant turn.",
+      "You retain synthesis, decision, and final verification responsibility. After an Agent reports, verify only high-risk claims with targeted checks instead of rerunning the same grep/find/read evidence collection.",
     ],
     parameters: Type.Object({
       prompt: Type.String({
@@ -1044,7 +1050,7 @@ Terse command-style prompts produce shallow, generic work.
       ),
       run_in_background: Type.Optional(
         Type.Boolean({
-          description: "Set to true to run in background. Returns agent ID immediately. You will be notified on completion.",
+          description: "Set to true only for genuinely disjoint work. Returns an agent ID immediately; completion is delivered automatically, so do not poll.",
         }),
       ),
       resume: Type.Optional(
@@ -1317,6 +1323,7 @@ Terse command-style prompts produce shallow, generic work.
             inheritContext,
             thinkingLevel: thinking,
             isBackground: true,
+            completionDelivery: "steer",
             isolation,
             invocation: agentInvocation,
             ...bgCallbacks,
@@ -1367,9 +1374,10 @@ Terse command-style prompts produce shallow, generic work.
           `Description: ${params.description}\n` +
           (record?.outputFile ? `Output file: ${record.outputFile}\n` : "") +
           (isQueued ? `Position: queued (max ${manager.getMaxConcurrent()} concurrent)\n` : "") +
-          `\nYou will be notified when this agent completes.\n` +
-          `Use get_subagent_result to retrieve full results, or steer_subagent to send it messages.\n` +
-          `Do not duplicate this agent's work.`,
+          `\nCompletion will be delivered automatically; do not poll get_subagent_result or sleep.\n` +
+          `While it runs, continue only with genuinely disjoint work. Do not repeat its evidence collection or otherwise duplicate its work.\n` +
+          `After the report, keep synthesis and final verification yourself, using only targeted checks for high-risk claims.\n` +
+          `Use steer_subagent to redirect the agent while it is running.`,
           {
             ...detailBase,
             toolUses: 0,

--- a/packages/pi-subagents/src/schedule.ts
+++ b/packages/pi-subagents/src/schedule.ts
@@ -11,8 +11,8 @@
  *   - `executeJob` calls `manager.spawn(..., { bypassQueue: true })` instead
  *     of dispatching a user message — schedule fires bypass maxConcurrent so
  *     a 5-minute interval can't be deferred behind 4 long-running agents.
- *   - Result delivery is implicit: spawn → background completion → existing
- *     `subagent-notification` followUp path. No new delivery code.
+ *   - Result delivery is implicit: spawn omits `completionDelivery`, so the
+ *     record keeps AgentManager's detached `followUp` default. No new delivery code.
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";

--- a/packages/pi-subagents/src/types.ts
+++ b/packages/pi-subagents/src/types.ts
@@ -69,6 +69,9 @@ export interface AgentConfig {
 
 export type JoinMode = 'async' | 'group' | 'smart';
 
+/** How a completed background agent is delivered into the parent agent loop. */
+export type CompletionDelivery = "steer" | "followUp";
+
 /**
  * Display mode for the persistent above-editor agent widget.
  * - `all`: show every agent (foreground + background).
@@ -93,6 +96,8 @@ export interface AgentRecord {
   promise?: Promise<string>;
   groupId?: string;
   joinMode?: JoinMode;
+  /** Completion delivery policy fixed when the record is created. */
+  completionDelivery: CompletionDelivery;
   /** Set when result was already consumed via get_subagent_result — suppresses completion notification. */
   resultConsumed?: boolean;
   /** Steering messages queued before the session was ready. */

--- a/packages/pi-subagents/test/agent-manager.test.ts
+++ b/packages/pi-subagents/test/agent-manager.test.ts
@@ -186,6 +186,24 @@ describe("AgentManager — completion callbacks", () => {
     manager?.dispose();
   });
 
+  it("stores an explicit completion delivery and defaults detached callers to followUp", () => {
+    vi.mocked(runAgent).mockImplementation(() => new Promise(() => {}));
+    manager = new AgentManager();
+
+    const defaultId = manager.spawn(mockPi, mockCtx, "general-purpose", "default", {
+      description: "default delivery",
+      isBackground: true,
+    });
+    const steerId = manager.spawn(mockPi, mockCtx, "general-purpose", "steer", {
+      description: "manual background delivery",
+      isBackground: true,
+      completionDelivery: "steer",
+    });
+
+    expect(manager.getRecord(defaultId)?.completionDelivery).toBe("followUp");
+    expect(manager.getRecord(steerId)?.completionDelivery).toBe("steer");
+  });
+
   it("does not let onComplete errors turn a completed agent into a failed run", async () => {
     manager = new AgentManager(() => {
       throw new Error("stale extension context");

--- a/packages/pi-subagents/test/completion-delivery.test.ts
+++ b/packages/pi-subagents/test/completion-delivery.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Deterministic completion-delivery wiring tests.
+ *
+ * These drive the real extension and AgentManager with a mocked child runner.
+ * They assert queue/orchestration behavior only; no model is asked to prove that
+ * it will follow the delegation prose.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getProjectSubagentsSettingsPath } from "../src/config-paths.js";
+
+vi.mock("../src/agent-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agent-runner.js")>("../src/agent-runner.js");
+  return { ...actual, runAgent: vi.fn() };
+});
+
+import { runAgent } from "../src/agent-runner.js";
+import subagentsExtension from "../src/index.js";
+
+interface Harness {
+  cwd: string;
+  previousCwd: string;
+  pi: any;
+  tools: Map<string, any>;
+  lifecycle: Map<string, any>;
+  ctx: any;
+}
+
+let active: Harness | undefined;
+
+function makeEventBus() {
+  const listeners = new Map<string, Set<(data: unknown) => unknown>>();
+  return {
+    on: vi.fn((event: string, handler: (data: unknown) => unknown) => {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(handler);
+      return vi.fn(() => listeners.get(event)?.delete(handler));
+    }),
+    emit: vi.fn((event: string, data: unknown) => {
+      for (const handler of listeners.get(event) ?? []) void handler(data);
+    }),
+  };
+}
+
+function makeCtx(cwd: string) {
+  return {
+    hasUI: false,
+    ui: {
+      setStatus: vi.fn(),
+      setWidget: vi.fn(),
+      notify: vi.fn(),
+    },
+    cwd,
+    model: undefined,
+    modelRegistry: {
+      find: vi.fn(),
+      getAll: vi.fn(() => []),
+      getAvailable: vi.fn(() => []),
+    },
+    sessionManager: {
+      getSessionId: vi.fn(() => "completion-delivery-session"),
+      getBranch: vi.fn(() => []),
+    },
+    getSystemPrompt: vi.fn(() => "parent prompt"),
+  } as any;
+}
+
+function setup(options: { customAgent?: { name: string; contents: string } } = {}): Harness {
+  const previousCwd = process.cwd();
+  const cwd = mkdtempSync(join(tmpdir(), "pi-completion-delivery-"));
+  const settingsPath = getProjectSubagentsSettingsPath(cwd);
+  mkdirSync(dirname(settingsPath), { recursive: true });
+  writeFileSync(settingsPath, JSON.stringify({ outputTranscript: false }));
+
+  if (options.customAgent) {
+    const agentPath = join(cwd, ".pi", "agents", `${options.customAgent.name}.md`);
+    mkdirSync(dirname(agentPath), { recursive: true });
+    writeFileSync(agentPath, options.customAgent.contents);
+  }
+
+  process.chdir(cwd);
+  const tools = new Map<string, any>();
+  const lifecycle = new Map<string, any>();
+  const events = makeEventBus();
+  const pi = {
+    registerMessageRenderer: vi.fn(),
+    registerTool: vi.fn((tool: any) => tools.set(tool.name, tool)),
+    registerCommand: vi.fn(),
+    on: vi.fn((event: string, handler: any) => lifecycle.set(event, handler)),
+    events,
+    appendEntry: vi.fn(),
+    sendMessage: vi.fn(),
+  } as any;
+
+  subagentsExtension(pi);
+  active = { cwd, previousCwd, pi, tools, lifecycle, ctx: makeCtx(cwd) };
+  return active;
+}
+
+function completedRun(overrides: Record<string, unknown> = {}) {
+  vi.mocked(runAgent).mockResolvedValue({
+    responseText: "CHILD-RESULT",
+    session: { dispose: vi.fn() } as any,
+    aborted: false,
+    steered: false,
+    ...overrides,
+  } as any);
+}
+
+async function spawnAgent(h: Harness, params: Record<string, unknown> = {}) {
+  return h.tools.get("Agent").execute(
+    `tool-${Math.random()}`,
+    {
+      prompt: "collect evidence",
+      description: "collect delegated evidence",
+      subagent_type: "general-purpose",
+      run_in_background: true,
+      ...params,
+    },
+    undefined,
+    undefined,
+    h.ctx,
+  );
+}
+
+function resultText(result: any): string {
+  return result.content[0].text;
+}
+
+function onlyDelivery(h: Harness) {
+  expect(h.pi.sendMessage).toHaveBeenCalledTimes(1);
+  return h.pi.sendMessage.mock.calls[0] as [any, any];
+}
+
+async function bindSession(h: Harness): Promise<void> {
+  await h.lifecycle.get("session_start")?.({ reason: "startup" }, h.ctx);
+}
+
+afterEach(async () => {
+  if (active) {
+    await active.lifecycle.get("session_shutdown")?.({}, active.ctx);
+    process.chdir(active.previousCwd);
+    rmSync(active.cwd, { recursive: true, force: true });
+    active = undefined;
+  }
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("background completion delivery", () => {
+  it("delivers a manual Agent-tool background completion as steer and explains the no-duplication contract", async () => {
+    completedRun();
+    const h = setup();
+    vi.useFakeTimers();
+
+    const launch = await spawnAgent(h);
+    expect(resultText(launch)).toContain("Completion will be delivered automatically");
+    expect(resultText(launch)).toContain("genuinely disjoint work");
+    expect(resultText(launch)).toContain("Do not repeat its evidence collection");
+
+    await vi.advanceTimersByTimeAsync(301);
+
+    const [message, options] = onlyDelivery(h);
+    expect(message.details.status).toBe("completed");
+    expect(options).toEqual({ deliverAs: "steer", triggerTurn: true });
+  });
+
+  it("uses steer when custom-agent frontmatter resolves the invocation to background", async () => {
+    completedRun();
+    const h = setup({
+      customAgent: {
+        name: "background-default",
+        contents: `---\ndescription: Background by default\nrun_in_background: true\n---\n\nResearch only.\n`,
+      },
+    });
+    vi.useFakeTimers();
+
+    await spawnAgent(h, {
+      subagent_type: "background-default",
+      run_in_background: undefined,
+    });
+    await vi.advanceTimersByTimeAsync(301);
+
+    expect(onlyDelivery(h)[1]).toEqual({ deliverAs: "steer", triggerTurn: true });
+  });
+
+  it("keeps scheduler completions on the default followUp delivery", async () => {
+    completedRun();
+    const h = setup();
+    vi.useFakeTimers();
+    await bindSession(h);
+
+    const scheduled = await h.tools.get("Agent").execute(
+      "tool-scheduled",
+      {
+        prompt: "run later",
+        description: "scheduled detached work",
+        subagent_type: "general-purpose",
+        schedule: "+1s",
+      },
+      undefined,
+      undefined,
+      h.ctx,
+    );
+    expect(resultText(scheduled)).toContain("Scheduled");
+
+    await vi.advanceTimersByTimeAsync(1_201);
+
+    expect(onlyDelivery(h)[1]).toEqual({ deliverAs: "followUp", triggerTurn: true });
+  });
+
+  it("keeps cross-extension RPC completions on the default followUp delivery", async () => {
+    completedRun();
+    const h = setup();
+    vi.useFakeTimers();
+    await bindSession(h);
+
+    h.pi.events.emit("subagents:rpc:spawn", {
+      requestId: "rpc-completion",
+      type: "general-purpose",
+      prompt: "detached RPC work",
+      options: { description: "detached RPC work", isBackground: true },
+    });
+    await vi.advanceTimersByTimeAsync(201);
+
+    expect(onlyDelivery(h)[1]).toEqual({ deliverAs: "followUp", triggerTurn: true });
+  });
+
+  it("returns foreground output inline without sending a background nudge", async () => {
+    completedRun();
+    const h = setup();
+    vi.useFakeTimers();
+
+    const result = await spawnAgent(h, { run_in_background: false });
+    expect(resultText(result)).toContain("CHILD-RESULT");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(h.pi.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("joins same-turn smart background agents into one steer notification", async () => {
+    completedRun();
+    const h = setup();
+    vi.useFakeTimers();
+
+    await Promise.all([
+      spawnAgent(h, { description: "first disjoint lane" }),
+      spawnAgent(h, { description: "second disjoint lane" }),
+    ]);
+    await vi.advanceTimersByTimeAsync(301);
+
+    const [message, options] = onlyDelivery(h);
+    expect(message.content).toContain("Background agent group completed");
+    expect(message.details.others).toHaveLength(1);
+    expect(options).toEqual({ deliverAs: "steer", triggerTurn: true });
+  });
+
+  it("cancels a held nudge when get_subagent_result consumes it inside the hold window", async () => {
+    completedRun();
+    const h = setup();
+    vi.useFakeTimers();
+
+    const launch = await spawnAgent(h);
+    const id = /Agent ID: (\S+)/.exec(resultText(launch))![1];
+    await vi.advanceTimersByTimeAsync(100);
+
+    const consumed = await h.tools.get("get_subagent_result").execute(
+      "tool-consume",
+      { agent_id: id },
+      undefined,
+      undefined,
+      h.ctx,
+    );
+    expect(resultText(consumed)).toContain("CHILD-RESULT");
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(h.pi.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("aborting wait:true leaves the child running and later delivers its recorded steer notification", async () => {
+    let resolveRun!: () => void;
+    let childSignal: AbortSignal | undefined;
+    vi.mocked(runAgent).mockImplementation(
+      (_ctx, _type, _prompt, options) => new Promise((resolve) => {
+        childSignal = options.signal;
+        resolveRun = () => resolve({
+          responseText: "CHILD-RESULT",
+          session: { dispose: vi.fn() } as any,
+          aborted: false,
+          steered: false,
+        });
+      }) as any,
+    );
+    const h = setup();
+    vi.useFakeTimers();
+
+    const launch = await spawnAgent(h);
+    const id = /Agent ID: (\S+)/.exec(resultText(launch))![1];
+    const controller = new AbortController();
+    const waitOutcome = h.tools.get("get_subagent_result").execute(
+      "tool-wait",
+      { agent_id: id, wait: true },
+      controller.signal,
+      undefined,
+      h.ctx,
+    ).then(
+      () => "resolved",
+      (error: unknown) => error instanceof Error ? error.name : String(error),
+    );
+
+    controller.abort();
+    expect(await waitOutcome).toBe("AbortError");
+    expect(childSignal?.aborted).toBe(false);
+
+    resolveRun();
+    await vi.advanceTimersByTimeAsync(301);
+
+    const [message, options] = onlyDelivery(h);
+    expect(message.content).toContain(id);
+    expect(options).toEqual({ deliverAs: "steer", triggerTurn: true });
+  });
+
+  it.each([
+    ["error", "error"],
+    ["aborted", "aborted"],
+    ["stopped", "stopped"],
+  ] as const)("keeps steer delivery and settles fleet state for %s completions", async (kind, expectedStatus) => {
+    let finishStopped: (() => void) | undefined;
+    if (kind === "error") {
+      vi.mocked(runAgent).mockRejectedValue(new Error("child failed"));
+    } else if (kind === "aborted") {
+      completedRun({ aborted: true, responseText: "partial" });
+    } else {
+      vi.mocked(runAgent).mockImplementation(
+        () => new Promise((resolve) => {
+          finishStopped = () => resolve({
+            responseText: "partial",
+            session: { dispose: vi.fn() } as any,
+            aborted: true,
+            steered: false,
+          });
+        }) as any,
+      );
+    }
+
+    const h = setup();
+    vi.useFakeTimers();
+    if (kind === "stopped") await bindSession(h);
+
+    const launch = await spawnAgent(h);
+    const id = /Agent ID: (\S+)/.exec(resultText(launch))![1];
+    if (kind === "stopped") {
+      h.pi.events.emit("subagents:rpc:stop", { requestId: "stop-terminal", agentId: id });
+      finishStopped?.();
+    }
+
+    await vi.advanceTimersByTimeAsync(301);
+
+    const [message, options] = onlyDelivery(h);
+    expect(message.details.status).toBe(expectedStatus);
+    expect(options).toEqual({ deliverAs: "steer", triggerTurn: true });
+    expect(h.pi.events.emit).toHaveBeenCalledWith(
+      "subagents:failed",
+      expect.objectContaining({ id, status: expectedStatus }),
+    );
+    const registry = (globalThis as any)[Symbol.for("pi-subagents:manager")];
+    expect(registry.hasRunning()).toBe(false);
+  });
+});

--- a/packages/pi-subagents/test/cross-extension-rpc.test.ts
+++ b/packages/pi-subagents/test/cross-extension-rpc.test.ts
@@ -83,13 +83,32 @@ describe("cross-extension RPC", () => {
       );
     });
 
-    it("passes options through to manager.spawn", async () => {
+    it("passes options through without adding a completion-delivery override", async () => {
       registerRpcHandlers(deps);
       const reply = vi.fn();
       events.on("subagents:rpc:spawn:reply:req-s2", reply);
       events.emit("subagents:rpc:spawn", {
         requestId: "req-s2", type: "Explore", prompt: "find it",
         options: { description: "search", isBackground: true },
+      });
+
+      await vi.waitFor(() => expect(reply).toHaveBeenCalled());
+      expect(manager.spawn).toHaveBeenCalledWith(
+        deps.pi, ctx, "Explore", "find it",
+        { description: "search", isBackground: true },
+      );
+      expect((manager.spawn as ReturnType<typeof vi.fn>).mock.calls[0][4]).not.toHaveProperty("completionDelivery");
+    });
+
+    it("drops completionDelivery from untyped callers so RPC stays followUp", async () => {
+      registerRpcHandlers(deps);
+      const reply = vi.fn();
+      events.on("subagents:rpc:spawn:reply:req-delivery", reply);
+      events.emit("subagents:rpc:spawn", {
+        requestId: "req-delivery",
+        type: "Explore",
+        prompt: "find it",
+        options: { description: "search", isBackground: true, completionDelivery: "steer" },
       });
 
       await vi.waitFor(() => expect(reply).toHaveBeenCalled());

--- a/packages/pi-subagents/test/group-join.test.ts
+++ b/packages/pi-subagents/test/group-join.test.ts
@@ -18,6 +18,7 @@ function makeRecord(id: string, overrides: Partial<AgentRecord> = {}): AgentReco
     status: "completed",
     toolUses: 0,
     startedAt: 0,
+    completionDelivery: "followUp",
     lifetimeUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     ...overrides,
   };

--- a/packages/pi-subagents/test/schedule.test.ts
+++ b/packages/pi-subagents/test/schedule.test.ts
@@ -281,7 +281,7 @@ describe("SubagentScheduler — fire path", () => {
     expect(manager.spawn).toHaveBeenCalledTimes(1);
   });
 
-  it("fire passes bypassQueue: true to manager.spawn", () => {
+  it("fire bypasses the queue and leaves completion delivery at the manager default", () => {
     scheduler.addJob({
       name: "every-1s", description: "x", schedule: "1s",
       subagent_type: "general-purpose", prompt: "x",
@@ -292,6 +292,7 @@ describe("SubagentScheduler — fire path", () => {
     const optsArg = manager.spawn.mock.calls[0][4];
     expect(optsArg.bypassQueue).toBe(true);
     expect(optsArg.isBackground).toBe(true);
+    expect(optsArg).not.toHaveProperty("completionDelivery");
   });
 
   it("disabled jobs do not fire", () => {

--- a/packages/pi-subagents/test/tool-description-mode.test.ts
+++ b/packages/pi-subagents/test/tool-description-mode.test.ts
@@ -132,21 +132,61 @@ describe("toolDescriptionMode", () => {
     expect(desc).toContain("## Usage notes");
   });
 
-  it("compact keeps every load-bearing contract — fails when a behavior change forgets compact", () => {
-    const tools = setup({ toolDescriptionMode: "compact" });
-    const desc: string = tools.get("Agent").description;
-    // One keyword per behavioral contract the orchestrator must know about.
-    // If you change one of these behaviors, update BOTH descriptions.
+  it("full and compact descriptions keep the foreground/background ownership contract", async () => {
+    const compact: string = setup({ toolDescriptionMode: "compact" }).get("Agent").description;
     for (const contract of [
       "run_in_background",
+      "foreground",
+      "next read, edit, or decision",
+      "genuinely disjoint work",
+      "automatically",
+      "Never poll/sleep",
+      "repeat its evidence collection",
+      "targeted verification",
+      "sibling tools already issued in this turn",
       "resume",
       "steer_subagent",
       'isolation: "worktree"',
       ".pi/agents/",
       "self-contained",
     ]) {
-      expect(desc).toContain(contract);
+      expect(compact).toContain(contract);
     }
+
+    // A fresh full-mode instance guards the same load-bearing orchestration
+    // contract independently of compact mode.
+    writeConfigFile(getProjectSubagentsSettingsPath(tmpDir), JSON.stringify({ toolDescriptionMode: "full" }));
+    const fullHarness = makePi();
+    subagentsExtension(fullHarness.pi);
+    const full: string = fullHarness.tools.get("Agent").description;
+    try {
+      for (const contract of [
+        "prerequisite for your next read, edit, or decision",
+        "genuinely disjoint work",
+        "delivered automatically",
+        "do NOT poll or sleep",
+        "do not repeat the agent's evidence collection",
+        "targeted checks",
+        "sibling tools already issued in the same assistant turn",
+      ]) {
+        expect(full).toContain(contract);
+      }
+    } finally {
+      await fullHarness.handlers.get("session_shutdown")?.({}, { hasUI: false, ui: {} } as any);
+    }
+  });
+
+  it("prompt guidelines carry the same foreground/background ownership contract", () => {
+    const tools = setup();
+    const guidelines: string[] = tools.get("Agent").promptGuidelines;
+    const text = guidelines.join("\n");
+
+    expect(text).toContain("prerequisite for your next read, edit, or decision");
+    expect(text).toContain("genuinely disjoint work");
+    expect(text).toContain("completion is delivered automatically");
+    expect(text).toContain("do not repeat its evidence collection");
+    expect(text).toContain("targeted checks");
+    expect(text).toContain("sibling tools already issued in the same assistant turn");
   });
 
   it("custom mode renders the canonical project template and de-duplicates unknown-placeholder warnings", async () => {

--- a/pi-subagents-background-duplication-design.md
+++ b/pi-subagents-background-duplication-design.md
@@ -1,0 +1,264 @@
+# pi-subagents 后台委派重复工作问题分析与推荐修复方案
+
+## 状态
+
+调查与三路独立评审已完成，推荐方案已收敛并于当前分支实施。实现保持本文 P0 边界：手动 Agent-tool background 使用 `steer`，scheduler/RPC 默认 `followUp`，并同步收紧模型合同与确定性测试；未引入本文明确排除的扩展机制。
+
+本文固定问题事实、初始候选方案、独立评审结论与推荐终稿，避免后续实施依赖口头上下文。
+
+## 观察样本
+
+来源 session：
+
+```text
+/root/.pi/agent/sessions/--root-.herdr-worktrees-ai-chatbot-fix-m14-internal-probe-boundary--/2026-08-13T08-26-26-365Z_019ffa3a-d0bd-7858-9d3b-8ec1b0090ad5.jsonl
+```
+
+任务要求移除一项 internal probe shared bearer 协议，同时保持既有 probe route、边界、集成测试和文档合同。
+
+### 时间线
+
+1. `08:27:50.558Z`：主 agent 启动一个后台 `Explore` sub-agent，要求全面梳理 secret/bearer 协议在 chat、admin、integration、standalone、Playwright、workspace contract、`.env` 和文档中的影响面。
+2. sub-agent 运行期间，主 agent 自己继续执行几乎相同的全仓 grep 和关键文件读取。
+3. `08:29:03.785Z`：sub-agent 完成，结果作为 `subagents:record` custom entry 写入 session。
+4. 主 agent 没有调用 `get_subagent_result`，JSONL 中也没有进入模型上下文的 `subagent-notification`；随后直接开始编辑。
+
+### 重复程度
+
+在派发到完成的 `73.227s` 窗口内：
+
+- 主 agent：37 次工具调用；
+- sub-agent：31 次工具调用；
+- 双方至少有 12 个完全相同的显式 read/list 目标，包括：
+  - `apps/chat-web/lib/provider-probe/http.ts`
+  - `apps/chat-web/lib/provider-probe/runtime.ts`
+  - `apps/chat-web/lib/provider-probe/service-auth.ts`
+  - `apps/chat-web/proxy.ts`
+  - `apps/admin-console/lib/provider-probe/config.ts`
+  - `apps/admin-console/lib/provider-probe/client.ts`
+  - `apps/admin-console/lib/provider-probe/http.ts`
+  - `apps/admin-console/lib/provider-probe/runtime.ts`
+  - `playwright.config.ts`
+  - `tests/standalone/health.test.ts`
+  - `tests/workspace/provider-probe-contract.test.ts`
+  - `apps/chat-web/lib/provider-probe/provider-probe.integration.ts`
+- 主 agent 还重复执行了 secret、service-auth、bearer、测试和文档的广域 grep。
+
+编辑前重读少量高风险文件本可算必要验证，但这里连“发现影响面”本身也全量重做，属于实质重复委派。
+
+### 额外质量信号
+
+sub-agent 报告曾建议删除 chat internal probe route，但用户要求明确规定该 route 必须保留。这说明：
+
+- sub-agent 结果不能不经判断直接实施；
+- “主 agent 负责理解和综合”是必要原则；
+- 但该原则不等于主 agent 应重新执行整轮证据收集，只应在拿到报告后定向抽查高风险结论。
+
+## 根因
+
+### 1. 派发方式与依赖关系不匹配
+
+这次 Explore 结果是后续实施的前置输入，却使用了 `run_in_background: true`。与此同时，没有给主 agent 留出一条明确且互不重叠的并行工作流。
+
+正确选择应是：
+
+- **结果是下一步 read/edit/decision 的前置条件**：foreground；
+- **主 agent 有可明确描述的独立工作**：background；
+- **目标已经明确、直接工具更便宜**：不派 sub-agent。
+
+### 2. completion notification 使用 `followUp`，完成结果被长工具循环饿死
+
+当前 `packages/pi-subagents/src/index.ts` 的 individual/group completion 都调用：
+
+```ts
+{ deliverAs: "followUp", triggerTurn: true }
+```
+
+Pi 对消息队列的定义是：
+
+- `steer`：当前 assistant turn 已发出的工具调用结束后、下一次 LLM 调用前交付；
+- `followUp`：等 agent 不再继续发工具调用后才交付。
+
+因此后台 agent 即使已经完成，只要主 agent 持续工具循环，结果也不会进入它的下一次推理上下文。`pi.appendEntry("subagents:record", ...)` 只负责持久化，不参与 LLM context，不能弥补这一点。
+
+### 3. 现有提示没有运行时约束
+
+当前工具描述和派发结果已经分别包含：
+
+- 不要重复 sub-agent 正在做的搜索；
+- `Do not duplicate this agent's work.`
+
+样本仍然发生重复，说明仅追加同类提示不足以稳定修复。现有措辞也容易与 `Never delegate understanding` 产生误读：模型可能把“保留理解责任”执行成“把所有证据重新收集一遍”。
+
+### 4. 后台任务缺少显式所有权边界
+
+Agent 调用只描述 sub-agent 做什么，没有要求主 agent说明“等待期间自己做什么”。工具和运行时无法判断 background 是否真的有并行价值。
+
+## 目标行为
+
+1. 若 sub-agent 结果是实施前置条件，主 agent 必须等待 foreground 结果，不得后台派发后自行重做。
+2. 手动启动、服务于当前任务的后台 agent 一完成，其结果应在下一次 LLM 调用前可见，而不是等整个长工具循环结束。
+3. scheduled/RPC 等脱离当前推理链的任务不应随意中断当前工作。
+4. 主 agent 保留最终综合和验证责任，但验证应为定向抽查，不是全量重跑。
+5. 修复不依赖猜测自然语言任务是否“相似”，也不以脆弱的路径锁作为第一版硬门禁。
+
+## 初始候选方案
+
+评审前提出四部分候选：
+
+1. 手动 background 强制增加自然语言 `parent_task`，要求主 agent 声明等待期间的独立工作流；
+2. 当前任务的手动 background completion 从 `followUp` 改为 `steer`，scheduler/RPC 保持 `followUp`；
+3. 澄清 foreground/background 选择和“理解责任不等于全量重搜”；
+4. 第一版不做路径硬阻塞，视需要再增加 overlap telemetry 或软警告。
+
+三路评审一致接受第 2、3 项，一致否决把第 1 项作为 P0 强制 API，并同意第 4 项至少不进入 P0。
+
+## 三路独立评审
+
+### 共识
+
+- 样本确有实质重复；根因同时包含错误的 background 选择与 completion 被 `followUp` 饿死。
+- `steer` 只能让完成结果在下一次 LLM 调用前可见，不能撤回同一 assistant turn 已经发出的 sibling tool calls。
+- 手动 Agent-tool background 应使用 `steer`；scheduler/RPC 等 detached 来源默认保持 `followUp`。
+- 不应通过 `invocation?.runInBackground` 或 `isBackground` 猜交付策略，应在 spawn 时直接写明。
+- 强制 `parent_task` 不可验证、容易填空话绕过，还会扩大 schema/frontmatter/兼容面；不应进入 P0。
+- full/compact tool description、`promptGuidelines` 和派发回显都应明确：前置结果必须 foreground；background 期间不得重做证据收集；收到报告后只做定向抽查。
+- 第一版不做路径锁，也不写“模型一定不会重复”的随机性测试。
+
+### 分路意见
+
+#### `xai/grok-4.6`
+
+- 推荐最小 `SpawnOptions.completionDelivery?: "steer" | "followUp"`，默认 `followUp`，仅 Agent 工具手动后台显式传 `steer`。
+- 认为 `AgentOrigin` 状态机、强制 `parent_task`、group 混类隔离和 P0 telemetry 都属过度设计。
+- 指出 smart group 只收同一 assistant turn 的 Agent-tool 调用，scheduler/RPC 不进入该 batch，因此当前天然同质。
+
+#### `volcengine-agent-plan/kimi-k3`
+
+- 同意 `steer` 是 P0，倾向用显式 `origin` 区分 Agent tool、scheduler、RPC。
+- 同样否决强制 `parent_task`；若未来保留门禁，必须依据 `resolvedConfig.runInBackground`，不能检查原始 `params.run_in_background`，否则 custom-agent frontmatter 会绕过或误伤。
+- 同意当前 group 天然同源，无需第一版引入拆组机制；暂不做 telemetry。
+
+#### `ollama-cloud/glm-5.2`
+
+首次运行触及 turn limit；沿原会话停止检索并收束后产出评审。
+
+- 同意手动 background 用 `steer`、scheduler/RPC 用 `followUp`，并否决强制 `parent_task`。
+- 倾向直接保存 `completionDelivery`，不增加 `AgentOrigin`。
+- 对未来不同 delivery class 混组更保守，建议若真的出现则拆组；将 overlap telemetry 视为 P1 而非 P0。
+
+### 分歧与取舍
+
+1. **记录 origin 还是记录交付策略**：采用 Grok/GLM 的 `completionDelivery`。运行时真正需要的是消息交付行为；记录 origin 再映射一次没有额外价值。
+2. **是否处理混合 delivery group**：P0 不做。现有 `currentBatchAgents` 只包含同一轮 Agent-tool background，scheduler/RPC 不参与；增加同质性测试和代码注释即可。未来若其他来源进入 group，再按真实用例拆组。
+3. **是否立即加 telemetry**：延后。当前已有足够证据修复明确的队列问题；先观察修复后是否仍复发，再决定采集什么信号。
+
+## 推荐终稿
+
+### P0-1 · 为每个后台记录固定 completion delivery
+
+增加最小类型和记录字段：
+
+```ts
+type CompletionDelivery = "steer" | "followUp";
+
+interface AgentRecord {
+  // ...
+  completionDelivery: CompletionDelivery;
+}
+
+interface SpawnOptions {
+  // ...
+  completionDelivery?: CompletionDelivery;
+}
+```
+
+`AgentManager.spawn()` 创建记录时固定：
+
+```ts
+completionDelivery: options.completionDelivery ?? "followUp"
+```
+
+调用策略：
+
+| 调用路径 | 策略 |
+|---|---|
+| Agent 工具手动 background，包括 frontmatter 默认 background | 显式 `completionDelivery: "steer"` |
+| scheduler | 省略，默认 `followUp` |
+| RPC/detached | 省略，默认 `followUp` |
+| foreground | inline result，不依赖后台 nudge |
+
+不新增 `AgentOrigin`，也不从现有 UI 字段反推来源。
+
+### P0-2 · completion notification 使用记录上的策略
+
+individual notification：
+
+```ts
+pi.sendMessage(message, {
+  deliverAs: record.completionDelivery,
+  triggerTurn: true,
+});
+```
+
+smart/group notification 使用该组首条记录的策略；通过测试固定“当前 batch 全部是 Agent-tool background，因此同为 `steer`”这一不变量。P0 不新增混类拆组逻辑。
+
+结果：手动 background 完成后，通知会在主 agent 当前已发出的工具批次结束、下一次 LLM 调用前进入上下文；scheduled/RPC 不会中途打断当前任务。
+
+### P0-3 · 收紧模型合同与派发回显
+
+统一更新 full/compact description、`promptGuidelines`、`examples/agent-tool-description.md` 和后台派发结果：
+
+> 若 sub-agent 结果是下一次 read、edit 或 decision 的前置条件，必须 foreground。只有存在真正互不重叠的工作时才使用 background。
+
+> 主 agent 保留综合、决策和最终验证责任，但不得重复 sub-agent 的证据收集。收到结果后只抽查高风险结论，不得全量重跑相同 grep/find/read。
+
+后台返回文本应明确：继续时只能做 genuinely disjoint work；结果完成后会通知，无需轮询，也不得同时重搜。
+
+不新增强制 `parent_task`。若修复后仍频繁复发，再基于数据评估可选 ownership 字段，而不是先扩公开 schema。
+
+### P0-4 · 同步维护边界与用户文档
+
+至少同步：
+
+- `packages/pi-subagents/README.md`
+- `packages/pi-subagents/README.zh-CN.md`
+- `packages/pi-subagents/CHANGELOG.md`
+- `packages/pi-subagents/UPSTREAM_SOURCE.md`
+- `packages/pi-subagents/examples/agent-tool-description.md`
+- 对应 changeset
+
+`UPSTREAM_SOURCE.md` 当前将 background followUp notifications 标为有意保持的上游行为；实现时必须改成“手动 Agent-tool background 使用 steer，detached/scheduled 保持 followUp”。发版继续遵守 Changesets version PR 流程。
+
+## 验证设计
+
+使用 mock `runAgent`、fake timers 和 `pi.sendMessage` spy，测试确定性的编排行为，不调用真实模型：
+
+1. Agent 工具手动 background 完成：`deliverAs === "steer"` 且 `triggerTurn === true`。
+2. custom-agent frontmatter 默认 background 也走 `steer`。
+3. scheduler completion：保持 `followUp`。
+4. RPC completion：默认 `followUp`。
+5. foreground `spawnAndWait`：只返回 inline result，不发后台 nudge。
+6. 同 turn 两个手动 background 经 smart join：单条 group notification，使用 `steer`。
+7. `get_subagent_result` 在 200ms hold window 内消费结果：取消待发 nudge。
+8. `wait: true` 被取消：不终止或消费 child，child 完成后仍按记录策略通知。
+9. error/aborted/stopped：使用同一 delivery 策略，widget/fleet 正常收尾。
+10. full/compact descriptions 与示例模板包含 foreground 前置条件和禁止重复收集规则。
+
+若需要验证 Pi 自身队列语义，使用 stub agent loop 断言 streaming 状态下 `steer` 进入 steer queue、`followUp` 进入 follow-up queue；不通过真实模型输出证明。
+
+## 明确不做
+
+- 不强制增加 `parent_task` 或 `parallel_plan`；
+- 不增加 `AgentOrigin` 状态机；
+- 不做路径级读写锁、`delegated_paths` 或自然语言重叠判断；
+- 不在 P0 增加 overlap telemetry；
+- 不改变 scheduler/RPC 的默认通知时序；
+- 不声称本方案能撤回同 turn 已发出的重复 sibling tools。
+
+## 残余风险与后续触发条件
+
+- 同 turn sibling 重复仍只能依靠更清晰的派发合同规避；`steer` 解决的是完成结果在后续轮次被饿死。
+- `steer` 会让真正并行任务的结果更早进入主推理链，可能改变原定 parent lane；这是及时消费结果的预期权衡，需在 changeset 中明示。
+- 多个未成组 steer 在默认 `one-at-a-time` 下可能跨 turn 串行；现有 smart group 是主要缓解。
+- 若上线后仍观察到重复委派，再增加只读 overlap telemetry，先测量 read/grep/find 重叠，再决定是否需要可选 ownership 字段或软警告；没有数据前不加硬门禁。


### PR DESCRIPTION
## Summary

- deliver manual Agent-tool background completions with `steer`, including frontmatter-resolved background agents
- keep scheduler and cross-extension RPC completion delivery on the detached `followUp` default
- clarify foreground/background ownership and targeted verification across model-facing contracts and bilingual docs
- add deterministic orchestration tests and patch changesets for the root bundle and standalone package

## Verification

- `pnpm --filter @zhcsyncer/pi-subagents check`
- `pnpm check`
- adversarial review: 3/3 valid routes, 0 blocking/advisory/contested findings
