### PR TITLE
feat: ship aggregate steers and meter quota windows

### DIFF
--- a/.changeset/aggregate-steer-same-ledger.md
+++ b/.changeset/aggregate-steer-same-ledger.md
@@ -3,4 +3,4 @@
 "@zhcsyncer/pi-tool-display-intent": minor
 ---
 
-Keep mid-turn steers on the same aggregate Tools ledger. While the turn is running, pin each steer’s first line under the header; after it settles, leave one `↳ N steers` reminder under the title. `Ctrl+O` restores each `↳` in place, highlighted, with framed gaps instead of opening a second book.
+Keep mid-turn steers on the same aggregate Tools ledger. While the turn is running, pin each steer’s first line under the header; after it settles, leave one `↳ N steers` reminder under the title instead of repeating the count in parentheses. `Ctrl+O` restores each `↳` in place, highlighted, with framed gaps instead of opening a second book.

--- a/.changeset/aggregate-steer-same-ledger.md
+++ b/.changeset/aggregate-steer-same-ledger.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": minor
+"@zhcsyncer/pi-tool-display-intent": minor
+---
+
+Keep mid-turn steers on the same aggregate Tools ledger. While the turn is running, pin each steer’s first line under the header; after it settles, keep `· N steers` in the title. `Ctrl+O` restores each `↳` in place instead of opening a second book.

--- a/.changeset/aggregate-steer-same-ledger.md
+++ b/.changeset/aggregate-steer-same-ledger.md
@@ -3,4 +3,4 @@
 "@zhcsyncer/pi-tool-display-intent": minor
 ---
 
-Keep mid-turn steers on the same aggregate Tools ledger. While the turn is running, pin each steer’s first line under the header; after it settles, keep `· N steers` in the title. `Ctrl+O` restores each `↳` in place instead of opening a second book.
+Keep mid-turn steers on the same aggregate Tools ledger. While the turn is running, pin each steer’s first line under the header; after it settles, leave one `↳ N steers` reminder under the title. `Ctrl+O` restores each `↳` in place, highlighted, with framed gaps instead of opening a second book.

--- a/.changeset/pi-meter-quota-windows.md
+++ b/.changeset/pi-meter-quota-windows.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-meter": minor
+"@zhcsyncer/pi-extensions": minor
+---
+
+Show SuperGrok at 0% used when the weekly percent is omitted, keep the footer on the current model's quota only, and let `/usage footer` switch local spend between rolling and calendar windows.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 | [pi-fast-mode/extension.md](./pi-fast-mode/extension.md) | 已落地 | 同模型 Fast / Priority：内存开关、loader 红线 |
 | [pi-herdr-companion/extension.md](./pi-herdr-companion/extension.md) | 已落地 | Herdr 可见进程、临时 `/btw`、blocked；worker 实现保留但不注册 |
 | [pi-tool-display-intent/aggregate-layout.md](./pi-tool-display-intent/aggregate-layout.md) | 已落地 | aggregate Tools 账本：按请求汇总、不改执行与历史 |
+| [pi-tool-display-intent/aggregate-steer.md](./pi-tool-display-intent/aggregate-steer.md) | 已落地 | steer 留在同一轮：钉顶首行、标题计数、展开后时间线高亮 |
 | [pi-todo/active-plan-lifecycle.md](./pi-todo/active-plan-lifecycle.md) | 已落地 | Todo 有界周期与 checkpoint 收缩 |
 | [pi-subagents/background-duplication.md](./pi-subagents/background-duplication.md) | 已落地 | 后台委派重复工作的根因与修复边界 |
 | [pi-plan-mode/plan-lifecycle.md](./pi-plan-mode/plan-lifecycle.md) | 已落地 | Plan 文档评审与工作生命周期正交 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,10 +11,11 @@
 | [pi-glance/input-stash.md](./pi-glance/input-stash.md) | 已落地 | 输入框单槽暂存：快捷键、边框提示、按 session 覆盖写 |
 | [pi-glance/working-indicator.md](./pi-glance/working-indicator.md) | 已落地 | Glance working row 的显示边界与主题跟随 |
 | [pi-meter/extension.md](./pi-meter/extension.md) | 已落地 | 本地账本与订阅剩余两套账 |
+| [pi-meter/quota-status.md](./pi-meter/quota-status.md) | 已落地 | 底栏只画当前模型套餐；本地滚动/日历窗口 |
 | [pi-fast-mode/extension.md](./pi-fast-mode/extension.md) | 已落地 | 同模型 Fast / Priority：内存开关、loader 红线 |
 | [pi-herdr-companion/extension.md](./pi-herdr-companion/extension.md) | 已落地 | Herdr 可见进程、临时 `/btw`、blocked；worker 实现保留但不注册 |
 | [pi-tool-display-intent/aggregate-layout.md](./pi-tool-display-intent/aggregate-layout.md) | 已落地 | aggregate Tools 账本：按请求汇总、不改执行与历史 |
-| [pi-tool-display-intent/aggregate-steer.md](./pi-tool-display-intent/aggregate-steer.md) | 已落地 | steer 留在同一轮：钉顶首行、标题计数、展开后时间线高亮 |
+| [pi-tool-display-intent/aggregate-steer.md](./pi-tool-display-intent/aggregate-steer.md) | 已落地 | steer 留在同一轮：钉顶首行、结束后留一行、展开后时间线高亮 |
 | [pi-todo/active-plan-lifecycle.md](./pi-todo/active-plan-lifecycle.md) | 已落地 | Todo 有界周期与 checkpoint 收缩 |
 | [pi-subagents/background-duplication.md](./pi-subagents/background-duplication.md) | 已落地 | 后台委派重复工作的根因与修复边界 |
 | [pi-plan-mode/plan-lifecycle.md](./pi-plan-mode/plan-lifecycle.md) | 已落地 | Plan 文档评审与工作生命周期正交 |

--- a/docs/pi-meter/extension.md
+++ b/docs/pi-meter/extension.md
@@ -9,7 +9,7 @@
 - 两套账分开：`message_end` → `extension-data/pi-meter/usage.jsonl`；订阅快照单独在 `quota.json`。远端额度不进账本，也不进本地 budget。
 - 常驻 chrome：一段 footer `setStatus`。左边本地用量，右边套餐窗口。
 - 对外只暴露 `/usage`。本地账是 `/usage footer|import|budget`，套餐剩余是 `/usage quota`（临时看板，不留在聊天记录里）。
-- 套餐条极性可切；颜色按剩余（约 30% / 15%）。本地摘要只显示紧凑的今日总量/费用。看板数字用 `34k` / `4.3M` / `5.35B`。
+- 套餐条极性可切；颜色按剩余（约 30% / 15%）。本地摘要默认显示过去 24 小时的总量/费用。看板数字用 `34k` / `4.3M` / `5.35B`。
 - 订阅刷新只在 `hasUI` 根会话的 `agent_settled` / `/usage quota` / `model_select`；TTL 60s + 最小间隔 30s。无 UI 进程只记本地账。
 - SuperGrok：`GET https://cli-chat-proxy.grok.com/v1/billing?format=credits` + `/login xai`。不打 `api.x.ai/v1/api-key`，不接 grok.com gRPC。
 - Ollama Cloud 是第四家订阅窗口，跟 Claude / Codex / SuperGrok 并列，不进本地账本。
@@ -49,11 +49,11 @@
 
 - `/usage`：本地看板。维度仍是 model / project / session；列能看到 tokens 总量和 in / out / cache 拆分。
 - `/usage quota`：临时看板看 Claude、Codex、SuperGrok、Ollama Cloud 的窗口百分比和重置时间；未登录的提供商收成底部一条淡提示，不逐条警告。
-- `/usage footer`：本地摘要、配额显隐、已用/剩余都收在这里，不再用直接参数。
-- 当前模型没有订阅窗口时，底栏给一条淡提示，不假装有额度。
+- `/usage footer`：本地摘要、滚动/日历窗口、配额显隐、已用/剩余都收在这里，不再用直接参数。
+- 底栏只画当前模型对应的那一家套餐。画不出来就短提示，绝不借别人的额度。
 - 空闲 TUI 只从磁盘慢刷共享快照和本地花费，不再打订阅 API。
 - 常驻 chrome 与 Glance **完全独立**：不改 Glance、不占用其右下角、不改其顶栏 Tokens。Glance 在场时，meter 是输入框外多出来的一行。
-- 套餐条极性可选「已用」或「剩余」。本地摘要只显示紧凑的今日总量/费用。
+- 套餐条极性可选「已用」或「剩余」。本地摘要默认显示紧凑的过去 24 小时总量/费用。
 - `/usage budget`：本地上限提醒，不拦请求。预算警告可以闪一下，不占常驻条。
 - `--no-session`、默认内存 sub-agent：只要扩展加载进该进程，用量进独立账本。
 - 旧 session 可选 `/usage import` 回填；装好之后的新用量不靠 import。
@@ -62,10 +62,10 @@
 
 不改 Glance，不读 Glance 配置，不往 Glance 右下角塞东西。Glance 的 context 条和顶栏 Tokens 继续只讲 session/context；meter 讲订阅窗口和本地账本。
 
-常驻面改走一段 footer `setStatus`（key `pi-meter`），不占 widget 整行。窗口语义写在数字前面：`today` 是本地今天花费，`week left` / `5h left` 是当前订阅窗口。
+常驻面改走一段 footer `setStatus`（key `pi-meter`），不占 widget 整行。窗口语义写在数字前面：`24h` / `today` 是本地花费，`xai week left` / `5h left` 是当前模型那一家的订阅窗口。
 
 ```text
-· today 12.4k $0.18 · week left ███░░ 49% (1d 23h)
+· 24h 12.4k $0.18 · xai week left ███░░ 49% (1d 23h)
 ```
 
 窄了先丢掉总量/费用，最后留套餐条 + 百分比。
@@ -79,7 +79,7 @@
 
 颜色锚在「还剩多少」，不要两套阈值：剩得多用 muted/普通色，剩余降到约 30% warning（amber），约 15% error（软红）。已用模式只是把同一根条反过来读。
 
-SuperGrok 本机已验证的主窗口是周池 `creditUsagePercent`。Build / Chat 是同一周池的产品拆分，不单独展示。
+SuperGrok 本机已验证的主窗口是周池。账单 JSON 有 `config` 但没有数字型 `creditUsagePercent` 时，当成已用 0% / 剩余 100%，照常画周窗。只有认不出 `config` 才算失败。Build / Chat 是同一周池的产品拆分，不单独展示。
 
 ## 心智模型
 

--- a/docs/pi-meter/quota-status.md
+++ b/docs/pi-meter/quota-status.md
@@ -1,0 +1,77 @@
+# pi-meter 套餐条与本地窗口口径
+
+稳定决策。实现后只留这里的 Why / 行为契约；过程量不要再写进文档。
+
+## 用户能看到的行为
+
+底栏只画**当前模型对应的那一家**套餐。画不出来就短提示，绝不借别人的额度。
+
+本地 token 统计默认按滚动窗口；可在 `/usage footer` 切回日历窗口。本地 budget 仍按自然日 / 周 / 月。
+
+## 已拍板
+
+### SuperGrok 缺百分比
+
+`GET .../billing?format=credits` 能读到 `config`（通常还有 `currentPeriod`），但没有数字型 `creditUsagePercent` 时，当成 **已用 0% / 剩余 100%**，照常画周窗。
+
+整段响应认不出 `config` 才算失败。不要再报 `missing creditUsagePercent`。
+
+原因：周窗刚重置或用量为 0 时，接口会省略该字段；网页 usage 此时是 0%。
+
+### 底栏不回退
+
+`xai` → SuperGrok，`openai-codex` → Codex，`anthropic` → Claude，`ollama-cloud` → Ollama。只画这一家的 `primary`。
+
+拿不到时：
+
+| 情况 | 底栏 |
+|---|---|
+| 当前模型没有订阅窗口（如本地 `ollama`） | `{provider} · no quota window` |
+| 有窗口但没 `/login` | `{brand} · not signed in` |
+| 已登录但这次没拉到 | `{brand} · unavailable` |
+
+### 品牌
+
+短小写，贴在窗口前面：
+
+```text
+· 24h 12.4k $0.18 · xai week left █████ 100% (6d)
+· 24h 12.4k $0.18 · openai week left ██░░░ 10% (2d)
+```
+
+映射：`supergrok` → `xai`，`codex` → `openai`，`claude` → `claude`，`ollama` → `ollama`。不用 `supergrok` / `OpenAI Codex`。
+
+### 未登录不打订阅接口
+
+本地 `auth.json` 没有对应凭证时，不要调用那家订阅 API，也不要走 `getApiKeyForProvider`（以免误触发 refresh）。
+
+看板底部仍汇总 `Not signed in: Claude — run /login`。`/login` 之后下一次 settled / refresh / 切模型再拉。
+
+失败快照（`ok: false`）不算 fresh，不要用 TTL 把错误锁 60 秒。未登录快照不要用 `lastAttemptAt` 挡住登录后的第一次拉取。
+
+### 本地账时间窗
+
+配置 `ledger.windowMode`: `rolling` | `calendar`。默认 `rolling`。`/usage footer` 增加一行可切。
+
+| key | rolling | calendar |
+|---|---|---|
+| today | 过去 24h | 今天 0 点起 |
+| week | 过去 7d | 本周一 0 点起 |
+| month | 过去 30d | 本月 1 日 0 点起 |
+| 6months | 过去 180d | 过去 180d |
+| year | 过去 365d | 今年 1 月 1 日 |
+| all | 全部 | 全部 |
+
+底栏本地摘要：rolling 写 `24h`，calendar 写 `today`。内部 preset key 仍是 `today-spend` 等，不要为改文案做迁移。
+
+本地 budget 的 `day` / `week` / `month` / `year` **保持日历**，不跟 `windowMode` 走。
+
+## 验收
+
+1. SuperGrok 响应有 `config`、无 `creditUsagePercent` → 看板 / 底栏显示周窗 0% 已用（剩余 100%），带重置时间（若有 period end）。
+2. 当前模型是 `xai`、SuperGrok 失败、Codex 成功 → 底栏是 `xai · unavailable`，没有 Codex 的 week 条。
+3. 当前模型是 `xai`、SuperGrok 成功 → `xai week left …`。
+4. 当前模型是本地 `ollama` → 仍是 `ollama · no quota window`。
+5. 未 `/login` Claude 时，刷新循环不打 Anthropic；看板仍把 Claude 收在底部未登录提示。
+6. 默认底栏本地数字是过去 24h，文案 `24h`；footer 切到 calendar 后变成当天 0 点起，文案 `today`。budget 数字不随该开关变。
+7. 双语 README 示例与上述底栏一致。用户可见变更带 changeset（`@zhcsyncer/pi-meter` + 根包，根包级别不低于子包）。

--- a/docs/pi-tool-display-intent/aggregate-layout.md
+++ b/docs/pi-tool-display-intent/aggregate-layout.md
@@ -56,7 +56,7 @@ user
 
 assistant 普通文字、thinking、custom tool 和 passthrough tool 都不切断 group。steer 也不切断。调用按 assistant source order 记录；同一 tool call id 的 streaming message update 不重复计数。
 
-Steer 的展示契约见 [`aggregate-steer.md`](./aggregate-steer.md)：进行中钉首行、结束后标题下留一行 `↳ N steers`、展开后 `↳` 留在时间线中间并整行高亮，不把正文拼进第一条 user。
+Steer 的展示契约见 [`aggregate-steer.md`](./aggregate-steer.md)：进行中钉首行、结束后标题下留一行 `↳ N steers`、展开后 `↳` 留在时间线中间并整行高亮，不把正文拼进第一条 user，标题括号里不再重复计数。
 
 ## 两层模型
 

--- a/docs/pi-tool-display-intent/aggregate-layout.md
+++ b/docs/pi-tool-display-intent/aggregate-layout.md
@@ -56,7 +56,7 @@ user
 
 assistant 普通文字、thinking、custom tool 和 passthrough tool 都不切断 group。steer 也不切断。调用按 assistant source order 记录；同一 tool call id 的 streaming message update 不重复计数。
 
-Steer 的展示契约见 [`aggregate-steer.md`](./aggregate-steer.md)：进行中钉首行、结束后只留 `· N steers`、展开后 `↳` 留在时间线中间，不把正文拼进第一条 user。
+Steer 的展示契约见 [`aggregate-steer.md`](./aggregate-steer.md)：进行中钉首行、结束后标题下留一行 `↳ N steers`、展开后 `↳` 留在时间线中间并整行高亮，不把正文拼进第一条 user。
 
 ## 两层模型
 

--- a/docs/pi-tool-display-intent/aggregate-layout.md
+++ b/docs/pi-tool-display-intent/aggregate-layout.md
@@ -42,18 +42,21 @@ Tools 是整轮总览，不是一段必须连续的时间线。passthrough 工�
 
 ## 分组边界
 
-一个 group 从一条 user message 开始，到下一条 user message 之前结束。同一请求内的多个 assistant/tool 低层 turn 属于同一 group：
+一个 group 从一条**新请求** user message 开始。同一请求内的多个 assistant/tool 低层 turn，以及插在 tool 批次之后的 **steer**，属于同一 group。follow-up 和闲时新提问才开下一本账。
 
 ```text
 user
   assistant + tools
   results
+  ↳ steer（不断 group）
   assistant + tools
   results
   assistant final response
 ```
 
-assistant 普通文字、thinking、custom tool 和 passthrough tool 都不切断 group。调用按 assistant source order 记录；同一 tool call id 的 streaming message update 不重复计数。
+assistant 普通文字、thinking、custom tool 和 passthrough tool 都不切断 group。steer 也不切断。调用按 assistant source order 记录；同一 tool call id 的 streaming message update 不重复计数。
+
+Steer 的展示契约见 [`aggregate-steer.md`](./aggregate-steer.md)：进行中钉首行、结束后只留 `· N steers`、展开后 `↳` 留在时间线中间，不把正文拼进第一条 user。
 
 ## 两层模型
 

--- a/docs/pi-tool-display-intent/aggregate-steer.md
+++ b/docs/pi-tool-display-intent/aggregate-steer.md
@@ -13,7 +13,7 @@
 1. **同一轮**：steer 不断 group。follow-up 与闲时新提问仍新开一轮。
 2. **留在工具流中间**：展开后 `↳` 插在它发生的那一截，不挪到第一条 user 下面。
 3. **进行中钉顶**：收起且未 settle 时，steer 首行按时间顺序钉在 Tools 头下，再下面才是旁白和当前活动。
-4. **结束后撤钉**：settle 后钉住区清空，标题留下 `· N steers`。
+4. **结束后留一行**：settle 后不再钉各条首行，标题下留一行 `↳ N steers`，标题里的 `· N steers` 仍在。
 5. **中间那条原生 `▎` user 框必须藏掉**（收起时零高）。否则和钉顶重复，看起来像又开了一个任务。
 6. **不改 session**：不改写 user/assistant/tool 正文，不给消息加持久化 `steering` 字段。
 
@@ -35,6 +35,7 @@
 
 ```text
 ✓ Tools (31 calls · 5 turns · 2 steers) · read ×18 · edit ×9
+  ↳ 2 steers
   took 2m14s · tok ↑62k ↓8.4k R120k W4.1k · at 14:32:14
 ```
 
@@ -42,17 +43,22 @@
 
 ```text
 ✓ Tools (31 calls · 5 turns · 2 steers) · read ×18 · edit ×9
+  ↳ 2 steers
   took 2m14s · …
   │ › 先读 README
   │ ✓ Read(README.md)
+  │
   │ ↳ 先确定方案
+  │
   │ › 按新约束改
   │ ✓ Edit(README.md)
+  │
   │ ↳ 不要改 grok，用 xai
+  │
   └ ◐ Bash(pnpm test)
 ```
 
-符号分开：原任务 `▎`，steer 用 accent 的 `↳`，旁白继续 `›`。标题 `· N steers` 跟在 turns 后面、failed 前面，用强调色，不当错误。1 条写 `steer`，多条写 `steers`。
+符号分开：原任务 `▎`，steer 用 accent 的 `↳`（展开时整条首行高亮），旁白继续 `›`。标题 `· N steers` 跟在 turns 后面、failed 前面，用强调色，不当错误。1 条写 `steer`，多条写 `steers`。展开后 `↳` 上下各空一行且空行带 `│`。
 
 钉住只取每条 steer 的**首行**（截到行宽），条数按时间全留，不做 `+N`。展开后才显示完整正文（过长按现有旁白/user 截断习惯，不要倾倒整段粘贴日志到无限高）。
 
@@ -84,9 +90,9 @@ reload / tree / compaction 用同一条位置规则从当前 branch 重建。接
 
 1. 工具批次之后插入 1 条或多条 steer：仍是一本 Tools，call/turn 累计，不新开第二本。
 2. 进行中账本头下按时间钉住各条 steer **首行**，再下面是 `›` 旁白和当前活动。
-3. settle 后钉住区消失，标题保留 `· N steers`；耗时从原请求开始算到本轮结束。
+3. settle 后各条首行撤掉，标题下留一行 `↳ N steers`，标题仍保留 `· N steers`；耗时从原请求开始算到本轮结束。
 4. 收起时中间不再出现第二条 `▎` user 框。
-5. `Ctrl+O` 后 `↳` 出现在当时的工具/旁白之间，accent 高亮，和 `›` / `✓` 一眼能分。
+5. `Ctrl+O` 后 `↳` 出现在当时的工具/旁白之间，首行整行 accent，上下带 `│` 空行，和 `›` / `✓` 一眼能分。
 6. 闲时新提问、follow-up（终态回答之后的 user）仍新开 Tools。
 7. reload / 切回 branch 后，toolResult 之后的 user 仍并入同一 group，计数和 `N steers` 正确。
 8. 不改写 Session 消息；切回 `individual` + `/reload` 仍能看到每条原始 user。

--- a/docs/pi-tool-display-intent/aggregate-steer.md
+++ b/docs/pi-tool-display-intent/aggregate-steer.md
@@ -13,7 +13,7 @@
 1. **同一轮**：steer 不断 group。follow-up 与闲时新提问仍新开一轮。
 2. **留在工具流中间**：展开后 `↳` 插在它发生的那一截，不挪到第一条 user 下面。
 3. **进行中钉顶**：收起且未 settle 时，steer 首行按时间顺序钉在 Tools 头下，再下面才是旁白和当前活动。
-4. **结束后留一行**：settle 后不再钉各条首行，标题下留一行 `↳ N steers`，标题里的 `· N steers` 仍在。
+4. **结束后留一行**：settle 后不再钉各条首行，标题下留一行 `↳ N steers`。标题括号里不再重复计数。
 5. **中间那条原生 `▎` user 框必须藏掉**（收起时零高）。否则和钉顶重复，看起来像又开了一个任务。
 6. **不改 session**：不改写 user/assistant/tool 正文，不给消息加持久化 `steering` 字段。
 
