### PR TITLE
fix(pi-recap): handle missing recap titles

### DIFF
--- a/.changeset/fuzzy-recaps-find-titles.md
+++ b/.changeset/fuzzy-recaps-find-titles.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-recap": patch
+---
+
+Derive a bounded fallback title from valid recap text with a persisted widget warning, and reject truncated, failed, empty, or malformed JSON-like model output without saving partial recap state.

--- a/packages/pi-recap/README.md
+++ b/packages/pi-recap/README.md
@@ -10,7 +10,8 @@ Features:
 - Automatically recap after the agent has been idle for a while.
 - Cancel an unfinished automatic recap when a new message arrives, preventing stale results from being stored or displayed.
 - Display automatic recap progress plus recap results and errors in an editor widget, without duplicating successful results in chat notifications.
-- Generate a short title as a recap side effect.
+- Generate a short title as a recap side effect, with a deterministic recap-derived fallback and visible warning when the model omits a usable title.
+- Reject empty, truncated, failed, or malformed JSON-like model output without saving partial recap state.
 - Optionally apply the title to the Pi session name.
 - Optionally sync Pi session name changes to the nearest terminal multiplexer: a Herdr pane label or tmux window name.
 - Configure common options with `/recap-config`.
@@ -142,6 +143,10 @@ Apply generated titles to Pi session names:
   }
 }
 ```
+
+When `title.generate` is enabled but the model omits a usable title, recap deterministically uses the cleaned one-line recap as the title, strictly capped by `title.maxLength`. The fallback still follows `title.applyToSessionName` and `title.applyPolicy`; `never`, `if-empty`, `if-empty-or-auto`, and `always` keep their existing meanings. The persisted recap records that the title came from the fallback, so the editor widget shows the warning after generation and after a session reload. Set `title.generate` to `false` to disable both model titles and this fallback.
+
+Plain text and ordinary bullet recap responses remain valid. Empty recaps, malformed or truncated JSON-like responses, and completions stopped with `length` or `error` are treated as failed recaps: the widget shows the failure, no recap entry is appended, the session is not renamed, and the previous recap source position is preserved.
 
 Disable automatic recap and keep manual `/recap` only:
 

--- a/packages/pi-recap/README.zh-CN.md
+++ b/packages/pi-recap/README.zh-CN.md
@@ -10,7 +10,8 @@
 - agent 完成后空闲一段时间自动生成 recap；
 - 发送新消息时取消尚未完成的自动 recap，避免写入或展示过期结果；
 - 使用 editor widget 展示自动 recap 的进度以及 recap 结果和错误，成功结果不会再重复显示为聊天区通知；
-- recap 时顺便生成短 title；
+- recap 时顺便生成短 title；模型未返回可用 title 时会确定性地从 recap 派生 fallback，并显示明确 warning；
+- 空输出、截断/失败响应或损坏的 JSON-like 输出不会保存半成品 recap 状态；
 - 是否用 title 更新 Pi session name 由配置控制；
 - session name 变化时可选同步最近一层终端复用器：Herdr pane label 或 tmux window name；
 - `/recap-config` 提供 TUI 常用配置；
@@ -142,6 +143,10 @@ examples/recap.json
   }
 }
 ```
+
+启用 `title.generate` 后，如果模型没有返回可用 title，recap 会确定性地使用清理成一行的 recap 作为 title，并严格限制在 `title.maxLength` 内。fallback 仍遵守 `title.applyToSessionName` 与 `title.applyPolicy`；`never`、`if-empty`、`if-empty-or-auto`、`always` 的原有语义不变。持久化 recap 会记录 title 来自 fallback，因此生成后以及 session reload 后，editor widget 都会显示 warning。将 `title.generate` 设为 `false` 会同时禁用模型 title 和该 fallback。
+
+纯文本与普通 bullet recap 响应仍然有效。空 recap、损坏或截断的 JSON-like 响应，以及以 `length` 或 `error` 结束的模型响应都会被视为 recap 失败：widget 会显示失败信息，不会 append recap entry、不会更新 session name，也不会推进上一次 recap 的 source 位置。
 
 关闭自动 recap，仅保留手动 `/recap`：
 

