### PR TITLE
feat(pi-fast-mode): add same-model priority scheduling

### DIFF
--- a/.changeset/fast-priority-mode.md
+++ b/.changeset/fast-priority-mode.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": minor
+"@zhcsyncer/pi-fast-mode": minor
+---
+
+Add same-model Fast / Priority scheduling for OpenAI and xAI. `/fast` and Ctrl+F toggle an in-memory switch only; `/fast default` writes `settings.json` without changing the current switch. The extension is also embedded in the root bundle.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A collection of Pi extensions by zhcsyncer.
 - [`@zhcsyncer/pi-context7`](./packages/pi-context7) — Context7 `resolve-library-id` / `query-docs` tools with compact self-contained TUI rendering and the full `context7-docs` skill.
 - [`@zhcsyncer/pi-ask-user-question`](./packages/pi-ask-user-question) — structured clarification questions with a non-overlay layout, context-aware number-key selection, centered previews, and readable post-interaction results.
 - [`@zhcsyncer/pi-subagents`](./packages/pi-subagents) — maintained fork of `@tintinweb/pi-subagents` with a brief ConversationViewer and collapsible tool TUI (model/effort chips). Also embedded in the root bundle.
+- [`@zhcsyncer/pi-fast-mode`](./packages/pi-fast-mode) — same-model Fast / Priority scheduling for OpenAI and xAI, with an in-memory `/fast` and Ctrl+F switch.
 
 ## Bundle-private Search Hub
 
@@ -57,7 +58,7 @@ pi -e git:github.com/zhcsyncer/pi-extensions
 
 ## Install from npm
 
-Install the complete bundle, including Glance, Plan Mode, Context7, Subagents, structured user questions, and the private Search Hub fork:
+Install the complete bundle, including Glance, Plan Mode, Context7, Subagents, structured user questions, Fast Mode, and the private Search Hub fork:
 
 ```bash
 pi install npm:@zhcsyncer/pi-extensions
@@ -111,6 +112,12 @@ Install only Subagents:
 pi install npm:@zhcsyncer/pi-subagents
 ```
 
+Install only Fast Mode:
+
+```bash
+pi install npm:@zhcsyncer/pi-fast-mode
+```
+
 ## Development
 
 Test the root bundle:
@@ -131,6 +138,7 @@ pi --no-extensions -e ./packages/pi-search-hub --list-models nope
 pi --no-extensions -e ./packages/pi-context7 --list-models nope
 pi --no-extensions -e ./packages/pi-ask-user-question --list-models nope
 pi --no-extensions -e ./packages/pi-subagents --list-models nope
+pi --no-extensions -e ./packages/pi-fast-mode --list-models nope
 ```
 
 When testing `pi-tool-display-intent`, do not load the original `pi-tool-display` or `pi-tool-display-summary` at the same time because all three can own the same built-in tool names.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,6 +15,7 @@ zhcsyncer 维护的一组 Pi extensions。
 - [`@zhcsyncer/pi-context7`](./packages/pi-context7) — Context7 `resolve-library-id` / `query-docs` 工具，自包含紧凑 TUI 渲染，并附带完整 `context7-docs` Skill。
 - [`@zhcsyncer/pi-ask-user-question`](./packages/pi-ask-user-question) — 结构化澄清问答，采用非浮层布局，支持上下文感知的数字键直选、居中预览和可读的交互后结果。
 - [`@zhcsyncer/pi-subagents`](./packages/pi-subagents) — `@tintinweb/pi-subagents` 维护 fork：摘要 ConversationViewer + 可折叠 tool TUI（model/effort）。也嵌入根 bundle。
+- [`@zhcsyncer/pi-fast-mode`](./packages/pi-fast-mode) — 同一模型的 Fast / Priority 调度，面向 OpenAI 与 xAI，内存开关为 `/fast` 和 Ctrl+F。
 
 ## Bundle 私有 Search Hub
 
@@ -57,7 +58,7 @@ pi -e git:github.com/zhcsyncer/pi-extensions
 
 ## 从 npm 安装
 
-安装包含 Glance、Plan Mode、Context7、Subagents、结构化用户问答，以及私有 Search Hub fork 的完整 bundle：
+安装包含 Glance、Plan Mode、Context7、Subagents、结构化用户问答、Fast Mode，以及私有 Search Hub fork 的完整 bundle：
 
 ```bash
 pi install npm:@zhcsyncer/pi-extensions
@@ -105,6 +106,12 @@ pi install npm:@zhcsyncer/pi-context7
 pi install npm:@zhcsyncer/pi-ask-user-question
 ```
 
+仅安装 Fast Mode：
+
+```bash
+pi install npm:@zhcsyncer/pi-fast-mode
+```
+
 ## 开发
 
 测试根 bundle：
@@ -125,6 +132,7 @@ pi --no-extensions -e ./packages/pi-search-hub --list-models nope
 pi --no-extensions -e ./packages/pi-context7 --list-models nope
 pi --no-extensions -e ./packages/pi-ask-user-question --list-models nope
 pi --no-extensions -e ./packages/pi-subagents --list-models nope
+pi --no-extensions -e ./packages/pi-fast-mode --list-models nope
 ```
 
 测试 `pi-tool-display-intent` 时，不要同时加载原始 `pi-tool-display` 或 `pi-tool-display-summary`，因为三者都可能持有同名内置工具。

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-This repository publishes ten public npm packages:
+This repository publishes eleven public npm packages:
 
 - `@zhcsyncer/pi-extensions`
 - `@zhcsyncer/pi-recap`
@@ -11,6 +11,7 @@ This repository publishes ten public npm packages:
 - `@zhcsyncer/pi-context7`
 - `@zhcsyncer/pi-ask-user-question`
 - `@zhcsyncer/pi-subagents`
+- `@zhcsyncer/pi-fast-mode`
 - `pi-provider-volcengine-agent-plan`
 
 

--- a/package.json
+++ b/package.json
@@ -105,9 +105,10 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset publish",
-    "check": "pnpm check:release-policy && pnpm check:recap && pnpm check:smoke && pnpm check:pack",
+    "check": "pnpm check:release-policy && pnpm check:recap && pnpm check:fast-mode && pnpm check:smoke && pnpm check:pack",
     "check:release-policy": "node --test scripts/release-policy.test.mjs scripts/npm-bootstrap.test.mjs scripts/check-smoke.test.mjs && node scripts/check-release-policy.mjs",
     "check:recap": "pnpm --filter @zhcsyncer/pi-recap check",
+    "check:fast-mode": "pnpm --filter @zhcsyncer/pi-fast-mode check",
     "check:smoke": "node scripts/check-smoke.mjs",
     "check:pack": "node scripts/check-pack.mjs"
   },
@@ -121,7 +122,8 @@
       "./packages/pi-search-hub/extensions/search-hub.ts",
       "./packages/pi-context7/extensions/context7.ts",
       "./packages/pi-ask-user-question/index.ts",
