### PR TITLE
fix(pi-fast-mode): load without Pi-incompatible pi-ai deep import

### DIFF
--- a/.changeset/fix-fast-mode-loader-import.md
+++ b/.changeset/fix-fast-mode-loader-import.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-fast-mode": patch
+"@zhcsyncer/pi-extensions": patch
+---
+
+Load Fast Mode without importing `@earendil-works/pi-ai/api/simple-options`, which Pi's extension loader cannot resolve.

--- a/packages/pi-fast-mode/README.md
+++ b/packages/pi-fast-mode/README.md
@@ -97,4 +97,6 @@ Do not assume every model is granted priority, and do not assume local cost is a
 pnpm --filter @zhcsyncer/pi-fast-mode check
 ```
 
-The package tests include a source-recipe check against the installed `@earendil-works/pi-ai` OpenAI and Codex `streamSimple` implementations. After bumping Pi, run that check. If it fails, re-read those functions and update `buildStreamOptions` only when the built-in recipe gained new fields.
+The extension must not import `@earendil-works/pi-ai/api/*`. Pi's loader aliases `@earendil-works/pi-ai` to `compat.js`, so those deep paths fail at load time. `extensions/stream-options.ts` keeps a local copy of the `streamSimple` option recipe instead.
+
+The package tests compare that local recipe with the installed `@earendil-works/pi-ai` helper, and they also check the OpenAI and Codex `streamSimple` source. After bumping Pi, run that check. If it fails, re-read those functions and update the local recipe only when the built-in one gained new fields.

--- a/packages/pi-fast-mode/README.zh-CN.md
+++ b/packages/pi-fast-mode/README.zh-CN.md
@@ -97,4 +97,6 @@ OpenAI 和 Codex 继续走 Pi 内置 `streamSimple` 的 options 收口，包括�
 pnpm --filter @zhcsyncer/pi-fast-mode check
 ```
 
-包测试会对照已安装的 `@earendil-works/pi-ai` 里 OpenAI 和 Codex 的 `streamSimple` 源码配方。升级 Pi 后请跑这项检查。如果失败，重新阅读这些函数；只有原厂配方增加了新字段时，才更新 `buildStreamOptions`。
+扩展不能导入 `@earendil-works/pi-ai/api/*`。Pi 的加载器会把 `@earendil-works/pi-ai` 指到 `compat.js`，这些深路径在加载时会失败。`extensions/stream-options.ts` 因此本地保留一份 `streamSimple` 的 options 收口。
+
+包测试会对照这份本地收口和已安装的 `@earendil-works/pi-ai` helper，也会检查 OpenAI 和 Codex 的 `streamSimple` 源码。升级 Pi 后请跑这项检查。如果失败，重新阅读这些函数；只有原厂配方增加了新字段时，才更新本地收口。

--- a/packages/pi-fast-mode/extensions/fast-mode.ts
+++ b/packages/pi-fast-mode/extensions/fast-mode.ts
@@ -11,7 +11,6 @@
  * Settings key: fast-mode.enabled
  * Current switch is in-memory only; it is not stored in the session.
  */