@@ -24,7 +24,7 @@
 ```text
 ▎ 原始任务
 
-◐ Tools (31 calls · 5 turns · 2 steers) · read ×18 · edit ×9
+◐ Tools (31 calls · 5 turns) · read ×18 · edit ×9
   ↳ 先确定方案
   ↳ 不要改 grok，用 xai
   › 正在按新约束改 README
@@ -34,7 +34,7 @@
 结束后：
 
 ```text
-✓ Tools (31 calls · 5 turns · 2 steers) · read ×18 · edit ×9
+✓ Tools (31 calls · 5 turns) · read ×18 · edit ×9
   ↳ 2 steers
   took 2m14s · tok ↑62k ↓8.4k R120k W4.1k · at 14:32:14
 ```
@@ -42,7 +42,7 @@
 `Ctrl+O` 展开：
 
 ```text
-✓ Tools (31 calls · 5 turns · 2 steers) · read ×18 · edit ×9
+✓ Tools (31 calls · 5 turns) · read ×18 · edit ×9
   ↳ 2 steers
   took 2m14s · …
   │ › 先读 README
@@ -58,7 +58,7 @@
   └ ◐ Bash(pnpm test)
 ```
 
-符号分开：原任务 `▎`，steer 用 accent 的 `↳`（展开时整条首行高亮），旁白继续 `›`。标题 `· N steers` 跟在 turns 后面、failed 前面，用强调色，不当错误。1 条写 `steer`，多条写 `steers`。展开后 `↳` 上下各空一行且空行带 `│`。
+符号分开：原任务 `▎`，steer 用 accent 的 `↳`（展开时整条首行高亮），旁白继续 `›`。计数只出现在标题下那一行，不当错误。1 条写 `steer`，多条写 `steers`。展开后 `↳` 上下各空一行且空行带 `│`；Pi 插在 user 前的无边空白会被收掉，避免边线断开。
 
 钉住只取每条 steer 的**首行**（截到行宽），条数按时间全留，不做 `+N`。展开后才显示完整正文（过长按现有旁白/user 截断习惯，不要倾倒整段粘贴日志到无限高）。
 
@@ -90,7 +90,7 @@ reload / tree / compaction 用同一条位置规则从当前 branch 重建。接
 
 1. 工具批次之后插入 1 条或多条 steer：仍是一本 Tools，call/turn 累计，不新开第二本。
 2. 进行中账本头下按时间钉住各条 steer **首行**，再下面是 `›` 旁白和当前活动。
-3. settle 后各条首行撤掉，标题下留一行 `↳ N steers`，标题仍保留 `· N steers`；耗时从原请求开始算到本轮结束。
+3. settle 后各条首行撤掉，标题下留一行 `↳ N steers`，标题括号里不再重复计数；耗时从原请求开始算到本轮结束。
 4. 收起时中间不再出现第二条 `▎` user 框。
 5. `Ctrl+O` 后 `↳` 出现在当时的工具/旁白之间，首行整行 accent，上下带 `│` 空行，和 `›` / `✓` 一眼能分。
 6. 闲时新提问、follow-up（终态回答之后的 user）仍新开 Tools。

--- a/docs/pi-tool-display-intent/aggregate-steer.md
+++ b/docs/pi-tool-display-intent/aggregate-steer.md
@@ -1,0 +1,93 @@
+# aggregate：steer 留在同一轮
+
+稳定决策。实现后只把 Why / 分组边界 / 展示契约留在 [`aggregate-layout.md`](./aggregate-layout.md)；本文件是本轮执行规格。
+
+## Goal
+
+一次用户请求被中途改口时，画面仍是**同一本 Tools 账本**。steer 是过程里的转向，不是新任务。
+
+不把多次 steer 拼进第一条 user 正文：那会抹掉改口时间点，也和 `/tree` 的每条 user 节点对不上。
+
+## 已拍板
+
+1. **同一轮**：steer 不断 group。follow-up 与闲时新提问仍新开一轮。
+2. **留在工具流中间**：展开后 `↳` 插在它发生的那一截，不挪到第一条 user 下面。
+3. **进行中钉顶**：收起且未 settle 时，steer 首行按时间顺序钉在 Tools 头下，再下面才是旁白和当前活动。
+4. **结束后撤钉**：settle 后钉住区清空，标题留下 `· N steers`。
+5. **中间那条原生 `▎` user 框必须藏掉**（收起时零高）。否则和钉顶重复，看起来像又开了一个任务。
+6. **不改 session**：不改写 user/assistant/tool 正文，不给消息加持久化 `steering` 字段。
+
+## 用户能看到的行为
+
+进行中：
+
+```text
+▎ 原始任务
+
+◐ Tools (31 calls · 5 turns · 2 steers) · read ×18 · edit ×9
+  ↳ 先确定方案
+  ↳ 不要改 grok，用 xai
+  › 正在按新约束改 README
+  ◐ Edit(README.md)
+```
+
+结束后：
+
+```text
+✓ Tools (31 calls · 5 turns · 2 steers) · read ×18 · edit ×9
+  took 2m14s · tok ↑62k ↓8.4k R120k W4.1k · at 14:32:14
+```
+
+`Ctrl+O` 展开：
+
+```text
+✓ Tools (31 calls · 5 turns · 2 steers) · read ×18 · edit ×9
+  took 2m14s · …
+  │ › 先读 README
+  │ ✓ Read(README.md)
+  │ ↳ 先确定方案
+  │ › 按新约束改
+  │ ✓ Edit(README.md)
+  │ ↳ 不要改 grok，用 xai
+  └ ◐ Bash(pnpm test)
+```
+
+符号分开：原任务 `▎`，steer 用 accent 的 `↳`，旁白继续 `›`。标题 `· N steers` 跟在 turns 后面、failed 前面，用强调色，不当错误。1 条写 `steer`，多条写 `steers`。
+
+钉住只取每条 steer 的**首行**（截到行宽），条数按时间全留，不做 `+N`。展开后才显示完整正文（过长按现有旁白/user 截断习惯，不要倾倒整段粘贴日志到无限高）。
+
+## 如何认出 steer
+
+落盘 user 消息没有 `steering` 字段，只有 `role / content / timestamp`。靠过程位置：
+
+| 情况 | 判定 |
+|---|---|
+| 本 group 未 settle，且上一条可见消息是 `toolUse` / `toolResult` 之后的 user | **steer**，并入当前 group |
+| 连续多条这样的 user（`steeringMode=all` 一次倒空） | 都是 steer，同一 group |
+| live：`input.streamingBehavior === "steer"`，或 agent 仍在跑、下一条 user 满足上一行 | 同上 |
+| 上一条已是终态 assistant（无未完成 tool 批次），再来的 user | **新一轮**（follow-up 或闲时提问） |
+| custom message（`sendMessage` / 子 agent 完成通知） | 不是 user，不断 group，也不当 steer 钉顶 |
+
+不要在 steer 到达时把上一批 running 工具标成 failed。真实 steer 是等当前 tool 批次跑完再插入的。
+
+reload / tree / compaction 用同一条位置规则从当前 branch 重建。接受：第一句 assistant 还没调用工具就改口时，reload 可能仍会拆开——宁可拆开，也不要把闲时新提问并进旧账。
+
+## 非目标
+
+- 不把 steer 文本写进上一条 user message。
+- 不给 session 加持久化标记。
+- 不改 tool 执行、call/result、模型上下文。
+- 不把 follow-up 当成 steer。
+- 不推断“分析中 / 实现中”。
+
+## 验收
+
+1. 工具批次之后插入 1 条或多条 steer：仍是一本 Tools，call/turn 累计，不新开第二本。
+2. 进行中账本头下按时间钉住各条 steer **首行**，再下面是 `›` 旁白和当前活动。
+3. settle 后钉住区消失，标题保留 `· N steers`；耗时从原请求开始算到本轮结束。
+4. 收起时中间不再出现第二条 `▎` user 框。
+5. `Ctrl+O` 后 `↳` 出现在当时的工具/旁白之间，accent 高亮，和 `›` / `✓` 一眼能分。
+6. 闲时新提问、follow-up（终态回答之后的 user）仍新开 Tools。
+7. reload / 切回 branch 后，toolResult 之后的 user 仍并入同一 group，计数和 `N steers` 正确。
+8. 不改写 Session 消息；切回 `individual` + `/reload` 仍能看到每条原始 user。
+9. 现有 aggregate 契约（旁白三行、failed 计数、passthrough、图片 fail-open、session 隔离）不回退。

--- a/packages/pi-meter/README.md
+++ b/packages/pi-meter/README.md
@@ -21,17 +21,17 @@ Do **not** load `@pi-plugins/usage` at the same time. Both register `/usage`. If
 
 ## Features
 
-- Footer line for today's local spend next to the current subscription window:
+- Footer line for the last 24 hours of local spend next to the current model's subscription window:
 
   ```text
-  · today 12.4k $0.18 · week left ███░░ 49% (1d 23h)
+  · 24h 12.4k $0.18 · xai week left ███░░ 49% (1d 23h)
   ```
 
   ![Meter footer](./assets/demo-meter-status.png)
 
 - Local dashboard by model, project, or session.
 - Claude, Codex, SuperGrok, and Ollama Cloud remaining after `/login` for that provider.
-- `/usage quota` opens a temporary dashboard. Unsigned-in providers stay as a muted summary at the bottom. Models with no subscription window show a muted footer hint.
+- `/usage quota` opens a temporary dashboard. Unsigned-in providers stay as a muted summary at the bottom. If the current model has no window, or that provider is unsigned / unavailable, the footer shows a short hint instead of another vendor's bar.
 - Optional local budgets. They warn; they never block requests.
 - Optional one-time import from older session files.
 
@@ -68,7 +68,7 @@ Then restart Pi or run `/reload`. If `@pi-plugins/usage` is already in `settings
 | `/usage` | Menu: dashboard, quota, footer, budgets, import |
 | `/usage quota` | Open the remaining/reset-time dashboard for Claude, Codex, SuperGrok, and Ollama Cloud |
 | `/usage quota refresh` | Refresh subscription windows and open the dashboard |
-| `/usage footer` | Configure the local summary, quota visibility, and used/remaining display |
+| `/usage footer` | Configure the local summary, rolling/calendar window, quota visibility, and used/remaining display |
 | `/usage import` | Back-fill from session files |
 | `/usage budget` | View or add a local budget |
 

--- a/packages/pi-meter/README.zh-CN.md
+++ b/packages/pi-meter/README.zh-CN.md
@@ -21,17 +21,17 @@
 
 ## 功能
 
-- 底栏同时显示今日本地花费和当前订阅窗口：
+- 底栏同时显示过去 24 小时的本地花费和当前模型对应的订阅窗口：
 
   ```text
-  · today 12.4k $0.18 · week left ███░░ 49% (1d 23h)
+  · 24h 12.4k $0.18 · xai week left ███░░ 49% (1d 23h)
   ```
 
   ![Meter 底栏](./assets/demo-meter-status.png)
 
 - 按模型、项目或 session 看本地看板。
 - `/login` 对应账号后，可看 Claude、Codex、SuperGrok、Ollama Cloud 剩余。
-- `/usage quota` 打开临时看板。未登录的提供商收在底部一条淡提示。当前模型没有订阅窗口时，底栏也只给一条淡提示。
+- `/usage quota` 打开临时看板。未登录的提供商收在底部一条淡提示。当前模型没有窗口、没登录或这次没拉到时，底栏只给短提示，不会画别家额度。
 - 可选本地 budget。只会提醒，从不拦请求。
 - 可选、一次性从旧 session 文件回填。
 
@@ -68,7 +68,7 @@ pi -e npm:@zhcsyncer/pi-meter
 | `/usage` | 菜单：看板、套餐、底栏、budget、回填 |
 | `/usage quota` | 打开 Claude、Codex、SuperGrok、Ollama Cloud 的剩余额度与重置时间看板 |
 | `/usage quota refresh` | 刷新订阅窗口并打开看板 |
-| `/usage footer` | 配置本地摘要、配额显示开关以及已用/剩余模式 |
+| `/usage footer` | 配置本地摘要、滚动/日历窗口、配额显示开关以及已用/剩余模式 |
 | `/usage import` | 从 session 文件回填 |
 | `/usage budget` | 查看或添加本地 budget |
 