-      "./packages/pi-subagents/src/index.ts"
+      "./packages/pi-subagents/src/index.ts",
+      "./packages/pi-fast-mode/extensions/fast-mode.ts"
     ],
     "skills": [
       "./packages/pi-context7/skills"

--- a/packages/pi-fast-mode/CHANGELOG.md
+++ b/packages/pi-fast-mode/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+Initial public release will be cut by Changesets from `0.0.0`.

--- a/packages/pi-fast-mode/LICENSE
+++ b/packages/pi-fast-mode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 zhcsyncer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-fast-mode/README.md
+++ b/packages/pi-fast-mode/README.md
@@ -1,0 +1,98 @@
+# pi-fast-mode
+
+[简体中文](./README.zh-CN.md)
+
+`pi-fast-mode` asks the **same model** for higher scheduling priority. It is not a faster model variant and it is not a thinking-level control.
+
+## Features
+
+- Toggle Fast / Priority with `/fast` or `Ctrl+F`.
+- Keep the current switch in memory only. It is never written to the session jsonl.
+- Set the next-process default with `/fast default on|off`. That command writes `settings.json` only and does not change the current switch.
+- Show a footer status on supported models. Hide it on unsupported models and leave the request unchanged.
+
+## Install
+
+```bash
+pi install npm:@zhcsyncer/pi-fast-mode
+# or via the root bundle
+pi install npm:@zhcsyncer/pi-extensions
+# local
+pi -e ./packages/pi-fast-mode
+```
+
+The root Git bundle also includes this extension:
+
+```bash
+pi install git:github.com/zhcsyncer/pi-extensions
+```
+
+## Commands
+
+```text
+/fast
+/fast on
+/fast off
+```
+
+Toggle or set the **current** in-memory switch. `Ctrl+F` is the same toggle, with a short repeat guard so a held key does not flip the switch repeatedly.
+
+```text
+/fast default on
+/fast default off
+```
+
+Write only `settings.json` `fast-mode.enabled`. The current switch stays as it is.
+
+There is no `/fast status` command and no `gpt-fast-mode` compatibility alias.
+
+## Settings
+
+The supported settings key is `fast-mode.enabled` in Pi `settings.json`:
+
+```json
+{
+  "fast-mode": {
+    "enabled": false
+  }
+}
+```
+
+`/fast default` is the supported way to change that field. Manual edits are read on `/reload` or process restart.
+
+## Footer
+
+- Supported model, on: `⚡ FAST` plus `priority if granted`
+- Supported model, off: dim `fast: off · Ctrl+F`
+- Unsupported model: hide the status and do not mutate the request
+
+## Supported providers
+
+The provider list is hardcoded. There is no user allowlist.
+
+- `openai` + `openai-responses` via `registerProvider` and `options.serviceTier = "priority"`
+- `openai-codex` + `openai-codex-responses` via the same
+- `xai` + `openai-responses` / `openai-completions` via `before_provider_request` payload `service_tier: "priority"`
+
+`options.maxTokens` is passed through unchanged. There is no 32k clamp.
+
+## Pricing and billing
+
+Do not assume every model is granted priority, and do not assume local cost is always about 2×.
+
+- OpenAI Fast / priority is officially priced for the GPT-5.6 family. Older models may reject or ignore the request.
+- xAI may return `service_tier: "default"`.
+- Completions (current grok-4.6) does not apply priority to local `usage.cost`. Glance and session cost can under-report.
+
+## Session lifetime
+
+- `/fast` and `Ctrl+F` change the in-memory switch only.
+- `/new`, `/resume`, and `/fork` in the same Pi process keep the current switch.
+- `/reload` or a process restart reloads `fast-mode.enabled` from `settings.json`.
+- `/fast default on|off` writes only the settings default.
+
+## Development
+
+```bash
+pnpm --filter @zhcsyncer/pi-fast-mode check
+```

--- a/packages/pi-fast-mode/README.md
+++ b/packages/pi-fast-mode/README.md
@@ -74,7 +74,7 @@ The provider list is hardcoded. There is no user allowlist.
 - `openai-codex` + `openai-codex-responses` via the same
 - `xai` + `openai-responses` / `openai-completions` via `before_provider_request` payload `service_tier: "priority"`
 
-`options.maxTokens` is passed through unchanged. There is no 32k clamp.
+OpenAI and Codex keep Pi's built-in `streamSimple` option recipe, including default `maxTokens` and remaining-context clamping, then add `serviceTier` only when Fast Mode is on. There is no extra 32k clamp.
 
 ## Pricing and billing
 
@@ -96,3 +96,5 @@ Do not assume every model is granted priority, and do not assume local cost is a
 ```bash
 pnpm --filter @zhcsyncer/pi-fast-mode check
 ```
+
+The package tests include a source-recipe check against the installed `@earendil-works/pi-ai` OpenAI and Codex `streamSimple` implementations. After bumping Pi, run that check. If it fails, re-read those functions and update `buildStreamOptions` only when the built-in recipe gained new fields.

--- a/packages/pi-fast-mode/README.zh-CN.md
+++ b/packages/pi-fast-mode/README.zh-CN.md
@@ -74,7 +74,7 @@ pi install git:github.com/zhcsyncer/pi-extensions
 - `openai-codex` + `openai-codex-responses` 同样如此
 - `xai` + `openai-responses` / `openai-completions` 通过 `before_provider_request` 的 payload `service_tier: "priority"`
 
-`options.maxTokens` 原样透传，没有 32k 上限。
+OpenAI 和 Codex 继续走 Pi 内置 `streamSimple` 的 options 收口，包括默认 `maxTokens` 和剩余上下文 clamp，只在 Fast Mode 开启时加 `serviceTier`。没有额外的 32k 上限。
 
 ## 价格与计费
 
@@ -96,3 +96,5 @@ pi install git:github.com/zhcsyncer/pi-extensions
 ```bash
 pnpm --filter @zhcsyncer/pi-fast-mode check
 ```
+
+包测试会对照已安装的 `@earendil-works/pi-ai` 里 OpenAI 和 Codex 的 `streamSimple` 源码配方。升级 Pi 后请跑这项检查。如果失败，重新阅读这些函数；只有原厂配方增加了新字段时，才更新 `buildStreamOptions`。

--- a/packages/pi-fast-mode/README.zh-CN.md
+++ b/packages/pi-fast-mode/README.zh-CN.md
@@ -1,0 +1,98 @@
+# pi-fast-mode
+
+[English](./README.md)
+
+`pi-fast-mode` 会向**同一个模型**请求更高的调度优先级。它不是更快的模型变体，也不是 thinking-level 控制。
+
+## 功能
+
+- 用 `/fast` 或 `Ctrl+F` 开关 Fast / Priority。
+- 当前开关只存在内存里，不会写入 session jsonl。
+- 用 `/fast default on|off` 设置下次进程的默认值。该命令只写 `settings.json`，不改当前开关。
+- 在支持的模型上显示 footer 状态。不支持的模型隐藏状态，并且不改请求。
+
+## 安装
+
+```bash
+pi install npm:@zhcsyncer/pi-fast-mode
+# 或通过根 bundle
+pi install npm:@zhcsyncer/pi-extensions
+# 本地
+pi -e ./packages/pi-fast-mode
+```
+
+根 Git bundle 也包含这个扩展：
+
+```bash
+pi install git:github.com/zhcsyncer/pi-extensions
+```
+
+## 命令
+
+```text
+/fast
+/fast on
+/fast off
+```
+
+切换或设置**当前**内存开关。`Ctrl+F` 是同一个开关，带短时防抖，按住键不会连续翻转。
+
+```text
+/fast default on
+/fast default off
+```
+
+只写入 `settings.json` 的 `fast-mode.enabled`。当前开关保持不变。
+
+没有 `/fast status` 命令，也没有 `gpt-fast-mode` 兼容别名。
+
+## 设置
+
+支持的设置键是 Pi `settings.json` 里的 `fast-mode.enabled`：
+
+```json
+{
+  "fast-mode": {
+    "enabled": false
+  }
+}
+```
+
+`/fast default` 是修改该字段的官方方式。手动编辑会在 `/reload` 或进程重启后生效。
+
+## 状态栏
+
+- 支持的模型，开启：`⚡ FAST` 加上 `priority if granted`
+- 支持的模型，关闭：暗色 `fast: off · Ctrl+F`
+- 不支持的模型：隐藏状态，并且不改请求
+
+## 支持的提供商
+
+提供商列表是写死的，没有用户白名单。
+
+- `openai` + `openai-responses` 通过 `registerProvider` 和 `options.serviceTier = "priority"`
+- `openai-codex` + `openai-codex-responses` 同样如此
+- `xai` + `openai-responses` / `openai-completions` 通过 `before_provider_request` 的 payload `service_tier: "priority"`
+
+`options.maxTokens` 原样透传，没有 32k 上限。
+
+## 价格与计费
+
+不要假设每个模型都会被授予 priority，也不要假设本地费用总是大约 2 倍。
+
+- OpenAI Fast / priority 官方定价面向 GPT-5.6 系列。更旧的模型可能拒绝或忽略该请求。
+- xAI 可能返回 `service_tier: "default"`。
+- Completions（当前 grok-4.6）不会把 priority 反映到本地 `usage.cost`。Glance 和 session 费用可能偏低。
+
+## Session 生命周期
+
+- `/fast` 和 `Ctrl+F` 只改内存开关。
+- 同一 Pi 进程里的 `/new`、`/resume`、`/fork` 会保留当前开关。
+- `/reload` 或进程重启会从 `settings.json` 重新读取 `fast-mode.enabled`。
+- `/fast default on|off` 只写设置里的默认值。
+
+## 开发
+
+```bash
+pnpm --filter @zhcsyncer/pi-fast-mode check
+```

--- a/packages/pi-fast-mode/extensions/fast-mode.ts
+++ b/packages/pi-fast-mode/extensions/fast-mode.ts
@@ -1,0 +1,318 @@
+/**
+ * Fast / Priority mode for Pi.
+ *
+ * Same model, higher scheduling priority:
+ * - openai / openai-codex Responses via options.serviceTier
+ * - xAI Responses / Completions via payload service_tier
+ *
+ * Toggle until you toggle again, /reload, or quit: /fast  or  Ctrl+F
+ * Startup default: /fast default on|off
+ *
+ * Settings key: fast-mode.enabled
+ * Current switch is in-memory only; it is not stored in the session.
+ */
+import {
+	clampThinkingLevel,
+	streamOpenAICodexResponses,
+	streamOpenAIResponses,
+	type Api,
+	type Context,
+	type Model,
+	type SimpleStreamOptions,
+} from "@earendil-works/pi-ai/compat";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { matchesKey } from "@earendil-works/pi-tui";
+import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const STATUS_KEY = "fast-mode";
+export const SETTINGS_FIELD = "fast-mode";
+export const SERVICE_TIER = "priority" as const;
+export const SHORTCUT = "ctrl+f";
+export const SHORTCUT_REPEAT_GUARD_MS = 800;
+
+export type ServiceTierOptions = SimpleStreamOptions & {
+	serviceTier?: typeof SERVICE_TIER;
+	reasoningEffort?: string;
+};
+
+export type FastModeModel = Pick<Model<Api>, "provider" | "api">;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function resolveSettingsPath(): string {
+	const piDir = process.env.PI_CODING_AGENT_DIR?.trim();
+	if (piDir) return join(piDir, "settings.json");
+	return join(homedir(), ".pi", "agent", "settings.json");
+}
+
+export function readSettingsFile(): { path: string; parsed: Record<string, unknown> } | undefined {
+	const path = resolveSettingsPath();
+	if (!existsSync(path)) return undefined;
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+		if (!isRecord(parsed)) return undefined;
+		return { path, parsed };
+	} catch {
+		return undefined;
+	}
+}
+
+export function loadDefaultEnabled(): boolean {
+	const settings = readSettingsFile();
+	if (!settings) return false;
+	const block = settings.parsed[SETTINGS_FIELD];
+	return isRecord(block) && block.enabled === true;
+}
+
+export function writeDefaultEnabled(enabled: boolean): void {
+	const path = resolveSettingsPath();
+	let parsed: Record<string, unknown> = {};
+	if (existsSync(path)) {
+		const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
+		if (!isRecord(raw)) throw new Error(`Invalid settings.json: ${path}`);
+		parsed = raw;
+	}
+	const previous = isRecord(parsed[SETTINGS_FIELD]) ? parsed[SETTINGS_FIELD] : {};
+	parsed[SETTINGS_FIELD] = { ...previous, enabled };
+	const temporary = `${path}.${process.pid}.tmp`;
+	writeFileSync(temporary, `${JSON.stringify(parsed, null, 2)}\n`, { encoding: "utf8" });
+	try {
+		renameSync(temporary, path);
+	} catch (error) {
+		try {
+			unlinkSync(temporary);
+		} catch {
+			// ignore cleanup failure
+		}
+		throw error;
+	}
+}
+
+export function supportsApi(model: FastModeModel | undefined): boolean {
+	if (!model) return false;
+	if (model.provider === "openai" || model.provider === "openai-codex") {
+		return model.api === "openai-responses" || model.api === "openai-codex-responses";
+	}
+	if (model.provider === "xai") {
+		return model.api === "openai-responses" || model.api === "openai-completions";
+	}
+	return false;
+}
+
+export function buildStreamOptions(
+	model: Model<Api>,
+	options: SimpleStreamOptions | undefined,
+	serviceTier: typeof SERVICE_TIER | undefined,
+): ServiceTierOptions {
+	const clamped = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
+	const reasoningEffort = clamped === "off" ? undefined : clamped;
+	return {
+		...options,
+		reasoningEffort,
+		...(serviceTier ? { serviceTier } : {}),
+	};
+}
+
+export function resolveServiceTier(
+	enabled: boolean,
+	model: Model<Api> | FastModeModel | undefined,
+): typeof SERVICE_TIER | undefined {
+	if (!enabled || !model || !supportsApi(model)) return undefined;
+	return SERVICE_TIER;
+}
+
+export function shouldReloadEnabledFromSettings(reason: unknown): boolean {
+	return reason === "startup" || reason === "reload";
+}
+
+export function applyXaiPriorityPayload(input: {
+	enabled: boolean;
+	model: FastModeModel | undefined;
+	payload: unknown;
+}): Record<string, unknown> | undefined {
+	if (!input.enabled || input.model?.provider !== "xai") return undefined;
+	if (!supportsApi(input.model)) return undefined;
+	if (!isRecord(input.payload)) return undefined;
+	return { ...input.payload, service_tier: SERVICE_TIER };
+}
+
+function modelLabel(model: ExtensionContext["model"]): string {
+	if (!model?.provider || !model.id) return "unknown model";
+	return `${model.provider}/${model.id}`;
+}
+
+export default function fastMode(pi: ExtensionAPI): void {
+	let enabled = loadDefaultEnabled();
+	let unsubscribeTerminalInput: (() => void) | undefined;
+	let shortcutRepeatGuard: ReturnType<typeof setTimeout> | undefined;
+	let shortcutLatched = false;
+
+	function resolveTier(model: Model<Api> | undefined): typeof SERVICE_TIER | undefined {
+		return resolveServiceTier(enabled, model);
+	}
+
+	function updateStatus(ctx: ExtensionContext): void {
+		if (!supportsApi(ctx.model)) {
+			ctx.ui.setStatus(STATUS_KEY, undefined);
+			return;
+		}
+		if (!enabled) {
+			ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("dim", "fast: off · Ctrl+F"));
+			return;
+		}
+		const label = ctx.ui.theme.fg("warning", ctx.ui.theme.bold("⚡ FAST"));
+		const detail = ctx.ui.theme.fg("muted", " priority if granted");
+		ctx.ui.setStatus(STATUS_KEY, `${label}${detail}`);
+	}
+
+	function announce(ctx: ExtensionContext): void {
+		if (!enabled) {
+			ctx.ui.notify("Fast mode OFF", "info");
+			return;
+		}
+		if (supportsApi(ctx.model)) {
+			ctx.ui.notify(`Fast mode ON · requesting ${SERVICE_TIER} · billed if granted`, "warning");
+			return;
+		}
+		ctx.ui.notify(`Fast mode ON, but ${modelLabel(ctx.model)} is not supported`, "warning");
+	}
+
+	function setEnabled(ctx: ExtensionContext, next: boolean): void {
+		enabled = next;
+		updateStatus(ctx);
+		announce(ctx);
+	}
+
+	function toggle(ctx: ExtensionContext): void {
+		setEnabled(ctx, !enabled);
+	}
+
+	function setDefaultEnabled(ctx: ExtensionContext, next: boolean): void {
+		try {
+			writeDefaultEnabled(next);
+		} catch (error) {
+			ctx.ui.notify(`Failed to write fast-mode default: ${error instanceof Error ? error.message : String(error)}`, "error");
+			return;
+		}
+		ctx.ui.notify(
+			next
+				? "Startup default is Fast ON. Current switch is unchanged."
+				: "Startup default is Fast OFF. Current switch is unchanged.",
+			"info",
+		);
+		updateStatus(ctx);
+	}
+
+	pi.registerProvider("openai-codex", {
+		api: "openai-codex-responses",
+		streamSimple(model, context: Context, options?: SimpleStreamOptions) {
+			const tier = resolveTier(model);
+			return streamOpenAICodexResponses(
+				model as Model<"openai-codex-responses">,
+				context,
+				buildStreamOptions(model, options, tier) as never,
+			);
+		},
+	});
+
+	pi.registerProvider("openai", {
+		api: "openai-responses",
+		streamSimple(model, context: Context, options?: SimpleStreamOptions) {
+			const tier = resolveTier(model);
+			return streamOpenAIResponses(
+				model as Model<"openai-responses">,
+				context,
+				buildStreamOptions(model, options, tier) as never,
+			);
+		},
+	});
+
+	// xAI is mixed-API (4.5 Responses, 4.6 Completions). registerProvider() can
+	// wrap only one api id, so inject the field on the serialized payload for both.
+	pi.on("before_provider_request", (event, ctx) => {
+		return applyXaiPriorityPayload({
+			enabled,
+			model: ctx.model,
+			payload: event.payload,
+		});
+	});
+
+	pi.registerCommand("fast", {
+		description: "Toggle Fast / Priority mode, or set the new-session default",
+		getArgumentCompletions: (prefix) => {
+			const values = ["on", "off", "default on", "default off"];
+			const items = values.filter((value) => value.startsWith(prefix.trim().toLowerCase()));
+			return items.length ? items.map((value) => ({ value, label: value })) : null;
+		},
+		handler: async (args, ctx) => {
+			const tokens = args.trim().toLowerCase().split(/\s+/).filter(Boolean);
+			if (tokens.length === 0) {
+				toggle(ctx);
+				return;
+			}
+			if (tokens[0] === "on" && tokens.length === 1) {
+				setEnabled(ctx, true);
+				return;
+			}
+			if (tokens[0] === "off" && tokens.length === 1) {
+				setEnabled(ctx, false);
+				return;
+			}
+			if (tokens[0] === "default") {
+				if (tokens[1] === "on" && tokens.length === 2) {
+					setDefaultEnabled(ctx, true);
+					return;
+				}
+				if (tokens[1] === "off" && tokens.length === 2) {
+					setDefaultEnabled(ctx, false);
+					return;
+				}
+				ctx.ui.notify("Usage: /fast default on|off", "error");
+				return;
+			}
+			ctx.ui.notify("Usage: /fast [on|off|default on|default off]", "error");
+		},
+	});
+
+	pi.on("session_start", (event, ctx) => {
+		if (shouldReloadEnabledFromSettings(event.reason)) {
+			enabled = loadDefaultEnabled();
+		}
+		unsubscribeTerminalInput?.();
+		if (shortcutRepeatGuard) clearTimeout(shortcutRepeatGuard);
+		shortcutRepeatGuard = undefined;
+		shortcutLatched = false;
+		unsubscribeTerminalInput = ctx.ui.onTerminalInput((data) => {
+			if (!matchesKey(data, SHORTCUT)) return undefined;
+
+			if (!shortcutLatched) {
+				shortcutLatched = true;
+				toggle(ctx);
+			}
+			if (shortcutRepeatGuard) clearTimeout(shortcutRepeatGuard);
+			shortcutRepeatGuard = setTimeout(() => {
+				shortcutLatched = false;
+				shortcutRepeatGuard = undefined;
+			}, SHORTCUT_REPEAT_GUARD_MS);
+			return { consume: true };
+		});
+		updateStatus(ctx);
+	});
+
+	pi.on("model_select", (_event, ctx) => {
+		updateStatus(ctx);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		unsubscribeTerminalInput?.();
+		unsubscribeTerminalInput = undefined;
+		if (shortcutRepeatGuard) clearTimeout(shortcutRepeatGuard);
+		shortcutRepeatGuard = undefined;
+		shortcutLatched = false;
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	});
+}