-import { buildBaseOptions } from "@earendil-works/pi-ai/api/simple-options";
 import {
 	clampThinkingLevel,
 	streamOpenAICodexResponses,
@@ -26,6 +25,7 @@ import { matchesKey } from "@earendil-works/pi-tui";
 import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { buildBaseOptions } from "./stream-options.ts";
 
 export const STATUS_KEY = "fast-mode";
 export const SETTINGS_FIELD = "fast-mode";

--- a/packages/pi-fast-mode/extensions/stream-options.ts
+++ b/packages/pi-fast-mode/extensions/stream-options.ts
@@ -1,0 +1,190 @@
+/**
+ * Local copy of Pi's streamSimple option recipe.
+ *
+ * Why this is forked: Pi's extension loader aliases `@earendil-works/pi-ai`
+ * to `dist/compat.js`. Deep imports such as
+ * `@earendil-works/pi-ai/api/simple-options` then resolve to
+ * `compat.js/api/simple-options` and fail to load. compat does not re-export
+ * `buildBaseOptions`, so the extension keeps a local recipe and only imports
+ * the loader-safe `@earendil-works/pi-ai/compat` surface.
+ *
+ * Keep this aligned with installed pi-ai `api/simple-options` +
+ * `utils/estimate`. Tests compare the two on representative fixtures.
+ */
+import type {
+	Api,
+	AssistantMessage,
+	Context,
+	Message,
+	Model,
+	SimpleStreamOptions,
+	StreamOptions,
+	Usage,
+} from "@earendil-works/pi-ai/compat";
+
+const CONTEXT_SAFETY_TOKENS = 4096;
+const MIN_MAX_TOKENS = 1;
+const CHARS_PER_TOKEN = 4;
+const ESTIMATED_IMAGE_CHARS = 4800;
+
+function calculateContextTokens(usage: Usage): number {
+	return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+}
+
+function safeJsonStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value) ?? "undefined";
+	} catch {
+		return "[unserializable]";
+	}
+}
+
+function estimateTextAndImageContentChars(content: unknown): number {
+	if (typeof content === "string") return content.length;
+	if (!Array.isArray(content)) return 0;
+	let chars = 0;
+	for (const block of content) {
+		if (!isRecord(block)) continue;
+		chars += block.type === "text" && typeof block.text === "string" ? block.text.length : ESTIMATED_IMAGE_CHARS;
+	}
+	return chars;
+}
+
+function estimateTextTokens(text: string): number {
+	return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+function estimateTextAndImageContentTokens(content: unknown): number {
+	return Math.ceil(estimateTextAndImageContentChars(content) / CHARS_PER_TOKEN);
+}
+
+function estimateMessageTokens(message: Message): number {
+	if (message.role === "user" || message.role === "toolResult") {
+		return estimateTextAndImageContentTokens(message.content);
+	}
+
+	let chars = 0;
+	for (const block of message.content) {
+		if (block.type === "text") {
+			chars += block.text.length;
+		} else if (block.type === "thinking") {
+			chars += block.thinking.length;
+		} else {
+			chars += block.name.length + safeJsonStringify(block.arguments).length;
+		}
+	}
+	return Math.ceil(chars / CHARS_PER_TOKEN);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getLastAssistantUsageInfo(messages: readonly Message[]): { usage: Usage; index: number } | undefined {
+	let latestPrefixTimestamp = Number.NEGATIVE_INFINITY;
+	let usageInfo: { usage: Usage; index: number } | undefined;
+	for (let i = 0; i < messages.length; i++) {
+		const message = messages[i];
+		if (message?.role === "assistant") {
+			const assistant = message as AssistantMessage;
+			const usageAppliesToPrefix = assistant.timestamp >= latestPrefixTimestamp;
+			if (
+				usageAppliesToPrefix &&
+				assistant.stopReason !== "aborted" &&
+				assistant.stopReason !== "error" &&
+				calculateContextTokens(assistant.usage) > 0
+			) {
+				usageInfo = { usage: assistant.usage, index: i };
+			}
+		}
+		if (message) latestPrefixTimestamp = Math.max(latestPrefixTimestamp, message.timestamp);
+	}
+	return usageInfo;
+}
+
+function estimateMessages(messages: readonly Message[]): {
+	tokens: number;
+	usageTokens: number;
+	trailingTokens: number;
+	lastUsageIndex: number | null;
+} {
+	const usageInfo = getLastAssistantUsageInfo(messages);
+	if (usageInfo) {
+		const usageTokens = calculateContextTokens(usageInfo.usage);
+		let trailingTokens = 0;
+		for (let i = usageInfo.index + 1; i < messages.length; i++) {
+			const message = messages[i];
+			if (message) trailingTokens += estimateMessageTokens(message);
+		}
+		return {
+			tokens: usageTokens + trailingTokens,
+			usageTokens,
+			trailingTokens,
+			lastUsageIndex: usageInfo.index,
+		};
+	}
+	let tokens = 0;
+	for (const message of messages) tokens += estimateMessageTokens(message);
+	return { tokens, usageTokens: 0, trailingTokens: tokens, lastUsageIndex: null };
+}
+
+function estimateToolsTokens(tools: Context["tools"]): number {
+	if (!tools || tools.length === 0) return 0;
+	return estimateTextTokens(safeJsonStringify(tools));
+}
+
+export function estimateContextTokens(context: Context): number {
+	const estimate = estimateMessages(context.messages);
+	if (estimate.lastUsageIndex !== null) {
+		const addedNames = new Set(
+			context.messages
+				.slice(estimate.lastUsageIndex + 1)
+				.filter((message) => message.role === "toolResult")
+				.flatMap((message) => message.addedToolNames ?? []),
+		);
+		const addedToolTokens = estimateToolsTokens(context.tools?.filter((tool) => addedNames.has(tool.name)));
+		return estimate.tokens + addedToolTokens;
+	}
+	const prefixTokens =
+		(context.systemPrompt ? estimateTextTokens(context.systemPrompt) : 0) + estimateToolsTokens(context.tools);
+	return estimate.tokens + prefixTokens;
+}
+
+export function clampMaxTokensToContext(model: Model<Api>, context: Context, maxTokens: number): number {
+	if (model.contextWindow <= 0) return Math.max(MIN_MAX_TOKENS, maxTokens);
+	const available = model.contextWindow - estimateContextTokens(context) - CONTEXT_SAFETY_TOKENS;
+	return Math.min(maxTokens, Math.max(MIN_MAX_TOKENS, available));
+}
+
+export function buildBaseOptions(
+	model: Model<Api>,
+	context: Context,
+	options?: SimpleStreamOptions,
+	apiKey?: string,
+): StreamOptions {
+	const samplingParams =
+		model.samplingParams || options?.samplingParams
+			? { ...model.samplingParams, ...options?.samplingParams }
+			: undefined;
+	return {
+		temperature: options?.temperature,
+		samplingParams,
+		maxTokens: clampMaxTokensToContext(model, context, options?.maxTokens ?? model.maxTokens),
+		signal: options?.signal,
+		telemetryContext: options?.telemetryContext,
+		apiKey: apiKey || options?.apiKey,
+		fetch: options?.fetch,
+		transport: options?.transport,
+		cacheRetention: options?.cacheRetention,
+		sessionId: options?.sessionId,
+		headers: options?.headers,
+		onPayload: options?.onPayload,
+		onResponse: options?.onResponse,
+		timeoutMs: options?.timeoutMs,
+		websocketConnectTimeoutMs: options?.websocketConnectTimeoutMs,
+		maxRetries: options?.maxRetries,
+		maxRetryDelayMs: options?.maxRetryDelayMs,
+		metadata: options?.metadata,
+		env: options?.env,
+	};
+}

--- a/packages/pi-fast-mode/tests/fast-mode.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode.test.ts
@@ -6,7 +6,7 @@ import test from "node:test";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { buildBaseOptions } from "@earendil-works/pi-ai/api/simple-options";
+import { buildBaseOptions as installedBuildBaseOptions } from "@earendil-works/pi-ai/api/simple-options";
 import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai/compat";
 import {
 	applyXaiPriorityPayload,
@@ -20,6 +20,7 @@ import {
 	writeDefaultEnabled,
 	type FastModeModel,
 } from "../extensions/fast-mode.ts";
+import { buildBaseOptions } from "../extensions/stream-options.ts";
 
 function model(provider: string, api: string): FastModeModel {
 	return { provider, api };
@@ -73,6 +74,54 @@ function openaiModel(overrides: Partial<Model<Api>> = {}): Model<Api> {
 }
 
 const emptyContext = { messages: [] } as Context;
+
+function importedSpecifiers(source: string): string[] {
+	return Array.from(
+		source.matchAll(/from\s+["']([^"']+)["']/g),
+		(match) => match[1] ?? "",
+	).filter(Boolean);
+}
+
+test("extension runtime stays on loader-safe pi-ai specifiers", () => {
+	const source = readFileSync(
+		join(dirname(fileURLToPath(import.meta.url)), "../extensions/fast-mode.ts"),
+		"utf8",
+	);
+	const helper = readFileSync(
+		join(dirname(fileURLToPath(import.meta.url)), "../extensions/stream-options.ts"),
+		"utf8",
+	);
+	const specifiers = [...importedSpecifiers(source), ...importedSpecifiers(helper)];
+	assert.equal(
+		specifiers.some((specifier) => specifier.startsWith("@earendil-works/pi-ai/api/")),
+		false,
+		"Pi aliases @earendil-works/pi-ai to compat.js, so /api/* imports fail at load time.",
+	);
+	assert.ok(specifiers.includes("@earendil-works/pi-ai/compat"));
+});
+
+test("local buildBaseOptions matches the installed pi-ai recipe", () => {
+	const gpt = openaiModel();
+	const options: SimpleStreamOptions = { maxTokens: 64000, temperature: 0.2, apiKey: "test-key" };
+	assert.deepEqual(
+		buildBaseOptions(gpt, emptyContext, options, options.apiKey),
+		installedBuildBaseOptions(gpt, emptyContext, options, options.apiKey),
+	);
+
+	const longContext = {
+		messages: [
+			{
+				role: "user",
+				content: [{ type: "text", text: "x".repeat(18000) }],
+			},
+		],
+	} as Context;
+	const tight = openaiModel({ contextWindow: 20000, maxTokens: 16000 });
+	assert.deepEqual(
+		buildBaseOptions(tight, longContext, { maxTokens: 64000, apiKey: "test-key" }, "test-key"),
+		installedBuildBaseOptions(tight, longContext, { maxTokens: 64000, apiKey: "test-key" }, "test-key"),
+	);
+});
 
 test("buildStreamOptions copies Pi streamSimple options and only adds serviceTier", () => {
 	const gpt = openaiModel();

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -66,6 +66,7 @@ const requiredPackFiles = new Map([
 		"packages/pi-subagents/README.zh-CN.md",
 		"packages/pi-subagents/UPSTREAM_SOURCE.md",
 		"packages/pi-fast-mode/extensions/fast-mode.ts",
+		"packages/pi-fast-mode/extensions/stream-options.ts",
 		"packages/pi-fast-mode/README.md",
 		"packages/pi-fast-mode/README.zh-CN.md",
 	]],
@@ -157,6 +158,7 @@ const requiredPackFiles = new Map([
 	]],
 	["./packages/pi-fast-mode", [
 		"extensions/fast-mode.ts",
+		"extensions/stream-options.ts",
 		"README.md",
 		"README.zh-CN.md",
 		"CHANGELOG.md",


### PR DESCRIPTION
## Summary

Pi 0.84's extension loader aliases `@earendil-works/pi-ai` to `dist/compat.js`. Fast Mode imported `@earendil-works/pi-ai/api/simple-options`, which then resolved to `compat.js/api/simple-options` and failed to load.

This keeps a local `streamSimple` option recipe and only uses the loader-safe `@earendil-works/pi-ai/compat` surface.

## Test plan

- [x] `pnpm --filter @zhcsyncer/pi-fast-mode check`
- [x] `pi --no-extensions -e ./packages/pi-fast-mode --list-models __pi_release_check__` (no Failed to load)
- [x] `node scripts/check-pack.mjs`

## Release

Changeset is included. Planned after this lands and the version PR is merged:

- `@zhcsyncer/pi-fast-mode` `0.1.0` → `0.1.1` (patch)
- `@zhcsyncer/pi-extensions` `0.19.0` → `0.19.1` (patch)