--- a/packages/pi-meter/extensions/meter.ts
+++ b/packages/pi-meter/extensions/meter.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { getAgentDir, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { FooterSettingsDashboard } from "../src/chrome/footer-settings.ts";
+import { FooterSettingsDashboard, type FooterEditorValue } from "../src/chrome/footer-settings.ts";
 import { QuotaDashboard } from "../src/chrome/quota-dashboard.ts";
 import { readLocalQuotaCache, STATUS_CACHE_POLL_MS } from "../src/chrome/status-cache.ts";
 import { renderStatusText, STATUS_KEY } from "../src/chrome/widget.ts";
@@ -19,7 +19,8 @@ import { parseSession, diffRecords, usageFromAssistantMessage } from "../src/led
 import { createLedgerStore, type FileLedgerStore } from "../src/ledger/store.ts";
 import { parseWindowArg, sessionIdFrom } from "../src/ledger/time.ts";
 import type { BudgetLimit, UsageRecord, WindowKey } from "../src/ledger/types.ts";
-import { chromeWindow } from "../src/quota/policy.ts";
+import { hasStoredQuotaCredential } from "../src/quota/auth.ts";
+import { resolveChromeQuota } from "../src/quota/policy.ts";
 import { preferredProvider, refreshQuotaSnapshots } from "../src/quota/refresh.ts";
 import type { QuotaSnapshot, QuotaStoreFile } from "../src/quota/types.ts";
 import { QUOTA_PROVIDERS, quotaProviderTitle } from "../src/quota/types.ts";
@@ -163,20 +164,24 @@ export default function piMeter(pi: ExtensionAPI): void {
 		if (chromeClosed || ctx.mode !== "tui" || !ctx.hasUI || !store || !config) return;
 		const records = await store.readAll();
 		const limits = (await store.loadBudgets()).limits;
-		const local = renderLocalFooter(config.footer.local, computeFooterStats(records, limits));
+		const windowMode = config.ledger.windowMode;
+		const local = renderLocalFooter(
+			config.footer.local,
+			computeFooterStats(records, limits, new Date(), windowMode),
+			windowMode,
+		);
 		const preferred = preferredProvider(ctx.model);
 		const showQuota = config.footer.quota.visible;
-		const view = showQuota && preferred && quota ? chromeWindow(quota, preferred) : undefined;
-		const quotaHint = showQuota && !preferred
-			? {
-				label: ctx.model?.provider?.trim() || "quota n/a",
-				value: "no quota window",
-			}
-			: undefined;
+		const resolved = showQuota
+			? resolveChromeQuota(quota, preferred, {
+				modelProvider: ctx.model?.provider,
+				signedIn: preferred ? hasStoredQuotaCredential(preferred) : false,
+			})
+			: {};
 		const text = renderStatusText({
 			local,
-			quota: view,
-			quotaHint,
+			quota: resolved.view,
+			quotaHint: resolved.hint,
 			polarity: config.footer.quota.polarity,
 		}, ctx.ui.theme);
 		if (hasStatus && text === lastStatusText) return;
@@ -305,10 +310,10 @@ export default function piMeter(pi: ExtensionAPI): void {
 		const window = parseWindowArg(arg);
 		if (window) {
 			if (ctx.mode !== "tui") {
-				printReport(await store!.readAll(), window, ctx.ui.notify);
+				printReport(await store!.readAll(), window, ctx.ui.notify, config!.ledger.windowMode);
 				return;
 			}
-			await openDashboard(window, store!, session, ctx);
+			await openDashboard(window, store!, session, ctx, config!.ledger.windowMode);
 			return;
 		}
 		if (arg.length > 0) {
@@ -316,14 +321,14 @@ export default function piMeter(pi: ExtensionAPI): void {
 			return;
 		}
 		if (ctx.mode !== "tui") {
-			printReport(await store!.readAll(), "today", ctx.ui.notify);
+			printReport(await store!.readAll(), "today", ctx.ui.notify, config!.ledger.windowMode);
 			return;
 		}
 		const choice = await pickUsageMenu(ctx);
 		if (!choice) return;
 		switch (choice) {
 			case "dashboard":
-				await openDashboard("today", store!, session, ctx);
+				await openDashboard("today", store!, session, ctx, config!.ledger.windowMode);
 				break;
 			case "quota":
 				await handleQuota("", ctx);
@@ -389,18 +394,18 @@ async function handleFooter(
 	const records = await store.readAll();
 	const limits = (await store.loadBudgets()).limits;
 	const preferred = preferredProvider(ctx.model);
-	const quotaView = preferred && quota ? chromeWindow(quota, preferred) : undefined;
-	const quotaHint = !preferred
-		? {
-			label: ctx.model?.provider?.trim() || "quota n/a",
-			value: "no quota window",
-		}
-		: undefined;
-	const next = await ctx.ui.custom<MeterConfig["footer"]>((tui, theme, _kb, done) => {
-		const dash = new FooterSettingsDashboard(config.footer, {
-			stats: computeFooterStats(records, limits),
-			quota: quotaView,
-			quotaHint,
+	const resolved = resolveChromeQuota(quota, preferred, {
+		modelProvider: ctx.model?.provider,
+		signedIn: preferred ? hasStoredQuotaCredential(preferred) : false,
+	});
+	const next = await ctx.ui.custom<FooterEditorValue>((tui, theme, _kb, done) => {
+		const dash = new FooterSettingsDashboard({
+			footer: config.footer,
+			windowMode: config.ledger.windowMode,
+		}, {
+			stats: computeFooterStats(records, limits, new Date(), config.ledger.windowMode),
+			quota: resolved.view,
+			quotaHint: resolved.hint,
 		}, {
 			fg: (color, text) => theme.fg(color as never, text),
 			bold: (text) => theme.bold(text),
@@ -416,7 +421,11 @@ async function handleFooter(
 		};
 	});
 	if (!next) return;
-	await persist({ ...config, footer: next }, ctx);
+	await persist({
+		...config,
+		footer: next.footer,
+		ledger: { ...config.ledger, windowMode: next.windowMode },
+	}, ctx);
 }
 
 async function openQuotaDashboard(
@@ -446,6 +455,7 @@ async function openDashboard(
 	store: FileLedgerStore,
 	session: SessionBits,
 	ctx: ExtensionContext,
+	windowMode: MeterConfig["ledger"]["windowMode"],
 ): Promise<void> {
 	const records = await store.readAll();
 	const budgets = (await store.loadBudgets()).limits.map((limit) => statusForLimit(records, limit, new Date(), session.sessionId));
@@ -453,7 +463,7 @@ async function openDashboard(
 		const dash = new Dashboard({ records, budgets }, {
 			fg: (color, text) => theme.fg(color as never, text),
 			bold: (text) => theme.bold(text),
-		}, initial);
+		}, initial, windowMode);
 		dash.onDone = () => done();
 		return {
 			render: (width: number) => dash.render(width),
@@ -489,7 +499,7 @@ function printHelp(notify: Notify): void {
 			"  /usage quota [refresh]",
 			"      Subscription remaining for Claude, Codex, SuperGrok, and Ollama Cloud.",
 			"  /usage footer",
-			"      Configure local summary, quota visibility, and used/remaining display.",
+			"      Configure local summary, rolling/calendar window, quota visibility, and used/remaining display.",
 			"  /usage import         Back-fill from session JSONL (idempotent).",
 			"  /usage budget [add]   View or add a local budget.",
 			"",
@@ -500,10 +510,15 @@ function printHelp(notify: Notify): void {
 	);
 }
 
-function printReport(records: UsageRecord[], window: WindowKey, notify: Notify): void {
+function printReport(
+	records: UsageRecord[],
+	window: WindowKey,
+	notify: Notify,
+	windowMode: MeterConfig["ledger"]["windowMode"],
+): void {
 	const out = [`pi-meter — ${window}`];
 	for (const dim of DIMENSIONS) {
-		const rows = aggregate(records, window, dim.key);
+		const rows = aggregate(records, window, dim.key, new Date(), windowMode);
 		const total = sumRows(rows);
 		out.push(`\nBy ${dim.label}:`);
 		for (const row of rows.slice(0, 10)) {

--- a/packages/pi-meter/extensions/meter.ts
+++ b/packages/pi-meter/extensions/meter.ts
@@ -17,7 +17,7 @@ import { fmtCompactTokens, fmtCost, fmtNum } from "../src/ledger/format.ts";
 import { aggregate, sumRows } from "../src/ledger/aggregate.ts";
 import { parseSession, diffRecords, usageFromAssistantMessage } from "../src/ledger/session-parser.ts";
 import { createLedgerStore, type FileLedgerStore } from "../src/ledger/store.ts";
-import { parseWindowArg, sessionIdFrom } from "../src/ledger/time.ts";
+import { parseWindowArg, sessionIdFrom, windowDisplayLabel } from "../src/ledger/time.ts";
 import type { BudgetLimit, UsageRecord, WindowKey } from "../src/ledger/types.ts";
 import { hasStoredQuotaCredential } from "../src/quota/auth.ts";
 import { resolveChromeQuota } from "../src/quota/policy.ts";
@@ -516,7 +516,7 @@ function printReport(
 	notify: Notify,
 	windowMode: MeterConfig["ledger"]["windowMode"],
 ): void {
-	const out = [`pi-meter — ${window}`];
+	const out = [`pi-meter — ${windowDisplayLabel(window, windowMode)}`];
 	for (const dim of DIMENSIONS) {
 		const rows = aggregate(records, window, dim.key, new Date(), windowMode);
 		const total = sumRows(rows);

--- a/packages/pi-meter/src/chrome/footer-settings.ts
+++ b/packages/pi-meter/src/chrome/footer-settings.ts
@@ -1,5 +1,5 @@
 import { Key, matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
-import type { MeterConfig } from "../config.ts";
+import type { LedgerWindowMode, MeterConfig } from "../config.ts";
 import { FOOTER_LOCALS, renderLocalFooter, type FooterStats } from "../ledger/footer.ts";
 import type { QuotaWindowView } from "../quota/policy.ts";
 import { renderStatusText } from "./widget.ts";
@@ -15,29 +15,35 @@ export interface FooterSettingsPreview {
 	quotaHint?: { label: string; value: string };
 }
 
-type FooterSettings = MeterConfig["footer"];
+export interface FooterEditorValue {
+	footer: MeterConfig["footer"];
+	windowMode: LedgerWindowMode;
+}
 
-const ROWS = ["local", "quota-visible", "quota-polarity"] as const;
+const ROWS = ["local", "quota-visible", "quota-polarity", "window-mode"] as const;
 type RowId = typeof ROWS[number];
 
 export class FooterSettingsDashboard {
 	private cursor = 0;
 	private cachedWidth = -1;
 	private cachedLines: string[] = [];
-	private value: FooterSettings;
+	private value: FooterEditorValue;
 
 	constructor(
-		current: FooterSettings,
+		current: FooterEditorValue,
 		private preview: FooterSettingsPreview,
 		private theme: FooterSettingsTheme,
 	) {
 		this.value = {
-			local: current.local,
-			quota: { ...current.quota },
+			footer: {
+				local: current.footer.local,
+				quota: { ...current.footer.quota },
+			},
+			windowMode: current.windowMode,
 		};
 	}
 
-	public onDone?: (value: FooterSettings) => void;
+	public onDone?: (value: FooterEditorValue) => void;
 
 	handleInput(data: string): void {
 		if (matchesKey(data, Key.escape) || data === "q" || data === "Q") {
@@ -61,10 +67,13 @@ export class FooterSettingsDashboard {
 		if (matchesKey(data, Key.left)) this.cycle(-1);
 	}
 
-	settings(): FooterSettings {
+	settings(): FooterEditorValue {
 		return {
-			local: this.value.local,
-			quota: { ...this.value.quota },
+			footer: {
+				local: this.value.footer.local,
+				quota: { ...this.value.footer.quota },
+			},
+			windowMode: this.value.windowMode,
 		};
 	}
 
@@ -77,10 +86,10 @@ export class FooterSettingsDashboard {
 		const t = this.theme;
 		const safeWidth = Math.max(1, width);
 		const preview = renderStatusText({
-			local: renderLocalFooter(this.value.local, this.preview.stats),
-			quota: this.value.quota.visible ? this.preview.quota : undefined,
-			quotaHint: this.value.quota.visible ? this.preview.quotaHint : undefined,
-			polarity: this.value.quota.polarity,
+			local: renderLocalFooter(this.value.footer.local, this.preview.stats, this.value.windowMode),
+			quota: this.value.footer.quota.visible ? this.preview.quota : undefined,
+			quotaHint: this.value.footer.quota.visible ? this.preview.quotaHint : undefined,
+			polarity: this.value.footer.quota.polarity,
 		}, t as never) ?? "· footer hidden";
 		const rows = ROWS.map((id, index) => this.renderRow(id, index === this.cursor, safeWidth));
 		const selected = ROWS[this.cursor];
@@ -104,16 +113,19 @@ export class FooterSettingsDashboard {
 	private cycle(delta: number): void {
 		switch (ROWS[this.cursor]) {
 			case "local": {
-				const index = FOOTER_LOCALS.findIndex((item) => item.key === this.value.local);
+				const index = FOOTER_LOCALS.findIndex((item) => item.key === this.value.footer.local);
 				const next = (index + delta + FOOTER_LOCALS.length) % FOOTER_LOCALS.length;
-				this.value.local = FOOTER_LOCALS[next]!.key;
+				this.value.footer.local = FOOTER_LOCALS[next]!.key;
 				break;
 			}
 			case "quota-visible":
-				this.value.quota.visible = !this.value.quota.visible;
+				this.value.footer.quota.visible = !this.value.footer.quota.visible;
 				break;
 			case "quota-polarity":
-				this.value.quota.polarity = this.value.quota.polarity === "remaining" ? "used" : "remaining";
+				this.value.footer.quota.polarity = this.value.footer.quota.polarity === "remaining" ? "used" : "remaining";
+				break;
+			case "window-mode":
+				this.value.windowMode = this.value.windowMode === "rolling" ? "calendar" : "rolling";
 				break;
 		}
 		this.invalidate();
@@ -122,12 +134,20 @@ export class FooterSettingsDashboard {
 	private renderRow(id: RowId, selected: boolean, width: number): string {
 		const t = this.theme;
 		const marker = selected ? "▶ " : "  ";
-		const label = id === "local" ? "Local summary" : id === "quota-visible" ? "Quota window" : "Quota display";
-		const value = id === "local"
-			? FOOTER_LOCALS.find((item) => item.key === this.value.local)?.label ?? this.value.local
+		const label = id === "local"
+			? "Local summary"
 			: id === "quota-visible"
-				? this.value.quota.visible ? "On" : "Off"
-				: this.value.quota.polarity === "remaining" ? "Remaining" : "Used";
+				? "Quota window"
+				: id === "quota-polarity"
+					? "Quota display"
+					: "Local window";
+		const value = id === "local"
+			? FOOTER_LOCALS.find((item) => item.key === this.value.footer.local)?.label ?? this.value.footer.local
+			: id === "quota-visible"
+				? this.value.footer.quota.visible ? "On" : "Off"
+				: id === "quota-polarity"
+					? this.value.footer.quota.polarity === "remaining" ? "Remaining" : "Used"
+					: this.value.windowMode === "rolling" ? "Rolling" : "Calendar";
 		const labelText = `${label}${" ".repeat(Math.max(1, 18 - label.length))}`;
 		return truncateToWidth(
 			marker + (selected ? t.fg("accent", t.bold(labelText)) : labelText) + t.fg(selected ? "accent" : "text", value),
@@ -137,8 +157,9 @@ export class FooterSettingsDashboard {
 	}
 
 	private description(id: RowId): string {
-		if (id === "local") return FOOTER_LOCALS.find((item) => item.key === this.value.local)?.description ?? "local usage summary";
+		if (id === "local") return FOOTER_LOCALS.find((item) => item.key === this.value.footer.local)?.description ?? "local usage summary";
 		if (id === "quota-visible") return "show or hide the current model's subscription window";
-		return "show subscription quota as remaining or used";
+		if (id === "quota-polarity") return "show subscription quota as remaining or used";
+		return "count local spend from now backwards, or from calendar midnights. Budgets stay on the calendar.";
 	}
 }

--- a/packages/pi-meter/src/chrome/usage-panel.ts
+++ b/packages/pi-meter/src/chrome/usage-panel.ts
@@ -1,6 +1,6 @@
 import { displayedPercent, formatResetLong, quotaTone } from "./format.ts";
 import type { QuotaPolarity } from "../config.ts";
-import { OLLAMA_API_KEY_ERROR } from "../quota/auth.ts";
+import { isUnsignedQuotaSnapshot } from "../quota/auth.ts";
 import type { QuotaSnapshot, QuotaWindow } from "../quota/types.ts";
 
 function bar(usedPercent: number, polarity: QuotaPolarity, width = 10): string {
@@ -9,14 +9,8 @@ function bar(usedPercent: number, polarity: QuotaPolarity, width = 10): string {
 	return `[${"█".repeat(filled)}${"░".repeat(Math.max(0, width - filled))}]`;
 }
 
-const UNSIGNED_IN_ERRORS = new Set([
-	"no subscription OAuth credentials — run /login",
-	"no snapshot yet",
-	OLLAMA_API_KEY_ERROR,
-]);
-
 function isUnsignedIn(snapshot: QuotaSnapshot): boolean {
-	return !snapshot.ok && snapshot.error !== undefined && UNSIGNED_IN_ERRORS.has(snapshot.error);
+	return isUnsignedQuotaSnapshot(snapshot);
 }
 
 function unsignedInHint(snapshots: readonly QuotaSnapshot[]): string | undefined {

--- a/packages/pi-meter/src/chrome/widget.ts
+++ b/packages/pi-meter/src/chrome/widget.ts
@@ -1,6 +1,7 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import type { QuotaPolarity } from "../config.ts";
 import type { QuotaWindowView } from "../quota/policy.ts";
+import { quotaProviderBrand } from "../quota/types.ts";
 import { displayedPercent, formatResetShort, quotaTone, renderQuotaBar } from "./format.ts";
 
 export const STATUS_KEY = "pi-meter";
@@ -30,7 +31,7 @@ function quotaCaption(quota: QuotaWindowView, polarity: QuotaPolarity, now: Date
 	const reset = formatResetShort(quota.window.resetsAt, now);
 	const stale = quota.stale ? " stale" : "";
 	return {
-		label: `${kind} ${verb}`,
+		label: `${quotaProviderBrand(quota.provider)} ${kind} ${verb}`,
 		value: `${renderQuotaBar(quota.window.usedPercent, polarity)} ${percent}%${reset ? ` (${reset})` : ""}${stale}`,
 		tone: quotaTone(quota.window.usedPercent),
 	};

--- a/packages/pi-meter/src/config.ts
+++ b/packages/pi-meter/src/config.ts
@@ -2,9 +2,11 @@ import { unlink } from "node:fs/promises";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { writeFileAtomically, isRecord, pathExists, readTextFile } from "./fs.ts";
 import { FOOTER_LOCALS, parseFooterLocal, type FooterLocal } from "./ledger/footer.ts";
+import { parseLedgerWindowMode, type LedgerWindowMode } from "./ledger/time.ts";
 import { getMeterPaths } from "./paths.ts";
 
 export type QuotaPolarity = "used" | "remaining";
+export type { LedgerWindowMode };
 
 export interface MeterConfig {
 	footer: {
@@ -17,6 +19,9 @@ export interface MeterConfig {
 	quota: {
 		snapshotTtlMs: number;
 		minRefreshIntervalMs: number;
+	};
+	ledger: {
+		windowMode: LedgerWindowMode;
 	};
 }
 
@@ -31,6 +36,9 @@ export const DEFAULT_METER_CONFIG: MeterConfig = {
 	quota: {
 		snapshotTtlMs: 60_000,
 		minRefreshIntervalMs: 30_000,
+	},
+	ledger: {
+		windowMode: "rolling",
 	},
 };
 
@@ -66,6 +74,7 @@ export function parseMeterConfig(value: unknown, extras: { footerLocal?: unknown
 		?? parseFooterLocal(extras.footerLocal)
 		?? parseFooterLocal(record.footerPreset)
 		?? DEFAULT_METER_CONFIG.footer.local;
+	const ledger = isRecord(record.ledger) ? record.ledger : {};
 	return {
 		footer: {
 			local,
@@ -80,6 +89,9 @@ export function parseMeterConfig(value: unknown, extras: { footerLocal?: unknown
 		quota: {
 			snapshotTtlMs: asPositiveInt(quota.snapshotTtlMs ?? record.snapshotTtlMs, DEFAULT_METER_CONFIG.quota.snapshotTtlMs),
 			minRefreshIntervalMs: asPositiveInt(quota.minRefreshIntervalMs ?? record.minRefreshIntervalMs, DEFAULT_METER_CONFIG.quota.minRefreshIntervalMs),
+		},
+		ledger: {
+			windowMode: parseLedgerWindowMode(ledger.windowMode) ?? DEFAULT_METER_CONFIG.ledger.windowMode,
 		},
 	};
 }

--- a/packages/pi-meter/src/ledger/aggregate.ts
+++ b/packages/pi-meter/src/ledger/aggregate.ts
@@ -1,6 +1,6 @@
 import { basename } from "node:path";
 import type { AggRow, Dimension, UsageRecord, WindowKey } from "./types.ts";
-import { windowStartMs } from "./time.ts";
+import { windowStartMs, type LedgerWindowMode } from "./time.ts";
 
 export function dimensionKey(dim: Dimension, rec: UsageRecord): { key: string; label: string } {
 	switch (dim) {
@@ -33,8 +33,9 @@ export function aggregate(
 	window: WindowKey,
 	dim: Dimension,
 	now: Date = new Date(),
+	windowMode: LedgerWindowMode = "rolling",
 ): AggRow[] {
-	const start = windowStartMs(window, now);
+	const start = windowStartMs(window, now, windowMode);
 	const map = new Map<string, AggRow>();
 	for (const rec of records) {
 		if (rec.ts < start) continue;
@@ -73,6 +74,10 @@ export function sumRows(rows: readonly AggRow[]): AggRow {
 	);
 }
 
-export function sumToday(records: readonly UsageRecord[], now: Date = new Date()): AggRow {
-	return sumRows(aggregate(records, "today", "model", now));
+export function sumToday(
+	records: readonly UsageRecord[],
+	now: Date = new Date(),
+	windowMode: LedgerWindowMode = "rolling",
+): AggRow {
+	return sumRows(aggregate(records, "today", "model", now, windowMode));
 }

--- a/packages/pi-meter/src/ledger/dashboard.ts
+++ b/packages/pi-meter/src/ledger/dashboard.ts
@@ -2,6 +2,7 @@ import { Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/
 import { aggregate, dimensionKey, sumRows } from "./aggregate.ts";
 import { DIMENSIONS, WINDOWS } from "./enums.ts";
 import { fmtBar, fmtCompactTokens, fmtCost, fmtNum, padRight } from "./format.ts";
+import type { LedgerWindowMode } from "./time.ts";
 import type { AggRow, BudgetStatus, Dimension, UsageRecord, WindowKey } from "./types.ts";
 
 export interface DashboardData {
@@ -35,6 +36,7 @@ export class Dashboard {
 		private data: DashboardData,
 		private theme: ThemePort,
 		initialWindow: WindowKey | null,
+		private windowMode: LedgerWindowMode = "rolling",
 	) {
 		if (initialWindow) {
 			const idx = WINDOWS.findIndex((window) => window.key === initialWindow);
@@ -119,7 +121,7 @@ export class Dashboard {
 		const dim = DIMENSIONS[this.dimIdx];
 		let recs = this.data.records;
 		for (const filter of this.filters) recs = recs.filter((record) => dimensionKey(filter.dim, record).key === filter.key);
-		return aggregate(recs, win.key, dim.key);
+		return aggregate(recs, win.key, dim.key, new Date(), this.windowMode);
 	}
 
 	render(width: number): string[] {

--- a/packages/pi-meter/src/ledger/dashboard.ts
+++ b/packages/pi-meter/src/ledger/dashboard.ts
@@ -2,7 +2,7 @@ import { Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/
 import { aggregate, dimensionKey, sumRows } from "./aggregate.ts";
 import { DIMENSIONS, WINDOWS } from "./enums.ts";
 import { fmtBar, fmtCompactTokens, fmtCost, fmtNum, padRight } from "./format.ts";
-import type { LedgerWindowMode } from "./time.ts";
+import { windowDisplayLabel, type LedgerWindowMode } from "./time.ts";
 import type { AggRow, BudgetStatus, Dimension, UsageRecord, WindowKey } from "./types.ts";
 
 export interface DashboardData {
@@ -134,7 +134,7 @@ export class Dashboard {
 		const lines: string[] = [];
 		lines.push(t.fg("accent", t.bold(`pi-meter — ${dim.label} usage`)));
 		const crumb = this.filters.length > 0 ? this.filters.map((filter) => filter.label).join(" ▸ ") : "—";
-		lines.push(t.fg("muted", `window: ${win.label}  •  ${fmtNum(rows.length)} ${dim.label.toLowerCase()}(s)  •  filter: ${crumb}`));
+		lines.push(t.fg("muted", `window: ${windowDisplayLabel(win.key, this.windowMode)}  •  ${fmtNum(rows.length)} ${dim.label.toLowerCase()}(s)  •  filter: ${crumb}`));
 		lines.push("");
 		if (rows.length === 0) {
 			lines.push(t.fg("dim", "No usage recorded in this window" + (this.filters.length ? " for this filter" : "") + "."));

--- a/packages/pi-meter/src/ledger/footer.ts
+++ b/packages/pi-meter/src/ledger/footer.ts
@@ -1,6 +1,7 @@
 import { aggregate, sumToday } from "./aggregate.ts";
 import { statusForLimit } from "./budget.ts";
 import { fmtCompactCost, fmtCompactTokens, fmtCost } from "./format.ts";
+import { windowStartMs, type LedgerWindowMode } from "./time.ts";
 import type { AggRow, BudgetLimit, UsageRecord } from "./types.ts";
 
 export type FooterLocal = "today-spend" | "today-tokens" | "today-cost" | "budget" | "model" | "off";
@@ -36,10 +37,19 @@ export function parseFooterPreset(value: unknown): FooterLocal | undefined {
 	return parseFooterLocal(value);
 }
 
-export function computeFooterStats(records: readonly UsageRecord[], limits: readonly BudgetLimit[], now = new Date()): FooterStats {
-	const today = sumToday(records, now);
-	const start = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-	const top = aggregate(records, "today", "model", now)[0];
+export function localWindowLabel(windowMode: LedgerWindowMode): string {
+	return windowMode === "calendar" ? "today" : "24h";
+}
+
+export function computeFooterStats(
+	records: readonly UsageRecord[],
+	limits: readonly BudgetLimit[],
+	now = new Date(),
+	windowMode: LedgerWindowMode = "rolling",
+): FooterStats {
+	const today = sumToday(records, now, windowMode);
+	const start = windowStartMs("today", now, windowMode);
+	const top = aggregate(records, "today", "model", now, windowMode)[0];
 	let budget: FooterStats["budget"] = null;
 	for (const limit of limits) {
 		const status = statusForLimit(records, limit, now, "");
@@ -61,29 +71,34 @@ export function computeFooterStats(records: readonly UsageRecord[], limits: read
 	};
 }
 
-export function renderLocalFooter(preset: FooterLocal, stats: FooterStats): string | undefined {
+export function renderLocalFooter(
+	preset: FooterLocal,
+	stats: FooterStats,
+	windowMode: LedgerWindowMode = "rolling",
+): string | undefined {
+	const when = localWindowLabel(windowMode);
 	switch (preset) {
 		case "off":
 			return undefined;
 		case "today-spend":
-			return todayLine(stats.today);
+			return todayLine(stats.today, when);
 		case "today-tokens":
-			return stats.today.tokens > 0 ? `today ${fmtCompactTokens(stats.today.tokens)}` : undefined;
+			return stats.today.tokens > 0 ? `${when} ${fmtCompactTokens(stats.today.tokens)}` : undefined;
 		case "today-cost":
 			return stats.today.costKnown && stats.today.cost > 0
-				? `today ${fmtCompactCost(stats.today.cost) ?? fmtCost(stats.today.cost)}`
+				? `${when} ${fmtCompactCost(stats.today.cost) ?? fmtCost(stats.today.cost)}`
 				: undefined;
 		case "budget":
 			return stats.budget ? budgetLine(stats.budget) : undefined;
 		case "model":
-			return stats.topModel ? `today ${shortModel(stats.topModel)} · ${stats.todayTurns} turns` : undefined;
+			return stats.topModel ? `${when} ${shortModel(stats.topModel)} · ${stats.todayTurns} turns` : undefined;
 	}
 }
 
-function todayLine(today: AggRow): string {
+function todayLine(today: AggRow, when: string): string {
 	const tokens = fmtCompactTokens(today.tokens);
 	const cost = today.costKnown ? fmtCompactCost(today.cost) : undefined;
-	return cost ? `today ${tokens} ${cost}` : `today ${tokens}`;
+	return cost ? `${when} ${tokens} ${cost}` : `${when} ${tokens}`;
 }
 
 function budgetLine(budget: NonNullable<FooterStats["budget"]>): string {

--- a/packages/pi-meter/src/ledger/time.ts
+++ b/packages/pi-meter/src/ledger/time.ts
@@ -8,6 +8,39 @@ export function parseLedgerWindowMode(value: unknown): LedgerWindowMode | undefi
 	return value === "rolling" || value === "calendar" ? value : undefined;
 }
 
+export function windowDisplayLabel(window: WindowKey, mode: LedgerWindowMode = "rolling"): string {
+	if (mode === "rolling") {
+		switch (window) {
+			case "today":
+				return "Last 24h";
+			case "week":
+				return "Last 7 days";
+			case "month":
+				return "Last 30 days";
+			case "6months":
+				return "Last 6 months";
+			case "year":
+				return "Last 365 days";
+			case "all":
+				return "All Time";
+		}
+	}
+	switch (window) {
+		case "today":
+			return "Today";
+		case "week":
+			return "This Week";
+		case "month":
+			return "This Month";
+		case "6months":
+			return "Last 6 Months";
+		case "year":
+			return "This Year";
+		case "all":
+			return "All Time";
+	}
+}
+
 export function pad2(n: number): string {
 	return n < 10 ? `0${n}` : String(n);
 }

--- a/packages/pi-meter/src/ledger/time.ts
+++ b/packages/pi-meter/src/ledger/time.ts
@@ -2,11 +2,37 @@ import type { Period, WindowKey } from "./types.ts";
 
 export const DAY_MS = 24 * 60 * 60 * 1000;
 
+export type LedgerWindowMode = "rolling" | "calendar";
+
+export function parseLedgerWindowMode(value: unknown): LedgerWindowMode | undefined {
+	return value === "rolling" || value === "calendar" ? value : undefined;
+}
+
 export function pad2(n: number): string {
 	return n < 10 ? `0${n}` : String(n);
 }
 
-export function windowStartMs(window: WindowKey, now: Date = new Date()): number {
+export function windowStartMs(
+	window: WindowKey,
+	now: Date = new Date(),
+	mode: LedgerWindowMode = "rolling",
+): number {
+	if (mode === "rolling") {
+		switch (window) {
+			case "today":
+				return now.getTime() - DAY_MS;
+			case "week":
+				return now.getTime() - 7 * DAY_MS;
+			case "month":
+				return now.getTime() - 30 * DAY_MS;
+			case "6months":
+				return now.getTime() - 180 * DAY_MS;
+			case "year":
+				return now.getTime() - 365 * DAY_MS;
+			case "all":
+				return 0;
+		}
+	}
 	switch (window) {
 		case "today":
 			return new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();

--- a/packages/pi-meter/src/quota/adapters/supergrok.ts
+++ b/packages/pi-meter/src/quota/adapters/supergrok.ts
@@ -21,10 +21,9 @@ export function parseSuperGrokBilling(payload: unknown, fetchedAt: number): Quot
 	}
 	const config = payload.config;
 	const period = isRecord(config.currentPeriod) ? config.currentPeriod : undefined;
-	const usedPercent = typeof config.creditUsagePercent === "number" ? config.creditUsagePercent : undefined;
-	if (usedPercent === undefined) {
-		return { provider: "supergrok", title: "SuperGrok", windows: [], fetchedAt, ok: false, error: "missing creditUsagePercent" };
-	}
+	const usedPercent = typeof config.creditUsagePercent === "number" && Number.isFinite(config.creditUsagePercent)
+		? config.creditUsagePercent
+		: 0;
 	const resetsAt = firstIso(
 		period?.end,
 		period?.endTime,

--- a/packages/pi-meter/src/quota/auth.ts
+++ b/packages/pi-meter/src/quota/auth.ts
@@ -10,6 +10,8 @@ export interface OAuthAccess {
 export const QUOTA_UNSIGNED_OAUTH_ERROR = "no subscription OAuth credentials — run /login";
 export const OLLAMA_API_KEY_ERROR = "no Ollama Cloud API key — set OLLAMA_CLOUD_API_KEY or run /login";
 export const QUOTA_NO_SNAPSHOT_YET = "no snapshot yet";
+/** Old SuperGrok parser; current code treats a missing percent as 0%. */
+export const QUOTA_OBSOLETE_SUPERGROK_PERCENT_ERROR = "missing creditUsagePercent";
 
 const QUOTA_AUTH: Record<QuotaProviderId, { providerId: string; type: "oauth" | "api_key" }> = {
 	claude: { providerId: "anthropic", type: "oauth" },
@@ -30,6 +32,18 @@ export function isUnsignedQuotaError(error: string | undefined): boolean {
 
 export function isUnsignedQuotaSnapshot(snapshot: { ok: boolean; error?: string } | undefined): boolean {
 	return snapshot !== undefined && !snapshot.ok && isUnsignedQuotaError(snapshot.error);
+}
+
+export function isObsoleteQuotaError(error: string | undefined): boolean {
+	return error === QUOTA_OBSOLETE_SUPERGROK_PERCENT_ERROR;
+}
+
+export function isObsoleteQuotaSnapshot(snapshot: { ok: boolean; error?: string } | undefined): boolean {
+	return snapshot !== undefined && !snapshot.ok && isObsoleteQuotaError(snapshot.error);
+}
+
+export function shouldBypassQuotaMinInterval(snapshot: { ok: boolean; error?: string } | undefined): boolean {
+	return isUnsignedQuotaSnapshot(snapshot) || isObsoleteQuotaSnapshot(snapshot);
 }
 
 export function hasStoredQuotaCredential(provider: QuotaProviderId): boolean {

--- a/packages/pi-meter/src/quota/auth.ts
+++ b/packages/pi-meter/src/quota/auth.ts
@@ -1,9 +1,40 @@
 import { readStoredCredential, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { sanitizeQuotaError } from "./sanitize.ts";
+import type { QuotaProviderId } from "./types.ts";
 
 export interface OAuthAccess {
 	accessToken: string;
 	accountId?: string;
+}
+
+export const QUOTA_UNSIGNED_OAUTH_ERROR = "no subscription OAuth credentials — run /login";
+export const OLLAMA_API_KEY_ERROR = "no Ollama Cloud API key — set OLLAMA_CLOUD_API_KEY or run /login";
+export const QUOTA_NO_SNAPSHOT_YET = "no snapshot yet";
+
+const QUOTA_AUTH: Record<QuotaProviderId, { providerId: string; type: "oauth" | "api_key" }> = {
+	claude: { providerId: "anthropic", type: "oauth" },
+	codex: { providerId: "openai-codex", type: "oauth" },
+	supergrok: { providerId: "xai", type: "oauth" },
+	ollama: { providerId: "ollama-cloud", type: "api_key" },
+};
+
+export function unsignedQuotaError(provider: QuotaProviderId): string {
+	return provider === "ollama" ? OLLAMA_API_KEY_ERROR : QUOTA_UNSIGNED_OAUTH_ERROR;
+}
+
+export function isUnsignedQuotaError(error: string | undefined): boolean {
+	return error === QUOTA_UNSIGNED_OAUTH_ERROR
+		|| error === OLLAMA_API_KEY_ERROR
+		|| error === QUOTA_NO_SNAPSHOT_YET;
+}
+
+export function isUnsignedQuotaSnapshot(snapshot: { ok: boolean; error?: string } | undefined): boolean {
+	return snapshot !== undefined && !snapshot.ok && isUnsignedQuotaError(snapshot.error);
+}
+
+export function hasStoredQuotaCredential(provider: QuotaProviderId): boolean {
+	const spec = QUOTA_AUTH[provider];
+	return readStoredCredential(spec.providerId)?.type === spec.type;
 }
 
 function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
@@ -29,8 +60,6 @@ function accountIdFromToken(token: string): string | undefined {
 	return undefined;
 }
 
-export const OLLAMA_API_KEY_ERROR = "no Ollama Cloud API key — set OLLAMA_CLOUD_API_KEY or run /login";
-
 export async function resolveApiKeyAccess(
 	ctx: Pick<ExtensionContext, "modelRegistry">,
 	providerId: string,
@@ -54,7 +83,7 @@ export async function resolveOAuthAccess(
 ): Promise<{ ok: true; access: OAuthAccess } | { ok: false; error: string }> {
 	const stored = readStoredCredential(providerId);
 	if (stored?.type !== "oauth") {
-		return { ok: false, error: "no subscription OAuth credentials — run /login" };
+		return { ok: false, error: QUOTA_UNSIGNED_OAUTH_ERROR };
 	}
 	try {
 		const accessToken = await ctx.modelRegistry.getApiKeyForProvider(providerId);

--- a/packages/pi-meter/src/quota/policy.ts
+++ b/packages/pi-meter/src/quota/policy.ts
@@ -1,5 +1,6 @@
-import type { QuotaProviderId, QuotaRefreshDecision, QuotaSnapshot, QuotaStoreFile } from "./types.ts";
-import { QUOTA_MIN_INTERVAL_MS, QUOTA_PROVIDERS, QUOTA_TTL_MS } from "./types.ts";
+import { isUnsignedQuotaSnapshot } from "./auth.ts";
+import type { QuotaProviderId, QuotaRefreshDecision, QuotaSnapshot, QuotaStoreFile, QuotaWindow } from "./types.ts";
+import { QUOTA_MIN_INTERVAL_MS, QUOTA_TTL_MS, quotaProviderBrand } from "./types.ts";
 
 export function emptyQuotaStore(now = Date.now(), ttlMs = QUOTA_TTL_MS, minIntervalMs = QUOTA_MIN_INTERVAL_MS): QuotaStoreFile {
 	return {
@@ -16,7 +17,7 @@ export function remainingPercent(usedPercent: number): number {
 }
 
 export function isSnapshotFresh(snapshot: QuotaSnapshot | undefined, now: number, ttlMs = QUOTA_TTL_MS): boolean {
-	if (!snapshot) return false;
+	if (!snapshot?.ok) return false;
 	return now - snapshot.fetchedAt < ttlMs;
 }
 
@@ -30,8 +31,9 @@ export function decideRefresh(
 	const minIntervalMs = options.minIntervalMs ?? store.minIntervalMs ?? QUOTA_MIN_INTERVAL_MS;
 	const snapshot = store.providers[provider];
 	const lastAttempt = store.lastAttemptAt[provider];
+	const unsigned = isUnsignedQuotaSnapshot(snapshot);
 	if (options.force) {
-		if (lastAttempt !== undefined && now - lastAttempt < minIntervalMs) {
+		if (!unsigned && lastAttempt !== undefined && now - lastAttempt < minIntervalMs) {
 			return { provider, refresh: false, reason: "min-interval" };
 		}
 		return { provider, refresh: true, reason: "forced" };
@@ -39,7 +41,7 @@ export function decideRefresh(
 	if (isSnapshotFresh(snapshot, now, ttlMs)) {
 		return { provider, refresh: false, reason: "fresh" };
 	}
-	if (lastAttempt !== undefined && now - lastAttempt < minIntervalMs) {
+	if (!unsigned && lastAttempt !== undefined && now - lastAttempt < minIntervalMs) {
 		return { provider, refresh: false, reason: "min-interval" };
 	}
 	return { provider, refresh: true, reason: snapshot ? "expired" : "missing" };
@@ -52,11 +54,17 @@ export function markAttempt(store: QuotaStoreFile, provider: QuotaProviderId, no
 	};
 }
 
-export function putSnapshot(store: QuotaStoreFile, snapshot: QuotaSnapshot): QuotaStoreFile {
+export function putSnapshot(
+	store: QuotaStoreFile,
+	snapshot: QuotaSnapshot,
+	options: { recordAttempt?: boolean } = {},
+): QuotaStoreFile {
 	return {
 		...store,
 		providers: { ...store.providers, [snapshot.provider]: snapshot },
-		lastAttemptAt: { ...store.lastAttemptAt, [snapshot.provider]: snapshot.fetchedAt },
+		lastAttemptAt: options.recordAttempt === false
+			? store.lastAttemptAt
+			: { ...store.lastAttemptAt, [snapshot.provider]: snapshot.fetchedAt },
 	};
 }
 
@@ -68,25 +76,59 @@ export function withStaleFlags(store: QuotaStoreFile, now: number, ttlMs = store
 	return { ...store, providers };
 }
 
+export interface QuotaWindowView {
+	provider: QuotaProviderId;
+	window: QuotaWindow;
+	stale: boolean;
+}
+
+export interface ChromeQuotaHint {
+	label: string;
+	value: string;
+}
+
 export function chromeWindow(store: QuotaStoreFile, preferred?: QuotaProviderId): QuotaWindowView | undefined {
-	const order: QuotaProviderId[] = preferred
-		? [preferred, ...QUOTA_PROVIDERS.filter((id) => id !== preferred)]
-		: [...QUOTA_PROVIDERS];
-	for (const id of order) {
-		const snapshot = store.providers[id];
-		if (snapshot?.ok && snapshot.primary) {
-			return {
-				provider: id,
-				window: snapshot.primary,
-				stale: snapshot.stale === true,
-			};
-		}
+	if (!preferred) return undefined;
+	const snapshot = store.providers[preferred];
+	if (snapshot?.ok && snapshot.primary) {
+		return {
+			provider: preferred,
+			window: snapshot.primary,
+			stale: snapshot.stale === true,
+		};
 	}
 	return undefined;
 }
 
-export interface QuotaWindowView {
-	provider: QuotaProviderId;
-	window: import("./types.ts").QuotaWindow;
-	stale: boolean;
+export function resolveChromeQuota(
+	store: QuotaStoreFile | undefined,
+	preferred: QuotaProviderId | undefined,
+	options: { modelProvider?: string; signedIn?: boolean } = {},
+): { view?: QuotaWindowView; hint?: ChromeQuotaHint } {
+	if (!preferred) {
+		return {
+			hint: {
+				label: options.modelProvider?.trim() || "quota n/a",
+				value: "no quota window",
+			},
+		};
+	}
+	const brand = quotaProviderBrand(preferred);
+	if (options.signedIn === false) {
+		return { hint: { label: brand, value: "not signed in" } };
+	}
+	const snapshot = store?.providers[preferred];
+	if (snapshot?.ok && snapshot.primary) {
+		return {
+			view: {
+				provider: preferred,
+				window: snapshot.primary,
+				stale: snapshot.stale === true,
+			},
+		};
+	}
+	if (isUnsignedQuotaSnapshot(snapshot)) {
+		return { hint: { label: brand, value: "not signed in" } };
+	}
+	return { hint: { label: brand, value: "unavailable" } };
 }

--- a/packages/pi-meter/src/quota/policy.ts
+++ b/packages/pi-meter/src/quota/policy.ts
@@ -1,4 +1,4 @@
-import { isUnsignedQuotaSnapshot } from "./auth.ts";
+import { isUnsignedQuotaSnapshot, shouldBypassQuotaMinInterval } from "./auth.ts";
 import type { QuotaProviderId, QuotaRefreshDecision, QuotaSnapshot, QuotaStoreFile, QuotaWindow } from "./types.ts";
 import { QUOTA_MIN_INTERVAL_MS, QUOTA_TTL_MS, quotaProviderBrand } from "./types.ts";
 
@@ -31,9 +31,9 @@ export function decideRefresh(
 	const minIntervalMs = options.minIntervalMs ?? store.minIntervalMs ?? QUOTA_MIN_INTERVAL_MS;
 	const snapshot = store.providers[provider];
 	const lastAttempt = store.lastAttemptAt[provider];
-	const unsigned = isUnsignedQuotaSnapshot(snapshot);
+	const bypassMinInterval = shouldBypassQuotaMinInterval(snapshot);
 	if (options.force) {
-		if (!unsigned && lastAttempt !== undefined && now - lastAttempt < minIntervalMs) {
+		if (!bypassMinInterval && lastAttempt !== undefined && now - lastAttempt < minIntervalMs) {
 			return { provider, refresh: false, reason: "min-interval" };
 		}
 		return { provider, refresh: true, reason: "forced" };
@@ -41,7 +41,7 @@ export function decideRefresh(
 	if (isSnapshotFresh(snapshot, now, ttlMs)) {
 		return { provider, refresh: false, reason: "fresh" };
 	}
-	if (!unsigned && lastAttempt !== undefined && now - lastAttempt < minIntervalMs) {
+	if (!bypassMinInterval && lastAttempt !== undefined && now - lastAttempt < minIntervalMs) {
 		return { provider, refresh: false, reason: "min-interval" };
 	}
 	return { provider, refresh: true, reason: snapshot ? "expired" : "missing" };
@@ -127,7 +127,9 @@ export function resolveChromeQuota(
 			},
 		};
 	}
-	if (isUnsignedQuotaSnapshot(snapshot)) {
+	// Live auth.json wins. A leftover unsigned snapshot after /login is "unavailable",
+	// not "not signed in".
+	if (options.signedIn !== true && isUnsignedQuotaSnapshot(snapshot)) {
 		return { hint: { label: brand, value: "not signed in" } };
 	}
 	return { hint: { label: brand, value: "unavailable" } };

--- a/packages/pi-meter/src/quota/refresh.ts
+++ b/packages/pi-meter/src/quota/refresh.ts
@@ -3,6 +3,7 @@ import { fetchClaudeQuota } from "./adapters/claude.ts";
 import { fetchCodexQuota } from "./adapters/codex.ts";
 import { fetchOllamaQuota } from "./adapters/ollama.ts";
 import { fetchSuperGrokQuota } from "./adapters/supergrok.ts";
+import { hasStoredQuotaCredential, isUnsignedQuotaSnapshot, unsignedQuotaError } from "./auth.ts";
 import { decideRefresh, markAttempt, putSnapshot, withStaleFlags } from "./policy.ts";
 import { sanitizeQuotaError } from "./sanitize.ts";
 import { loadQuotaStore, saveQuotaStore } from "./store.ts";
@@ -42,7 +43,19 @@ export interface RefreshOptions {
 	ttlMs?: number;
 	minIntervalMs?: number;
 	fetchers?: Partial<Record<QuotaProviderId, QuotaFetcher>>;
+	hasCredential?: (provider: QuotaProviderId) => boolean;
 	now?: number;
+}
+
+function unsignedSnapshot(provider: QuotaProviderId, fetchedAt: number): QuotaSnapshot {
+	return {
+		provider,
+		title: quotaProviderTitle(provider),
+		windows: [],
+		fetchedAt,
+		ok: false,
+		error: unsignedQuotaError(provider),
+	};
 }
 
 export async function refreshQuotaSnapshots(
@@ -63,6 +76,8 @@ export async function refreshQuotaSnapshots(
 
 	const targets = options.providers ?? QUOTA_PROVIDERS;
 	const fetched: QuotaProviderId[] = [];
+	const hasCredential = options.hasCredential ?? hasStoredQuotaCredential;
+	let dirty = false;
 	for (const provider of targets) {
 		const decision = decideRefresh(store, provider, now, {
 			force: options.force,
@@ -70,6 +85,13 @@ export async function refreshQuotaSnapshots(
 			minIntervalMs: store.minIntervalMs,
 		});
 		if (!decision.refresh) continue;
+		if (!hasCredential(provider)) {
+			if (!isUnsignedQuotaSnapshot(store.providers[provider])) {
+				store = putSnapshot(store, unsignedSnapshot(provider, now), { recordAttempt: false });
+				dirty = true;
+			}
+			continue;
+		}
 		store = markAttempt(store, provider, now);
 		await saveQuotaStore(store, agentDir);
 		const fetcher = options.fetchers?.[provider] ?? DEFAULT_FETCHERS[provider];
@@ -86,7 +108,8 @@ export async function refreshQuotaSnapshots(
 			});
 		}
 		fetched.push(provider);
+		dirty = true;
 	}
-	if (fetched.length > 0) await saveQuotaStore(store, agentDir);
+	if (dirty) await saveQuotaStore(store, agentDir);
 	return { store: withStaleFlags(store, now), fetched };
 }

--- a/packages/pi-meter/src/quota/types.ts
+++ b/packages/pi-meter/src/quota/types.ts
@@ -49,3 +49,16 @@ export function quotaProviderTitle(id: QuotaProviderId): string {
 			return "Ollama Cloud";
 	}
 }
+
+export function quotaProviderBrand(id: QuotaProviderId): string {
+	switch (id) {
+		case "claude":
+			return "claude";
+		case "codex":
+			return "openai";
+		case "supergrok":
+			return "xai";
+		case "ollama":
+			return "ollama";
+	}
+}

--- a/packages/pi-meter/tests/chrome.test.ts
+++ b/packages/pi-meter/tests/chrome.test.ts
@@ -61,7 +61,7 @@ describe("status chrome", () => {
 			polarity: "remaining",
 			now: new Date("2026-08-15T12:00:00Z"),
 		}, theme));
-		expect(plain).toBe("· today 12.4k $0.18 · week left ██░░░ 34% (3d)");
+		expect(plain).toBe("· 24h 12.4k $0.18 · xai week left ██░░░ 34% (3d)");
 	});
 
 	it("keeps the window verb when flipping to used", () => {
@@ -73,8 +73,8 @@ describe("status chrome", () => {
 			now: new Date("2026-08-15T12:00:00Z"),
 		}, theme));
 		expect(plain.startsWith("· ")).toBe(true);
-		expect(plain).toContain("today 12.4k $0.18");
-		expect(plain).toContain("week used");
+		expect(plain).toContain("24h 12.4k $0.18");
+		expect(plain).toContain("xai week used");
 		expect(plain).toContain("66%");
 	});
 
@@ -84,14 +84,14 @@ describe("status chrome", () => {
 			{ ts: now.getTime(), sid: "s", cwd: "/p", model: "xai/grok-4", in: 12400, out: 0, cR: 0, cW: 0, tot: 12400, cost: 0.18, costKnown: true },
 		], [], now);
 		const local = renderLocalFooter("today-tokens", stats);
-		expect(local).toBe("today 12.4k");
+		expect(local).toBe("24h 12.4k");
 		const plain = strip(renderStatusText({
 			local,
 			quota,
 			polarity: "remaining",
 			now: new Date("2026-08-15T12:00:00Z"),
 		}, theme));
-		expect(plain).toBe("· today 12.4k · week left ██░░░ 34% (3d)");
+		expect(plain).toBe("· 24h 12.4k · xai week left ██░░░ 34% (3d)");
 	});
 
 	it("labels Claude 5h and Codex week windows", () => {
@@ -110,7 +110,7 @@ describe("status chrome", () => {
 			},
 			polarity: "remaining",
 		}, theme));
-		expect(plain).toBe("· today 12.4k $0.18 · 5h left █░░░░ 28%");
+		expect(plain).toBe("· 24h 12.4k $0.18 · ollama 5h left █░░░░ 28%");
 		expect(plain).not.toContain("(");
 	});
 
@@ -121,7 +121,7 @@ describe("status chrome", () => {
 			quotaHint: { label: "ollama", value: "no quota window" },
 			polarity: "remaining",
 		}, theme));
-		expect(plain).toBe("· today 12.4k $0.18 · ollama · no quota window");
+		expect(plain).toBe("· 24h 12.4k $0.18 · ollama · no quota window");
 		expect(plain).not.toContain("week left");
 		expect(plain).not.toContain("█");
 	});
@@ -133,7 +133,34 @@ describe("status chrome", () => {
 			quotaHint: { label: "quota n/a", value: "no quota window" },
 			polarity: "remaining",
 		}, theme));
-		expect(plain).toBe("· today 12.4k $0.18 · quota n/a · no quota window");
+		expect(plain).toBe("· 24h 12.4k $0.18 · quota n/a · no quota window");
+	});
+
+	it("prefixes the quota bar with the short brand", () => {
+		const local = renderLocalFooter("today-spend", { today, todayTurns: 3, topModel: "openai-codex/gpt", budget: null });
+		const plain = strip(renderStatusText({
+			local,
+			quota: {
+				provider: "codex",
+				stale: false,
+				window: { id: "week", label: "Week limit", usedPercent: 90, resetsAt: "2026-08-17T12:00:00Z" },
+			},
+			polarity: "remaining",
+			now: new Date("2026-08-15T12:00:00Z"),
+		}, theme));
+		expect(plain).toBe("· 24h 12.4k $0.18 · openai week left █░░░░ 10% (2d)");
+	});
+
+	it("keeps SuperGrok failure on xai instead of drawing a Codex bar", () => {
+		const local = renderLocalFooter("today-spend", { today, todayTurns: 3, topModel: "xai/grok-4", budget: null });
+		const plain = strip(renderStatusText({
+			local,
+			quotaHint: { label: "xai", value: "unavailable" },
+			polarity: "remaining",
+		}, theme));
+		expect(plain).toBe("· 24h 12.4k $0.18 · xai · unavailable");
+		expect(plain).not.toContain("week left");
+		expect(plain).not.toContain("█");
 	});
 });
 
@@ -158,8 +185,11 @@ function snapshot(over: Partial<QuotaSnapshot> & Pick<QuotaSnapshot, "provider" 
 describe("footer settings dashboard", () => {
 	it("previews and saves all footer settings together", () => {
 		const dash = new FooterSettingsDashboard({
-			local: "today-spend",
-			quota: { visible: true, polarity: "remaining" },
+			footer: {
+				local: "today-spend",
+				quota: { visible: true, polarity: "remaining" },
+			},
+			windowMode: "rolling",
 		}, {
 			stats: { today, todayTurns: 3, topModel: "ollama-cloud/glm", budget: null },
 			quota: {
@@ -173,8 +203,8 @@ describe("footer settings dashboard", () => {
 		});
 		const initial = strip(dash.render(100).join("\n"));
 		expect(initial).toContain("pi-meter — footer settings");
-		expect(initial).toContain("today 12.4k $0.18");
-		expect(initial).toContain("5h left");
+		expect(initial).toContain("24h 12.4k $0.18");
+		expect(initial).toContain("ollama 5h left");
 
 		dash.handleInput(" ");
 		dash.handleInput("\x1b[B");
@@ -185,12 +215,38 @@ describe("footer settings dashboard", () => {
 		dash.onDone = (value) => { saved = value; };
 		dash.handleInput("q");
 		expect(saved).toEqual({
-			local: "today-tokens",
-			quota: { visible: false, polarity: "used" },
+			footer: {
+				local: "today-tokens",
+				quota: { visible: false, polarity: "used" },
+			},
+			windowMode: "rolling",
 		});
 		const changed = strip(dash.render(100).join("\n"));
-		expect(changed).toContain("today 12.4k");
+		expect(changed).toContain("24h 12.4k");
 		expect(changed).not.toContain("5h used");
+	});
+
+	it("can switch the local window mode", () => {
+		const dash = new FooterSettingsDashboard({
+			footer: {
+				local: "today-spend",
+				quota: { visible: true, polarity: "remaining" },
+			},
+			windowMode: "rolling",
+		}, {
+			stats: { today, todayTurns: 3, topModel: "xai/grok-4", budget: null },
+		}, {
+			fg: (color, text) => theme.fg(color as never, text),
+			bold: (text) => theme.bold(text),
+		});
+		dash.handleInput("\x1b[B");
+		dash.handleInput("\x1b[B");
+		dash.handleInput("\x1b[B");
+		dash.handleInput(" ");
+		expect(dash.settings().windowMode).toBe("calendar");
+		const preview = strip(dash.render(100).join("\n"));
+		expect(preview).toContain("today 12.4k $0.18");
+		expect(preview).not.toContain("24h");
 	});
 });
 

--- a/packages/pi-meter/tests/extension.test.ts
+++ b/packages/pi-meter/tests/extension.test.ts
@@ -181,7 +181,7 @@ describe("extension runtime", () => {
 		piMeter(pi);
 		await handlers.get("session_start")?.[0]?.({ type: "session_start", reason: "startup" }, ctx);
 		expect(widgets.size).toBe(0);
-		expect(statuses.get("pi-meter")).toContain("today");
+		expect(statuses.get("pi-meter")).toContain("24h");
 		await handlers.get("session_shutdown")?.[0]?.({ type: "session_shutdown" }, ctx);
 	});
 
@@ -207,7 +207,7 @@ describe("extension runtime", () => {
 		await commands.get("usage").handler("footer", ctx);
 		expect(customComponents).toHaveLength(1);
 		expect(notifications).toEqual([]);
-		expect(statuses.get("pi-meter")).toContain("today 12.4k");
+		expect(statuses.get("pi-meter")).toContain("24h 12.4k");
 		const saved = JSON.parse(readFileSync(getMeterPaths(agentDir).configFile, "utf8"));
 		expect(saved).toMatchObject({
 			footer: {
@@ -238,6 +238,7 @@ describe("extension runtime", () => {
 				quota: { visible: false, polarity: "used" },
 			},
 			quota: { snapshotTtlMs: 90_000, minRefreshIntervalMs: 45_000 },
+			ledger: { windowMode: "rolling" },
 		});
 		await handlers.get("session_shutdown")?.[0]?.({ type: "session_shutdown" }, ctx);
 	});
@@ -279,6 +280,9 @@ describe("extension runtime", () => {
 		vi.spyOn(globalThis, "clearInterval").mockImplementation(() => {});
 		const fetchSpy = vi.fn();
 		vi.stubGlobal("fetch", fetchSpy);
+		writeFileSync(join(agentDir, "auth.json"), `${JSON.stringify({
+			xai: { type: "oauth", refresh: "x", access: "y" },
+		})}\n`);
 		const paths = getMeterPaths(agentDir);
 		mkdirSync(paths.dataDir, { recursive: true });
 		const writeQuota = (usedPercent: number, fetchedAt = Date.now()) => {
@@ -313,7 +317,7 @@ describe("extension runtime", () => {
 		writeQuota(80);
 		writeFileSync(paths.usageFile, `${JSON.stringify([Date.now(), "other", "/p", "xai/grok-4", 12400, 0, 0, 0, 12400, 0.18, 1])}\n`);
 		await polls[0]?.();
-		expect(statuses.get("pi-meter")).toContain("today 12.4k $0.18");
+		expect(statuses.get("pi-meter")).toContain("24h 12.4k $0.18");
 		expect(statuses.get("pi-meter")).toContain("20%");
 		expect(fetchSpy).not.toHaveBeenCalled();
 
@@ -330,6 +334,9 @@ describe("extension runtime", () => {
 	});
 
 	it("keeps a supported provider's quota window in the footer", async () => {
+		writeFileSync(join(agentDir, "auth.json"), `${JSON.stringify({
+			xai: { type: "oauth", refresh: "x", access: "y" },
+		})}\n`);
 		const paths = getMeterPaths(agentDir);
 		mkdirSync(paths.dataDir, { recursive: true });
 		writeFileSync(paths.quotaFile, `${JSON.stringify({
@@ -352,8 +359,8 @@ describe("extension runtime", () => {
 		const { pi, ctx, handlers, statuses } = harness({ hasUI: true, mode: "tui" });
 		piMeter(pi);
 		await handlers.get("session_start")?.[0]?.({ type: "session_start", reason: "startup" }, ctx);
-		expect(statuses.get("pi-meter")).toContain("today");
-		expect(statuses.get("pi-meter")).toContain("week left");
+		expect(statuses.get("pi-meter")).toContain("24h");
+		expect(statuses.get("pi-meter")).toContain("xai week left");
 		expect(statuses.get("pi-meter")).toContain("49%");
 		expect(statuses.get("pi-meter")).not.toContain("no quota window");
 		await handlers.get("session_shutdown")?.[0]?.({ type: "session_shutdown" }, ctx);
@@ -386,7 +393,7 @@ describe("extension runtime", () => {
 		});
 		piMeter(pi);
 		await handlers.get("session_start")?.[0]?.({ type: "session_start", reason: "startup" }, ctx);
-		expect(statuses.get("pi-meter")).toContain("today");
+		expect(statuses.get("pi-meter")).toContain("24h");
 		expect(statuses.get("pi-meter")).toContain("ollama");
 		expect(statuses.get("pi-meter")).toContain("no quota window");
 		expect(statuses.get("pi-meter")).not.toContain("5h left");
@@ -421,8 +428,8 @@ describe("extension runtime", () => {
 		await handlers.get("session_start")?.[0]?.({ type: "session_start", reason: "startup" }, ctx);
 		await handlers.get("agent_settled")?.[0]?.({ type: "agent_settled" }, ctx);
 		const footer = statuses.get("pi-meter");
-		expect(footer).toContain("today");
-		expect(footer).toContain("5h left");
+		expect(footer).toContain("24h");
+		expect(footer).toContain("ollama 5h left");
 		expect(footer).toContain("28%");
 		expect(footer).not.toContain("(");
 		expect(footer).not.toContain("no quota window");
@@ -453,6 +460,89 @@ describe("extension runtime", () => {
 		expect(dashboard).toMatch(/Not signed in:.*Ollama Cloud.*run \/login/);
 		expect(dashboard).not.toContain("no Ollama Cloud API key");
 		expect(fetchSpy).not.toHaveBeenCalled();
+		await handlers.get("session_shutdown")?.[0]?.({ type: "session_shutdown" }, ctx);
+	});
+
+	it("does not call subscription APIs or getApiKeyForProvider when auth.json has no credentials", async () => {
+		const getApiKeyForProvider = vi.fn(async () => "should-not-be-used");
+		const fetchSpy = vi.fn();
+		vi.stubGlobal("fetch", fetchSpy);
+		const { default: piMeter } = await import("../extensions/meter.ts");
+		const { pi, ctx, handlers, statuses } = harness({
+			hasUI: true,
+			mode: "tui",
+			model: { provider: "xai", id: "grok-4" },
+			getApiKeyForProvider,
+		});
+		piMeter(pi);
+		await handlers.get("session_start")?.[0]?.({ type: "session_start", reason: "startup" }, ctx);
+		await handlers.get("agent_settled")?.[0]?.({ type: "agent_settled" }, ctx);
+		expect(getApiKeyForProvider).not.toHaveBeenCalled();
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(statuses.get("pi-meter")).toContain("xai");
+		expect(statuses.get("pi-meter")).toContain("not signed in");
+		await handlers.get("session_shutdown")?.[0]?.({ type: "session_shutdown" }, ctx);
+	});
+
+	it("does not fall back to Codex when SuperGrok is unavailable", async () => {
+		const paths = getMeterPaths(agentDir);
+		mkdirSync(paths.dataDir, { recursive: true });
+		writeFileSync(paths.quotaFile, `${JSON.stringify({
+			version: 1,
+			ttlMs: 60_000,
+			minIntervalMs: 30_000,
+			providers: {
+				supergrok: {
+					provider: "supergrok",
+					title: "SuperGrok",
+					windows: [],
+					fetchedAt: Date.now(),
+					ok: false,
+					error: "HTTP 500",
+				},
+				codex: {
+					provider: "codex",
+					title: "OpenAI Codex",
+					primary: { id: "week", label: "Week limit", usedPercent: 20 },
+					windows: [{ id: "week", label: "Week limit", usedPercent: 20 }],
+					fetchedAt: Date.now(),
+					ok: true,
+				},
+			},
+			lastAttemptAt: {},
+		})}\n`);
+		writeFileSync(join(agentDir, "auth.json"), `${JSON.stringify({
+			xai: { type: "oauth", refresh: "x", access: "y" },
+		})}\n`);
+		const { default: piMeter } = await import("../extensions/meter.ts");
+		const { pi, ctx, handlers, statuses } = harness({
+			hasUI: true,
+			mode: "tui",
+			model: { provider: "xai", id: "grok-4" },
+		});
+		piMeter(pi);
+		await handlers.get("session_start")?.[0]?.({ type: "session_start", reason: "startup" }, ctx);
+		const footer = statuses.get("pi-meter") ?? "";
+		expect(footer).toContain("xai");
+		expect(footer).toContain("unavailable");
+		expect(footer).not.toContain("openai");
+		expect(footer).not.toContain("week left");
+		expect(footer).not.toContain("█");
+		await handlers.get("session_shutdown")?.[0]?.({ type: "session_shutdown" }, ctx);
+	});
+
+	it("saves windowMode from /usage footer", async () => {
+		const { default: piMeter } = await import("../extensions/meter.ts");
+		const { pi, ctx, handlers, commands } = harness({
+			hasUI: true,
+			mode: "tui",
+			customInputs: ["\x1b[B", "\x1b[B", "\x1b[B", " ", "q"],
+		});
+		piMeter(pi);
+		await handlers.get("session_start")?.[0]?.({ type: "session_start", reason: "startup" }, ctx);
+		await commands.get("usage").handler("footer", ctx);
+		const saved = JSON.parse(readFileSync(getMeterPaths(agentDir).configFile, "utf8"));
+		expect(saved.ledger.windowMode).toBe("calendar");
 		await handlers.get("session_shutdown")?.[0]?.({ type: "session_shutdown" }, ctx);
 	});
 });

--- a/packages/pi-meter/tests/ledger.test.ts
+++ b/packages/pi-meter/tests/ledger.test.ts
@@ -59,6 +59,16 @@ describe("usage capture", () => {
 });
 
 describe("aggregation", () => {
+	it("counts rolling windows from now and calendar windows from local midnights", () => {
+		const now = new Date(2026, 7, 15, 18, 0, 0);
+		const yesterdayEvening = rec({ ts: new Date(2026, 7, 14, 20, 0, 0).getTime(), tot: 100, cost: 0.5 });
+		const thisMorning = rec({ ts: new Date(2026, 7, 15, 10, 0, 0).getTime(), tot: 50, cost: 0.2 });
+		const lastWeek = rec({ ts: new Date(2026, 7, 10, 12, 0, 0).getTime(), tot: 200, cost: 0.1 });
+		const records = [yesterdayEvening, thisMorning, lastWeek];
+		expect(sumRows(aggregate(records, "today", "model", now, "rolling")).tokens).toBe(150);
+		expect(sumRows(aggregate(records, "today", "model", now, "calendar")).tokens).toBe(50);
+	});
+
 	it("keeps input / output / cache read / cache write instead of only total", () => {
 		const rows = aggregate([
 			rec(),
@@ -142,6 +152,15 @@ describe("local budgets", () => {
 		expect(status.exceeded).toBe(false);
 		expect(budgetKey(limit, now)).toContain("cost");
 	});
+
+	it("keeps budget periods on the calendar when the ledger is rolling", () => {
+		const now = new Date(2026, 7, 15, 18, 0, 0);
+		const yesterday = rec({ ts: new Date(2026, 7, 14, 20, 0, 0).getTime(), cost: 0.5 });
+		const today = rec({ ts: now.getTime(), cost: 0.2 });
+		const limit = { scope: "global" as const, period: "day" as const, metric: "cost" as const, max: 1 };
+		const status = statusForLimit([yesterday, today], limit, now, "sess-1");
+		expect(status.current).toBe(0.2);
+	});
 });
 
 describe("config parsing", () => {
@@ -165,6 +184,12 @@ describe("config parsing", () => {
 			quotaPolarity: "used",
 		});
 		expect(parsed.footer.quota).toEqual({ visible: true, polarity: "remaining" });
+	});
+
+	it("defaults ledger.windowMode to rolling and accepts calendar", () => {
+		expect(parseMeterConfig({}).ledger.windowMode).toBe("rolling");
+		expect(parseMeterConfig({ ledger: { windowMode: "calendar" } }).ledger.windowMode).toBe("calendar");
+		expect(parseMeterConfig({ ledger: { windowMode: "sideways" } }).ledger.windowMode).toBe("rolling");
 	});
 });
 

--- a/packages/pi-meter/tests/ledger.test.ts
+++ b/packages/pi-meter/tests/ledger.test.ts
@@ -111,6 +111,14 @@ describe("dashboard", () => {
 		expect(text).toContain("5.35B");
 		expect(text).toMatch(/Total/);
 	});
+
+	it("labels rolling windows as last-N, calendar windows as calendar days", async () => {
+		const { Dashboard } = await import("../src/ledger/dashboard.ts");
+		const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text };
+		const data = { records: [rec()], budgets: [] };
+		expect(new Dashboard(data, theme, "today", "rolling").render(80).join("\n")).toContain("Last 24h");
+		expect(new Dashboard(data, theme, "today", "calendar").render(80).join("\n")).toContain("Today");
+	});
 });
 
 describe("session import", () => {

--- a/packages/pi-meter/tests/quota.test.ts
+++ b/packages/pi-meter/tests/quota.test.ts
@@ -8,7 +8,7 @@ import { fetchOllamaQuota, OLLAMA_USAGE_URL, parseOllamaUsage } from "../src/quo
 import { parseSuperGrokBilling } from "../src/quota/adapters/supergrok.ts";
 import { readLocalQuotaCache } from "../src/chrome/status-cache.ts";
 import { OLLAMA_API_KEY_ERROR } from "../src/quota/auth.ts";
-import { QUOTA_UNSIGNED_OAUTH_ERROR } from "../src/quota/auth.ts";
+import { QUOTA_OBSOLETE_SUPERGROK_PERCENT_ERROR, QUOTA_UNSIGNED_OAUTH_ERROR } from "../src/quota/auth.ts";
 import { decideRefresh, emptyQuotaStore, markAttempt, putSnapshot, resolveChromeQuota } from "../src/quota/policy.ts";
 import { preferredProvider, refreshQuotaSnapshots } from "../src/quota/refresh.ts";
 import { sanitizeQuotaError } from "../src/quota/sanitize.ts";
@@ -60,6 +60,21 @@ describe("refresh policy", () => {
 			windows: [],
 		}));
 		expect(decideRefresh(store, "claude", now)).toMatchObject({ refresh: true, reason: "expired" });
+	});
+
+	it("refetches an obsolete SuperGrok percent error even inside the min interval", () => {
+		let store = emptyQuotaStore(now);
+		store = putSnapshot(store, snapshot({
+			provider: "supergrok",
+			title: "SuperGrok",
+			ok: false,
+			error: QUOTA_OBSOLETE_SUPERGROK_PERCENT_ERROR,
+			fetchedAt: now - 1_000,
+			primary: undefined,
+			windows: [],
+		}));
+		expect(decideRefresh(store, "supergrok", now)).toMatchObject({ refresh: true });
+		expect(decideRefresh(store, "supergrok", now, { force: true })).toMatchObject({ refresh: true, reason: "forced" });
 	});
 
 	it("does not let an unsigned snapshot's lastAttemptAt block the next pull", () => {
@@ -334,6 +349,23 @@ describe("provider parsers", () => {
 		});
 		expect(resolveChromeQuota(failed, undefined, { modelProvider: "ollama" })).toEqual({
 			hint: { label: "ollama", value: "no quota window" },
+		});
+	});
+
+	it("does not keep a leftover unsigned snapshot after the user signs in", () => {
+		const store = putSnapshot(emptyQuotaStore(now), snapshot({
+			provider: "supergrok",
+			title: "SuperGrok",
+			ok: false,
+			error: QUOTA_UNSIGNED_OAUTH_ERROR,
+			primary: undefined,
+			windows: [],
+		}), { recordAttempt: false });
+		expect(resolveChromeQuota(store, "supergrok", { signedIn: true })).toEqual({
+			hint: { label: "xai", value: "unavailable" },
+		});
+		expect(resolveChromeQuota(store, "supergrok", { signedIn: false })).toEqual({
+			hint: { label: "xai", value: "not signed in" },
 		});
 	});
 

--- a/packages/pi-meter/tests/quota.test.ts
+++ b/packages/pi-meter/tests/quota.test.ts
@@ -8,7 +8,8 @@ import { fetchOllamaQuota, OLLAMA_USAGE_URL, parseOllamaUsage } from "../src/quo
 import { parseSuperGrokBilling } from "../src/quota/adapters/supergrok.ts";
 import { readLocalQuotaCache } from "../src/chrome/status-cache.ts";
 import { OLLAMA_API_KEY_ERROR } from "../src/quota/auth.ts";
-import { decideRefresh, emptyQuotaStore, markAttempt, putSnapshot } from "../src/quota/policy.ts";
+import { QUOTA_UNSIGNED_OAUTH_ERROR } from "../src/quota/auth.ts";
+import { decideRefresh, emptyQuotaStore, markAttempt, putSnapshot, resolveChromeQuota } from "../src/quota/policy.ts";
 import { preferredProvider, refreshQuotaSnapshots } from "../src/quota/refresh.ts";
 import { sanitizeQuotaError } from "../src/quota/sanitize.ts";
 import { saveQuotaStore } from "../src/quota/store.ts";
@@ -47,6 +48,31 @@ describe("refresh policy", () => {
 		expect(decideRefresh(store, "claude", now, { force: true })).toMatchObject({ refresh: true, reason: "forced" });
 		store = markAttempt(store, "claude", now - 5_000);
 		expect(decideRefresh(store, "claude", now, { force: true })).toMatchObject({ refresh: false, reason: "min-interval" });
+	});
+
+	it("does not treat a failed snapshot as fresh", () => {
+		let store = emptyQuotaStore(now);
+		store = putSnapshot(store, snapshot({
+			ok: false,
+			error: "HTTP 500",
+			fetchedAt: now - 90_000,
+			primary: undefined,
+			windows: [],
+		}));
+		expect(decideRefresh(store, "claude", now)).toMatchObject({ refresh: true, reason: "expired" });
+	});
+
+	it("does not let an unsigned snapshot's lastAttemptAt block the next pull", () => {
+		let store = emptyQuotaStore(now);
+		store = putSnapshot(store, snapshot({
+			ok: false,
+			error: QUOTA_UNSIGNED_OAUTH_ERROR,
+			fetchedAt: now - 1_000,
+			primary: undefined,
+			windows: [],
+		}), { recordAttempt: false });
+		store = markAttempt(store, "claude", now - 5_000);
+		expect(decideRefresh(store, "claude", now)).toMatchObject({ refresh: true });
 	});
 });
 
@@ -101,6 +127,7 @@ describe("refreshQuotaSnapshots", () => {
 			agentDir(),
 			{
 				now,
+				hasCredential: () => true,
 				fetchers: {
 					claude: async () => {
 						throw new Error("Bearer eyJabc exploded");
@@ -136,6 +163,7 @@ describe("refreshQuotaSnapshots", () => {
 			dir,
 			{
 				now,
+				hasCredential: () => true,
 				fetchers: {
 					claude: async (_ctx, fetchedAt = now) => ({
 						provider: "claude",
@@ -178,6 +206,7 @@ describe("refreshQuotaSnapshots", () => {
 		const claude = vi.fn(async (_ctx, fetchedAt = now) => snapshot({ fetchedAt }));
 		await refreshQuotaSnapshots({ hasUI: true, modelRegistry: {} as never }, dir, {
 			now,
+			hasCredential: () => true,
 			fetchers: {
 				claude,
 				codex: async () => snapshot({ provider: "codex", fetchedAt: now }),
@@ -188,9 +217,33 @@ describe("refreshQuotaSnapshots", () => {
 		expect(claude).toHaveBeenCalledTimes(1);
 		await refreshQuotaSnapshots({ hasUI: true, modelRegistry: {} as never }, dir, {
 			now: now + 10_000,
+			hasCredential: () => true,
 			fetchers: { claude, codex: vi.fn(), supergrok: vi.fn(), ollama: vi.fn() },
 		});
 		expect(claude).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not call fetchers or getApiKeyForProvider when auth.json has no credentials", async () => {
+		const getApiKeyForProvider = vi.fn(async () => "should-not-be-used");
+		const fetchers = {
+			claude: vi.fn(),
+			codex: vi.fn(),
+			supergrok: vi.fn(),
+			ollama: vi.fn(),
+		};
+		const result = await refreshQuotaSnapshots(
+			{ hasUI: true, modelRegistry: { getApiKeyForProvider } as never },
+			agentDir(),
+			{ now, fetchers, hasCredential: () => false },
+		);
+		expect(result.fetched).toEqual([]);
+		expect(getApiKeyForProvider).not.toHaveBeenCalled();
+		expect(fetchers.claude).not.toHaveBeenCalled();
+		expect(fetchers.codex).not.toHaveBeenCalled();
+		expect(fetchers.supergrok).not.toHaveBeenCalled();
+		expect(fetchers.ollama).not.toHaveBeenCalled();
+		expect(result.store.providers.claude).toMatchObject({ ok: false, error: QUOTA_UNSIGNED_OAUTH_ERROR });
+		expect(result.store.lastAttemptAt.claude).toBeUndefined();
 	});
 });
 
@@ -210,6 +263,25 @@ describe("provider parsers", () => {
 		expect(parsed.ok).toBe(true);
 		expect(parsed.primary).toMatchObject({ id: "weekly", usedPercent: 51, resetsAt: "2026-08-17T16:55:31.897Z" });
 		expect(parsed.windows).toEqual([parsed.primary]);
+	});
+
+	it("treats a recognizable SuperGrok config without creditUsagePercent as 0% used", () => {
+		const parsed = parseSuperGrokBilling({
+			config: {
+				currentPeriod: { type: "USAGE_PERIOD_TYPE_WEEKLY", end: "2026-08-17T16:55:31.897623+00:00" },
+				billingPeriodEnd: "2026-08-17T16:55:31.897623+00:00",
+			},
+		}, now);
+		expect(parsed.ok).toBe(true);
+		expect(parsed.error).toBeUndefined();
+		expect(parsed.primary).toMatchObject({ id: "weekly", usedPercent: 0, resetsAt: "2026-08-17T16:55:31.897Z" });
+	});
+
+	it("still fails SuperGrok when the payload has no config object", () => {
+		expect(parseSuperGrokBilling({ creditUsagePercent: 10 }, now)).toMatchObject({
+			ok: false,
+			error: "unexpected response",
+		});
 	});
 
 	it("parses Claude 5h/week windows and Codex used_percent", () => {
@@ -237,6 +309,32 @@ describe("provider parsers", () => {
 	it("maps only ollama-cloud models onto the Ollama quota adapter", () => {
 		expect(preferredProvider({ provider: "ollama-cloud" })).toBe("ollama");
 		expect(preferredProvider({ provider: "ollama" })).toBeUndefined();
+	});
+
+	it("does not fall back to another vendor's quota window in the footer", () => {
+		const store = putSnapshot(emptyQuotaStore(now), snapshot({
+			provider: "codex",
+			title: "OpenAI Codex",
+			primary: { id: "week", label: "Week limit", usedPercent: 20 },
+			windows: [{ id: "week", label: "Week limit", usedPercent: 20 }],
+		}));
+		const failed = putSnapshot(store, snapshot({
+			provider: "supergrok",
+			title: "SuperGrok",
+			ok: false,
+			error: "HTTP 500",
+			primary: undefined,
+			windows: [],
+		}));
+		expect(resolveChromeQuota(failed, "supergrok", { signedIn: true })).toEqual({
+			hint: { label: "xai", value: "unavailable" },
+		});
+		expect(resolveChromeQuota(failed, "supergrok", { signedIn: false })).toEqual({
+			hint: { label: "xai", value: "not signed in" },
+		});
+		expect(resolveChromeQuota(failed, undefined, { modelProvider: "ollama" })).toEqual({
+			hint: { label: "ollama", value: "no quota window" },
+		});
 	});
 
 	it("parses Ollama Cloud session and weekly fractions without a reset time", () => {

--- a/packages/pi-tool-display-intent/README.md
+++ b/packages/pi-tool-display-intent/README.md
@@ -68,10 +68,11 @@ Layout and ownership changes take effect after `/reload`.
   ◐ Bash(pnpm test)
 
 ✓ Tools (17 calls · 3 turns) · read ×12 · ask_user_question ×1 · edit ×8 · bash ×17
+  ↳ 2 steers
   took 2m14s · tok ↑62k ↓8.4k R120k W4.1k · at 2026-04-08 14:32:14
 ```
 
-While a turn is running, the latest assistant note stays under the header as Markdown, up to three lines. After it settles, notes hide and a muted receipt shows duration, tokens, cache, and local time. Collapsed failures are `N failed` only. `Ctrl+O` expands the original timeline without dumping file contents or diffs. Images and `Agent` keep their original renderers. Switch back with `/tool-display-intent layout individual` then `/reload`.
+While a turn is running, the latest assistant note stays under the header as Markdown, up to three lines. After it settles, notes hide and a muted receipt shows duration, tokens, cache, and local time. Collapsed failures are `N failed` only. Mid-turn steers stay on the same Tools ledger: first lines pin under the header while it runs, then one `↳ N steers` line remains. `Ctrl+O` expands the original timeline, with each `↳` in place, without dumping file contents or diffs. Images and `Agent` keep their original renderers. Switch back with `/tool-display-intent layout individual` then `/reload`.
 
 Aggregate always uses a compact accent-gutter user prompt.
 

--- a/packages/pi-tool-display-intent/README.zh-CN.md
+++ b/packages/pi-tool-display-intent/README.zh-CN.md
@@ -68,10 +68,11 @@ pi install npm:@zhcsyncer/pi-extensions
   ◐ Bash(pnpm test)
 
 ✓ Tools (17 calls · 3 turns) · read ×12 · ask_user_question ×1 · edit ×8 · bash ×17
+  ↳ 2 steers
   took 2m14s · tok ↑62k ↓8.4k R120k W4.1k · at 2026-04-08 14:32:14
 ```
 
-进行中时，最新一条 assistant 旁白按 Markdown 停在标题下，最多三行。结束后旁白收起，mute 收据显示耗时、token、cache 和本地时间。收起时失败只显示 `N failed`。`Ctrl+O` 展开原时间线，不倾倒文件内容或 diff。图片和 `Agent` 仍用原 renderer。切回：`/tool-display-intent layout individual` 再 `/reload`。
+进行中时，最新一条 assistant 旁白按 Markdown 停在标题下，最多三行。结束后旁白收起，mute 收据显示耗时、token、cache 和本地时间。收起时失败只显示 `N failed`。中途 steer 仍是同一本 Tools：进行中钉各条首行，结束后留一行 `↳ N steers`。`Ctrl+O` 展开原时间线，每条 `↳` 留在当时的位置，不倾倒文件内容或 diff。图片和 `Agent` 仍用原 renderer。切回：`/tool-display-intent layout individual` 再 `/reload`。
 
 Aggregate 固定用左侧强调色细杠的用户行。
 

--- a/packages/pi-tool-display-intent/src/aggregate-activity.ts
+++ b/packages/pi-tool-display-intent/src/aggregate-activity.ts
@@ -349,12 +349,16 @@ function renderNarrationMarkdownLines(text: string, width: number): string[] {
 	return wrapped.length > 0 ? wrapped : [text];
 }
 
-function colorSteerMark(theme: AggregateRenderTheme): string {
+function colorSteerText(theme: AggregateRenderTheme, text: string): string {
 	try {
-		return theme.fg("accent", AGGREGATE_STEER_MARK);
+		return theme.fg("accent", text);
 	} catch {
-		return AGGREGATE_STEER_MARK;
+		return text;
 	}
+}
+
+export function formatAggregateSteerCount(count: number): string {
+	return `${count} ${count === 1 ? "steer" : "steers"}`;
 }
 
 export function renderCollapsedSteerPins(
@@ -364,10 +368,29 @@ export function renderCollapsedSteerPins(
 ): string[] {
 	const safeWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : 0;
 	if (safeWidth === 0 || steers.length === 0) return [];
-	const mark = colorSteerMark(theme);
 	return steers.map((steer) =>
-		truncateToWidth(`  ${mark} ${steer.firstLine}`, safeWidth, "…"),
+		truncateToWidth(
+			`  ${colorSteerText(theme, `${AGGREGATE_STEER_MARK} ${steer.firstLine}`)}`,
+			safeWidth,
+			"…",
+		),
 	);
+}
+
+export function renderSettledSteerReminder(
+	steerCount: number,
+	width: number,
+	theme: AggregateRenderTheme,
+): string[] {
+	const safeWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : 0;
+	if (safeWidth === 0 || steerCount <= 0) return [];
+	return [
+		truncateToWidth(
+			`  ${colorSteerText(theme, `${AGGREGATE_STEER_MARK} ${formatAggregateSteerCount(steerCount)}`)}`,
+			safeWidth,
+			"…",
+		),
+	];
 }
 
 export function renderExpandedAggregateSteer(
@@ -380,8 +403,12 @@ export function renderExpandedAggregateSteer(
 	while (lines.length > 0 && !lines[0]!.trim()) lines.shift();
 	while (lines.length > 0 && !lines[lines.length - 1]!.trim()) lines.pop();
 	const body = lines.length > 0 ? lines : [""];
-	const mark = colorSteerMark(theme);
-	const marked = body.map((line, index) => index === 0 ? `${mark} ${line}` : line);
+	const marked = [
+		"",
+		...body.map((line, index) =>
+			index === 0 ? colorSteerText(theme, `${AGGREGATE_STEER_MARK} ${line}`) : line),
+		"",
+	];
 	return applyAggregateGroupFrame(marked, width, theme, edge);
 }
 
@@ -1456,8 +1483,7 @@ export function renderAggregateActivity(
 	const callTurn = ` (${view.callCount} call${view.callCount === 1 ? "" : "s"} · ${view.agentTurnCount} turn${view.agentTurnCount === 1 ? "" : "s"}`;
 	let totals = theme.fg("muted", callTurn);
 	if ((view.steerCount ?? 0) > 0) {
-		const label = view.steerCount === 1 ? "steer" : "steers";
-		let steer = ` · ${view.steerCount} ${label}`;
+		let steer = ` · ${formatAggregateSteerCount(view.steerCount)}`;
 		try {
 			steer = theme.fg("accent", steer);
 		} catch {
@@ -1474,15 +1500,17 @@ export function renderAggregateActivity(
 	}
 
 	const lines = [truncateToWidth(header, safeWidth, "…")];
+	if (view.settled) {
+		lines.push(...renderSettledSteerReminder(view.steerCount ?? 0, safeWidth, theme));
+	} else {
+		lines.push(...renderCollapsedSteerPins(view.pinnedSteers ?? [], safeWidth, theme));
+	}
 	const stats = formatAggregateStatsLine(view);
 	if (stats) {
 		lines.push(truncateToWidth(`  ${theme.fg("muted", stats)}`, safeWidth, "…"));
 	}
-	if (!view.settled) {
-		lines.push(...renderCollapsedSteerPins(view.pinnedSteers ?? [], safeWidth, theme));
-		if (view.latestNarration) {
-			lines.push(...renderCollapsedAssistantNarration(view.latestNarration, safeWidth, theme));
-		}
+	if (!view.settled && view.latestNarration) {
+		lines.push(...renderCollapsedAssistantNarration(view.latestNarration, safeWidth, theme));
 	}
 	for (const row of view.displayRows) {
 		if (row.state === "success") {

--- a/packages/pi-tool-display-intent/src/aggregate-activity.ts
+++ b/packages/pi-tool-display-intent/src/aggregate-activity.ts
@@ -35,6 +35,12 @@ export interface AggregateUsageTotals {
 	cacheWrite: number;
 }
 
+export interface AggregateSteer {
+	id: string;
+	text: string;
+	firstLine: string;
+}
+
 export interface AggregateGroup {
 	groupId: string;
 	leaderToolCallId?: string;
@@ -43,6 +49,8 @@ export interface AggregateGroup {
 	narrationById: Map<string, string>;
 	agentTurnIds: string[];
 	usageByKey: Map<string, AggregateUsageTotals>;
+	steers: AggregateSteer[];
+	hasSeenToolBatch: boolean;
 	settled: boolean;
 	startedAtMs?: number;
 	endedAtMs?: number;
@@ -72,6 +80,8 @@ export interface AggregateActivityView {
 	activeOverflow: number;
 	failed: AggregateMember[];
 	failedCount: number;
+	steerCount: number;
+	pinnedSteers: Array<{ id: string; firstLine: string }>;
 	toolSummaries: AggregateToolSummary[];
 }
 
@@ -125,6 +135,7 @@ const ACTIVE_ROW_LIMIT = 3;
 const AGGREGATE_FRAME_CONTINUE = "  │ ";
 const AGGREGATE_FRAME_END = "  └ ";
 export const AGGREGATE_ASSISTANT_MARK = "›";
+export const AGGREGATE_STEER_MARK = "↳";
 const COLLAPSED_NARRATION_ROW_LIMIT = 3;
 const COLLAPSED_NARRATION_SOURCE_MAX_LENGTH = 2_000;
 const OSC_SEQUENCE_PATTERN = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
@@ -338,6 +349,42 @@ function renderNarrationMarkdownLines(text: string, width: number): string[] {
 	return wrapped.length > 0 ? wrapped : [text];
 }
 
+function colorSteerMark(theme: AggregateRenderTheme): string {
+	try {
+		return theme.fg("accent", AGGREGATE_STEER_MARK);
+	} catch {
+		return AGGREGATE_STEER_MARK;
+	}
+}
+
+export function renderCollapsedSteerPins(
+	steers: ReadonlyArray<{ firstLine: string }>,
+	width: number,
+	theme: AggregateRenderTheme,
+): string[] {
+	const safeWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : 0;
+	if (safeWidth === 0 || steers.length === 0) return [];
+	const mark = colorSteerMark(theme);
+	return steers.map((steer) =>
+		truncateToWidth(`  ${mark} ${steer.firstLine}`, safeWidth, "…"),
+	);
+}
+
+export function renderExpandedAggregateSteer(
+	text: string,
+	width: number,
+	theme: AggregateRenderTheme,
+	edge: AggregateFrameEdge = "only",
+): string[] {
+	const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+	while (lines.length > 0 && !lines[0]!.trim()) lines.shift();
+	while (lines.length > 0 && !lines[lines.length - 1]!.trim()) lines.pop();
+	const body = lines.length > 0 ? lines : [""];
+	const mark = colorSteerMark(theme);
+	const marked = body.map((line, index) => index === 0 ? `${mark} ${line}` : line);
+	return applyAggregateGroupFrame(marked, width, theme, edge);
+}
+
 export function renderCollapsedAssistantNarration(
 	text: string,
 	width: number,
@@ -405,6 +452,35 @@ function entryId(entry: unknown, fallback: string): string {
 function isAssistantTerminalFailure(message: unknown): boolean {
 	const reason = toRecord(message).stopReason;
 	return reason === "aborted" || reason === "error";
+}
+
+function isAssistantTerminal(message: unknown): boolean {
+	const reason = toRecord(message).stopReason;
+	return reason === "stop" || reason === "error" || reason === "aborted" || reason === "length";
+}
+
+export function userMessageText(message: unknown): string {
+	const content = toRecord(message).content;
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.filter((entry) => toRecord(entry).type === "text")
+		.map((entry) => String(toRecord(entry).text ?? ""))
+		.join("");
+}
+
+export function steerFirstLine(text: string): string {
+	const sanitized = text
+		.replace(OSC_SEQUENCE_PATTERN, "")
+		.replace(ANSI_SEQUENCE_PATTERN, "")
+		.replace(NARRATION_CONTROL_PATTERN, "")
+		.replace(/\r\n/g, "\n")
+		.replace(/\r/g, "\n");
+	for (const line of sanitized.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed) return trimmed;
+	}
+	return "";
 }
 
 function parseTimestampMs(value: unknown): number | undefined {
@@ -554,6 +630,8 @@ export class AggregateProjection {
 	private readonly visibleFrameContent = new Set<string>();
 	private readonly frameInvalidators: FrameInvalidator[] = [];
 	private readonly invalidators = new Map<string, () => void>();
+	private readonly assignedSteerIds = new Set<string>();
+	private readonly steersByInstance = new WeakMap<object, string>();
 	private sourceOrder = 0;
 	private completionOrder = 0;
 	private liveGroupSequence = 0;
@@ -625,7 +703,13 @@ export class AggregateProjection {
 	}
 
 	hasVisibleFrameContent(itemId: string): boolean {
-		if (!itemId.startsWith("assistant-before:") && !itemId.startsWith("assistant:")) return true;
+		if (
+			!itemId.startsWith("assistant-before:") &&
+			!itemId.startsWith("assistant:") &&
+			!itemId.startsWith("steer:")
+		) {
+			return true;
+		}
 		return this.visibleFrameContent.has(itemId);
 	}
 
@@ -775,6 +859,82 @@ export class AggregateProjection {
 		return resolvedId;
 	}
 
+	shouldTreatAsSteer(streamingBehavior?: "steer" | "followUp"): boolean {
+		const group = this.activeGroupId ? this.groupsById.get(this.activeGroupId) : undefined;
+		if (!group || group.settled) return false;
+		if (streamingBehavior === "followUp") return false;
+		if (streamingBehavior === "steer") return true;
+		return group.hasSeenToolBatch;
+	}
+
+	recordSteer(text: string, timestampMs?: number): string | undefined {
+		const group = this.activeGroupId ? this.groupsById.get(this.activeGroupId) : undefined;
+		if (!group) return undefined;
+		const id = `steer:${group.groupId}:${group.steers.length}`;
+		group.steers.push({
+			id,
+			text,
+			firstLine: steerFirstLine(text),
+		});
+		this.trackFramedItem(id, group.groupId);
+		this.rememberEndedAt(timestampMs);
+		this.invalidateIds(group.leaderToolCallId);
+		return id;
+	}
+
+	ingestUserMessage(
+		message: unknown,
+		options: {
+			streamingBehavior?: "steer" | "followUp";
+			collapseRetainedDone?: boolean;
+			groupId?: string;
+			timestampMs?: number;
+		} = {},
+	): "steer" | "group" | undefined {
+		if (messageRole(message) !== "user") return undefined;
+		const timestampMs = options.timestampMs ?? messageTimestampMs(message);
+		if (this.shouldTreatAsSteer(options.streamingBehavior)) {
+			this.recordSteer(userMessageText(message), timestampMs);
+			return "steer";
+		}
+		const groupId = options.groupId ??
+			(timestampMs !== undefined ? `live-user-${timestampMs}` : undefined);
+		this.startUserGroup(groupId, timestampMs, {
+			collapseRetainedDone: options.collapseRetainedDone,
+		});
+		return "group";
+	}
+
+	getSteer(id: string): AggregateSteer | undefined {
+		for (const group of this.groups) {
+			const found = group.steers.find((steer) => steer.id === id);
+			if (found) return found;
+		}
+		return undefined;
+	}
+
+	matchSteerForComponent(component: object, text?: string): AggregateSteer | undefined {
+		const existingId = this.steersByInstance.get(component);
+		if (existingId) {
+			const existing = this.getSteer(existingId);
+			if (existing) return existing;
+		}
+		if (text === undefined) return undefined;
+		for (const group of this.groups) {
+			for (const steer of group.steers) {
+				if (steer.text !== text || this.assignedSteerIds.has(steer.id)) continue;
+				this.assignedSteerIds.add(steer.id);
+				this.steersByInstance.set(component, steer.id);
+				return steer;
+			}
+		}
+		for (const group of this.groups) {
+			const found = group.steers.find((steer) => steer.text === text);
+			if (found) return found;
+		}
+		return undefined;
+	}
+
 	connectRenderer(
 		toolCallId: string,
 		toolName: string,
@@ -796,6 +956,7 @@ export class AggregateProjection {
 		if (messageRole(message) !== "assistant") return;
 		this.rememberAgentTurn(message);
 		const calls = toolCallsFromMessage(message);
+		if (calls.length > 0) this.markGroupSawToolBatch();
 		if (isInterimAssistantMessage(message)) {
 			const frameId = aggregateAssistantFrameId(message);
 			const narration = firstVisibleAssistantText(message);
@@ -813,6 +974,7 @@ export class AggregateProjection {
 				if (this.membersById.has(call.id)) this.markFailed(call.id, summary);
 			}
 		}
+		this.maybeSettleFromTerminalAssistant(message);
 	}
 
 	ingestToolResult(
@@ -830,6 +992,7 @@ export class AggregateProjection {
 				retainDone: options.retainDone,
 			});
 		}
+		this.markGroupSawToolBatch(this.membersById.get(String(record.toolCallId))?.groupId);
 		this.rememberEndedAt(messageTimestampMs(message, options.fallbackTimestamp));
 	}
 
@@ -930,6 +1093,7 @@ export class AggregateProjection {
 		this.framedGroupById.clear();
 		this.visibleFrameContent.clear();
 		this.frameInvalidators.length = 0;
+		this.assignedSteerIds.clear();
 		this.sourceOrder = 0;
 		this.completionOrder = 0;
 		this.activeGroupId = undefined;
@@ -941,11 +1105,11 @@ export class AggregateProjection {
 			const role = messageRole(message);
 			if (role === "user") {
 				const restoredId = entryId(entry, `restored-user-${++fallbackGroupIndex}`);
-				this.startUserGroup(
-					restoredId,
-					messageTimestampMs(message, toRecord(entry).timestamp),
-					{ collapseRetainedDone: false },
-				);
+				this.ingestUserMessage(message, {
+					groupId: restoredId,
+					collapseRetainedDone: false,
+					timestampMs: messageTimestampMs(message, toRecord(entry).timestamp),
+				});
 				continue;
 			}
 			if (role === "assistant") {
@@ -1049,8 +1213,28 @@ export class AggregateProjection {
 			activeOverflow: Math.max(0, activeAll.length - ACTIVE_ROW_LIMIT),
 			failed,
 			failedCount: grouped.filter((entry) => entry.state === "failed").length,
+			steerCount: group.steers.length,
+			pinnedSteers: group.settled
+				? []
+				: group.steers.map((steer) => ({ id: steer.id, firstLine: steer.firstLine })),
 			toolSummaries: [...summaries.values()],
 		};
+	}
+
+	private markGroupSawToolBatch(groupId = this.activeGroupId): void {
+		if (!groupId) return;
+		const group = this.groupsById.get(groupId);
+		if (group) group.hasSeenToolBatch = true;
+	}
+
+	private maybeSettleFromTerminalAssistant(message: unknown): void {
+		if (!isAssistantTerminal(message)) return;
+		const group = this.activeGroupId ? this.groupsById.get(this.activeGroupId) : undefined;
+		if (!group) return;
+		if (group.members.some((member) => member.state === "pending" || member.state === "running")) {
+			return;
+		}
+		group.settled = true;
 	}
 
 	private ensureGroup(groupId: string): AggregateGroup {
@@ -1063,6 +1247,8 @@ export class AggregateProjection {
 				narrationById: new Map(),
 				agentTurnIds: [],
 				usageByKey: new Map(),
+				steers: [],
+				hasSeenToolBatch: false,
 				settled: false,
 			};
 			this.groups.push(group);
@@ -1093,6 +1279,7 @@ export class AggregateProjection {
 		}
 
 		const group = this.ensureActiveGroup();
+		group.hasSeenToolBatch = true;
 		this.evictOldestRetainedDone(group);
 		const previousLeader = group.leaderToolCallId;
 		const member: AggregateMember = {
@@ -1266,10 +1453,19 @@ export function renderAggregateActivity(
 	const hasFailure = view.failedCount > 0;
 	const marker = hasFailure ? "!" : view.hasRunning ? "◐" : "✓";
 	const markerColor = hasFailure ? "error" : view.hasRunning ? "warning" : "success";
-	const totals = theme.fg(
-		"muted",
-		` (${view.callCount} call${view.callCount === 1 ? "" : "s"} · ${view.agentTurnCount} turn${view.agentTurnCount === 1 ? "" : "s"})`,
-	);
+	const callTurn = ` (${view.callCount} call${view.callCount === 1 ? "" : "s"} · ${view.agentTurnCount} turn${view.agentTurnCount === 1 ? "" : "s"}`;
+	let totals = theme.fg("muted", callTurn);
+	if ((view.steerCount ?? 0) > 0) {
+		const label = view.steerCount === 1 ? "steer" : "steers";
+		let steer = ` · ${view.steerCount} ${label}`;
+		try {
+			steer = theme.fg("accent", steer);
+		} catch {
+			// Theme helpers must not crash the ledger header.
+		}
+		totals += steer;
+	}
+	totals += theme.fg("muted", ")");
 	let header = `${theme.fg(markerColor, marker)} ${theme.fg("toolTitle", theme.bold?.("Tools") ?? "Tools")}${totals}`;
 	if (hasFailure) header += theme.fg("error", ` · ${view.failedCount} failed`);
 	for (const summary of view.toolSummaries) {
@@ -1282,8 +1478,11 @@ export function renderAggregateActivity(
 	if (stats) {
 		lines.push(truncateToWidth(`  ${theme.fg("muted", stats)}`, safeWidth, "…"));
 	}
-	if (!view.settled && view.latestNarration) {
-		lines.push(...renderCollapsedAssistantNarration(view.latestNarration, safeWidth, theme));
+	if (!view.settled) {
+		lines.push(...renderCollapsedSteerPins(view.pinnedSteers ?? [], safeWidth, theme));
+		if (view.latestNarration) {
+			lines.push(...renderCollapsedAssistantNarration(view.latestNarration, safeWidth, theme));
+		}
 	}
 	for (const row of view.displayRows) {
 		if (row.state === "success") {
@@ -1472,14 +1671,16 @@ export function registerAggregateProjectionEvents(
 	});
 	pi.on("session_compact", async (_event, ctx) => rebuild(ctx));
 	pi.on("session_tree", async (_event, ctx) => rebuild(ctx));
+	let pendingStreamingBehavior: "steer" | "followUp" | undefined;
+	pi.on("input", async (event) => {
+		pendingStreamingBehavior = event.streamingBehavior;
+	});
 	pi.on("message_start", async (event) => {
 		if (messageRole(event.message) === "user") {
 			clearSettleTimer();
-			const timestamp = toRecord(event.message).timestamp;
-			projection.startUserGroup(
-				typeof timestamp === "number" ? `live-user-${timestamp}` : undefined,
-				parseTimestampMs(timestamp),
-			);
+			const behavior = pendingStreamingBehavior;
+			pendingStreamingBehavior = undefined;
+			projection.ingestUserMessage(event.message, { streamingBehavior: behavior });
 		}
 	});
 	pi.on("message_update", async (event) => projection.ingestAssistantMessage(event.message));

--- a/packages/pi-tool-display-intent/src/aggregate-activity.ts
+++ b/packages/pi-tool-display-intent/src/aggregate-activity.ts
@@ -1480,18 +1480,10 @@ export function renderAggregateActivity(
 	const hasFailure = view.failedCount > 0;
 	const marker = hasFailure ? "!" : view.hasRunning ? "◐" : "✓";
 	const markerColor = hasFailure ? "error" : view.hasRunning ? "warning" : "success";
-	const callTurn = ` (${view.callCount} call${view.callCount === 1 ? "" : "s"} · ${view.agentTurnCount} turn${view.agentTurnCount === 1 ? "" : "s"}`;
-	let totals = theme.fg("muted", callTurn);
-	if ((view.steerCount ?? 0) > 0) {
-		let steer = ` · ${formatAggregateSteerCount(view.steerCount)}`;
-		try {
-			steer = theme.fg("accent", steer);
-		} catch {
-			// Theme helpers must not crash the ledger header.
-		}
-		totals += steer;
-	}
-	totals += theme.fg("muted", ")");
+	const totals = theme.fg(
+		"muted",
+		` (${view.callCount} call${view.callCount === 1 ? "" : "s"} · ${view.agentTurnCount} turn${view.agentTurnCount === 1 ? "" : "s"})`,
+	);
 	let header = `${theme.fg(markerColor, marker)} ${theme.fg("toolTitle", theme.bold?.("Tools") ?? "Tools")}${totals}`;
 	if (hasFailure) header += theme.fg("error", ` · ${view.failedCount} failed`);
 	for (const summary of view.toolSummaries) {

--- a/packages/pi-tool-display-intent/src/user-message-box-native.ts
+++ b/packages/pi-tool-display-intent/src/user-message-box-native.ts
@@ -3,11 +3,19 @@ import {
   UserMessageComponent,
 } from "@earendil-works/pi-coding-agent";
 import {
+  isUserMessageExpanded,
   patchNativeUserMessagePrototype,
   type PatchableUserMessagePrototype,
+  type UserMessageSteerPresentation,
   type UserMessageTheme,
 } from "./user-message-box-renderer.js";
 import { unregisterUserMessageRenderPrototypePatch } from "./user-message-box-patch.js";
+import { extractUserMessageMarkdownState } from "./user-message-box-markdown.js";
+import {
+  getActiveAggregateProjection,
+  renderExpandedAggregateSteer,
+  resolveAggregateRenderTheme,
+} from "./aggregate-activity.js";
 import type { ToolDisplayConfig } from "./types.js";
 import { onReloadShutdown } from "./extension-lifecycle.js";
 
@@ -15,6 +23,43 @@ const registeredNativeUserMessageApis = new WeakSet<ExtensionAPI>();
 
 function getUserMessagePrototype(): PatchableUserMessagePrototype {
   return UserMessageComponent.prototype as unknown as PatchableUserMessagePrototype;
+}
+
+function readUserMessageText(instance: object): string | undefined {
+  const text = (instance as { text?: unknown }).text;
+  if (typeof text === "string") return text;
+  return extractUserMessageMarkdownState(instance)?.text;
+}
+
+export function resolveAggregateSteerUserPresentation(
+  instance: object,
+  width: number,
+): UserMessageSteerPresentation | undefined {
+  const projection = getActiveAggregateProjection();
+  if (!projection) return undefined;
+  const text = readUserMessageText(instance);
+  const steer = projection.matchSteerForComponent(instance, text);
+  if (!steer) return undefined;
+  projection.connectFrameRenderer(steer.id, () => {
+    try {
+      (instance as { invalidate?: () => void }).invalidate?.();
+    } catch {
+      // A stale transcript component may already be disposed.
+    }
+  });
+  if (!isUserMessageExpanded(instance)) {
+    projection.markFrameContentVisible(steer.id, false);
+    return { hide: true };
+  }
+  projection.markFrameContentVisible(steer.id, true);
+  return {
+    lines: renderExpandedAggregateSteer(
+      steer.text,
+      width,
+      resolveAggregateRenderTheme(projection),
+      projection.getFrameEdge(steer.id) ?? "only",
+    ),
+  };
 }
 
 function patchUserMessageRender(
@@ -27,6 +72,7 @@ function patchUserMessageRender(
     getTheme,
     isEnabled,
     isCompact,
+    (instance, width) => isCompact() ? resolveAggregateSteerUserPresentation(instance, width) : undefined,
   );
 }
 

--- a/packages/pi-tool-display-intent/src/user-message-box-native.ts
+++ b/packages/pi-tool-display-intent/src/user-message-box-native.ts
@@ -2,6 +2,7 @@ import {
   type ExtensionAPI,
   UserMessageComponent,
 } from "@earendil-works/pi-coding-agent";
+import { Container, Spacer } from "@earendil-works/pi-tui";
 import {
   isUserMessageExpanded,
   patchNativeUserMessagePrototype,
@@ -20,6 +21,19 @@ import type { ToolDisplayConfig } from "./types.js";
 import { onReloadShutdown } from "./extension-lifecycle.js";
 
 const registeredNativeUserMessageApis = new WeakSet<ExtensionAPI>();
+const CONTAINER_STEER_SPACER_KEY = Symbol.for(
+  "pi-tool-display-intent.steer-user-spacer.v1",
+);
+const pendingSpacerByContainer = new WeakMap<object, Spacer>();
+const spacerBeforeUser = new WeakMap<object, Spacer>();
+
+interface PatchableContainerPrototype {
+  addChild(component: unknown): void;
+  [CONTAINER_STEER_SPACER_KEY]?: {
+    originalAddChild: (component: unknown) => void;
+    patchedAddChild: (component: unknown) => void;
+  };
+}
 
 function getUserMessagePrototype(): PatchableUserMessagePrototype {
   return UserMessageComponent.prototype as unknown as PatchableUserMessagePrototype;
@@ -31,6 +45,54 @@ function readUserMessageText(instance: object): string | undefined {
   return extractUserMessageMarkdownState(instance)?.text;
 }
 
+function getContainerPrototype(): PatchableContainerPrototype {
+  return Container.prototype as unknown as PatchableContainerPrototype;
+}
+
+export function patchSteerUserLeadingSpacer(): void {
+  const prototype = getContainerPrototype();
+  if (prototype[CONTAINER_STEER_SPACER_KEY]) return;
+  const originalAddChild = prototype.addChild;
+  const patchedAddChild = function addChildTrackingSteerSpacer(
+    this: object,
+    component: unknown,
+  ): void {
+    originalAddChild.call(this, component);
+    if (component instanceof Spacer) {
+      pendingSpacerByContainer.set(this, component);
+      return;
+    }
+    const pending = pendingSpacerByContainer.get(this);
+    if (component instanceof UserMessageComponent && pending) {
+      spacerBeforeUser.set(component, pending);
+      suppressSteerLeadingSpacer(component);
+    }
+    pendingSpacerByContainer.delete(this);
+  };
+  prototype.addChild = patchedAddChild;
+  prototype[CONTAINER_STEER_SPACER_KEY] = { originalAddChild, patchedAddChild };
+}
+
+export function restoreSteerUserLeadingSpacer(): void {
+  const prototype = getContainerPrototype();
+  const state = prototype[CONTAINER_STEER_SPACER_KEY];
+  if (!state) return;
+  if (prototype.addChild === state.patchedAddChild) {
+    prototype.addChild = state.originalAddChild;
+  }
+  delete prototype[CONTAINER_STEER_SPACER_KEY];
+}
+
+function suppressSteerLeadingSpacer(instance: object): void {
+  const spacer = spacerBeforeUser.get(instance);
+  if (!spacer) return;
+  const projection = getActiveAggregateProjection();
+  const text = readUserMessageText(instance);
+  if (!projection || text === undefined) return;
+  if (!projection.matchSteerForComponent(instance, text)) return;
+  spacer.setLines(0);
+}
+
 export function resolveAggregateSteerUserPresentation(
   instance: object,
   width: number,
@@ -40,6 +102,7 @@ export function resolveAggregateSteerUserPresentation(
   const text = readUserMessageText(instance);
   const steer = projection.matchSteerForComponent(instance, text);
   if (!steer) return undefined;
+  suppressSteerLeadingSpacer(instance);
   projection.connectFrameRenderer(steer.id, () => {
     try {
       (instance as { invalidate?: () => void }).invalidate?.();
@@ -67,6 +130,7 @@ function patchUserMessageRender(
   isEnabled: () => boolean,
   isCompact: () => boolean,
 ): void {
+  patchSteerUserLeadingSpacer();
   patchNativeUserMessagePrototype(
     getUserMessagePrototype(),
     getTheme,
@@ -77,6 +141,7 @@ function patchUserMessageRender(
 }
 
 function restoreUserMessageRender(): void {
+  restoreSteerUserLeadingSpacer();
   unregisterUserMessageRenderPrototypePatch(getUserMessagePrototype());
 }
 

--- a/packages/pi-tool-display-intent/src/user-message-box-patch.ts
+++ b/packages/pi-tool-display-intent/src/user-message-box-patch.ts
@@ -4,8 +4,12 @@ const USER_MESSAGE_PATCH_OWNER = {};
 
 export interface PatchableUserMessagePrototype {
   render: UserMessageRenderFn;
+  setExpanded?: (expanded: boolean) => void;
+  invalidate?: () => void;
   __piUserMessageOriginalRender?: UserMessageRenderFn;
+  __piUserMessageOriginalSetExpanded?: (expanded: boolean) => void;
   __piUserMessageNativePatched?: boolean;
+  __piUserMessageSetExpandedPatched?: boolean;
   __piUserMessagePatchVersion?: number;
   __piUserMessagePatchOwner?: object;
 }
@@ -18,8 +22,18 @@ export function unregisterUserMessageRenderPrototypePatch(
     prototype.render = originalRender;
   }
 
+  if (prototype.__piUserMessageSetExpandedPatched) {
+    if (prototype.__piUserMessageOriginalSetExpanded) {
+      prototype.setExpanded = prototype.__piUserMessageOriginalSetExpanded;
+    } else {
+      delete prototype.setExpanded;
+    }
+  }
+
   delete prototype.__piUserMessageOriginalRender;
+  delete prototype.__piUserMessageOriginalSetExpanded;
   delete prototype.__piUserMessageNativePatched;
+  delete prototype.__piUserMessageSetExpandedPatched;
   delete prototype.__piUserMessagePatchVersion;
   delete prototype.__piUserMessagePatchOwner;
 }

--- a/packages/pi-tool-display-intent/src/user-message-box-renderer.ts
+++ b/packages/pi-tool-display-intent/src/user-message-box-renderer.ts
@@ -59,7 +59,14 @@ const CONTENT_HORIZONTAL_PADDING_COLUMNS = 1;
 const USER_MESSAGE_TOP_MARGIN_LINES = 1;
 const AGGREGATE_USER_GUTTER = "▎";
 const AGGREGATE_USER_GUTTER_GAP = " ";
-const USER_MESSAGE_PATCH_VERSION = 14;
+const USER_MESSAGE_PATCH_VERSION = 15;
+export const USER_MESSAGE_EXPANDED_KEY = Symbol.for(
+  "pi-tool-display-intent.aggregate-user-expanded.v1",
+);
+
+export type UserMessageSteerPresentation =
+  | { hide: true }
+  | { hide?: false; lines: string[] };
 const MAX_USER_MESSAGE_MARKDOWN_TEXT_LENGTH = 100_000;
 const MAX_USER_MESSAGE_MARKDOWN_LINE_COUNT = 2_000;
 
@@ -385,14 +392,35 @@ function renderUserMessageBodyLines(
   }
 }
 
+export function isUserMessageExpanded(instance: object): boolean {
+  return (instance as { [USER_MESSAGE_EXPANDED_KEY]?: boolean })[USER_MESSAGE_EXPANDED_KEY] === true;
+}
+
+function installUserMessageSetExpanded(prototype: PatchableUserMessagePrototype): void {
+  if (prototype.__piUserMessageSetExpandedPatched) return;
+  prototype.__piUserMessageOriginalSetExpanded = prototype.setExpanded;
+  prototype.setExpanded = function setAggregateUserMessageExpanded(this: PatchableUserMessagePrototype, expanded: boolean): void {
+    (this as { [USER_MESSAGE_EXPANDED_KEY]?: boolean })[USER_MESSAGE_EXPANDED_KEY] = expanded === true;
+    prototype.__piUserMessageOriginalSetExpanded?.call(this, expanded);
+    try {
+      this.invalidate?.();
+    } catch {
+      // A stale transcript component may already be disposed.
+    }
+  };
+  prototype.__piUserMessageSetExpandedPatched = true;
+}
+
 export function patchNativeUserMessagePrototype(
   prototype: PatchableUserMessagePrototype,
   getTheme: () => UserMessageTheme | undefined,
   isEnabled: () => boolean,
   isCompact?: () => boolean,
+  getSteerPresentation?: (instance: object, width: number) => UserMessageSteerPresentation | undefined,
 ): void {
   const finalOutputCache = new WeakMap<object, CachedUserMessageFinalOutput>();
   const originalBodyLineCache = new WeakMap<object, CachedUserMessageBodyLines>();
+  installUserMessageSetExpanded(prototype);
 
   patchUserMessageRenderPrototype(
     prototype,
@@ -414,6 +442,11 @@ export function patchNativeUserMessagePrototype(
 
         const theme = getTheme();
         const compact = isCompact?.() === true;
+        if (compact && getSteerPresentation && canCacheFinalOutput) {
+          const presentation = getSteerPresentation(this as object, safeWidth);
+          if (presentation?.hide === true) return [];
+          if (presentation?.lines) return presentation.lines;
+        }
         if (canCacheFinalOutput) {
           const cached = finalOutputCache.get(this as object);
           if (cached && hasSameFinalOutputState(cached, safeWidth, theme, markdownState, compact)) {

--- a/packages/pi-tool-display-intent/tests/aggregate-activity.test.ts
+++ b/packages/pi-tool-display-intent/tests/aggregate-activity.test.ts
@@ -377,7 +377,8 @@ test("a steered user message stays on the same Tools ledger", () => {
 	assert.equal(same?.groupId, live?.groupId);
 	assert.equal(same?.hasRunning, true);
 	const rendered = renderAggregateActivity(same!, 160, plainTheme());
-	assert.match(rendered[0] ?? "", /Tools \(1 call · 1 turn · 1 steer\)/);
+	assert.match(rendered[0] ?? "", /Tools \(1 call · 1 turn\)/);
+	assert.doesNotMatch(rendered[0] ?? "", /steer/);
 	assert.match(rendered.join("\n"), /↳ 先确定方案/);
 	assert.match(rendered.join("\n"), /› 合并已完成/);
 	assert.ok(
@@ -417,7 +418,8 @@ test("multiple steers pin first lines in arrival order", () => {
 		"不要改 grok，用 xai",
 	]);
 	const rendered = renderAggregateActivity(view!, 80, plainTheme());
-	assert.match(rendered[0] ?? "", /· 2 steers\)/);
+	assert.match(rendered[0] ?? "", /Tools \(1 call · 1 turn\)/);
+	assert.doesNotMatch(rendered[0] ?? "", /steer/);
 	const pinLines = rendered.filter((line) => line.includes("↳"));
 	assert.equal(pinLines.length, 2);
 	assert.match(pinLines[0] ?? "", /↳ 先确定方案/);
@@ -460,7 +462,8 @@ test("settling replaces first-line pins with one steer reminder", () => {
 	assert.deepEqual(view?.pinnedSteers, []);
 	assert.equal(view?.durationMs, endedAt - startedAt);
 	const rendered = renderAggregateActivity(view!, 160, plainTheme());
-	assert.match(rendered[0] ?? "", /Tools \(1 call · 1 turn · 2 steers\)/);
+	assert.match(rendered[0] ?? "", /Tools \(1 call · 1 turn\)/);
+	assert.doesNotMatch(rendered[0] ?? "", /steer/);
 	assert.equal(rendered[1], "  ↳ 2 steers");
 	assert.doesNotMatch(rendered.join("\n"), /先确定方案|不要改 grok/);
 	assert.match(rendered.join("\n"), /took 2m14s/);
@@ -539,7 +542,10 @@ test("rebuild treats a user after toolResult as a steer on the same group", () =
 	assert.equal(view?.agentTurnCount, 2);
 	assert.equal(projection.getGroups().length, 1);
 	assert.equal(projection.getSteer("steer:user-1:0")?.firstLine, "先确定方案");
-	assert.match(renderAggregateActivity(view!, 120, plainTheme())[0] ?? "", /· 1 steer\)/);
+	const rebuilt = renderAggregateActivity(view!, 120, plainTheme());
+	assert.match(rebuilt[0] ?? "", /Tools \(2 calls · 2 turns\)/);
+	assert.doesNotMatch(rebuilt[0] ?? "", /steer/);
+	assert.match(rebuilt.join("\n"), /↳ 1 steer/);
 });
 
 test("rebuild keeps a follow-up after a final assistant on a new group", () => {

--- a/packages/pi-tool-display-intent/tests/aggregate-activity.test.ts
+++ b/packages/pi-tool-display-intent/tests/aggregate-activity.test.ts
@@ -341,7 +341,7 @@ test("settled Tools ledger shows duration, tokens, cache, and completion time un
 	assert.doesNotMatch(rendered.join("\n"), /›/);
 });
 
-test("a steered follow-up user message settles the previous Tools ledger", () => {
+test("a steered user message stays on the same Tools ledger", () => {
 	const startedAt = Date.parse("2026-04-08T14:30:00");
 	const steeredAt = Date.parse("2026-04-08T14:31:20");
 	const projection = createProjection();
@@ -360,16 +360,215 @@ test("a steered follow-up user message settles the previous Tools ledger", () =>
 	projection.markStarted("read-before-steer", "read", { path: "README.md" });
 	const live = projection.getView("read-before-steer");
 	assert.equal(live?.settled, false);
+	assert.equal(live?.failedCount, 0);
 	assert.match(renderAggregateActivity(live!, 160, plainTheme()).join("\n"), /› 合并已完成/);
 
-	projection.startUserGroup("user-after-steer", steeredAt);
-	const settled = projection.getView("read-before-steer");
-	assert.equal(settled?.settled, true);
-	assert.equal(settled?.failedCount, 1);
-	assert.equal(settled?.durationMs, steeredAt - startedAt);
-	const rendered = renderAggregateActivity(settled!, 160, plainTheme());
-	assert.match(rendered.join("\n"), /took 1m20s/);
-	assert.doesNotMatch(rendered.join("\n"), /›|合并已完成/);
+	const kind = projection.ingestUserMessage({
+		role: "user",
+		content: "先确定方案",
+		timestamp: steeredAt,
+	}, { streamingBehavior: "steer" });
+	assert.equal(kind, "steer");
+	const same = projection.getView("read-before-steer");
+	assert.equal(same?.settled, false);
+	assert.equal(same?.failedCount, 0);
+	assert.equal(same?.steerCount, 1);
+	assert.equal(same?.groupId, live?.groupId);
+	assert.equal(same?.hasRunning, true);
+	const rendered = renderAggregateActivity(same!, 160, plainTheme());
+	assert.match(rendered[0] ?? "", /Tools \(1 call · 1 turn · 1 steer\)/);
+	assert.match(rendered.join("\n"), /↳ 先确定方案/);
+	assert.match(rendered.join("\n"), /› 合并已完成/);
+	assert.ok(
+		rendered.findIndex((line) => line.includes("↳"))
+			< rendered.findIndex((line) => line.includes("›")),
+	);
+	assert.doesNotMatch(rendered.join("\n"), /took /);
+});
+
+test("multiple steers pin first lines in arrival order", () => {
+	const projection = createProjection();
+	projection.startUserGroup("user-multi-steer");
+	projection.ingestAssistantMessage({
+		role: "assistant",
+		id: "assistant-multi-steer",
+		stopReason: "toolUse",
+		content: [
+			{ type: "text", text: "正在按新约束改 README" },
+			{ type: "toolCall", ...call("edit-multi", "edit", { path: "README.md" }) },
+		],
+	});
+	projection.markStarted("edit-multi", "edit", { path: "README.md" });
+	projection.ingestUserMessage({
+		role: "user",
+		content: "先确定方案\n后面还有一段不应钉住",
+		timestamp: 2,
+	});
+	projection.ingestUserMessage({
+		role: "user",
+		content: "不要改 grok，用 xai",
+		timestamp: 3,
+	});
+	const view = projection.getView("edit-multi");
+	assert.equal(view?.steerCount, 2);
+	assert.deepEqual(view?.pinnedSteers.map((steer) => steer.firstLine), [
+		"先确定方案",
+		"不要改 grok，用 xai",
+	]);
+	const rendered = renderAggregateActivity(view!, 80, plainTheme());
+	assert.match(rendered[0] ?? "", /· 2 steers\)/);
+	const pinLines = rendered.filter((line) => line.includes("↳"));
+	assert.equal(pinLines.length, 2);
+	assert.match(pinLines[0] ?? "", /↳ 先确定方案/);
+	assert.doesNotMatch(pinLines[0] ?? "", /不应钉住/);
+	assert.match(pinLines[1] ?? "", /↳ 不要改 grok，用 xai/);
+	assert.ok(
+		rendered.findIndex((line) => line.includes("先确定方案"))
+			< rendered.findIndex((line) => line.includes("正在按新约束改 README")),
+	);
+});
+
+test("settling clears pinned steers but keeps the header count", () => {
+	const startedAt = Date.parse("2026-04-08T14:30:00");
+	const endedAt = Date.parse("2026-04-08T14:32:14");
+	const projection = createProjection();
+	projection.startUserGroup("user-settle-steers", startedAt);
+	projection.ingestAssistantMessage({
+		role: "assistant",
+		id: "assistant-settle-steers",
+		stopReason: "toolUse",
+		timestamp: startedAt + 1_000,
+		content: [{ type: "toolCall", ...call("read-settle-steers", "read", { path: "a.ts" }) }],
+	});
+	projection.markStarted("read-settle-steers", "read", { path: "a.ts" });
+	projection.ingestUserMessage({
+		role: "user",
+		content: "先确定方案",
+		timestamp: startedAt + 2_000,
+	});
+	projection.ingestUserMessage({
+		role: "user",
+		content: "不要改 grok，用 xai",
+		timestamp: startedAt + 3_000,
+	});
+	projection.markComplete("read-settle-steers", { content: [{ type: "text", text: "ok" }] }, false);
+	projection.markGroupSettled("user-settle-steers", endedAt);
+	const view = projection.getView("read-settle-steers");
+	assert.equal(view?.settled, true);
+	assert.equal(view?.steerCount, 2);
+	assert.deepEqual(view?.pinnedSteers, []);
+	assert.equal(view?.durationMs, endedAt - startedAt);
+	const rendered = renderAggregateActivity(view!, 160, plainTheme());
+	assert.match(rendered[0] ?? "", /Tools \(1 call · 1 turn · 2 steers\)/);
+	assert.doesNotMatch(rendered.join("\n"), /↳|先确定方案|不要改 grok/);
+	assert.match(rendered.join("\n"), /took 2m14s/);
+});
+
+test("a follow-up after a final assistant starts a new Tools group", () => {
+	const projection = createProjection();
+	projection.startUserGroup("user-original");
+	projection.ingestAssistantMessage({
+		role: "assistant",
+		id: "assistant-original",
+		stopReason: "toolUse",
+		content: [{ type: "toolCall", ...call("read-original", "read", { path: "a.ts" }) }],
+	});
+	projection.markStarted("read-original", "read", { path: "a.ts" });
+	projection.markComplete("read-original", { content: [{ type: "text", text: "ok" }] }, false);
+	projection.ingestAssistantMessage({
+		role: "assistant",
+		id: "assistant-final",
+		stopReason: "stop",
+		content: [{ type: "text", text: "做完了" }],
+	});
+	assert.equal(projection.getView("read-original")?.settled, true);
+
+	const kind = projection.ingestUserMessage({
+		role: "user",
+		content: "再帮我改测试",
+		timestamp: 9,
+	});
+	assert.equal(kind, "group");
+	projection.ingestAssistantMessage({
+		role: "assistant",
+		id: "assistant-follow-up",
+		stopReason: "toolUse",
+		content: [{ type: "toolCall", ...call("edit-follow-up", "edit", { path: "a.ts" }) }],
+	});
+	const original = projection.getView("read-original");
+	const followUp = projection.getView("edit-follow-up");
+	assert.equal(original?.steerCount, 0);
+	assert.equal(original?.callCount, 1);
+	assert.notEqual(followUp?.groupId, original?.groupId);
+	assert.equal(followUp?.callCount, 1);
+	assert.equal(followUp?.steerCount, 0);
+});
+
+test("rebuild treats a user after toolResult as a steer on the same group", () => {
+	const projection = createProjection();
+	const branch = [
+		userEntry("user-1", "原始任务"),
+		assistantEntry("assistant-1", [call("read-1", "read", { path: "a.ts" })]),
+		resultEntry("result-1", "read-1", "read"),
+		userEntry("user-steer", "先确定方案"),
+		assistantEntry("assistant-2", [call("edit-1", "edit", { path: "a.ts" })]),
+		resultEntry("result-2", "edit-1", "edit"),
+	];
+	projection.rebuild(branch, messages(branch));
+	const view = projection.getView("edit-1");
+	assert.equal(view?.callCount, 2);
+	assert.equal(view?.steerCount, 1);
+	assert.equal(view?.agentTurnCount, 2);
+	assert.equal(projection.getGroups().length, 1);
+	assert.equal(projection.getSteer("steer:user-1:0")?.firstLine, "先确定方案");
+	assert.match(renderAggregateActivity(view!, 120, plainTheme())[0] ?? "", /· 1 steer\)/);
+});
+
+test("rebuild keeps a follow-up after a final assistant on a new group", () => {
+	const projection = createProjection();
+	const branch = [
+		userEntry("user-1", "原始任务"),
+		assistantEntry("assistant-1", [call("read-1", "read", { path: "a.ts" })]),
+		resultEntry("result-1", "read-1", "read"),
+		{
+			type: "message",
+			id: "assistant-final",
+			message: {
+				role: "assistant",
+				id: "assistant-final",
+				stopReason: "stop",
+				content: [{ type: "text", text: "做完了" }],
+			},
+		},
+		userEntry("user-2", "再改测试"),
+		assistantEntry("assistant-2", [call("edit-1", "edit", { path: "a.ts" })]),
+		resultEntry("result-2", "edit-1", "edit"),
+	];
+	projection.rebuild(branch, messages(branch));
+	assert.equal(projection.getGroups().length, 2);
+	assert.equal(projection.getView("read-1")?.steerCount, 0);
+	assert.equal(projection.getView("edit-1")?.steerCount, 0);
+	assert.notEqual(projection.getView("read-1")?.groupId, projection.getView("edit-1")?.groupId);
+});
+
+test("custom messages do not open a group or count as steers", () => {
+	const projection = createProjection();
+	const branch = [
+		userEntry("user-1", "原始任务"),
+		assistantEntry("assistant-1", [call("read-1", "read", { path: "a.ts" })]),
+		resultEntry("result-1", "read-1", "read"),
+		{
+			type: "custom_message",
+			id: "custom-1",
+			customType: "subagent-notification",
+			message: { role: "custom", content: "child done", timestamp: 2 },
+		},
+		userEntry("user-steer", "先确定方案"),
+	];
+	projection.rebuild(branch, messages(branch));
+	assert.equal(projection.ingestUserMessage({ role: "custom", content: "child done" }), undefined);
+	assert.equal(projection.getGroups().length, 1);
+	assert.equal(projection.getView("read-1")?.steerCount, 1);
 });
 
 test("a new passthrough call still replaces the oldest retained done row", () => {

--- a/packages/pi-tool-display-intent/tests/aggregate-activity.test.ts
+++ b/packages/pi-tool-display-intent/tests/aggregate-activity.test.ts
@@ -18,6 +18,7 @@ import {
 	renderAggregateActivity,
 	renderAggregateMemberRow,
 	renderCollapsedAssistantNarration,
+	renderExpandedAggregateSteer,
 	restoreAggregateToolExecutions,
 } from "../src/aggregate-activity.ts";
 
@@ -428,7 +429,7 @@ test("multiple steers pin first lines in arrival order", () => {
 	);
 });
 
-test("settling clears pinned steers but keeps the header count", () => {
+test("settling replaces first-line pins with one steer reminder", () => {
 	const startedAt = Date.parse("2026-04-08T14:30:00");
 	const endedAt = Date.parse("2026-04-08T14:32:14");
 	const projection = createProjection();
@@ -460,8 +461,25 @@ test("settling clears pinned steers but keeps the header count", () => {
 	assert.equal(view?.durationMs, endedAt - startedAt);
 	const rendered = renderAggregateActivity(view!, 160, plainTheme());
 	assert.match(rendered[0] ?? "", /Tools \(1 call · 1 turn · 2 steers\)/);
-	assert.doesNotMatch(rendered.join("\n"), /↳|先确定方案|不要改 grok/);
+	assert.equal(rendered[1], "  ↳ 2 steers");
+	assert.doesNotMatch(rendered.join("\n"), /先确定方案|不要改 grok/);
 	assert.match(rendered.join("\n"), /took 2m14s/);
+	assert.ok(
+		rendered.findIndex((line) => line.includes("↳ 2 steers"))
+			< rendered.findIndex((line) => line.includes("took 2m14s")),
+	);
+});
+
+test("expanded steer rows highlight the first line and keep framed gaps", () => {
+	const rendered = renderExpandedAggregateSteer("先确定方案\n后面还有一段", 80, {
+		fg: (color, text) => color === "accent" ? `[accent]${text}` : text,
+	});
+	assert.equal(rendered.length, 4);
+	assert.match(rendered[0] ?? "", /│\s*$/);
+	assert.match(rendered[1] ?? "", /│.*\[accent\]↳ 先确定方案/);
+	assert.match(rendered[2] ?? "", /│.*后面还有一段/);
+	assert.doesNotMatch(rendered[2] ?? "", /\[accent\]/);
+	assert.match(rendered[3] ?? "", /[│└]\s*$/);
 });
 
 test("a follow-up after a final assistant starts a new Tools group", () => {

--- a/packages/pi-tool-display-intent/tests/aggregate-thinking-placeholder.test.ts
+++ b/packages/pi-tool-display-intent/tests/aggregate-thinking-placeholder.test.ts
@@ -362,12 +362,18 @@ test("expanded timeline keeps a steer between tools and later narration", () => 
 
 		const firstNarration = firstAssistant.render(100).join("\n");
 		const readRow = read.render(100).join("\n");
-		const steerRow = steer.render(100).join("\n");
+		const steerLines = steer.render(100);
+		const steerRow = steerLines.join("\n");
 		const secondNarration = secondAssistant.render(100).join("\n");
 		const editRow = edit.render(100).join("\n");
 		assert.match(firstNarration, /│.*›.*先读 README/);
 		assert.match(readRow, /│.*Read\(README\.md\)/);
-		assert.match(steerRow, /│.*↳.*先确定方案/);
+		assert.equal(steerLines.length, 3);
+		assert.match(steerLines[0] ?? "", /│/);
+		assert.doesNotMatch(steerLines[0] ?? "", /↳|›|✓/);
+		assert.match(steerLines[1] ?? "", /│.*↳.*先确定方案/);
+		assert.match(steerLines[2] ?? "", /│/);
+		assert.doesNotMatch(steerLines[2] ?? "", /↳|›|✓/);
 		assert.doesNotMatch(steerRow, /▎/);
 		assert.match(secondNarration, /│.*›.*按新约束改/);
 		assert.match(editRow, /└.*Edit\(README\.md\)/);

--- a/packages/pi-tool-display-intent/tests/aggregate-thinking-placeholder.test.ts
+++ b/packages/pi-tool-display-intent/tests/aggregate-thinking-placeholder.test.ts
@@ -2,14 +2,23 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
 	AssistantMessageComponent,
+	ToolExecutionComponent,
+	UserMessageComponent,
 	initTheme,
 } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import {
 	AggregateProjection,
 	DEFAULT_AGGREGATE_RENDER_PASSTHROUGH,
 	patchAggregateToolExecutions,
 	restoreAggregateToolExecutions,
 } from "../src/aggregate-activity.ts";
+import {
+	patchNativeUserMessagePrototype,
+	type PatchableUserMessagePrototype,
+} from "../src/user-message-box-renderer.ts";
+import { resolveAggregateSteerUserPresentation } from "../src/user-message-box-native.ts";
+import { unregisterUserMessageRenderPrototypePatch } from "../src/user-message-box-patch.ts";
 import {
 	isInterimAssistantNarration,
 	omitThinkingContentBlocks,
@@ -280,6 +289,90 @@ test("mid-turn thinking is not framed as narration", () => {
 		assert.doesNotMatch(expanded.join("\n"), /›|The user wants me/);
 		assert.equal(projection.getFramedItemIds(frameId).includes(frameId), false);
 	} finally {
+		restoreAggregateThinkingPlaceholders();
+		restoreAggregateToolExecutions();
+	}
+});
+
+test("expanded timeline keeps a steer between tools and later narration", () => {
+	initTheme("dark", false);
+	const projection = new AggregateProjection((toolName) =>
+		(DEFAULT_AGGREGATE_RENDER_PASSTHROUGH as readonly string[]).includes(toolName));
+	const userPrototype = UserMessageComponent.prototype as unknown as PatchableUserMessagePrototype;
+	patchAggregateToolExecutions(projection);
+	patchAggregateThinkingPlaceholders(() => true);
+	patchNativeUserMessagePrototype(
+		userPrototype,
+		() => undefined,
+		() => true,
+		() => true,
+		resolveAggregateSteerUserPresentation,
+	);
+	try {
+		projection.startUserGroup("user-timeline");
+		const first = assistant([
+			{ type: "text", text: "先读 README" },
+			{ type: "toolCall", id: "read-1", name: "read", arguments: { path: "README.md" } },
+		], { id: "assistant-first" });
+		projection.ingestAssistantMessage(first);
+		projection.markStarted("read-1", "read", { path: "README.md" });
+		projection.markComplete("read-1", { content: [{ type: "text", text: "ok" }] }, false);
+		projection.ingestUserMessage({
+			role: "user",
+			content: "先确定方案",
+			timestamp: 2,
+		});
+		const second = assistant([
+			{ type: "text", text: "按新约束改" },
+			{ type: "toolCall", id: "edit-1", name: "edit", arguments: { path: "README.md" } },
+		], { id: "assistant-second" });
+		projection.ingestAssistantMessage(second);
+		projection.markStarted("edit-1", "edit", { path: "README.md" });
+
+		const tool = (name: string, id: string, args: Record<string, unknown>) =>
+			new ToolExecutionComponent(
+				name,
+				id,
+				args,
+				{},
+				{
+					name,
+					label: name,
+					description: name,
+					parameters: { type: "object", properties: {} },
+					execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+					renderCall: () => new Text(name, 0, 0),
+					renderResult: () => new Text(name, 0, 0),
+				} as never,
+				{ requestRender() {} } as never,
+				process.cwd(),
+			);
+		const read = tool("read", "read-1", { path: "README.md" });
+		const edit = tool("edit", "edit-1", { path: "README.md" });
+		const steer = new UserMessageComponent("先确定方案");
+		const firstAssistant = createComponent(first, true);
+		const secondAssistant = createComponent(second, true);
+
+		assert.deepEqual(steer.render(100), []);
+		assert.doesNotMatch(steer.render(100).join("\n"), /▎|↳/);
+
+		for (const component of [firstAssistant, secondAssistant, read, edit, steer] as Array<{ setExpanded(expanded: boolean): void }>) {
+			component.setExpanded(true);
+		}
+
+		const firstNarration = firstAssistant.render(100).join("\n");
+		const readRow = read.render(100).join("\n");
+		const steerRow = steer.render(100).join("\n");
+		const secondNarration = secondAssistant.render(100).join("\n");
+		const editRow = edit.render(100).join("\n");
+		assert.match(firstNarration, /│.*›.*先读 README/);
+		assert.match(readRow, /│.*Read\(README\.md\)/);
+		assert.match(steerRow, /│.*↳.*先确定方案/);
+		assert.doesNotMatch(steerRow, /▎/);
+		assert.match(secondNarration, /│.*›.*按新约束改/);
+		assert.match(editRow, /└.*Edit\(README\.md\)/);
+	} finally {
+		unregisterUserMessageRenderPrototypePatch(userPrototype);
 		restoreAggregateThinkingPlaceholders();
 		restoreAggregateToolExecutions();
 	}

--- a/packages/pi-tool-display-intent/tests/user-message-box.test.ts
+++ b/packages/pi-tool-display-intent/tests/user-message-box.test.ts
@@ -1,8 +1,24 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  initTheme,
+  UserMessageComponent,
+} from "@earendil-works/pi-coding-agent";
+import { Container, Spacer, Text } from "@earendil-works/pi-tui";
+import {
+  AggregateProjection,
+  DEFAULT_AGGREGATE_RENDER_PASSTHROUGH,
+  patchAggregateToolExecutions,
+  restoreAggregateToolExecutions,
+} from "../src/aggregate-activity.ts";
+import {
   extractUserMessageMarkdownState,
 } from "../src/user-message-box-markdown.ts";
+import {
+  patchSteerUserLeadingSpacer,
+  resolveAggregateSteerUserPresentation,
+  restoreSteerUserLeadingSpacer,
+} from "../src/user-message-box-native.ts";
 import {
   patchUserMessageRenderPrototype,
   type PatchableUserMessagePrototype,
@@ -969,6 +985,53 @@ test("individual user boxes ignore aggregate steer presentation", () => {
   const rendered = prototype.render(40);
   assert.ok(rendered.some((line) => line.includes("╭")));
   assert.match(rendered.join("\n"), /先确定方案/);
+});
+
+test("steer users collapse the leading Pi spacer so the expanded frame stays continuous", () => {
+  initTheme("dark", false);
+  const projection = new AggregateProjection((toolName) =>
+    (DEFAULT_AGGREGATE_RENDER_PASSTHROUGH as readonly string[]).includes(toolName));
+  const userPrototype = UserMessageComponent.prototype as unknown as PatchableUserMessagePrototype;
+  patchAggregateToolExecutions(projection);
+  patchSteerUserLeadingSpacer();
+  patchNativeUserMessagePrototype(
+    userPrototype,
+    () => undefined,
+    () => true,
+    () => true,
+    resolveAggregateSteerUserPresentation,
+  );
+  try {
+    projection.startUserGroup("user-spacer");
+    projection.markStarted("read-1", "read", { path: "a.ts" });
+    projection.ingestUserMessage({
+      role: "user",
+      content: "先确定方案",
+      timestamp: 2,
+    });
+    const container = new Container();
+    const spacer = new Spacer(1);
+    const user = new UserMessageComponent("先确定方案");
+    container.addChild(new Text("above", 0, 0));
+    container.addChild(spacer);
+    container.addChild(user);
+    (user as UserMessageComponent & { setExpanded(expanded: boolean): void }).setExpanded(true);
+    const rendered = container.render(80);
+    const join = rendered.join("\n");
+    assert.match(join, /above/);
+    assert.match(join, /↳.*先确定方案/);
+    const above = rendered.findIndex((line) => line.includes("above"));
+    const steer = rendered.findIndex((line) => line.includes("↳"));
+    assert.ok(above >= 0 && steer > above);
+    assert.ok(
+      rendered.slice(above + 1, steer).every((line) => line.includes("│")),
+      "no unframed blank between the previous row and ↳",
+    );
+  } finally {
+    restoreSteerUserLeadingSpacer();
+    unregisterUserMessageRenderPrototypePatch(userPrototype);
+    restoreAggregateToolExecutions();
+  }
 });
 
 test("unregistering the user message patch restores the original renderer", () => {

--- a/packages/pi-tool-display-intent/tests/user-message-box.test.ts
+++ b/packages/pi-tool-display-intent/tests/user-message-box.test.ts
@@ -12,6 +12,7 @@ import {
   shouldBypassUserMessageMarkdownRebuild,
   createUserMessageMarkdownLineRenderer,
 } from "../src/user-message-box-renderer.ts";
+import { unregisterUserMessageRenderPrototypePatch } from "../src/user-message-box-patch.ts";
 import {
   addUserMessageVerticalPadding,
   applyUserMessageBackground,
@@ -905,4 +906,85 @@ test("nativeRender builds correct box structure with all required line types", (
   assert.ok(rendered.length >= 5);
   assert.equal(rendered.filter((l) => l.includes("│")).length, 4); // 2 content + 2 padding
   assert.equal(rendered.filter((l) => l.includes("╭") || l.includes("╰")).length, 2);
+});
+
+test("aggregate collapsed steer user boxes render at zero height", () => {
+  const prototype: PatchableUserMessagePrototype = {
+    render: () => ["先确定方案"],
+  };
+  patchNativeUserMessagePrototype(
+    prototype,
+    () => undefined,
+    () => true,
+    () => true,
+    () => ({ hide: true }),
+  );
+  assert.deepEqual(prototype.render(40), []);
+});
+
+test("aggregate expanded steer user boxes use an accent ↳ instead of the task gutter", () => {
+  const prototype: PatchableUserMessagePrototype = {
+    render: () => ["先确定方案"],
+  };
+  patchNativeUserMessagePrototype(
+    prototype,
+    () => undefined,
+    () => true,
+    () => true,
+    () => ({ lines: ["  │ ↳ 先确定方案"] }),
+  );
+  const rendered = prototype.render(40);
+  assert.match(rendered.join("\n"), /↳ 先确定方案/);
+  assert.doesNotMatch(rendered.join("\n"), /▎/);
+  assert.doesNotMatch(rendered.join("\n"), /╭|╰/);
+});
+
+test("aggregate original user prompts keep the gutter when they are not steers", () => {
+  const prototype: PatchableUserMessagePrototype = {
+    render: () => ["原始任务"],
+  };
+  patchNativeUserMessagePrototype(
+    prototype,
+    () => undefined,
+    () => true,
+    () => true,
+    () => undefined,
+  );
+  const rendered = prototype.render(40);
+  assert.match(rendered.join("\n"), /▎ 原始任务/);
+  assert.doesNotMatch(rendered.join("\n"), /↳/);
+});
+
+test("individual user boxes ignore aggregate steer presentation", () => {
+  const prototype: PatchableUserMessagePrototype = {
+    render: () => ["先确定方案"],
+  };
+  patchNativeUserMessagePrototype(
+    prototype,
+    () => undefined,
+    () => true,
+    () => false,
+    () => ({ hide: true }),
+  );
+  const rendered = prototype.render(40);
+  assert.ok(rendered.some((line) => line.includes("╭")));
+  assert.match(rendered.join("\n"), /先确定方案/);
+});
+
+test("unregistering the user message patch restores the original renderer", () => {
+  const originalRender = () => ["orig"];
+  const prototype: PatchableUserMessagePrototype = {
+    render: originalRender,
+  };
+  patchNativeUserMessagePrototype(
+    prototype,
+    () => undefined,
+    () => true,
+    () => true,
+    () => ({ hide: true }),
+  );
+  assert.deepEqual(prototype.render(40), []);
+  unregisterUserMessageRenderPrototypePatch(prototype);
+  assert.deepEqual(prototype.render(40), ["orig"]);
+  assert.equal(prototype.setExpanded, undefined);
 });


### PR DESCRIPTION
## User-visible

- Aggregate Tools keeps mid-turn steers on the same ledger. First lines pin while the turn runs; after it settles, one `↳ N steers` line remains. `Ctrl+O` restores each `↳` in place without rewriting session messages.
- Meter footer stays on the current model's quota, treats SuperGrok missing `creditUsagePercent` as 0% used, and lets `/usage footer` switch local spend between rolling and calendar windows.

## Release plan (confirmed)

| Package | From | Bump | To |
|---|---|---|---|
| `@zhcsyncer/pi-tool-display-intent` | 0.8.1 | minor | 0.9.0 |
| `@zhcsyncer/pi-meter` | 0.1.1 | minor | 0.2.0 |
| `@zhcsyncer/pi-extensions` | 0.23.0 | minor | 0.24.0 |