--- a/packages/pi-fast-mode/extensions/fast-mode.ts
+++ b/packages/pi-fast-mode/extensions/fast-mode.ts
@@ -11,6 +11,7 @@
  * Settings key: fast-mode.enabled
  * Current switch is in-memory only; it is not stored in the session.
  */
+import { buildBaseOptions } from "@earendil-works/pi-ai/api/simple-options";
 import {
 	clampThinkingLevel,
 	streamOpenAICodexResponses,
@@ -32,7 +33,7 @@ export const SERVICE_TIER = "priority" as const;
 export const SHORTCUT = "ctrl+f";
 export const SHORTCUT_REPEAT_GUARD_MS = 800;
 
-export type ServiceTierOptions = SimpleStreamOptions & {
+export type ServiceTierOptions = ReturnType<typeof buildBaseOptions> & {
 	serviceTier?: typeof SERVICE_TIER;
 	reasoningEffort?: string;
 };
@@ -105,13 +106,15 @@ export function supportsApi(model: FastModeModel | undefined): boolean {
 
 export function buildStreamOptions(
 	model: Model<Api>,
+	context: Context,
 	options: SimpleStreamOptions | undefined,
 	serviceTier: typeof SERVICE_TIER | undefined,
 ): ServiceTierOptions {
+	const base = buildBaseOptions(model, context, options, options?.apiKey);
 	const clamped = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
 	const reasoningEffort = clamped === "off" ? undefined : clamped;
 	return {
-		...options,
+		...base,
 		reasoningEffort,
 		...(serviceTier ? { serviceTier } : {}),
 	};
@@ -214,7 +217,7 @@ export default function fastMode(pi: ExtensionAPI): void {
 			return streamOpenAICodexResponses(
 				model as Model<"openai-codex-responses">,
 				context,
-				buildStreamOptions(model, options, tier) as never,
+				buildStreamOptions(model, context, options, tier) as never,
 			);
 		},
 	});
@@ -226,7 +229,7 @@ export default function fastMode(pi: ExtensionAPI): void {
 			return streamOpenAIResponses(
 				model as Model<"openai-responses">,
 				context,
-				buildStreamOptions(model, options, tier) as never,
+				buildStreamOptions(model, context, options, tier) as never,
 			);
 		},
 	});