--- a/packages/pi-recap/extensions/recap-output.ts
+++ b/packages/pi-recap/extensions/recap-output.ts
@@ -1,0 +1,195 @@
+export type RecapTitleSource = "model" | "recap-fallback";
+
+export type ResolvedRecapOutput =
+	| {
+			ok: true;
+			recap: string;
+			title?: string;
+			titleSource?: RecapTitleSource;
+	  }
+	| {
+			ok: false;
+			error: string;
+	  };
+
+export type ResolveRecapOutputOptions = {
+	stopReason: unknown;
+	errorMessage?: unknown;
+	generateTitle: boolean;
+	titleMaxLength: number;
+};
+
+export const RECAP_FALLBACK_WARNING = "Model did not generate a usable title; using a recap-derived fallback.";
+
+export function recapOutputWarning(titleSource: RecapTitleSource | undefined): string | undefined {
+	return titleSource === "recap-fallback" ? RECAP_FALLBACK_WARNING : undefined;
+}
+
+export function cleanOneLine(value: string, maxLength?: number): string {
+	let cleaned = value
+		.replace(/```(?:json)?|```/gi, "")
+		.replace(/[\x00-\x1f\x7f]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+
+	if (maxLength !== undefined) {
+		const limit = Number.isFinite(maxLength) ? Math.max(0, Math.floor(maxLength)) : 0;
+		const characters = Array.from(cleaned);
+		if (characters.length > limit) {
+			if (limit <= 1) return characters.slice(0, limit).join("");
+			cleaned = `${characters.slice(0, limit - 1).join("")}…`;
+		}
+	}
+	return cleaned;
+}
+
+type ModelPayload =
+	| { kind: "json"; value: unknown }
+	| { kind: "plain"; value: string }
+	| { kind: "invalid-json" };
+
+function tryParseJson(value: string): ModelPayload | undefined {
+	try {
+		return { kind: "json", value: JSON.parse(value) as unknown };
+	} catch {
+		return undefined;
+	}
+}
+
+function parseStructuredJson(value: string): ModelPayload {
+	return tryParseJson(value) ?? { kind: "invalid-json" };
+}
+
+function clearlyMalformedJson(value: string): boolean {
+	const trimmed = value.trimStart();
+	if (/^\{\s*"[^"]*"\s*:/s.test(trimmed)) return true;
+	if (/^\[\s*(?:["{\[]|-?\d|true\b|false\b|null\b)/s.test(trimmed)) return true;
+	return /^["'](?:recap|title)["']\s*:/i.test(trimmed);
+}
+
+const JSON_FENCE_OPENING = /^```json\b[^\S\r\n]*(?:\r?\n)?/i;
+const GENERIC_FENCE_OPENING = /^```(?:[a-z0-9_-]+)?[^\S\r\n]*\r?\n/i;
+
+function completeJsonFenceBody(value: string): string | undefined {
+	const match = value.match(/^```json\b[^\S\r\n]*(?:\r?\n)?([\s\S]*)\r?\n?```[^\S\r\n]*$/i);
+	return match ? (match[1] ?? "").trim() : undefined;
+}
+
+function completeGenericFenceBody(value: string): string | undefined {
+	const match = value.match(/^```(?:[a-z0-9_-]+)?[^\S\r\n]*\r?\n([\s\S]*)\r?\n?```[^\S\r\n]*$/i);
+	return match ? (match[1] ?? "").trim() : undefined;
+}
+
+function isExplicitJsonLike(value: string): boolean {
+	const trimmed = value.trimStart();
+	if (JSON_FENCE_OPENING.test(trimmed)) return true;
+	if (trimmed.startsWith("{") || trimmed.startsWith("[")) return true;
+	if (/^["'](?:recap|title)["']\s*:/i.test(trimmed)) return true;
+
+	const genericOpening = trimmed.match(GENERIC_FENCE_OPENING);
+	return genericOpening ? isExplicitJsonLike(trimmed.slice(genericOpening[0].length)) : false;
+}
+
+function parseExplicitJsonLike(value: string): ModelPayload {
+	const trimmed = value.trim();
+	const wholeJson = tryParseJson(trimmed);
+	if (wholeJson) return wholeJson;
+
+	const jsonFenceBody = completeJsonFenceBody(trimmed);
+	if (jsonFenceBody !== undefined) return parseStructuredJson(jsonFenceBody);
+	if (JSON_FENCE_OPENING.test(trimmed)) return { kind: "invalid-json" };
+
+	const genericFenceBody = completeGenericFenceBody(trimmed);
+	if (genericFenceBody !== undefined) {
+		return isExplicitJsonLike(genericFenceBody)
+			? parseExplicitJsonLike(genericFenceBody)
+			: { kind: "invalid-json" };
+	}
+
+	const genericOpening = trimmed.match(GENERIC_FENCE_OPENING);
+	if (genericOpening && isExplicitJsonLike(trimmed.slice(genericOpening[0].length))) {
+		return { kind: "invalid-json" };
+	}
+
+	return { kind: "invalid-json" };
+}
+
+function parseModelPayload(raw: string): ModelPayload {
+	const trimmed = raw.trim();
+	const wholeJson = tryParseJson(trimmed);
+	if (wholeJson) return wholeJson;
+
+	const jsonFenceBody = completeJsonFenceBody(trimmed);
+	if (jsonFenceBody !== undefined) return parseStructuredJson(jsonFenceBody);
+	if (JSON_FENCE_OPENING.test(trimmed)) return { kind: "invalid-json" };
+
+	const completeFenceBody = completeGenericFenceBody(trimmed);
+	if (completeFenceBody !== undefined) return parseModelPayload(completeFenceBody);
+
+	const openingFence = trimmed.match(GENERIC_FENCE_OPENING);
+	if (openingFence) {
+		const body = trimmed.slice(openingFence[0].length);
+		const parsedBody = parseModelPayload(body);
+		return parsedBody.kind === "plain" ? { kind: "plain", value: body } : { kind: "invalid-json" };
+	}
+
+	const jsonPreamble = trimmed.match(
+		/^(?:(?:sure|certainly)[,!.]?\s*)?here(?:'s| is)\s+(?:(?:the|your|requested)\s+)*(?:(?:recap|result)\s+)?json(?:\s+(?:output|response))?\s*:\s*([\s\S]*)$/i,
+	);
+	if (jsonPreamble) {
+		const candidate = jsonPreamble[1]?.trim() ?? "";
+		if (isExplicitJsonLike(candidate)) return parseExplicitJsonLike(candidate);
+	}
+
+	if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+		return clearlyMalformedJson(trimmed) ? { kind: "invalid-json" } : { kind: "plain", value: trimmed };
+	}
+
+	return clearlyMalformedJson(trimmed) ? { kind: "invalid-json" } : { kind: "plain", value: trimmed };
+}
+
+function failureForStopReason(stopReason: unknown, errorMessage: unknown): string | undefined {
+	if (stopReason === "length") return "Recap model output was truncated by the token limit";
+	if (stopReason !== "error") return undefined;
+
+	const detail = typeof errorMessage === "string" ? errorMessage.trim() : "";
+	return detail ? `Recap model failed: ${detail}` : "Recap model failed";
+}
+
+export function resolveRecapOutput(raw: string, options: ResolveRecapOutputOptions): ResolvedRecapOutput {
+	const stopFailure = failureForStopReason(options.stopReason, options.errorMessage);
+	if (stopFailure) return { ok: false, error: stopFailure };
+	if (!raw.trim()) return { ok: false, error: "Recap model returned empty output" };
+
+	const payload = parseModelPayload(raw);
+	if (payload.kind === "invalid-json") {
+		return { ok: false, error: "Recap model returned malformed or truncated JSON" };
+	}
+
+	let recapValue: string;
+	let modelTitle: string | undefined;
+	if (payload.kind === "json") {
+		if (typeof payload.value !== "object" || payload.value === null || Array.isArray(payload.value)) {
+			return { ok: false, error: "Recap model returned JSON without a valid recap" };
+		}
+		const record = payload.value as Record<string, unknown>;
+		if (typeof record.recap !== "string") {
+			return { ok: false, error: "Recap model returned JSON without a valid recap" };
+		}
+		recapValue = record.recap;
+		modelTitle = typeof record.title === "string" ? record.title : undefined;
+	} else {
+		recapValue = payload.value;
+	}
+
+	const recap = cleanOneLine(recapValue);
+	if (!recap) return { ok: false, error: "Recap model returned an empty recap" };
+	if (!options.generateTitle) return { ok: true, recap };
+
+	const title = cleanOneLine(modelTitle ?? "", options.titleMaxLength);
+	if (title) return { ok: true, recap, title, titleSource: "model" };
+
+	const fallbackTitle = cleanOneLine(recap, options.titleMaxLength);
+	if (!fallbackTitle) return { ok: false, error: "Recap model returned an empty recap" };
+	return { ok: true, recap, title: fallbackTitle, titleSource: "recap-fallback" };
+}

--- a/packages/pi-recap/extensions/recap.ts
+++ b/packages/pi-recap/extensions/recap.ts
@@ -25,6 +25,11 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { CancellableLoader, Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
 import {
+	recapOutputWarning,
+	resolveRecapOutput,
+	type RecapTitleSource,
+} from "./recap-output.ts";
+import {
 	migrateMultiplexerConfig,
 	MultiplexerManager,
 	type MultiplexerConfig,
@@ -36,11 +41,11 @@ const CUSTOM_TYPE = "recap";
 const WIDGET_KEY = "recap";
 const LEGACY_STATUS_KEY = "recap";
 
-type RecapReason = "manual" | "auto";
-type TitleApplyPolicy = "never" | "if-empty" | "if-empty-or-auto" | "always";
+export type RecapReason = "manual" | "auto";
+export type TitleApplyPolicy = "never" | "if-empty" | "if-empty-or-auto" | "always";
 type WidgetPlacement = "aboveEditor" | "belowEditor";
 
-type RecapConfig = {
+export type RecapConfig = {
 	recap: {
 		enabled: boolean;
 		auto: boolean;
@@ -66,9 +71,10 @@ type RecapConfig = {
 	multiplexer: MultiplexerConfig;
 };
 
-type RecapEntryData = {
+export type RecapEntryData = {
 	recap: string;
 	title?: string;
+	titleSource?: RecapTitleSource;
 	reason: RecapReason;
 	model?: string;
 	source: {
@@ -80,7 +86,7 @@ type RecapEntryData = {
 	sessionNamePolicy: TitleApplyPolicy;
 };
 
-const DEFAULT_CONFIG: RecapConfig = {
+export const DEFAULT_CONFIG: RecapConfig = {
 	recap: {
 		enabled: true,
 		auto: true,
@@ -529,39 +535,6 @@ function buildSystemPrompt(config: RecapConfig): string {
 	].join("\n");
 }
 
-function parseModelJson(raw: string): { recap: string; title?: string } {
-	const trimmed = raw.trim();
-	const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1]?.trim();
-	const object = (fenced ?? trimmed.match(/\{[\s\S]*\}/)?.[0] ?? trimmed).trim();
-
-	try {
-		const parsed = JSON.parse(object) as unknown;
-		if (isRecord(parsed)) {
-			return {
-				recap: typeof parsed.recap === "string" ? parsed.recap : trimmed,
-				title: typeof parsed.title === "string" ? parsed.title : undefined,
-			};
-		}
-	} catch {
-		// fall through
-	}
-
-	return { recap: trimmed };
-}
-
-function cleanOneLine(value: string, maxLength?: number): string {
-	let cleaned = value
-		.replace(/```(?:json)?|```/gi, "")
-		.replace(/[\x00-\x1f\x7f]/g, " ")
-		.replace(/\s+/g, " ")
-		.trim();
-
-	if (maxLength && cleaned.length > maxLength) {
-		cleaned = `${cleaned.slice(0, Math.max(1, maxLength - 1))}…`;
-	}
-	return cleaned;
-}
-
 function resolveRecapModel(ctx: ExtensionContext, config: RecapConfig) {
 	if (config.recap.model === "current") return ctx.model;
 
@@ -576,32 +549,51 @@ function resolveRecapModel(ctx: ExtensionContext, config: RecapConfig) {
 	return config.recap.fallbackToCurrentModel ? ctx.model : undefined;
 }
 
+export type TitleApplicationInput = {
+	title?: string;
+	applyToSessionName: boolean;
+	policy: TitleApplyPolicy;
+	currentSessionName?: string;
+	lastAppliedSessionName: boolean;
+	lastAppliedTitle?: string;
+};
+
+export function shouldApplyTitleForPolicy(input: TitleApplicationInput): boolean {
+	if (!input.applyToSessionName || !input.title) return false;
+	if (input.policy === "never") return false;
+	if (input.policy === "always") return true;
+	if (!input.currentSessionName) return true;
+	if (input.policy === "if-empty") return false;
+	return Boolean(
+		input.lastAppliedSessionName &&
+		input.lastAppliedTitle &&
+		input.currentSessionName === input.lastAppliedTitle,
+	);
+}
+
 function shouldApplyTitle(title: string | undefined, pi: ExtensionAPI, ctx: ExtensionContext, config: RecapConfig, state: RecapState): boolean {
-	if (!config.title.applyToSessionName) return false;
-	if (!title) return false;
-
-	const policy = config.title.applyPolicy;
-	if (policy === "never") return false;
-	if (policy === "always") return true;
-
-	const current = currentSessionName(pi, ctx);
-	if (!current) return true;
-	if (policy === "if-empty") return false;
-
-	return Boolean(state.lastAppliedSessionName && state.lastAppliedTitle && current === state.lastAppliedTitle);
+	return shouldApplyTitleForPolicy({
+		title,
+		applyToSessionName: config.title.applyToSessionName,
+		policy: config.title.applyPolicy,
+		currentSessionName: currentSessionName(pi, ctx),
+		lastAppliedSessionName: state.lastAppliedSessionName,
+		lastAppliedTitle: state.lastAppliedTitle,
+	});
 }
 
 function formatModelName(model: NonNullable<ExtensionContext["model"]> | undefined): string | undefined {
 	return model ? `${model.provider}/${model.id}` : undefined;
 }
 
-type RunRecapOptions = {
+export type RunRecapOptions = {
 	force?: boolean;
 	signal?: AbortSignal;
 	showProgress?: boolean;
+	completeModel?: typeof complete;
 };
 
-async function runRecap(
+export async function runRecap(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	config: RecapConfig,
@@ -609,7 +601,7 @@ async function runRecap(
 	reason: RecapReason,
 	options: RunRecapOptions = {},
 ): Promise<RecapEntryData | undefined> {
-	const { force = false, signal, showProgress = true } = options;
+	const { force = false, signal, showProgress = true, completeModel = complete } = options;
 	if (state.running) return undefined;
 	if (!config.recap.enabled) {
 		if (reason === "manual" && ctx.mode === "tui") displayRecapError(ctx, config, "Recap is disabled by config");
@@ -669,7 +661,7 @@ async function runRecap(
 			return undefined;
 		}
 
-		const response = await complete(
+		const response = await completeModel(
 			model,
 			{
 				systemPrompt: buildSystemPrompt(config),
@@ -697,16 +689,19 @@ async function runRecap(
 			.map((item) => item.text)
 			.join("\n")
 			.trim();
-
-		if (!raw) {
-			displayRecapError(ctx, config, "Recap model returned empty output");
+		const resolved = resolveRecapOutput(raw, {
+			stopReason: response.stopReason,
+			errorMessage: response.errorMessage,
+			generateTitle: config.title.generate,
+			titleMaxLength: config.title.maxLength,
+		});
+		if (!resolved.ok) {
+			displayRecapError(ctx, config, resolved.error);
 			displayed = true;
 			return undefined;
 		}
 
-		const parsed = parseModelJson(raw);
-		const recap = cleanOneLine(parsed.recap);
-		const title = config.title.generate ? cleanOneLine(parsed.title ?? "", config.title.maxLength) || undefined : undefined;
+		const { recap, title, titleSource } = resolved;
 		const appliedSessionName = shouldApplyTitle(title, pi, ctx, config, state);
 
 		if (appliedSessionName && title) {
@@ -720,6 +715,7 @@ async function runRecap(
 		const data: RecapEntryData = {
 			recap,
 			title,
+			titleSource,
 			reason,
 			model: formatModelName(model),
 			source: {
@@ -792,9 +788,11 @@ function displayRecapWidget(ctx: ExtensionContext, config: RecapConfig, data: Re
 				hour: "2-digit",
 				minute: "2-digit",
 			}).format(data.generatedAt);
+			const warning = recapOutputWarning(data.titleSource);
 			const text = [
 				theme.fg("muted", "RECAP  ") + theme.fg("accent", theme.bold(title)),
 				theme.fg("text", data.recap),
+				...(warning ? [theme.fg("warning", `WARNING  ${warning}`)] : []),
 				theme.fg("dim", `Generated ${generatedTime}`),
 			].join("\n");
 
@@ -1002,7 +1000,7 @@ type ActiveRecapRun = {
 	signal?: AbortSignal;
 };
 
-type RecapState = {
+export type RecapState = {
 	config: RecapConfig;
 	running: boolean;
 	nextRunId: number;
@@ -1062,28 +1060,40 @@ function scheduleAutoRecap(pi: ExtensionAPI, ctx: ExtensionContext, state: Recap
 	}, config.recap.idleAfterTurnMs);
 }
 
-async function refreshStateFromSession(ctx: ExtensionContext, state: RecapState) {
-	const entries = ctx.sessionManager.getBranch();
+export function restoreRecapState(entries: SessionEntry[], currentSessionName: string | undefined) {
 	const last = getLastRecap(entries);
-
-	state.lastRecap = last?.data;
-	state.lastRecapAt = last?.data.generatedAt;
-	state.lastRecapSourceToEntryId = last?.data.source?.toEntryId;
-
-	const current = ctx.sessionManager.getSessionName();
-	state.lastAppliedSessionName = Boolean(last?.data.appliedSessionName && last.data.title && current === last.data.title);
-	state.lastAppliedTitle = state.lastAppliedSessionName ? last?.data.title : undefined;
+	const lastAppliedSessionName = Boolean(
+		last?.data.appliedSessionName && last.data.title && currentSessionName === last.data.title,
+	);
+	return {
+		lastRecap: last?.data,
+		lastRecapAt: last?.data.generatedAt,
+		lastRecapSourceToEntryId: last?.data.source?.toEntryId,
+		lastAppliedSessionName,
+		lastAppliedTitle: lastAppliedSessionName ? last?.data.title : undefined,
+	};
 }
 
-export default function (pi: ExtensionAPI) {
-	const state: RecapState = {
-		config: DEFAULT_CONFIG,
+async function refreshStateFromSession(ctx: ExtensionContext, state: RecapState) {
+	Object.assign(
+		state,
+		restoreRecapState(ctx.sessionManager.getBranch(), ctx.sessionManager.getSessionName()),
+	);
+}
+
+export function createRecapState(config: RecapConfig = DEFAULT_CONFIG): RecapState {
+	return {
+		config,
 		running: false,
 		nextRunId: 0,
 		applyingSessionName: false,
 		lastAppliedSessionName: false,
 		multiplexer: new MultiplexerManager(),
 	};
+}
+
+export default function (pi: ExtensionAPI) {
+	const state = createRecapState();
 
 	pi.on("session_start", async (_event, ctx) => {
 		try {

--- a/packages/pi-recap/tests/recap-contract.test.ts
+++ b/packages/pi-recap/tests/recap-contract.test.ts
@@ -1,0 +1,442 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent";
+import recapExtension, {
+	DEFAULT_CONFIG,
+	createRecapState,
+	restoreRecapState,
+	runRecap,
+	shouldApplyTitleForPolicy,
+	type RecapConfig,
+	type RecapEntryData,
+	type RunRecapOptions,
+} from "../extensions/recap.ts";
+import {
+	RECAP_FALLBACK_WARNING,
+	recapOutputWarning,
+	resolveRecapOutput,
+	type ResolveRecapOutputOptions,
+} from "../extensions/recap-output.ts";
+
+const DEFAULT_OUTPUT_OPTIONS: ResolveRecapOutputOptions = {
+	stopReason: "stop",
+	generateTitle: true,
+	titleMaxLength: 50,
+};
+
+function resolve(raw: string, options: Partial<ResolveRecapOutputOptions> = {}) {
+	return resolveRecapOutput(raw, { ...DEFAULT_OUTPUT_OPTIONS, ...options });
+}
+
+test("whole-response and fenced JSON keep the model title", () => {
+	const expected = {
+		ok: true as const,
+		recap: "Fixed the parser.",
+		title: "Parser fix",
+		titleSource: "model" as const,
+	};
+	assert.deepEqual(resolve('{"recap":"Fixed the parser.","title":"Parser fix"}'), expected);
+	assert.deepEqual(resolve('```json\n{"recap":"Fixed the parser.","title":"Parser fix"}\n```'), expected);
+});
+
+test("JSON strings may contain triple backticks without ending a structural fence", () => {
+	const payload = '{"recap":"Documented ```json and ``` fences","title":"Fence docs"}';
+	const expected = {
+		ok: true as const,
+		recap: "Documented and fences",
+		title: "Fence docs",
+		titleSource: "model" as const,
+	};
+	assert.deepEqual(resolve(payload), expected);
+	assert.deepEqual(resolve(`\`\`\`json\n${payload}\n\`\`\``), expected);
+});
+
+test("missing, blank, and non-string JSON titles use a strictly bounded recap fallback", () => {
+	for (const title of [undefined, "   ", 42]) {
+		const payload = JSON.stringify({ recap: "  Fixed\n parser   and tests.  ", ...(title === undefined ? {} : { title }) });
+		const result = resolve(payload, { titleMaxLength: 10 });
+		assert.deepEqual(result, {
+			ok: true,
+			recap: "Fixed parser and tests.",
+			title: "Fixed par…",
+			titleSource: "recap-fallback",
+		});
+		assert.ok(result.ok && result.title.length <= 10);
+	}
+
+	assert.deepEqual(resolve('{"recap":"A longer recap"}', { titleMaxLength: 1 }), {
+		ok: true,
+		recap: "A longer recap",
+		title: "A",
+		titleSource: "recap-fallback",
+	});
+});
+
+test("plain text and ordinary bullets remain valid recap input and use fallback titles", () => {
+	assert.deepEqual(resolve("- Fixed parser\n- Added tests", { titleMaxLength: 14 }), {
+		ok: true,
+		recap: "- Fixed parser - Added tests",
+		title: "- Fixed parse…",
+		titleSource: "recap-fallback",
+	});
+	for (const recap of [
+		"- Updated src/{parser,title}.ts",
+		"[Issue #73] Fixed fallback handling",
+		"{parser,title}.ts updated",
+		"Here is the result: fixed fallback handling",
+		"Here is the JSON parser fix: replaced regex with structural parsing.",
+		"Here is the JSON: parser fix uses structural parsing.",
+	]) {
+		assert.deepEqual(resolve(recap, { titleMaxLength: 100 }), {
+			ok: true,
+			recap,
+			title: recap,
+			titleSource: "recap-fallback",
+		});
+	}
+
+	assert.deepEqual(resolve("Improved handling of ```json fences in recap output", { titleMaxLength: 50 }), {
+		ok: true,
+		recap: "Improved handling of fences in recap output",
+		title: "Improved handling of fences in recap output",
+		titleSource: "recap-fallback",
+	});
+});
+
+test("fallback truncation is Unicode-safe", () => {
+	assert.deepEqual(resolve("🚀 launch parser fallback", { titleMaxLength: 2 }), {
+		ok: true,
+		recap: "🚀 launch parser fallback",
+		title: "🚀…",
+		titleSource: "recap-fallback",
+	});
+	assert.deepEqual(resolve("🚀 launch parser fallback", { titleMaxLength: 1 }), {
+		ok: true,
+		recap: "🚀 launch parser fallback",
+		title: "🚀",
+		titleSource: "recap-fallback",
+	});
+});
+
+test("generate=false never derives or persists a title", () => {
+	assert.deepEqual(resolve('{"recap":"Fixed the parser.","title":"Ignored"}', { generateTitle: false }), {
+		ok: true,
+		recap: "Fixed the parser.",
+	});
+	assert.deepEqual(resolve("Plain recap", { generateTitle: false }), {
+		ok: true,
+		recap: "Plain recap",
+	});
+});
+
+test("malformed JSON-like output, invalid recap JSON, and empty recap fail instead of becoming recap text", () => {
+	for (const raw of [
+		'{"recap":"unfinished',
+		'```json\n{"recap":"unfinished',
+		'Sure, here is the JSON:\n{"recap":"unfinished',
+		'Certainly, here\'s your requested recap JSON response:\n{"recap":"unfinished',
+		'Here is the JSON:\n```json\n{"recap":"unfinished',
+		'"recap":"missing object braces"',
+		'{"recap":"   ","title":"Title"}',
+		'{"title":"Title"}',
+		'["bullet-looking JSON"]',
+	]) {
+		const result = resolve(raw);
+		assert.equal(result.ok, false, raw);
+	}
+	assert.deepEqual(resolve("   \n\t"), {
+		ok: false,
+		error: "Recap model returned empty output",
+	});
+});
+
+test("length and error stop reasons reject even otherwise valid partial content", () => {
+	assert.deepEqual(resolve('{"recap":"Looks valid","title":"Title"}', { stopReason: "length" }), {
+		ok: false,
+		error: "Recap model output was truncated by the token limit",
+	});
+	assert.deepEqual(
+		resolve('{"recap":"Looks valid","title":"Title"}', {
+			stopReason: "error",
+			errorMessage: "provider stream failed",
+		}),
+		{
+			ok: false,
+			error: "Recap model failed: provider stream failed",
+		},
+	);
+});
+
+test("title policies keep their existing behavior for fallback titles", () => {
+	const fallbackTitle = "Fallback title";
+	const base = {
+		title: fallbackTitle,
+		applyToSessionName: true,
+		currentSessionName: "User title",
+		lastAppliedSessionName: false,
+	};
+
+	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "never" }), false);
+	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "always" }), true);
+	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "if-empty" }), false);
+	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "if-empty", currentSessionName: undefined }), true);
+	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "if-empty-or-auto" }), false);
+	assert.equal(
+		shouldApplyTitleForPolicy({
+			...base,
+			policy: "if-empty-or-auto",
+			currentSessionName: "Previous automatic title",
+			lastAppliedSessionName: true,
+			lastAppliedTitle: "Previous automatic title",
+		}),
+		true,
+	);
+	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "always", title: undefined }), false);
+	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "always", applyToSessionName: false }), false);
+});
+
+type CompletionSpec = {
+	text: string;
+	stopReason: "stop" | "length" | "error";
+	errorMessage?: string;
+};
+
+function renderWidget(value: unknown): string {
+	const renderer = value as (
+		tui: unknown,
+		theme: { fg: (color: string, text: string) => string; bold: (text: string) => string },
+	) => { render: (width: number) => string[] };
+	const widget = renderer(undefined, {
+		fg: (_color, text) => text,
+		bold: (text) => text,
+	});
+	return widget.render(200).join("\n");
+}
+
+function createRunHarness(spec: CompletionSpec) {
+	const appended: Array<{ customType: string; data: RecapEntryData }> = [];
+	const sessionNames: string[] = [];
+	const widgets: unknown[] = [];
+	let currentSessionName = "Existing session";
+	const entries = [
+		{
+			id: "source-entry",
+			type: "message",
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "Fix the recap title behavior" }],
+				timestamp: 1,
+			},
+		},
+	] as unknown as SessionEntry[];
+	const pi = {
+		appendEntry(customType: string, data: RecapEntryData) {
+			appended.push({ customType, data });
+		},
+		getSessionName() {
+			return currentSessionName;
+		},
+		setSessionName(title: string) {
+			currentSessionName = title;
+			sessionNames.push(title);
+		},
+	} as unknown as ExtensionAPI;
+	const ctx = {
+		mode: "tui",
+		hasUI: true,
+		signal: new AbortController().signal,
+		model: { provider: "test", id: "recap-model" },
+		modelRegistry: {
+			async getApiKeyAndHeaders() {
+				return { ok: true, apiKey: "test-key" };
+			},
+		},
+		sessionManager: {
+			getBranch() {
+				return entries;
+			},
+			getSessionName() {
+				return currentSessionName;
+			},
+		},
+		ui: {
+			setStatus() {},
+			setWidget(_key: string, value: unknown) {
+				widgets.push(value);
+			},
+			notify() {},
+		},
+	} as unknown as ExtensionContext;
+	const config = structuredClone(DEFAULT_CONFIG) as RecapConfig;
+	config.title.applyToSessionName = true;
+	config.title.applyPolicy = "always";
+	config.title.maxLength = 18;
+	const state = createRecapState(config);
+	const completeModel: NonNullable<RunRecapOptions["completeModel"]> = async () =>
+		({
+			role: "assistant",
+			content: spec.text ? [{ type: "text", text: spec.text }] : [],
+			stopReason: spec.stopReason,
+			errorMessage: spec.errorMessage,
+		}) as never;
+
+	return { pi, ctx, config, state, completeModel, appended, sessionNames, widgets };
+}
+
+test("always applies and persists a recap-derived fallback title", async () => {
+	const harness = createRunHarness({ text: "Implemented fallback title behavior", stopReason: "stop" });
+	const result = await runRecap(harness.pi, harness.ctx, harness.config, harness.state, "manual", {
+		force: true,
+		showProgress: false,
+		completeModel: harness.completeModel,
+	});
+
+	assert.equal(result?.title, "Implemented fallb…");
+	assert.equal(result?.titleSource, "recap-fallback");
+	assert.equal(result?.appliedSessionName, true);
+	assert.deepEqual(harness.sessionNames, ["Implemented fallb…"]);
+	assert.equal(harness.appended.length, 1);
+	assert.equal(harness.appended[0]?.data.titleSource, "recap-fallback");
+	assert.equal(harness.state.lastRecapSourceToEntryId, "source-entry");
+
+	assert.match(renderWidget(harness.widgets.at(-1)), new RegExp(`WARNING  ${RECAP_FALLBACK_WARNING}`));
+});
+
+test("plain recap text containing a json fence marker still persists", async () => {
+	const harness = createRunHarness({ text: "Improved handling of ```json fences", stopReason: "stop" });
+	const result = await runRecap(harness.pi, harness.ctx, harness.config, harness.state, "manual", {
+		force: true,
+		showProgress: false,
+		completeModel: harness.completeModel,
+	});
+
+	assert.equal(result?.recap, "Improved handling of fences");
+	assert.equal(result?.titleSource, "recap-fallback");
+	assert.equal(harness.appended.length, 1);
+	assert.deepEqual(harness.sessionNames, [result?.title]);
+	assert.equal(harness.state.lastRecapSourceToEntryId, "source-entry");
+});
+
+test("malformed JSON and length/error completions cannot save, rename, or advance recap source", async (t) => {
+	const cases: Array<[string, CompletionSpec]> = [
+		["malformed JSON", { text: '{"recap":"truncated', stopReason: "stop" }],
+		["prefaced truncated JSON fence", { text: 'Here is the JSON:\n```json\n{"recap":"truncated', stopReason: "stop" }],
+		["empty output", { text: "", stopReason: "stop" }],
+		["structured empty recap", { text: '{"recap":"   ","title":"Title"}', stopReason: "stop" }],
+		["length", { text: '{"recap":"partial', stopReason: "length" }],
+		["error", { text: '{"recap":"partial', stopReason: "error", errorMessage: "provider failed" }],
+	];
+
+	for (const [name, spec] of cases) {
+		await t.test(name, async () => {
+			const harness = createRunHarness(spec);
+			harness.state.lastRecapSourceToEntryId = "previous-source";
+			const result = await runRecap(harness.pi, harness.ctx, harness.config, harness.state, "manual", {
+				force: true,
+				showProgress: false,
+				completeModel: harness.completeModel,
+			});
+
+			assert.equal(result, undefined);
+			assert.deepEqual(harness.appended, []);
+			assert.deepEqual(harness.sessionNames, []);
+			assert.equal(harness.state.lastRecap, undefined);
+			assert.equal(harness.state.lastRecapSourceToEntryId, "previous-source");
+			assert.equal(harness.state.lastAppliedSessionName, false);
+			assert.equal(typeof harness.widgets.at(-1), "function");
+		});
+	}
+});
+
+test("persisted title source restores warning while old entries remain compatible", () => {
+	const oldData: RecapEntryData = {
+		recap: "Old recap",
+		title: "Old title",
+		reason: "manual",
+		source: { toEntryId: "old-source" },
+		generatedAt: 10,
+		appliedSessionName: true,
+		sessionNamePolicy: "always",
+	};
+	const oldEntry = { id: "old-recap", type: "custom", customType: "recap", data: oldData } as unknown as SessionEntry;
+	const oldState = restoreRecapState([oldEntry], "Old title");
+	assert.equal(oldState.lastRecap, oldData);
+	assert.equal(oldState.lastRecapSourceToEntryId, "old-source");
+	assert.equal(oldState.lastAppliedSessionName, true);
+	assert.equal(recapOutputWarning(oldState.lastRecap?.titleSource), undefined);
+
+	const fallbackData: RecapEntryData = { ...oldData, titleSource: "recap-fallback" };
+	const fallbackEntry = { ...oldEntry, data: fallbackData } as unknown as SessionEntry;
+	const fallbackState = restoreRecapState([fallbackEntry], "Old title");
+	assert.equal(recapOutputWarning(fallbackState.lastRecap?.titleSource), RECAP_FALLBACK_WARNING);
+});
+
+test("session_start restores a persisted fallback warning into the widget", async () => {
+	const root = await mkdtemp(path.join(tmpdir(), "pi-recap-reload-"));
+	const agentDir = path.join(root, "agent");
+	const configPath = path.join(agentDir, "extension-data", "pi-recap", "config.json");
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		await mkdir(path.dirname(configPath), { recursive: true });
+		await writeFile(configPath, `${JSON.stringify({ multiplexer: { enabled: false } })}\n`, "utf8");
+
+		const fallbackData: RecapEntryData = {
+			recap: "Reloaded recap",
+			title: "Reloaded fallback",
+			titleSource: "recap-fallback",
+			reason: "manual",
+			source: { toEntryId: "source-before-reload" },
+			generatedAt: 10,
+			appliedSessionName: true,
+			sessionNamePolicy: "always",
+		};
+		const entry = {
+			id: "persisted-recap",
+			type: "custom",
+			customType: "recap",
+			data: fallbackData,
+		} as unknown as SessionEntry;
+		const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => Promise<void>>();
+		const widgets: unknown[] = [];
+		const pi = {
+			on(event: string, handler: unknown) {
+				handlers.set(event, handler as (event: unknown, ctx: ExtensionContext) => Promise<void>);
+			},
+			registerCommand() {},
+			getSessionName() {
+				return fallbackData.title;
+			},
+		} as unknown as ExtensionAPI;
+		const ctx = {
+			cwd: root,
+			mode: "tui",
+			isProjectTrusted: () => false,
+			sessionManager: {
+				getBranch: () => [entry],
+				getSessionName: () => fallbackData.title,
+				getSessionId: () => "session-id",
+			},
+			ui: {
+				setStatus() {},
+				setWidget(_key: string, value: unknown) {
+					widgets.push(value);
+				},
+				notify() {},
+			},
+		} as unknown as ExtensionContext;
+
+		recapExtension(pi);
+		const sessionStart = handlers.get("session_start");
+		assert.ok(sessionStart);
+		await sessionStart({}, ctx);
+		assert.match(renderWidget(widgets.at(-1)), new RegExp(`WARNING  ${RECAP_FALLBACK_WARNING}`));
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(root, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary

- derive a bounded, Unicode-safe fallback title when a valid recap omits a usable model title
- persist the title source and show a widget warning when the fallback is used
- reject empty, failed, truncated, or malformed JSON-like output before renaming or advancing recap state
- preserve plain-text and bullet recaps, including text that merely mentions JSON fences
- add bilingual documentation, contract tests, and patch changesets for the standalone and bundled packages

## Validation

- `pnpm --filter @zhcsyncer/pi-recap check` (49/49)
- `pnpm check:release-policy` (24/24)
- `pnpm check:smoke`
- `pnpm check:pack`
- `git diff --check`

Closes #73
