### PR TITLE
fix(pi-meter): stop import doubling live usage and keep cache write visible

### DIFF
--- a/.changeset/pi-meter-dashboard-cache-write.md
+++ b/.changeset/pi-meter-dashboard-cache-write.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-meter": patch
+---
+
+Keep cache write visible in the `/usage` dashboard at typical terminal widths.

--- a/.changeset/pi-meter-import-dedup.md
+++ b/.changeset/pi-meter-import-dedup.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-meter": patch
+---
+
+Stop `/usage import` from double-counting turns already captured live, and collapse those duplicate ledger rows.

--- a/packages/pi-meter/README.md
+++ b/packages/pi-meter/README.md
@@ -29,12 +29,12 @@ Do **not** load `@pi-plugins/usage` at the same time. Both register `/usage`. If
 
   ![Meter footer](./assets/demo-meter-status.png)
 
-- Local dashboard by model, project, or session.
+- Local dashboard by model, project, or session, including cache write.
 - Claude, Codex, SuperGrok, and Ollama Cloud remaining after `/login` for that provider.
 - `/usage quota` opens a temporary dashboard. Unsigned-in providers stay as a muted summary at the bottom. If the current model has no window, or that provider is unsigned / unavailable, the footer shows a short hint instead of another vendor's bar.
 - Other extensions can register a quota source. The footer still follows the current model only.
 - Optional local budgets. They warn; they never block requests.
-- Optional one-time import from older session files.
+- Optional import from older session files. Safe to re-run: already-captured turns are not counted twice.
 
   ![Quota dashboard](./assets/demo-quota-dashboard.png)
 