--- a/packages/pi-fast-mode/package.json
+++ b/packages/pi-fast-mode/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@zhcsyncer/pi-fast-mode",
+  "version": "0.0.0",
+  "description": "Same-model Fast / Priority scheduling for Pi on OpenAI and xAI.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zhcsyncer/pi-extensions.git",
+    "directory": "packages/pi-fast-mode"
+  },
+  "homepage": "https://github.com/zhcsyncer/pi-extensions/tree/main/packages/pi-fast-mode#readme",
+  "bugs": {
+    "url": "https://github.com/zhcsyncer/pi-extensions/issues"
+  },
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "fast-mode",
+    "priority",
+    "openai",
+    "xai"
+  ],
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json",
+    "test": "tsx --test tests/*.test.ts",
+    "check": "pnpm typecheck && pnpm test"
+  },
+  "files": [
+    "extensions",
+    "CHANGELOG.md",
+    "README.md",
+    "README.zh-CN.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "pi": {
+    "extensions": [
+      "./extensions/fast-mode.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
+    "@earendil-works/pi-tui": "0.84.0",
+    "@types/node": "25.6.0",
+    "tsx": "4.22.4",
+    "typescript": "6.0.3"
+  }
+}

--- a/packages/pi-fast-mode/tests/fast-mode-command.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode-command.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import fastMode, {
+	loadDefaultEnabled,
+	STATUS_KEY,
+	writeDefaultEnabled,
+} from "../extensions/fast-mode.ts";
+
+type RegisteredCommand = {
+	handler: (args: string, ctx: ExtensionContext) => Promise<void> | void;
+};
+
+function createCtx(statuses: Array<string | undefined>, notifies: string[]) {
+	return {
+		model: { provider: "openai", id: "gpt-5.6", api: "openai-responses" },
+		ui: {
+			theme: {
+				fg: (_color: string, text: string) => text,
+				bold: (text: string) => text,
+			},
+			setStatus(key: string, value: string | undefined) {
+				assert.equal(key, STATUS_KEY);
+				statuses.push(value);
+			},
+			notify(message: string) {
+				notifies.push(message);
+			},
+			onTerminalInput() {
+				return () => {};
+			},
+		},
+	} as unknown as ExtensionContext;
+}
+
+async function withLoadedExtension<T>(
+	run: (input: {
+		commands: Map<string, RegisteredCommand>;
+		handlers: Map<string, (event: { reason?: string }, ctx: ExtensionContext) => void>;
+	}) => Promise<T>,
+): Promise<T> {
+	const root = await mkdtemp(path.join(tmpdir(), "pi-fast-mode-cmd-"));
+	const agentDir = path.join(root, "agent");
+	await mkdir(agentDir, { recursive: true });
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		const commands = new Map<string, RegisteredCommand>();
+		const handlers = new Map<string, (event: { reason?: string }, ctx: ExtensionContext) => void>();
+		const pi = {
+			registerProvider() {},
+			registerCommand(name: string, spec: RegisteredCommand) {
+				commands.set(name, spec);
+			},
+			on(event: string, handler: (event: { reason?: string }, ctx: ExtensionContext) => void) {
+				handlers.set(event, handler);
+			},
+		} as unknown as ExtensionAPI;
+		fastMode(pi);
+		return await run({ commands, handlers });
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+test("/fast default writes settings and leaves the current switch unchanged", async () => {
+	await withLoadedExtension(async ({ commands, handlers }) => {
+		const statuses: Array<string | undefined> = [];
+		const notifies: string[] = [];
+		const ctx = createCtx(statuses, notifies);
+		const command = commands.get("fast");
+		const sessionStart = handlers.get("session_start");
+		assert.ok(command);
+		assert.ok(sessionStart);
+
+		sessionStart({ reason: "startup" }, ctx);
+		await command.handler("on", ctx);
+		assert.match(String(statuses.at(-1)), /FAST/);
+
+		statuses.length = 0;
+		notifies.length = 0;
+		await command.handler("default off", ctx);
+
+		assert.equal(loadDefaultEnabled(), false);
+		assert.match(String(statuses.at(-1)), /FAST/);
+		assert.match(notifies.join("\n"), /Current switch is unchanged/);
+	});
+});
+
+test("Ctrl+F consumes the key and keeps the repeat guard", async () => {
+	await withLoadedExtension(async ({ handlers }) => {
+		const statuses: Array<string | undefined> = [];
+		const notifies: string[] = [];
+		let inputHandler: ((data: string) => { consume: true } | undefined) | undefined;
+		const ctx = {
+			model: { provider: "openai", id: "gpt-5.6", api: "openai-responses" },
+			ui: {
+				theme: {
+					fg: (_color: string, text: string) => text,
+					bold: (text: string) => text,
+				},
+				setStatus(key: string, value: string | undefined) {
+					assert.equal(key, STATUS_KEY);
+					statuses.push(value);
+				},
+				notify(message: string) {
+					notifies.push(message);
+				},
+				onTerminalInput(handler: (data: string) => { consume: true } | undefined) {
+					inputHandler = handler;
+					return () => {
+						inputHandler = undefined;
+					};
+				},
+			},
+		} as unknown as ExtensionContext;
+		const sessionStart = handlers.get("session_start");
+		assert.ok(sessionStart);
+
+		sessionStart({ reason: "startup" }, ctx);
+		assert.ok(inputHandler);
+		assert.equal(inputHandler("x"), undefined);
+
+		assert.deepEqual(inputHandler("\u0006"), { consume: true });
+		assert.match(String(statuses.at(-1)), /FAST/);
+		const afterFirst = statuses.at(-1);
+
+		assert.deepEqual(inputHandler("\u0006"), { consume: true });
+		assert.equal(statuses.at(-1), afterFirst);
+	});
+});
+
+test("/new /resume /fork keep the current switch; /reload rereads settings", async () => {
+	await withLoadedExtension(async ({ commands, handlers }) => {
+		const statuses: Array<string | undefined> = [];
+		const notifies: string[] = [];
+		const ctx = createCtx(statuses, notifies);
+		const command = commands.get("fast");
+		const sessionStart = handlers.get("session_start");
+		assert.ok(command);
+		assert.ok(sessionStart);
+
+		sessionStart({ reason: "startup" }, ctx);
+		await command.handler("on", ctx);
+		writeDefaultEnabled(false);
+
+		for (const reason of ["new", "resume", "fork"] as const) {
+			sessionStart({ reason }, ctx);
+			assert.match(String(statuses.at(-1)), /FAST/, reason);
+		}
+
+		sessionStart({ reason: "reload" }, ctx);
+		assert.match(String(statuses.at(-1)), /fast: off/);
+		assert.equal(loadDefaultEnabled(), false);
+	});
+});

--- a/packages/pi-fast-mode/tests/fast-mode.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { Api, Model, SimpleStreamOptions } from "@earendil-works/pi-ai/compat";
+import {
+	applyXaiPriorityPayload,
+	buildStreamOptions,
+	loadDefaultEnabled,
+	resolveServiceTier,
+	resolveSettingsPath,
+	SERVICE_TIER,
+	shouldReloadEnabledFromSettings,
+	supportsApi,
+	writeDefaultEnabled,
+	type FastModeModel,
+} from "../extensions/fast-mode.ts";
+
+function model(provider: string, api: string): FastModeModel {
+	return { provider, api };
+}
+
+async function withSettingsDir<T>(run: (agentDir: string) => Promise<T>): Promise<T> {
+	const root = await mkdtemp(path.join(tmpdir(), "pi-fast-mode-"));
+	const agentDir = path.join(root, "agent");
+	await mkdir(agentDir, { recursive: true });
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	try {
+		return await run(agentDir);
+	} finally {
+		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previous;
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+test("supportsApi accepts only the hardcoded OpenAI and xAI surfaces", () => {
+	assert.equal(supportsApi(undefined), false);
+	assert.equal(supportsApi(model("openai", "openai-responses")), true);
+	assert.equal(supportsApi(model("openai-codex", "openai-codex-responses")), true);
+	assert.equal(supportsApi(model("xai", "openai-responses")), true);
+	assert.equal(supportsApi(model("xai", "openai-completions")), true);
+	assert.equal(supportsApi(model("openai", "openai-completions")), false);
+	assert.equal(supportsApi(model("openai-codex", "openai-responses")), true);
+	assert.equal(supportsApi(model("anthropic", "openai-responses")), false);
+	assert.equal(supportsApi(model("google", "google-generative-ai")), false);
+});
+
+test("resolveServiceTier injects priority only when the in-memory switch is on", () => {
+	const gpt = model("openai", "openai-responses");
+	assert.equal(resolveServiceTier(false, gpt), undefined);
+	assert.equal(resolveServiceTier(true, undefined), undefined);
+	assert.equal(resolveServiceTier(true, model("anthropic", "anthropic-messages")), undefined);
+	assert.equal(resolveServiceTier(true, gpt), SERVICE_TIER);
+	assert.equal(resolveServiceTier(true, model("xai", "openai-completions")), SERVICE_TIER);
+});
+
+test("buildStreamOptions passes maxTokens through and only adds serviceTier when requested", () => {
+	const gpt = {
+		provider: "openai",
+		id: "gpt-5.6",
+		api: "openai-responses",
+	} as Model<Api>;
+	const options: SimpleStreamOptions = { maxTokens: 64000, temperature: 0.2 };
+
+	assert.deepEqual(buildStreamOptions(gpt, options, undefined), {
+		maxTokens: 64000,
+		temperature: 0.2,
+		reasoningEffort: undefined,
+	});
+	assert.deepEqual(buildStreamOptions(gpt, options, SERVICE_TIER), {
+		maxTokens: 64000,
+		temperature: 0.2,
+		reasoningEffort: undefined,
+		serviceTier: SERVICE_TIER,
+	});
+});
+
+test("applyXaiPriorityPayload only mutates matching xAI payloads when enabled", () => {
+	const payload = { model: "grok-4.6", max_tokens: 8000 };
+	assert.equal(
+		applyXaiPriorityPayload({ enabled: false, model: model("xai", "openai-completions"), payload }),
+		undefined,
+	);
+	assert.equal(
+		applyXaiPriorityPayload({ enabled: true, model: model("openai", "openai-responses"), payload }),
+		undefined,
+	);
+	assert.equal(
+		applyXaiPriorityPayload({ enabled: true, model: model("xai", "anthropic-messages"), payload }),
+		undefined,
+	);
+	assert.equal(
+		applyXaiPriorityPayload({ enabled: true, model: model("xai", "openai-completions"), payload: "raw" }),
+		undefined,
+	);
+	assert.deepEqual(
+		applyXaiPriorityPayload({ enabled: true, model: model("xai", "openai-completions"), payload }),
+		{ model: "grok-4.6", max_tokens: 8000, service_tier: SERVICE_TIER },
+	);
+	assert.deepEqual(
+		applyXaiPriorityPayload({ enabled: true, model: model("xai", "openai-responses"), payload }),
+		{ model: "grok-4.6", max_tokens: 8000, service_tier: SERVICE_TIER },
+	);
+	assert.deepEqual(payload, { model: "grok-4.6", max_tokens: 8000 });
+});
+
+test("new, resume, and fork keep the current switch; startup and reload reread settings", () => {
+	assert.equal(shouldReloadEnabledFromSettings("startup"), true);
+	assert.equal(shouldReloadEnabledFromSettings("reload"), true);
+	assert.equal(shouldReloadEnabledFromSettings("new"), false);
+	assert.equal(shouldReloadEnabledFromSettings("resume"), false);
+	assert.equal(shouldReloadEnabledFromSettings("fork"), false);
+	assert.equal(shouldReloadEnabledFromSettings(undefined), false);
+});
+
+test("loadDefaultEnabled reads only settings.json fast-mode.enabled", async () => {
+	await withSettingsDir(async (agentDir) => {
+		assert.equal(resolveSettingsPath(), path.join(agentDir, "settings.json"));
+		assert.equal(loadDefaultEnabled(), false);
+
+		await writeFile(
+			path.join(agentDir, "settings.json"),
+			`${JSON.stringify({ "fast-mode": { enabled: true }, other: 1 })}\n`,
+			"utf8",
+		);
+		assert.equal(loadDefaultEnabled(), true);
+
+		await writeFile(
+			path.join(agentDir, "settings.json"),
+			`${JSON.stringify({ "fast-mode": { enabled: false } })}\n`,
+			"utf8",
+		);
+		assert.equal(loadDefaultEnabled(), false);
+
+		await writeFile(path.join(agentDir, "settings.json"), "{not-json", "utf8");
+		assert.equal(loadDefaultEnabled(), false);
+	});
+});
+
+test("writeDefaultEnabled atomically updates only the fast-mode object", async () => {
+	await withSettingsDir(async (agentDir) => {
+		const settingsPath = path.join(agentDir, "settings.json");
+		await writeFile(
+			settingsPath,
+			`${JSON.stringify({ theme: "dark", "fast-mode": { extra: "keep-me" } }, null, 2)}\n`,
+			"utf8",
+		);
+
+		writeDefaultEnabled(true);
+		const afterOn = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+		assert.deepEqual(afterOn, {
+			theme: "dark",
+			"fast-mode": { extra: "keep-me", enabled: true },
+		});
+		assert.equal(loadDefaultEnabled(), true);
+
+		writeDefaultEnabled(false);
+		const afterOff = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
+		assert.deepEqual(afterOff, {
+			theme: "dark",
+			"fast-mode": { extra: "keep-me", enabled: false },
+		});
+		assert.equal(loadDefaultEnabled(), false);
+	});
+});
+
+test("writing the default does not imply a current-switch change", async () => {
+	await withSettingsDir(async () => {
+		let current = true;
+		writeDefaultEnabled(false);
+		assert.equal(current, true);
+		assert.equal(loadDefaultEnabled(), false);
+		current = !current;
+		assert.equal(current, false);
+		assert.equal(loadDefaultEnabled(), false);
+	});
+});

--- a/packages/pi-fast-mode/tests/fast-mode.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode.test.ts
@@ -3,7 +3,11 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import type { Api, Model, SimpleStreamOptions } from "@earendil-works/pi-ai/compat";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildBaseOptions } from "@earendil-works/pi-ai/api/simple-options";
+import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai/compat";
 import {
 	applyXaiPriorityPayload,
 	buildStreamOptions,
@@ -57,26 +61,86 @@ test("resolveServiceTier injects priority only when the in-memory switch is on",
 	assert.equal(resolveServiceTier(true, model("xai", "openai-completions")), SERVICE_TIER);
 });
 
-test("buildStreamOptions passes maxTokens through and only adds serviceTier when requested", () => {
-	const gpt = {
+function openaiModel(overrides: Partial<Model<Api>> = {}): Model<Api> {
+	return {
 		provider: "openai",
 		id: "gpt-5.6",
 		api: "openai-responses",
+		contextWindow: 128000,
+		maxTokens: 16000,
+		...overrides,
 	} as Model<Api>;
-	const options: SimpleStreamOptions = { maxTokens: 64000, temperature: 0.2 };
+}
 
-	assert.deepEqual(buildStreamOptions(gpt, options, undefined), {
-		maxTokens: 64000,
-		temperature: 0.2,
+const emptyContext = { messages: [] } as Context;
+
+test("buildStreamOptions copies Pi streamSimple options and only adds serviceTier", () => {
+	const gpt = openaiModel();
+	const options: SimpleStreamOptions = { maxTokens: 64000, temperature: 0.2, apiKey: "test-key" };
+	const expected = {
+		...buildBaseOptions(gpt, emptyContext, options, options.apiKey),
 		reasoningEffort: undefined,
-	});
-	assert.deepEqual(buildStreamOptions(gpt, options, SERVICE_TIER), {
-		maxTokens: 64000,
-		temperature: 0.2,
-		reasoningEffort: undefined,
+	};
+
+	assert.deepEqual(buildStreamOptions(gpt, emptyContext, options, undefined), expected);
+	assert.deepEqual(buildStreamOptions(gpt, emptyContext, options, SERVICE_TIER), {
+		...expected,
 		serviceTier: SERVICE_TIER,
 	});
 });
+
+test("buildStreamOptions keeps Pi maxTokens defaulting and context clamping", () => {
+	const gpt = openaiModel({ contextWindow: 20000, maxTokens: 16000 });
+	const shortContext = { messages: [] } as Context;
+	const longContext = {
+		messages: [
+			{
+				role: "user",
+				content: [{ type: "text", text: "x".repeat(18000) }],
+			},
+		],
+	} as Context;
+
+	const withoutCallerCap = buildStreamOptions(gpt, shortContext, { apiKey: "test-key" }, undefined);
+	assert.equal(
+		withoutCallerCap.maxTokens,
+		buildBaseOptions(gpt, shortContext, { apiKey: "test-key" }, "test-key").maxTokens,
+	);
+
+	const oversized = { maxTokens: 64000, apiKey: "test-key" };
+	const clamped = buildStreamOptions(gpt, longContext, oversized, SERVICE_TIER);
+	assert.ok((clamped.maxTokens ?? 0) < 64000);
+	assert.equal(
+		clamped.maxTokens,
+		buildBaseOptions(gpt, longContext, oversized, oversized.apiKey).maxTokens,
+	);
+	assert.equal(clamped.serviceTier, SERVICE_TIER);
+});
+
+test("OpenAI streamSimple wrappers still match the installed pi-ai recipe", () => {
+	const openaiSource = readInstalledApiSource("openai-responses.js");
+	const codexSource = readInstalledApiSource("openai-codex-responses.js");
+	const recipe =
+		/export const streamSimple = \(model, context, options\) => \{[\s\S]*?buildBaseOptions\(model, context, options, options\?\.apiKey\);[\s\S]*?clampThinkingLevel\(model, options\.reasoning\)[\s\S]*?return stream\(model, context, \{\s*\.\.\.base,\s*reasoningEffort,\s*\}\);/;
+	const codexRecipe =
+		/export const streamSimple = \(model, context, options\) => \{[\s\S]*?buildBaseOptions\(model, context, options, apiKey\);[\s\S]*?clampThinkingLevel\(model, options\.reasoning\)[\s\S]*?return stream\(model, context, \{\s*\.\.\.base,\s*reasoningEffort,\s*\}\);/;
+
+	assert.match(
+		openaiSource,
+		recipe,
+		"pi-ai openai-responses streamSimple changed. Re-read it and update buildStreamOptions if the recipe gained new fields.",
+	);
+	assert.match(
+		codexSource,
+		codexRecipe,
+		"pi-ai openai-codex-responses streamSimple changed. Re-read it and update buildStreamOptions if the recipe gained new fields.",
+	);
+});
+
+function readInstalledApiSource(fileName: string): string {
+	const simpleOptionsUrl = import.meta.resolve("@earendil-works/pi-ai/api/simple-options");
+	return readFileSync(join(dirname(fileURLToPath(simpleOptionsUrl)), fileName), "utf8");
+}
 
 test("applyXaiPriorityPayload only mutates matching xAI payloads when enabled", () => {
 	const payload = { model: "grok-4.6", max_tokens: 8000 };

--- a/packages/pi-fast-mode/tsconfig.json
+++ b/packages/pi-fast-mode/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": [
+    "extensions/**/*.ts",
+    "tests/**/*.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,27 @@ importers:
         specifier: 4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/pi-fast-mode:
+    devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.84.0
+        version: 0.84.0
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      tsx:
+        specifier: 4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
   packages/pi-glance:
     devDependencies:
       '@earendil-works/pi-ai':

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -16,6 +16,7 @@ const packagePaths = [
 	"./packages/pi-context7",
 	"./packages/pi-ask-user-question",
 	"./packages/pi-subagents",
+	"./packages/pi-fast-mode",
 	"./providers/pi-provider-volcengine-agent-plan",
 ];
 
@@ -64,6 +65,9 @@ const requiredPackFiles = new Map([
 		"packages/pi-subagents/README.md",
 		"packages/pi-subagents/README.zh-CN.md",
 		"packages/pi-subagents/UPSTREAM_SOURCE.md",
+		"packages/pi-fast-mode/extensions/fast-mode.ts",
+		"packages/pi-fast-mode/README.md",
+		"packages/pi-fast-mode/README.zh-CN.md",
 	]],
 	["./packages/pi-recap", [
 		"extensions/recap.ts",
@@ -151,6 +155,13 @@ const requiredPackFiles = new Map([
 		"UPSTREAM_LICENSE",
 		"UPSTREAM_SOURCE.md",
 	]],
+	["./packages/pi-fast-mode", [
+		"extensions/fast-mode.ts",
+		"README.md",
+		"README.zh-CN.md",
+		"CHANGELOG.md",
+		"LICENSE",
+	]],
 	["./providers/pi-provider-volcengine-agent-plan", [
 		"index.ts",
 		"README.md",
@@ -176,6 +187,8 @@ const maintainedReadmes = [
 	"packages/pi-ask-user-question/README.zh-CN.md",
 	"packages/pi-subagents/README.md",
 	"packages/pi-subagents/README.zh-CN.md",
+	"packages/pi-fast-mode/README.md",
+	"packages/pi-fast-mode/README.zh-CN.md",
 	"providers/pi-provider-volcengine-agent-plan/README.md",
 	"providers/pi-provider-volcengine-agent-plan/README.zh-CN.md",
 	"packages/pi-todo/README.md",
@@ -231,6 +244,10 @@ await assertBilingualPair(
 await assertBilingualPair(
 	"packages/pi-subagents/README.md",
 	"packages/pi-subagents/README.zh-CN.md",
+);
+await assertBilingualPair(
+	"packages/pi-fast-mode/README.md",
+	"packages/pi-fast-mode/README.zh-CN.md",
 );
 await assertBilingualPair(
 	"providers/pi-provider-volcengine-agent-plan/README.md",

--- a/scripts/check-smoke.mjs
+++ b/scripts/check-smoke.mjs
@@ -42,6 +42,7 @@ const packagePaths = [
 	"./packages/pi-context7",
 	"./packages/pi-ask-user-question",
 	"./packages/pi-subagents",
+	"./packages/pi-fast-mode",
 	"./providers/pi-provider-volcengine-agent-plan",
 ];
 

--- a/scripts/reconcile-release.sh
+++ b/scripts/reconcile-release.sh
@@ -11,6 +11,7 @@ PACKAGES=(
   "@zhcsyncer/pi-context7|packages/pi-context7/package.json|packages/pi-context7/CHANGELOG.md|pi-context7|child"
   "@zhcsyncer/pi-ask-user-question|packages/pi-ask-user-question/package.json|packages/pi-ask-user-question/CHANGELOG.md|pi-ask-user-question|child"
   "@zhcsyncer/pi-subagents|packages/pi-subagents/package.json|packages/pi-subagents/CHANGELOG.md|pi-subagents|child"
+  "@zhcsyncer/pi-fast-mode|packages/pi-fast-mode/package.json|packages/pi-fast-mode/CHANGELOG.md|pi-fast-mode|child"
   "pi-provider-volcengine-agent-plan|providers/pi-provider-volcengine-agent-plan/package.json|providers/pi-provider-volcengine-agent-plan/CHANGELOG.md|pi-provider-volcengine-agent-plan|child"
 )
 

--- a/scripts/release-policy.mjs
+++ b/scripts/release-policy.mjs
@@ -14,6 +14,7 @@ export const CHILD_PACKAGES = Object.freeze([
 	"@zhcsyncer/pi-context7",
 	"@zhcsyncer/pi-ask-user-question",
 	"@zhcsyncer/pi-subagents",
+	"@zhcsyncer/pi-fast-mode",
 ]);
 
 /**

--- a/scripts/release-policy.test.mjs
+++ b/scripts/release-policy.test.mjs
@@ -13,6 +13,7 @@ const PLAN_MODE = "@zhcsyncer/pi-plan-mode";
 const CONTEXT7 = "@zhcsyncer/pi-context7";
 const ASK_USER_QUESTION = "@zhcsyncer/pi-ask-user-question";
 const SUBAGENTS = "@zhcsyncer/pi-subagents";
+const FAST_MODE = "@zhcsyncer/pi-fast-mode";
 const AGENT_PLAN = "pi-provider-volcengine-agent-plan";
 
 function releases(...entries) {
@@ -85,6 +86,12 @@ test("requires the root package when Ask User Question releases", () => {
 test("requires the root package when Subagents releases", () => {
 	assert.deepEqual(validateReleasePolicy(releases([SUBAGENTS, "minor"])), [
 		`${SUBAGENTS} has a minor release, but ${ROOT} is missing from the release plan.`,
+	]);
+});
+
+test("requires the root package when Fast Mode releases", () => {
+	assert.deepEqual(validateReleasePolicy(releases([FAST_MODE, "minor"])), [
+		`${FAST_MODE} has a minor release, but ${ROOT} is missing from the release plan.`,
 	]);
 });
 


### PR DESCRIPTION
## Summary

- add standalone `@zhcsyncer/pi-fast-mode` and embed it in the root bundle
- toggle Fast / Priority in memory with `/fast` and Ctrl+F; persist only `settings.json` via `/fast default`
- request OpenAI / Codex `serviceTier` and xAI `service_tier` without inventing a faster model or thinking-level control
- reuse Pi's `streamSimple` option recipe on OpenAI / Codex, then add `serviceTier` only when Fast Mode is on
- add bilingual docs, helper tests, and minor changesets for the new package and root bundle

## Release plan (confirmed)

- `@zhcsyncer/pi-fast-mode` `0.0.0` → `0.1.0`
- `@zhcsyncer/pi-extensions` `0.17.2` → `0.18.0`

## Validation

- `pnpm --filter @zhcsyncer/pi-fast-mode check`
- `pnpm check:release-policy`
- `pnpm check:smoke`
- `pnpm check:pack`