@@ -70,7 +70,7 @@ Then restart Pi or run `/reload`. If `@pi-plugins/usage` is already in `settings
 | `/usage quota` | Open the remaining/reset-time dashboard for Claude, Codex, SuperGrok, and Ollama Cloud |
 | `/usage quota refresh` | Refresh subscription windows and open the dashboard |
 | `/usage footer` | Configure the local summary, rolling/calendar window, quota visibility, and used/remaining display |
-| `/usage import` | Back-fill from session files |
+| `/usage import` | Back-fill from session files without double-counting live turns |
 | `/usage budget` | View or add a local budget |
 
 ## License

--- a/packages/pi-meter/README.zh-CN.md
+++ b/packages/pi-meter/README.zh-CN.md
@@ -29,12 +29,12 @@
 
   ![Meter 底栏](./assets/demo-meter-status.png)
 
-- 按模型、项目或 session 看本地看板。
+- 按模型、项目或 session 看本地看板，含 cache write。
 - `/login` 对应账号后，可看 Claude、Codex、SuperGrok、Ollama Cloud 剩余。
 - `/usage quota` 打开临时看板。未登录的提供商收在底部一条淡提示。当前模型没有窗口、没登录或这次没拉到时，底栏只给短提示，不会画别家额度。
 - 其他扩展可以登记配额源。底栏仍然只跟当前模型走。
 - 可选本地 budget。只会提醒，从不拦请求。
-- 可选、一次性从旧 session 文件回填。
+- 可选从旧 session 文件回填。可重复执行：已经记过的回合不会再计一次。
 
   ![套餐看板](./assets/demo-quota-dashboard.png)
 
@@ -70,7 +70,7 @@ pi -e npm:@zhcsyncer/pi-meter
 | `/usage quota` | 打开 Claude、Codex、SuperGrok、Ollama Cloud 的剩余额度与重置时间看板 |
 | `/usage quota refresh` | 刷新订阅窗口并打开看板 |
 | `/usage footer` | 配置本地摘要、滚动/日历窗口、配额显示开关以及已用/剩余模式 |
-| `/usage import` | 从 session 文件回填 |
+| `/usage import` | 从 session 文件回填，不会把已捕获的回合再记一遍 |
 | `/usage budget` | 查看或添加本地 budget |
 
 ## 许可证

--- a/packages/pi-meter/extensions/meter.ts
+++ b/packages/pi-meter/extensions/meter.ts
@@ -15,7 +15,7 @@ import { Dashboard } from "../src/ledger/dashboard.ts";
 import { DIMENSIONS } from "../src/ledger/enums.ts";
 import { fmtCompactTokens, fmtCost, fmtNum } from "../src/ledger/format.ts";
 import { aggregate, sumRows } from "../src/ledger/aggregate.ts";
-import { parseSession, diffRecords, usageFromAssistantMessage } from "../src/ledger/session-parser.ts";
+import { parseSession, diffRecords, collapseDuplicateRecords, usageFromAssistantMessage, assistantUsageWithoutTimestamp } from "../src/ledger/session-parser.ts";
 import { createLedgerStore, type FileLedgerStore } from "../src/ledger/store.ts";
 import { parseWindowArg, sessionIdFrom, windowDisplayLabel } from "../src/ledger/time.ts";
 import type { BudgetLimit, UsageRecord, WindowKey } from "../src/ledger/types.ts";
@@ -111,14 +111,16 @@ export default function piMeter(pi: ExtensionAPI): void {
 	async function captureMessage(ctx: ExtensionContext, message: unknown): Promise<void> {
 		await ensureReady(ctx);
 		const record = usageFromAssistantMessage(message, {
-			ts: Date.now(),
 			sid: session.sessionId,
 			cwd: session.cwd,
 		});
-		if (!record || !store) return;
-		if (typeof (message as { timestamp?: unknown }).timestamp === "number") {
-			record.ts = (message as { timestamp: number }).timestamp;
+		if (!record) {
+			if (assistantUsageWithoutTimestamp(message)) {
+				notify(ctx, "pi-meter skipped a turn: assistant usage has no message.timestamp.", "warning");
+			}
+			return;
 		}
+		if (!store) return;
 		await store.append(record);
 		await checkBudgets(ctx, record);
 		await renderChrome(ctx);
@@ -578,6 +580,7 @@ async function importHistory(store: FileLedgerStore, notify: Notify): Promise<vo
 	}
 	const existing = await store.readAll();
 	const incoming: UsageRecord[] = [];
+	let skipped = 0;
 	for (const file of files) {
 		let content: string;
 		try {
@@ -586,15 +589,26 @@ async function importHistory(store: FileLedgerStore, notify: Notify): Promise<vo
 			continue;
 		}
 		const sid = (file.split(/[/\\]/).pop() ?? file).replace(/\.jsonl$/, "");
-		incoming.push(...parseSession(content, sid).records);
+		const parsed = parseSession(content, sid);
+		incoming.push(...parsed.records);
+		skipped += parsed.skipped;
 	}
-	const fresh = diffRecords(existing, incoming);
-	if (fresh.length === 0) {
-		notify(`Nothing new to import. (${existing.length} records already tracked.)`, "info");
+	const collapsed = collapseDuplicateRecords(existing);
+	const fresh = diffRecords(collapsed, incoming);
+	const removed = existing.length - collapsed.length;
+	if (fresh.length === 0 && removed === 0) {
+		const detail = skipped > 0 ? ` Skipped ${fmtNum(skipped)} assistant turns without message.timestamp.` : "";
+		notify(`Nothing new to import. (${existing.length} records already tracked.)${detail}`, skipped > 0 ? "warning" : "info");
 		return;
 	}
-	for (const record of fresh) await store.append(record);
-	notify(`Imported ${fmtNum(fresh.length)} records from ${files.length} session files.`, "info");
+	if (removed > 0) await store.replaceAll([...collapsed, ...fresh]);
+	else for (const record of fresh) await store.append(record);
+	const parts: string[] = [];
+	if (fresh.length > 0) parts.push(`Imported ${fmtNum(fresh.length)} records from ${files.length} session files`);
+	else parts.push("Nothing new to import");
+	if (removed > 0) parts.push(`removed ${fmtNum(removed)} duplicate records`);
+	if (skipped > 0) parts.push(`skipped ${fmtNum(skipped)} without message.timestamp`);
+	notify(`${parts.join("; ")}.`, skipped > 0 ? "warning" : "info");
 }
 
 async function addBudget(arg: string, store: FileLedgerStore, session: SessionBits, ctx: ExtensionContext): Promise<void> {

--- a/packages/pi-meter/src/ledger/dashboard.ts
+++ b/packages/pi-meter/src/ledger/dashboard.ts
@@ -22,6 +22,46 @@ interface DrillFilter {
 }
 
 const PAGE = 16;
+const MARKER = 2;
+const MIN_NAME = 12;
+const METRIC_HEADERS = ["tokens", "in", "out", "cache r", "cache w", "cost"] as const;
+
+interface DashLayout {
+	nameW: number;
+	barW: number;
+	numW: number;
+	gap: number;
+	showBar: boolean;
+}
+
+function metricBlockWidth(numW: number, gap: number): number {
+	return METRIC_HEADERS.length * numW + gap * METRIC_HEADERS.length;
+}
+
+function barBlockWidth(barW: number, gap: number, showBar: boolean): number {
+	return showBar ? barW + gap : 0;
+}
+
+function fixedWidth(layout: Pick<DashLayout, "barW" | "numW" | "gap" | "showBar">): number {
+	return MARKER + barBlockWidth(layout.barW, layout.gap, layout.showBar) + metricBlockWidth(layout.numW, layout.gap);
+}
+
+/** Fit name + optional bar + tokens/in/out/cache r/cache w/cost into `width` without clipping metrics. */
+function dashLayout(width: number, maxLabel: number): DashLayout {
+	const wantedName = Math.max(MIN_NAME, maxLabel + 2);
+	const candidates: Array<Pick<DashLayout, "barW" | "numW" | "gap" | "showBar">> = [
+		{ barW: 10, numW: 10, gap: 2, showBar: true },
+		{ barW: 8, numW: 8, gap: 1, showBar: true },
+		{ barW: 0, numW: 7, gap: 1, showBar: false },
+	];
+	for (const candidate of candidates) {
+		const room = width - fixedWidth(candidate);
+		if (room < MIN_NAME) continue;
+		return { ...candidate, nameW: Math.min(wantedName, room) };
+	}
+	const fallback = { barW: 0, numW: 7, gap: 1, showBar: false as const };
+	return { ...fallback, nameW: Math.max(8, width - fixedWidth(fallback)) };
+}
 
 export class Dashboard {
 	private windowIdx = 0;
@@ -144,79 +184,64 @@ export class Dashboard {
 		}
 
 		const costCell = (row: AggRow): string => (row.costKnown ? fmtCost(row.cost) : "n/a");
-		const barW = 10;
-		const numW = 10;
-		const gap = 2;
-		const marker = 2;
-		const numCols = 6;
-		const fixed = marker + barW + numW * numCols + gap * (numCols + 1);
 		const maxLabel = Math.max(visibleWidth(dim.label), ...rows.map((row) => visibleWidth(row.label)));
-		const nameW = Math.min(Math.max(14, maxLabel + 2), Math.max(14, width - fixed));
-		const ruleW = Math.min(width, marker + nameW + barW + numW * numCols + gap * (numCols + 1));
+		const layout = dashLayout(width, maxLabel);
+		const { nameW, barW, numW, gap, showBar } = layout;
+		const gapStr = " ".repeat(gap);
+		const ruleW = Math.min(width, MARKER + nameW + barBlockWidth(barW, gap, showBar) + metricBlockWidth(numW, gap));
+		const joinRow = (name: string, bar: string | undefined, metrics: string[]): string => {
+			const parts = [name];
+			if (showBar && bar !== undefined) parts.push(bar);
+			parts.push(...metrics);
+			return parts.join(gapStr);
+		};
+		const metricTexts = (values: readonly string[], paint: (text: string, index: number) => string): string[] =>
+			values.map((value, index) => padRight(paint(value, index), numW));
 		const header =
-			padRight(`  ${t.fg("dim", dim.label)}`, marker + nameW) +
-			"  " +
-			padRight(t.fg("dim", "usage"), barW) +
-			"  " +
-			padRight(t.fg("dim", "tokens"), numW) +
-			"  " +
-			padRight(t.fg("dim", "in"), numW) +
-			"  " +
-			padRight(t.fg("dim", "out"), numW) +
-			"  " +
-			padRight(t.fg("dim", "cache r"), numW) +
-			"  " +
-			padRight(t.fg("dim", "cache w"), numW) +
-			"  " +
-			padRight(t.fg("dim", "cost"), numW);
+			joinRow(
+				padRight(`  ${t.fg("dim", dim.label)}`, MARKER + nameW),
+				showBar ? padRight(t.fg("dim", "usage"), barW) : undefined,
+				metricTexts(METRIC_HEADERS, (text) => t.fg("dim", text)),
+			);
 		lines.push(truncateToWidth(header, width));
 		lines.push(t.fg("border", "─".repeat(ruleW)));
 
 		const maxTokens = rows[0]?.tokens ?? 1;
 		const pageStart = this.scroll;
 		const pageEnd = Math.min(rows.length, pageStart + PAGE);
+		const rowMetrics = (row: AggRow): string[] => [
+			fmtCompactTokens(row.tokens),
+			fmtCompactTokens(row.input),
+			fmtCompactTokens(row.output),
+			fmtCompactTokens(row.cacheRead),
+			fmtCompactTokens(row.cacheWrite),
+			costCell(row),
+		];
 		for (let i = pageStart; i < pageEnd; i++) {
 			const row = rows[i];
+			if (!row) continue;
 			const isCursor = i === this.cursor;
 			const ratio = maxTokens > 0 ? row.tokens / maxTokens : 0;
 			const nameRaw = truncateToWidth(row.label, nameW, "");
-			const name = padRight((isCursor ? "▶ " : "  ") + (isCursor ? t.fg("accent", t.bold(nameRaw)) : nameRaw), marker + nameW);
-			const line =
-				name +
-				"  " +
-				t.fg("accent", padRight(fmtBar(ratio, barW), barW)) +
-				"  " +
-				padRight(t.fg("text", fmtCompactTokens(row.tokens)), numW) +
-				"  " +
-				padRight(t.fg("text", fmtCompactTokens(row.input)), numW) +
-				"  " +
-				padRight(t.fg("text", fmtCompactTokens(row.output)), numW) +
-				"  " +
-				padRight(t.fg("muted", fmtCompactTokens(row.cacheRead)), numW) +
-				"  " +
-				padRight(t.fg("muted", fmtCompactTokens(row.cacheWrite)), numW) +
-				"  " +
-				padRight(t.fg(row.costKnown ? "success" : "dim", costCell(row)), numW);
+			const name = padRight((isCursor ? "▶ " : "  ") + (isCursor ? t.fg("accent", t.bold(nameRaw)) : nameRaw), MARKER + nameW);
+			const line = joinRow(
+				name,
+				showBar ? t.fg("accent", padRight(fmtBar(ratio, barW), barW)) : undefined,
+				metricTexts(rowMetrics(row), (text, index) => {
+					if (index < 3) return t.fg("text", text);
+					if (index < 5) return t.fg("muted", text);
+					return t.fg(row.costKnown ? "success" : "dim", text);
+				}),
+			);
 			lines.push(truncateToWidth(line, width));
 		}
 
 		lines.push(t.fg("border", "─".repeat(ruleW)));
-		const totalLine =
-			padRight("  " + t.fg("accent", t.bold("Total")), marker + nameW) +
-			"  " +
-			" ".repeat(barW) +
-			"  " +
-			padRight(t.fg("accent", fmtCompactTokens(total.tokens)), numW) +
-			"  " +
-			padRight(t.fg("accent", fmtCompactTokens(total.input)), numW) +
-			"  " +
-			padRight(t.fg("accent", fmtCompactTokens(total.output)), numW) +
-			"  " +
-			padRight(t.fg("accent", fmtCompactTokens(total.cacheRead)), numW) +
-			"  " +
-			padRight(t.fg("accent", fmtCompactTokens(total.cacheWrite)), numW) +
-			"  " +
-			padRight(t.fg("accent", costCell(total)), numW);
+		const totalLine = joinRow(
+			padRight("  " + t.fg("accent", t.bold("Total")), MARKER + nameW),
+			showBar ? " ".repeat(barW) : undefined,
+			metricTexts(rowMetrics(total), (text) => t.fg("accent", text)),
+		);
 		lines.push(truncateToWidth(totalLine, width));
 		if (rows.length > PAGE) lines.push(t.fg("dim", `   showing ${pageStart + 1}-${pageEnd} of ${rows.length}`));
 

--- a/packages/pi-meter/src/ledger/session-parser.ts
+++ b/packages/pi-meter/src/ledger/session-parser.ts
@@ -5,19 +5,22 @@ export interface ParsedSession {
 	cwd: string | null;
 	sid: string;
 	records: UsageRecord[];
+	skipped: number;
 }
 
 export function usageFromAssistantMessage(
 	message: unknown,
-	meta: { ts: number; sid: string; cwd: string },
+	meta: { sid: string; cwd: string },
 ): UsageRecord | undefined {
-	if (!isRecord(message) || message.role !== "assistant" || !isRecord(message.usage)) return undefined;
+	if (!isAssistantUsage(message)) return undefined;
+	const ts = messageTimestamp(message);
+	if (ts === undefined) return undefined;
 	const usage = message.usage;
 	const cost = isRecord(usage.cost) && typeof usage.cost.total === "number" ? usage.cost.total : 0;
 	const provider = typeof message.provider === "string" ? message.provider : "unknown";
 	const model = typeof message.model === "string" ? message.model : "unknown";
 	return {
-		ts: meta.ts,
+		ts,
 		sid: meta.sid,
 		cwd: meta.cwd,
 		model: `${provider}/${model}`,
@@ -31,8 +34,13 @@ export function usageFromAssistantMessage(
 	};
 }
 
+export function assistantUsageWithoutTimestamp(message: unknown): boolean {
+	return isAssistantUsage(message) && messageTimestamp(message) === undefined;
+}
+
 export function parseSession(content: string, sid: string): ParsedSession {
 	let cwd: string | null = null;
+	let skipped = 0;
 	const records: UsageRecord[] = [];
 
 	for (const line of content.split("\n")) {
@@ -49,23 +57,63 @@ export function parseSession(content: string, sid: string): ParsedSession {
 			continue;
 		}
 		if (entry.type !== "message") continue;
-		const ts = typeof entry.timestamp === "string"
-			? Date.parse(entry.timestamp)
-			: Number(entry.timestamp) || 0;
-		const rec = usageFromAssistantMessage(entry.message, { ts, sid, cwd: cwd ?? "" });
-		if (rec) records.push(rec);
+		const rec = usageFromAssistantMessage(entry.message, { sid, cwd: cwd ?? "" });
+		if (rec) {
+			records.push(rec);
+			continue;
+		}
+		if (assistantUsageWithoutTimestamp(entry.message)) skipped += 1;
 	}
 
-	return { cwd, sid, records };
+	return { cwd, sid, records, skipped };
 }
 
+/** Live capture and import identity: assistant `message.timestamp` (Unix ms). */
 export function recordKey(record: UsageRecord): string {
 	return `${record.ts}|${record.sid}|${record.model}`;
 }
 
+/** Same turn when live used message start and an old import used entry persist time. */
+export function payloadKey(record: UsageRecord): string {
+	return `${record.sid}|${record.model}|${record.in}|${record.out}|${record.cR}|${record.cW}|${record.tot}`;
+}
+
+export function collapseDuplicateRecords(records: readonly UsageRecord[]): UsageRecord[] {
+	const winner = new Map<string, number>();
+	for (let i = 0; i < records.length; i++) {
+		const record = records[i];
+		if (!record) continue;
+		const key = payloadKey(record);
+		const prevIndex = winner.get(key);
+		const previous = prevIndex === undefined ? undefined : records[prevIndex];
+		if (previous === undefined || record.ts < previous.ts) winner.set(key, i);
+	}
+	const keep = new Set(winner.values());
+	return records.filter((_, i) => keep.has(i));
+}
+
 export function diffRecords(existing: readonly UsageRecord[], incoming: readonly UsageRecord[]): UsageRecord[] {
-	const seen = new Set(existing.map(recordKey));
-	return incoming.filter((record) => !seen.has(recordKey(record)));
+	const seenExact = new Set(existing.map(recordKey));
+	const seenPayload = new Set(existing.map(payloadKey));
+	const fresh: UsageRecord[] = [];
+	for (const record of incoming) {
+		const exact = recordKey(record);
+		const payload = payloadKey(record);
+		if (seenExact.has(exact) || seenPayload.has(payload)) continue;
+		seenExact.add(exact);
+		seenPayload.add(payload);
+		fresh.push(record);
+	}
+	return fresh;
+}
+
+function isAssistantUsage(message: unknown): message is Record<string, unknown> & { usage: Record<string, unknown> } {
+	return isRecord(message) && message.role === "assistant" && isRecord(message.usage);
+}
+
+function messageTimestamp(message: Record<string, unknown>): number | undefined {
+	if (typeof message.timestamp === "number" && Number.isFinite(message.timestamp)) return message.timestamp;
+	return undefined;
 }
 
 function num(value: unknown): number {

--- a/packages/pi-meter/src/ledger/store.ts
+++ b/packages/pi-meter/src/ledger/store.ts
@@ -2,6 +2,7 @@ import { appendFile, copyFile, unlink } from "node:fs/promises";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { ensurePrivateDir, isRecord, pathExists, readTextFile, withDirectoryLock, writeFileAtomically } from "../fs.ts";
 import { getMeterPaths, type MeterPaths } from "../paths.ts";
+import { collapseDuplicateRecords } from "./session-parser.ts";
 import type { BudgetLimit, BudgetsConfig, UsageRecord } from "./types.ts";
 
 export interface LedgerStore {
@@ -163,6 +164,22 @@ export class FileLedgerStore implements LedgerStore {
 		}
 	}
 
+	async replaceAll(records: readonly UsageRecord[]): Promise<void> {
+		await withDirectoryLock(this.paths.dataDir, ".usage.lock", async () => {
+			const body = records.map((record) => `${JSON.stringify(serializeUsageRecord(record))}\n`).join("");
+			await writeFileAtomically(this.paths.usageFile, body);
+		});
+	}
+
+	async compactDuplicates(): Promise<number> {
+		const records = await this.readAll();
+		const collapsed = collapseDuplicateRecords(records);
+		const removed = records.length - collapsed.length;
+		if (removed === 0) return 0;
+		await this.replaceAll(collapsed);
+		return removed;
+	}
+
 	async readAll(): Promise<UsageRecord[]> {
 		const raw = await readTextFile(this.paths.usageFile);
 		if (!raw) return [];
@@ -200,5 +217,11 @@ export class FileLedgerStore implements LedgerStore {
 export async function createLedgerStore(agentDir = getAgentDir()): Promise<{ store: FileLedgerStore; migration?: string }> {
 	const paths = getMeterPaths(agentDir);
 	const migration = await migrateLegacyLedger(paths);
-	return { store: new FileLedgerStore(paths), ...(migration ? { migration } : {}) };
+	const store = new FileLedgerStore(paths);
+	const removed = await store.compactDuplicates();
+	const notes = [
+		migration,
+		removed > 0 ? `Removed ${removed} duplicate usage records from the local ledger.` : undefined,
+	].filter((note): note is string => Boolean(note));
+	return { store, ...(notes.length > 0 ? { migration: notes.join(" ") } : {}) };
 }

--- a/packages/pi-meter/tests/extension.test.ts
+++ b/packages/pi-meter/tests/extension.test.ts
@@ -4,8 +4,9 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { findConflictingUsageCommand } from "../src/conflict.ts";
-import { createLedgerStore } from "../src/ledger/store.ts";
+import { createLedgerStore, parseUsageLine, serializeUsageRecord } from "../src/ledger/store.ts";
 import { getMeterPaths } from "../src/paths.ts";
+import type { UsageRecord } from "../src/ledger/types.ts";
 
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 let agentDir: string;
@@ -173,6 +174,76 @@ describe("extension runtime", () => {
 		expect(raw).toContain("ephemeral");
 		expect(raw).toContain("11");
 		expect(raw).not.toContain("creditUsagePercent");
+	});
+
+	it("does not import a live-captured turn when the session entry timestamp is later", async () => {
+		const messageTs = 1_700_000_000_000;
+		const sid = "hist-sess";
+		const sessionFile = join(agentDir, "sessions", `${sid}.jsonl`);
+		mkdirSync(join(agentDir, "sessions"), { recursive: true });
+		writeFileSync(sessionFile, `${JSON.stringify({
+			type: "message",
+			timestamp: new Date(messageTs + 30_000).toISOString(),
+			message: {
+				role: "assistant",
+				provider: "xai",
+				model: "grok-4",
+				timestamp: messageTs,
+				usage: { input: 11, output: 2, cacheRead: 3, cacheWrite: 4, totalTokens: 20, cost: { total: 0.01 } },
+			},
+		})}\n`);
+		const { default: piMeter } = await import("../extensions/meter.ts");
+		const { pi, ctx, handlers, commands, notifications } = harness({
+			hasUI: true,
+			mode: "print",
+			sessionFile,
+		});
+		piMeter(pi);
+		await handlers.get("session_start")?.[0]?.({ type: "session_start", reason: "startup" }, ctx);
+		await handlers.get("message_end")?.[0]?.({
+			type: "message_end",
+			message: {
+				role: "assistant",
+				provider: "xai",
+				model: "grok-4",
+				timestamp: messageTs,
+				usage: { input: 11, output: 2, cacheRead: 3, cacheWrite: 4, totalTokens: 20, cost: { total: 0.01 } },
+			},
+		}, ctx);
+		await commands.get("usage").handler("import", ctx);
+		const rows = readFileSync(getMeterPaths(agentDir).usageFile, "utf8").trim().split("\n").map(parseUsageLine);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.ts).toBe(messageTs);
+		expect(notifications.some((item) => item.message.includes("Nothing new to import"))).toBe(true);
+	});
+
+	it("collapses already-written live/import duplicates when the ledger opens", async () => {
+		const messageTs = 1_700_000_000_000;
+		const live: UsageRecord = {
+			ts: messageTs,
+			sid: "hist-sess",
+			cwd: "/work",
+			model: "xai/grok-4",
+			in: 11,
+			out: 2,
+			cR: 3,
+			cW: 4,
+			tot: 20,
+			cost: 0.01,
+			costKnown: true,
+		};
+		const duplicate = { ...live, ts: messageTs + 30_000 };
+		const paths = getMeterPaths(agentDir);
+		mkdirSync(paths.dataDir, { recursive: true });
+		writeFileSync(paths.usageFile, `${JSON.stringify(serializeUsageRecord(live))}\n${JSON.stringify(serializeUsageRecord(duplicate))}\n`);
+		const { default: piMeter } = await import("../extensions/meter.ts");
+		const { pi, ctx, handlers, notifications } = harness({ hasUI: true, mode: "print" });
+		piMeter(pi);
+		await handlers.get("session_start")?.[0]?.({ type: "session_start", reason: "startup" }, ctx);
+		const rows = readFileSync(paths.usageFile, "utf8").trim().split("\n").map(parseUsageLine);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.ts).toBe(messageTs);
+		expect(notifications.some((item) => item.message.includes("duplicate usage records"))).toBe(true);
 	});
 
 	it("publishes one footer status instead of a widget row", async () => {

--- a/packages/pi-meter/tests/ledger.test.ts
+++ b/packages/pi-meter/tests/ledger.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { aggregate, sumRows } from "../src/ledger/aggregate.ts";
 import { budgetKey, statusForLimit } from "../src/ledger/budget.ts";
-import { diffRecords, parseSession, usageFromAssistantMessage } from "../src/ledger/session-parser.ts";
+import { collapseDuplicateRecords, diffRecords, parseSession, usageFromAssistantMessage } from "../src/ledger/session-parser.ts";
 import { parseUsageLine, serializeUsageRecord } from "../src/ledger/store.ts";
 import { parseMeterConfig } from "../src/config.ts";
 import { sessionIdFrom } from "../src/ledger/time.ts";
@@ -28,6 +29,7 @@ describe("usage capture", () => {
 			role: "assistant",
 			provider: "xai",
 			model: "grok-4",
+			timestamp: 1000,
 			usage: {
 				input: 12,
 				output: 3,
@@ -36,7 +38,7 @@ describe("usage capture", () => {
 				totalTokens: 99,
 				cost: { total: 0.02 },
 			},
-		}, { ts: 1000, sid: "ephemeral", cwd: "/work" });
+		}, { sid: "ephemeral", cwd: "/work" });
 		expect(record).toEqual({
 			ts: 1000,
 			sid: "ephemeral",
@@ -50,6 +52,15 @@ describe("usage capture", () => {
 			cost: 0.02,
 			costKnown: true,
 		});
+	});
+
+	it("skips assistant usage without message.timestamp instead of inventing a clock", () => {
+		expect(usageFromAssistantMessage({
+			role: "assistant",
+			provider: "xai",
+			model: "grok-4",
+			usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { total: 0 } },
+		}, { sid: "sess", cwd: "/work" })).toBeUndefined();
 	});
 
 	it("treats missing session files as ephemeral so --no-session still records", () => {
@@ -112,6 +123,33 @@ describe("dashboard", () => {
 		expect(text).toMatch(/Total/);
 	});
 
+	it("keeps cache write visible at typical TUI widths", async () => {
+		const { Dashboard } = await import("../src/ledger/dashboard.ts");
+		const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text };
+		const view = new Dashboard({
+			records: [rec({
+				model: "anthropic/claude-sonnet-4-5-very-long-id",
+				tot: 4_300_000,
+				in: 34_000,
+				out: 210,
+				cR: 5_350_000_000,
+				cW: 777_000,
+			})],
+			budgets: [],
+		}, theme, "all");
+		for (const width of [80, 100, 160]) {
+			const lines = view.render(width);
+			const text = lines.join("\n");
+			expect(text).toContain("cache w");
+			expect(text).toContain("777k");
+			for (const line of lines) {
+				if (line.includes("cache w") || line.includes("777k")) {
+					expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+				}
+			}
+		}
+	});
+
 	it("labels rolling windows as last-N, calendar windows as calendar days", async () => {
 		const { Dashboard } = await import("../src/ledger/dashboard.ts");
 		const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text };
@@ -122,23 +160,33 @@ describe("dashboard", () => {
 });
 
 describe("session import", () => {
-	it("parses assistant usage from session JSONL and dedupes by turn", () => {
-		const content = [
+	const messageTs = Date.parse("2026-08-15T12:00:00.000Z");
+	const entryIso = "2026-08-15T12:00:30.000Z";
+
+	function jsonl(over: { messageTs?: number | null; entry?: string } = {}): string {
+		const message: Record<string, unknown> = {
+			role: "assistant",
+			provider: "anthropic",
+			model: "claude",
+			usage: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, totalTokens: 10, cost: { total: 0.1 } },
+		};
+		if (over.messageTs !== null) message.timestamp = over.messageTs ?? messageTs;
+		return [
 			JSON.stringify({ type: "session", cwd: "/repo" }),
 			JSON.stringify({
 				type: "message",
-				timestamp: "2026-08-15T12:00:00.000Z",
-				message: {
-					role: "assistant",
-					provider: "anthropic",
-					model: "claude",
-					usage: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, totalTokens: 10, cost: { total: 0.1 } },
-				},
+				timestamp: over.entry ?? entryIso,
+				message,
 			}),
 		].join("\n");
-		const parsed = parseSession(content, "hist");
+	}
+
+	it("parses assistant usage from session JSONL and dedupes by turn", () => {
+		const parsed = parseSession(jsonl(), "hist");
 		expect(parsed.cwd).toBe("/repo");
+		expect(parsed.skipped).toBe(0);
 		expect(parsed.records[0]).toMatchObject({
+			ts: messageTs,
 			sid: "hist",
 			cwd: "/repo",
 			model: "anthropic/claude",
@@ -148,6 +196,61 @@ describe("session import", () => {
 			cW: 4,
 		});
 		expect(diffRecords(parsed.records, parsed.records)).toEqual([]);
+	});
+
+	it("skips JSONL assistant usage that has no message.timestamp", () => {
+		const parsed = parseSession(jsonl({ messageTs: null }), "hist");
+		expect(parsed.cwd).toBe("/repo");
+		expect(parsed.records).toEqual([]);
+		expect(parsed.skipped).toBe(1);
+	});
+
+	it("uses message.timestamp rather than the later JSONL entry timestamp", () => {
+		const parsed = parseSession(jsonl(), "hist");
+		expect(parsed.records[0]?.ts).toBe(messageTs);
+		expect(parsed.records[0]?.ts).not.toBe(Date.parse(entryIso));
+	});
+
+	it("does not import a live-captured turn when the JSONL entry timestamp is later", () => {
+		const live = rec({
+			ts: messageTs,
+			sid: "hist",
+			cwd: "/repo",
+			model: "anthropic/claude",
+			in: 1,
+			out: 2,
+			cR: 3,
+			cW: 4,
+			tot: 10,
+			cost: 0.1,
+		});
+		const parsed = parseSession(jsonl(), "hist");
+		expect(parsed.records).toHaveLength(1);
+		expect(diffRecords([live], parsed.records)).toEqual([]);
+	});
+
+	it("treats an old entry-timestamp import as the same turn as a message.timestamp import", () => {
+		const oldImport = rec({
+			ts: Date.parse(entryIso),
+			sid: "hist",
+			cwd: "/repo",
+			model: "anthropic/claude",
+			in: 1,
+			out: 2,
+			cR: 3,
+			cW: 4,
+			tot: 10,
+			cost: 0.1,
+		});
+		expect(diffRecords([oldImport], parseSession(jsonl(), "hist").records)).toEqual([]);
+	});
+
+	it("collapses already-written duplicates that share sid/model/tokens and keeps the earlier row", () => {
+		const live = rec({ ts: messageTs, sid: "hist", model: "anthropic/claude", in: 1, out: 2, cR: 3, cW: 4, tot: 10 });
+		const imported = rec({ ts: Date.parse(entryIso), sid: "hist", model: "anthropic/claude", in: 1, out: 2, cR: 3, cW: 4, tot: 10, cwd: "/other" });
+		const other = rec({ ts: messageTs + 5_000, sid: "hist", model: "anthropic/claude", in: 9, out: 2, cR: 3, cW: 4, tot: 18 });
+		expect(collapseDuplicateRecords([live, imported, other])).toEqual([live, other]);
+		expect(collapseDuplicateRecords([imported, live, other])).toEqual([live, other]);
 	});
 });
 


### PR DESCRIPTION
## Summary

- `/usage import` now uses `message.timestamp` like live capture, so already-recorded turns are not counted twice
- already-written live/import duplicates are collapsed; turns without `message.timestamp` are skipped with a warning
- `/usage` dashboard keeps the cache write column visible at typical terminal widths

## Release plan

- `@zhcsyncer/pi-meter`: `0.3.0` → `0.3.1` (patch)
- `@zhcsyncer/pi-extensions`: `0.25.0` → `0.25.1` (required aggregate-root patch)

## Validation

- `pnpm --filter @zhcsyncer/pi-meter check`
- `pnpm changeset status`