### PR TITLE
feat(herdr-companion): add /herdr-worktree start and cleanup

### DIFF
--- a/.changeset/herdr-worktree-cleanup.md
+++ b/.changeset/herdr-worktree-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": minor
+"@zhcsyncer/pi-herdr-companion": minor
+---
+
+Add `/herdr-worktree cleanup` to remove the current linked Herdr worktree. By default it also deletes the local branch; `--keep-branch` keeps the branch. Remote branches are left untouched.

--- a/.changeset/herdr-worktree-start.md
+++ b/.changeset/herdr-worktree-start.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": minor
+"@zhcsyncer/pi-herdr-companion": minor
+---
+
+Add `/herdr-worktree start` to distill an executable plan from the current session, then create a linked worktree and start Pi with only that plan.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@
 | [pi-meter/extension.md](./pi-meter/extension.md) | 已落地 | 本地账本与订阅剩余两套账 |
 | [pi-meter/quota-status.md](./pi-meter/quota-status.md) | 已落地 | 底栏只画当前模型套餐；本地滚动/日历窗口 |
 | [pi-fast-mode/extension.md](./pi-fast-mode/extension.md) | 已落地 | 同模型 Fast / Priority：内存开关、loader 红线 |
-| [pi-herdr-companion/extension.md](./pi-herdr-companion/extension.md) | 已落地 | Herdr 可见进程、临时 `/btw`、blocked；worker 实现保留但不注册 |
+| [pi-herdr-companion/extension.md](./pi-herdr-companion/extension.md) | 已落地 | Herdr 可见进程、临时 `/btw`、blocked、当前 linked worktree 的确定性 cleanup；worker 实现保留但不注册 |
 | [pi-tool-display-intent/aggregate-layout.md](./pi-tool-display-intent/aggregate-layout.md) | 已落地 | aggregate Tools 账本：按请求汇总、不改执行与历史 |
 | [pi-tool-display-intent/aggregate-steer.md](./pi-tool-display-intent/aggregate-steer.md) | 已落地 | steer 留在同一轮：钉顶首行、结束后留一行、展开后时间线高亮 |
 | [pi-todo/active-plan-lifecycle.md](./pi-todo/active-plan-lifecycle.md) | 已落地 | Todo 有界周期与 checkpoint 收缩 |

--- a/docs/pi-herdr-companion/extension.md
+++ b/docs/pi-herdr-companion/extension.md
@@ -1,6 +1,6 @@
 # Herdr Companion
 
-状态：已落地。`herdr_worker` 实现保留、不注册。
+状态：已落地。`herdr_worker` 实现保留、不注册。`/herdr-worktree` 目前只实现 `cleanup`。
 
 ## 为什么做
 
@@ -15,6 +15,7 @@ Pi 在 Herdr 里缺三件用户能看见的事：长跑命令要占一扇可见 
 - **进程认的是同一 Herdr server 里的 live terminal**，不是当时的 pane ID。挪到别的 Tab / Workspace 后继续跟；跨 socket 或冷启动后的旧所有权丢掉，不套到另一块 terminal 上。
 - **`/btw` 是临时可见支线**，不是可恢复 session。合回是用户动作。父子共享 cwd，所以文件、Git、端口会互相踩。
 - **`/herdr-config` 先改草稿**。Save 才写 `extension-data/pi-herdr-companion/config.json`；Discard 等于没打开；Reset draft 只重置草稿。`/herdr-config reset` 才立刻打回已保存文件。
+- **`/herdr-worktree cleanup` 认的是当前 Herdr workspace 那棵 linked worktree**，不是模型现场拼的 git。身份来自 `HERDR_WORKSPACE_ID` + `herdr workspace get` 的 `worktree.is_linked_worktree`；分支和脏树只看这棵 checkout 上的可控 git。
 
 ## 红线
 
@@ -23,6 +24,7 @@ Pi 在 Herdr 里缺三件用户能看见的事：长跑命令要占一扇可见 
 - 不要同时加载另一个 `/btw`。
 - `herdr_worker` 不进工具面：用 sysprompt 当回调合同，会漏进 `Agent` / subagent，上报会乱。实现留在 `src/worker.ts`，扩展启动时不注册。
 - Companion 不替代 Herdr 的 Pi integration。
+- `/herdr-worktree cleanup` 硬拒绝 `main` / `master`、primary checkout、脏树；不问 squash / MR / `merge-base`。默认顺序必须是 `git checkout --detach` → 当前 worktree 里 `git branch -D` → 最后 `herdr worktree remove --workspace <id>`。`--keep-branch` 跳过前两步。不要先 `workspace close`，也不要把还不存在的 `--keep-branch` 传给 Herdr。远程分支默认不动。
 
 ## 非显然外部事实
 

--- a/docs/pi-herdr-companion/extension.md
+++ b/docs/pi-herdr-companion/extension.md
@@ -1,6 +1,6 @@
 # Herdr Companion
 
-状态：已落地。`herdr_worker` 实现保留、不注册。`/herdr-worktree` 目前只实现 `cleanup`。
+状态：已落地。`herdr_worker` 实现保留、不注册。`/herdr-worktree` 实现 `start` 与 `cleanup`。
 
 ## 为什么做
 
@@ -15,6 +15,7 @@ Pi 在 Herdr 里缺三件用户能看见的事：长跑命令要占一扇可见 
 - **进程认的是同一 Herdr server 里的 live terminal**，不是当时的 pane ID。挪到别的 Tab / Workspace 后继续跟；跨 socket 或冷启动后的旧所有权丢掉，不套到另一块 terminal 上。
 - **`/btw` 是临时可见支线**，不是可恢复 session。合回是用户动作。父子共享 cwd，所以文件、Git、端口会互相踩。
 - **`/herdr-config` 先改草稿**。Save 才写 `extension-data/pi-herdr-companion/config.json`；Discard 等于没打开；Reset draft 只重置草稿。`/herdr-config reset` 才立刻打回已保存文件。
+- **`/herdr-worktree start` 先整理、后派出**。整理在命令里单独调模型，不走 session agent run，确认前不写 transcript。结果只进多行编辑器；保存后才建树，transcript 只留 `[已派出]`。子 session 只拿到最终那份计划。
 - **`/herdr-worktree cleanup` 认的是当前 Herdr workspace 那棵 linked worktree**，不是模型现场拼的 git。身份来自 `HERDR_WORKSPACE_ID` + `herdr workspace get` 的 `worktree.is_linked_worktree`；分支和脏树只看这棵 checkout 上的可控 git。
 
 ## 红线
@@ -24,6 +25,7 @@ Pi 在 Herdr 里缺三件用户能看见的事：长跑命令要占一扇可见 
 - 不要同时加载另一个 `/btw`。
 - `herdr_worker` 不进工具面：用 sysprompt 当回调合同，会漏进 `Agent` / subagent，上报会乱。实现留在 `src/worker.ts`，扩展启动时不注册。
 - Companion 不替代 Herdr 的 Pi integration。
+- `/herdr-worktree start` 不打包主对话，不对已有树上的 Pi 再说话，不等子 session 做完。目标分支是 `main` / `master`、计划为空、或该分支已有 linked worktree 时硬拒绝。确定性顺序是 `worktree create --focus` → `agent start --kind pi` → `agent prompt --wait --until working`。不要把 `--keep-branch` 传给 Herdr。
 - `/herdr-worktree cleanup` 硬拒绝 `main` / `master`、primary checkout、脏树；不问 squash / MR / `merge-base`。默认顺序必须是 `git checkout --detach` → 当前 worktree 里 `git branch -D` → 最后 `herdr worktree remove --workspace <id>`。`--keep-branch` 跳过前两步。不要先 `workspace close`，也不要把还不存在的 `--keep-branch` 传给 Herdr。远程分支默认不动。
 
 ## 非显然外部事实

--- a/packages/pi-herdr-companion/README.md
+++ b/packages/pi-herdr-companion/README.md
@@ -2,7 +2,7 @@
 
 [简体中文](./README.zh-CN.md)
 
-A standalone Pi extension for using Pi inside [Herdr](https://herdr.dev). It adds visible long-running process panes, temporary `/btw` side threads, configurable blocked-state reporting, and one settings UI.
+A standalone Pi extension for using Pi inside [Herdr](https://herdr.dev). It adds visible long-running process panes, temporary `/btw` side threads, configurable blocked-state reporting, a settings UI, and `/herdr-worktree cleanup` for the current linked worktree.
 
 The extension stays silent when Pi is outside Herdr or Herdr cannot identify the calling pane.
 
@@ -17,6 +17,7 @@ The extension stays silent when Pi is outside Herdr or Herdr cannot identify the
 - `/btw` opens a temporary side conversation. Nothing returns to the parent until you merge.
 - Configured tools and extension events can show as blocked in Herdr.
 - `/herdr-config` edits runtime guidance, process defaults, and blocked rules.
+- `/herdr-worktree cleanup` removes the current linked Herdr worktree. By default it also deletes the local branch; `--keep-branch` keeps the branch. Remote branches are left untouched.
 
 ## Install
 
@@ -40,7 +41,7 @@ pi install /absolute/path/to/pi-extensions/packages/pi-herdr-companion
 
 `@zhcsyncer/pi-extensions` embeds these sources for release consistency but does **not** enable the companion. Install it separately.
 
-`herdr_process` and blocked reporting work in TUI, RPC, JSON, and print modes. `/btw` and `/herdr-config` need Pi TUI.
+`herdr_process` and blocked reporting work in TUI, RPC, JSON, and print modes. `/btw`, `/herdr-config`, and `/herdr-worktree` need Pi TUI.
 
 ## Processes
 
@@ -90,6 +91,17 @@ Do not load another extension that registers `/btw`. `/new`, `/resume`, or `/for
 ## Blocked reporting
 
 While a configured tool is running, or while a configured extension event payload is `{ active: true }`, Herdr can show a blocked label. `{ active: false }` clears an event. The default tracks `ask_user_question` as `question`.
+
+## `/herdr-worktree`
+
+Run this in the finished feature session that owns the linked worktree:
+
+```text
+/herdr-worktree cleanup
+/herdr-worktree cleanup --keep-branch
+```
+
+Default: detach the current linked worktree, delete the local branch, then remove the Herdr worktree. `--keep-branch` only removes the worktree. The command refuses `main` / `master`, the primary checkout, and a dirty tree. It asks once before changing anything. Remote branches are never deleted.
 
 ## Settings
 

--- a/packages/pi-herdr-companion/README.md
+++ b/packages/pi-herdr-companion/README.md
@@ -2,7 +2,7 @@
 
 [简体中文](./README.zh-CN.md)
 
-A standalone Pi extension for using Pi inside [Herdr](https://herdr.dev). It adds visible long-running process panes, temporary `/btw` side threads, configurable blocked-state reporting, a settings UI, and `/herdr-worktree cleanup` for the current linked worktree.
+A standalone Pi extension for using Pi inside [Herdr](https://herdr.dev). It adds visible long-running process panes, temporary `/btw` side threads, configurable blocked-state reporting, a settings UI, and `/herdr-worktree` to start or clean up a linked worktree.
 
 The extension stays silent when Pi is outside Herdr or Herdr cannot identify the calling pane.
 
@@ -17,6 +17,7 @@ The extension stays silent when Pi is outside Herdr or Herdr cannot identify the
 - `/btw` opens a temporary side conversation. Nothing returns to the parent until you merge.
 - Configured tools and extension events can show as blocked in Herdr.
 - `/herdr-config` edits runtime guidance, process defaults, and blocked rules.
+- `/herdr-worktree start` distills a dispatch plan from this session, then creates a linked worktree and starts Pi with only that plan.
 - `/herdr-worktree cleanup` removes the current linked Herdr worktree. By default it also deletes the local branch; `--keep-branch` keeps the branch. Remote branches are left untouched.
 
 ## Install
@@ -94,14 +95,16 @@ While a configured tool is running, or while a configured extension event payloa
 
 ## `/herdr-worktree`
 
-Run this in the finished feature session that owns the linked worktree:
-
 ```text
+/herdr-worktree start
+/herdr-worktree start feat/foo
 /herdr-worktree cleanup
 /herdr-worktree cleanup --keep-branch
 ```
 
-Default: detach the current linked worktree, delete the local branch, then remove the Herdr worktree. `--keep-branch` only removes the worktree. The command refuses `main` / `master`, the primary checkout, and a dirty tree. It asks once before changing anything. Remote branches are never deleted.
+`start` extracts an executable goal and plan from this session without writing a turn to the transcript, then opens a review editor. After you save that plan, it creates a linked worktree, starts Pi there, and sends only the reviewed plan. It refuses `main` / `master` as the destination, an empty plan, and a branch that already has a linked worktree. It does not pack this conversation, and it does not wait for the child to finish.
+
+`cleanup` is for the finished feature session that owns the linked worktree. Default: detach, delete the local branch, then remove the Herdr worktree. `--keep-branch` only removes the worktree. It refuses `main` / `master`, the primary checkout, and a dirty tree. Remote branches are never deleted.
 
 ## Settings
 

--- a/packages/pi-herdr-companion/README.zh-CN.md
+++ b/packages/pi-herdr-companion/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](./README.md)
 
-供 Pi 在 [Herdr](https://herdr.dev) 中使用的独立扩展。提供可见的长跑进程 Pane、临时 `/btw` 支线、可配置的 blocked 上报、设置界面，以及用于当前 linked worktree 的 `/herdr-worktree cleanup`。
+供 Pi 在 [Herdr](https://herdr.dev) 中使用的独立扩展。提供可见的长跑进程 Pane、临时 `/btw` 支线、可配置的 blocked 上报、设置界面，以及用于派出或拆掉 linked worktree 的 `/herdr-worktree`。
 
 Pi 不在 Herdr 中，或 Herdr 无法识别当前 Pane 时，扩展保持静默。
 
@@ -17,6 +17,7 @@ Pi 不在 Herdr 中，或 Herdr 无法识别当前 Pane 时，扩展保持静默
 - `/btw` 打开临时支线。只有你主动 merge 后，内容才会回到父会话。
 - 已配置的工具和扩展事件可以在 Herdr 里显示为 blocked。
 - `/herdr-config` 编辑 runtime guidance、进程默认值和 blocked 规则。
+- `/herdr-worktree start` 从当前 session 抽出一份可执行计划，再建 linked worktree，并只把这份计划交给新的 Pi。
 - `/herdr-worktree cleanup` 拆掉当前 linked Herdr worktree。默认同时删除本地分支；`--keep-branch` 只拆 worktree。远程分支默认不动。
 
 ## 安装
@@ -94,14 +95,16 @@ Child 是**临时的，不会存成 Pi session**。merge 前关掉，未合回�
 
 ## `/herdr-worktree`
 
-在已经做完的 feature session 里执行：
-
 ```text
+/herdr-worktree start
+/herdr-worktree start feat/foo
 /herdr-worktree cleanup
 /herdr-worktree cleanup --keep-branch
 ```
 
-默认：拆当前 linked worktree，并删除本地分支。`--keep-branch` 只拆 worktree。当前在 `main` / `master`、主 checkout、或工作区有未提交改动时会直接拒绝。动手前只确认一次。远程分支不会被删除。
+`start` 会根据当前讨论抽出可执行的目标和计划，这一步不写进 transcript，然后打开编辑器让你 review。保存后才建 linked worktree、在那边起 Pi，并且只把你确认过的计划打过去。目标分支是 `main` / `master`、计划为空、或这条分支已经有 linked worktree 时会拒绝。不打包当前对话，也不等子 session 做完。
+
+`cleanup` 在已经做完的 feature session 里执行。默认：拆当前 linked worktree，并删除本地分支。`--keep-branch` 只拆 worktree。当前在 `main` / `master`、主 checkout、或工作区有未提交改动时会直接拒绝。远程分支不会被删除。
 
 ## 设置
 

--- a/packages/pi-herdr-companion/README.zh-CN.md
+++ b/packages/pi-herdr-companion/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](./README.md)
 
-供 Pi 在 [Herdr](https://herdr.dev) 中使用的独立扩展。提供可见的长跑进程 Pane、临时 `/btw` 支线、可配置的 blocked 上报，以及一个设置界面。
+供 Pi 在 [Herdr](https://herdr.dev) 中使用的独立扩展。提供可见的长跑进程 Pane、临时 `/btw` 支线、可配置的 blocked 上报、设置界面，以及用于当前 linked worktree 的 `/herdr-worktree cleanup`。
 
 Pi 不在 Herdr 中，或 Herdr 无法识别当前 Pane 时，扩展保持静默。
 
@@ -17,6 +17,7 @@ Pi 不在 Herdr 中，或 Herdr 无法识别当前 Pane 时，扩展保持静默
 - `/btw` 打开临时支线。只有你主动 merge 后，内容才会回到父会话。
 - 已配置的工具和扩展事件可以在 Herdr 里显示为 blocked。
 - `/herdr-config` 编辑 runtime guidance、进程默认值和 blocked 规则。
+- `/herdr-worktree cleanup` 拆掉当前 linked Herdr worktree。默认同时删除本地分支；`--keep-branch` 只拆 worktree。远程分支默认不动。
 
 ## 安装
 
@@ -40,7 +41,7 @@ pi install /absolute/path/to/pi-extensions/packages/pi-herdr-companion
 
 `@zhcsyncer/pi-extensions` 为发版一致性内嵌了这些源码，但**不会**启用 Companion。请单独安装。
 
-`herdr_process` 和 blocked 上报可用于 TUI、RPC、JSON 和 print mode。`/btw` 与 `/herdr-config` 需要 Pi TUI。
+`herdr_process` 和 blocked 上报可用于 TUI、RPC、JSON 和 print mode。`/btw`、`/herdr-config` 与 `/herdr-worktree` 需要 Pi TUI。
 
 ## 进程
 
@@ -90,6 +91,17 @@ Child 是**临时的，不会存成 Pi session**。merge 前关掉，未合回�
 ## Blocked 上报
 
 已配置的工具在执行期间，或已配置的扩展事件 payload 为 `{ active: true }` 时，Herdr 可以显示 blocked 标签。`{ active: false }` 清除事件。默认把 `ask_user_question` 显示为 `question`。
+
+## `/herdr-worktree`
+
+在已经做完的 feature session 里执行：
+
+```text
+/herdr-worktree cleanup
+/herdr-worktree cleanup --keep-branch
+```
+
+默认：拆当前 linked worktree，并删除本地分支。`--keep-branch` 只拆 worktree。当前在 `main` / `master`、主 checkout、或工作区有未提交改动时会直接拒绝。动手前只确认一次。远程分支不会被删除。
 
 ## 设置
 

--- a/packages/pi-herdr-companion/src/extension.ts
+++ b/packages/pi-herdr-companion/src/extension.ts
@@ -20,6 +20,7 @@ import { registerBtwParent } from "./btw/parent.ts";
 import { BTW_PAYLOAD_ENV } from "./btw/types.ts";
 import { HerdrClient } from "./herdr-client.ts";
 import { ProcessManager } from "./process/manager.ts";
+import { registerHerdrWorktreeCommand } from "./worktree/command.ts";
 import { restoreProcessRegistry, PROCESS_STATE_CUSTOM_TYPE } from "./process/registry.ts";
 import { registerHerdrProcessTool } from "./process/tool.ts";
 import { ProcessWidgetController } from "./process/ui.ts";
@@ -142,6 +143,11 @@ export default async function herdrCompanionExtension(pi: ExtensionAPI): Promise
 				}
 				await openCompanionConfigUi(ctx, configController);
 			},
+		});
+		registerHerdrWorktreeCommand(pi, {
+			runtime,
+			client,
+			exec: (command, args, execOptions) => pi.exec(command, args, execOptions),
 		});
 
 		const btwStore = new BtwContextStore(defaultBtwStateRoot(runtime));

--- a/packages/pi-herdr-companion/src/herdr-client.ts
+++ b/packages/pi-herdr-companion/src/herdr-client.ts
@@ -87,6 +87,36 @@ export interface HerdrWorkspace {
 	worktree?: HerdrWorkspaceWorktree;
 }
 
+export interface HerdrWorktreeCheckout {
+	path: string;
+	branch?: string;
+	isLinkedWorktree: boolean;
+	openWorkspaceId?: string;
+	label?: string;
+}
+
+export interface CreateWorktreeOptions {
+	workspaceId?: string;
+	cwd?: string;
+	branch: string;
+	base?: string;
+	label?: string;
+	focus?: boolean;
+}
+
+export interface CreatedWorktree {
+	workspace: HerdrWorkspace;
+	rootPaneId: string;
+	worktree: HerdrWorktreeCheckout;
+}
+
+export type HerdrAgentStatus = "idle" | "working" | "blocked" | "done" | "unknown";
+
+export interface PromptUntilOptions {
+	until: HerdrAgentStatus;
+	timeoutMs: number;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -140,7 +170,12 @@ const SAFE_OPERATIONS = new Set([
 	"agent prompt",
 	"agent focus",
 	"workspace get",
+	"workspace focus",
+	"worktree list",
+	"worktree create",
 	"worktree remove",
+	"agent list",
+	"agent wait",
 ]);
 
 function safeOperation(args: readonly string[]): string {
@@ -309,6 +344,38 @@ function parseWorkspace(value: unknown, operation: string): HerdrWorkspace {
 			? {}
 			: { worktree: parseWorkspaceWorktree(value.worktree, operation) }),
 	};
+}
+
+function parseWorktreeCheckout(value: unknown, operation: string): HerdrWorktreeCheckout {
+	if (!isRecord(value) || typeof value.path !== "string" || !value.path.trim()) {
+		throw new HerdrProtocolError(operation, "an invalid worktree object");
+	}
+	if (typeof value.is_linked_worktree !== "boolean") {
+		throw new HerdrProtocolError(operation, "an invalid worktree.is_linked_worktree");
+	}
+	for (const [field, candidate] of [
+		["branch", value.branch],
+		["open_workspace_id", value.open_workspace_id],
+		["label", value.label],
+	] as const) {
+		if (candidate !== undefined && candidate !== null && typeof candidate !== "string") {
+			throw new HerdrProtocolError(operation, `an invalid worktree.${field}`);
+		}
+	}
+	return {
+		path: value.path,
+		isLinkedWorktree: value.is_linked_worktree,
+		...(typeof value.branch === "string" ? { branch: value.branch } : {}),
+		...(typeof value.open_workspace_id === "string" ? { openWorkspaceId: value.open_workspace_id } : {}),
+		...(typeof value.label === "string" ? { label: value.label } : {}),
+	};
+}
+
+function parseRootPaneId(value: unknown, operation: string): string {
+	if (!isRecord(value) || typeof value.pane_id !== "string" || !value.pane_id.trim()) {
+		throw new HerdrProtocolError(operation, "an invalid root_pane");
+	}
+	return value.pane_id;
 }
 
 function optionalPid(value: unknown, operation: string, field: string): number | undefined {
@@ -586,5 +653,66 @@ export class HerdrClient {
 			"worktree remove",
 			signal,
 		);
+	}
+
+	async listWorktrees(
+		options: { workspaceId?: string; cwd?: string } = {},
+		signal?: AbortSignal,
+	): Promise<HerdrWorktreeCheckout[]> {
+		const args = [
+			"worktree",
+			"list",
+			...(options.workspaceId ? ["--workspace", options.workspaceId] : []),
+			...(options.cwd ? ["--cwd", options.cwd] : []),
+		];
+		const result = await this.executeJson(args, 5_000, "worktree list", signal);
+		if (!Array.isArray(result.worktrees)) throw new HerdrProtocolError("worktree list", "an invalid worktrees array");
+		return result.worktrees.map((worktree) => parseWorktreeCheckout(worktree, "worktree list"));
+	}
+
+	async createWorktree(options: CreateWorktreeOptions, signal?: AbortSignal): Promise<CreatedWorktree> {
+		const args = [
+			"worktree",
+			"create",
+			...(options.workspaceId ? ["--workspace", options.workspaceId] : []),
+			...(options.cwd ? ["--cwd", options.cwd] : []),
+			"--branch",
+			options.branch,
+			...(options.base ? ["--base", options.base] : []),
+			...(options.label ? ["--label", options.label] : []),
+			options.focus ? "--focus" : "--no-focus",
+		];
+		const result = await this.executeJson(args, 30_000, "worktree create", signal);
+		return {
+			workspace: parseWorkspace(result.workspace, "worktree create"),
+			rootPaneId: parseRootPaneId(result.root_pane, "worktree create"),
+			worktree: parseWorktreeCheckout(result.worktree, "worktree create"),
+		};
+	}
+
+	async listAgents(signal?: AbortSignal): Promise<HerdrAgent[]> {
+		const result = await this.executeJson(["agent", "list"], 5_000, "agent list", signal);
+		if (!Array.isArray(result.agents)) throw new HerdrProtocolError("agent list", "an invalid agents array");
+		return result.agents.map((agent) => parseAgent(agent, "agent list"));
+	}
+
+	async promptAgentUntil(
+		target: string,
+		prompt: string,
+		options: PromptUntilOptions,
+		signal?: AbortSignal,
+	): Promise<HerdrAgent> {
+		const result = await this.executeJson([
+			"agent",
+			"prompt",
+			target,
+			prompt,
+			"--wait",
+			"--until",
+			options.until,
+			"--timeout",
+			String(options.timeoutMs),
+		], options.timeoutMs + 2_000, "agent prompt", signal);
+		return parseAgent(result.agent, "agent prompt");
 	}
 }

--- a/packages/pi-herdr-companion/src/herdr-client.ts
+++ b/packages/pi-herdr-companion/src/herdr-client.ts
@@ -73,6 +73,20 @@ export interface StartAgentOptions {
 	timeoutMs?: number;
 }
 
+export interface HerdrWorkspaceWorktree {
+	repoKey?: string;
+	repoName?: string;
+	repoRoot?: string;
+	checkoutPath: string;
+	isLinkedWorktree: boolean;
+}
+
+export interface HerdrWorkspace {
+	workspaceId: string;
+	label?: string;
+	worktree?: HerdrWorkspaceWorktree;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -125,6 +139,8 @@ const SAFE_OPERATIONS = new Set([
 	"agent rename",
 	"agent prompt",
 	"agent focus",
+	"workspace get",
+	"worktree remove",
 ]);
 
 function safeOperation(args: readonly string[]): string {
@@ -250,6 +266,48 @@ function parseAgent(value: unknown, operation: string): HerdrAgent {
 		...(typeof value.name === "string" ? { name: value.name } : {}),
 		...(typeof value.agent === "string" ? { agent: value.agent } : {}),
 		...(typeof value.agent_status === "string" ? { status: value.agent_status } : {}),
+	};
+}
+
+function parseWorkspaceWorktree(value: unknown, operation: string): HerdrWorkspaceWorktree {
+	if (!isRecord(value)) throw new HerdrProtocolError(operation, "an invalid workspace.worktree");
+	if (typeof value.checkout_path !== "string" || !value.checkout_path.trim()) {
+		throw new HerdrProtocolError(operation, "an invalid workspace.worktree.checkout_path");
+	}
+	if (typeof value.is_linked_worktree !== "boolean") {
+		throw new HerdrProtocolError(operation, "an invalid workspace.worktree.is_linked_worktree");
+	}
+	for (const [field, candidate] of [
+		["repo_key", value.repo_key],
+		["repo_name", value.repo_name],
+		["repo_root", value.repo_root],
+	] as const) {
+		if (candidate !== undefined && candidate !== null && typeof candidate !== "string") {
+			throw new HerdrProtocolError(operation, `an invalid workspace.worktree.${field}`);
+		}
+	}
+	return {
+		checkoutPath: value.checkout_path,
+		isLinkedWorktree: value.is_linked_worktree,
+		...(typeof value.repo_key === "string" ? { repoKey: value.repo_key } : {}),
+		...(typeof value.repo_name === "string" ? { repoName: value.repo_name } : {}),
+		...(typeof value.repo_root === "string" ? { repoRoot: value.repo_root } : {}),
+	};
+}
+
+function parseWorkspace(value: unknown, operation: string): HerdrWorkspace {
+	if (!isRecord(value) || typeof value.workspace_id !== "string" || !value.workspace_id.trim()) {
+		throw new HerdrProtocolError(operation, "an invalid workspace object");
+	}
+	if (value.label !== undefined && value.label !== null && typeof value.label !== "string") {
+		throw new HerdrProtocolError(operation, "an invalid workspace.label");
+	}
+	return {
+		workspaceId: value.workspace_id,
+		...(typeof value.label === "string" ? { label: value.label } : {}),
+		...(value.worktree === undefined || value.worktree === null
+			? {}
+			: { worktree: parseWorkspaceWorktree(value.worktree, operation) }),
 	};
 }
 
@@ -514,5 +572,19 @@ export class HerdrClient {
 
 	async focusAgent(target: string, signal?: AbortSignal): Promise<void> {
 		await this.executeJson(["agent", "focus", target], 5_000, "agent focus", signal);
+	}
+
+	async getWorkspace(workspaceId: string, signal?: AbortSignal): Promise<HerdrWorkspace> {
+		const result = await this.executeJson(["workspace", "get", workspaceId], 5_000, "workspace get", signal);
+		return parseWorkspace(result.workspace, "workspace get");
+	}
+
+	async removeWorktree(workspaceId: string, signal?: AbortSignal): Promise<void> {
+		await this.executeJson(
+			["worktree", "remove", "--workspace", workspaceId],
+			15_000,
+			"worktree remove",
+			signal,
+		);
 	}
 }

--- a/packages/pi-herdr-companion/src/worktree/brief.ts
+++ b/packages/pi-herdr-companion/src/worktree/brief.ts
@@ -1,0 +1,120 @@
+export const DISPATCHED_ENTRY_TYPE = "herdr-worktree-dispatched";
+export const NOT_READY_PREFIX = "NOT_READY";
+export const PROTECTED_BRANCHES = new Set(["main", "master"]);
+export const DISTILL_MAX_CHARS = 48_000;
+export const DISTILL_MAX_TOKENS = 4_096;
+
+export function buildDistillInstruction(branch?: string): string {
+	const branchLine = branch
+		? `第一行必须是：Branch: ${branch}`
+		: "第一行写：Branch: <建议的分支名>";
+	return [
+		"只从当前讨论抽出可执行的目标和计划。",
+		"不要复述讨论过程，不要写被否决的方案，不要开始实现。",
+		`若目标或计划还不够具体，只回复 ${NOT_READY_PREFIX} 和原因。`,
+		branchLine,
+		"从第二行起写目标和步骤。",
+	].join("\n");
+}
+
+export type ParsedDispatchBrief =
+	| { status: "not-ready"; reason: string }
+	| { status: "ready"; branch: string; brief: string }
+	| { status: "invalid"; message: string };
+
+function isProtectedBranch(branch: string): boolean {
+	return PROTECTED_BRANCHES.has(branch);
+}
+
+function validBranchName(branch: string): boolean {
+	return Boolean(branch) && !branch.startsWith("-") && !/[\s\0\n\r]/.test(branch);
+}
+
+export function extractContentText(content: unknown): string {
+	if (typeof content === "string") return content.trim();
+	if (!Array.isArray(content)) return "";
+	return content
+		.filter((part): part is { type: string; text: string } =>
+			Boolean(part) && typeof part === "object" && (part as { type?: unknown }).type === "text" &&
+			typeof (part as { text?: unknown }).text === "string")
+		.map((part) => part.text)
+		.join("")
+		.trim();
+}
+
+export function lastAssistantText(entries: readonly { type?: string; message?: { role?: string; content?: unknown } }[]): string {
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		const entry = entries[index];
+		if (entry?.type !== "message" || entry.message?.role !== "assistant") continue;
+		const text = extractContentText(entry.message.content);
+		if (text) return text;
+	}
+	return "";
+}
+
+export function sessionHasDistillableConversation(
+	entries: readonly { type?: string; message?: { role?: string; content?: unknown } }[],
+): boolean {
+	return entries.some((entry) => {
+		if (entry.type !== "message") return false;
+		const role = entry.message?.role;
+		if (role !== "user" && role !== "assistant") return false;
+		return extractContentText(entry.message?.content).length > 0;
+	});
+}
+
+export function serializeSessionForDistill(
+	entries: readonly { type?: string; message?: { role?: string; content?: unknown } }[],
+	maxChars = DISTILL_MAX_CHARS,
+): string {
+	const parts: string[] = [];
+	for (const entry of entries) {
+		if (entry.type !== "message") continue;
+		const role = entry.message?.role;
+		if (role !== "user" && role !== "assistant") continue;
+		const text = extractContentText(entry.message?.content);
+		if (!text) continue;
+		parts.push(`${role === "user" ? "User" : "Assistant"}:\n${text}`);
+	}
+	const serialized = parts.join("\n\n");
+	if (serialized.length <= maxChars) return serialized;
+	return `[Earlier discussion omitted]\n${serialized.slice(serialized.length - maxChars)}`;
+}
+
+export function parseDispatchBrief(text: string, pinnedBranch?: string): ParsedDispatchBrief {
+	const trimmed = text.trim();
+	if (!trimmed) return { status: "invalid", message: "The dispatch plan is empty." };
+	if (trimmed.startsWith(NOT_READY_PREFIX)) {
+		const reason = trimmed.slice(NOT_READY_PREFIX.length).replace(/^[:：\s]+/, "").trim();
+		return { status: "not-ready", reason: reason || "the current discussion is not ready to dispatch" };
+	}
+
+	const lines = trimmed.split(/\r?\n/);
+	const header = /^Branch:\s*(\S+)\s*$/.exec(lines[0] ?? "");
+	const parsedBranch = header?.[1];
+	const body = header ? lines.slice(1).join("\n").trim() : trimmed;
+	const branch = pinnedBranch ?? parsedBranch;
+	if (!branch) return { status: "invalid", message: "The dispatch plan must start with Branch: <name>." };
+	if (!validBranchName(branch)) return { status: "invalid", message: `Refusing to dispatch to invalid branch ${branch}.` };
+	if (isProtectedBranch(branch)) {
+		return { status: "invalid", message: `Refusing to dispatch to ${branch}.` };
+	}
+	if (!body) return { status: "invalid", message: "The dispatch plan has no executable goal or steps." };
+	const brief = `Branch: ${branch}\n${body}`;
+	return { status: "ready", branch, brief };
+}
+
+export function wrapDisplayLines(text: string, width: number): string[] {
+	const columns = Math.max(1, width);
+	const lines: string[] = [];
+	for (const line of text.split("\n")) {
+		if (line.length === 0) {
+			lines.push("");
+			continue;
+		}
+		for (let index = 0; index < line.length; index += columns) {
+			lines.push(line.slice(index, index + columns));
+		}
+	}
+	return lines.length > 0 ? lines : [""];
+}

--- a/packages/pi-herdr-companion/src/worktree/cleanup.ts
+++ b/packages/pi-herdr-companion/src/worktree/cleanup.ts
@@ -1,0 +1,135 @@
+import type { ExecResult } from "@earendil-works/pi-coding-agent";
+import type { HerdrClient, HerdrExecutor } from "../herdr-client.ts";
+import type { RuntimeSnapshot } from "../runtime.ts";
+
+const GIT_TIMEOUT_MS = 10_000;
+const PROTECTED_BRANCHES = new Set(["main", "master"]);
+
+export class GitCommandError extends Error {
+	readonly operation: string;
+	readonly exitCode: number;
+	readonly killed: boolean;
+
+	constructor(args: readonly string[], result: ExecResult) {
+		const operation = `git ${args[0] ?? "command"}`;
+		const status = result.killed ? "timed out or was cancelled" : `failed with exit code ${result.code}`;
+		const detail = firstLine(result.stderr || result.stdout);
+		super(detail ? `${operation} ${status}: ${detail}` : `${operation} ${status}`);
+		this.name = "GitCommandError";
+		this.operation = operation;
+		this.exitCode = result.code;
+		this.killed = result.killed;
+	}
+}
+
+export interface CleanupUi {
+	confirm(title: string, message: string): Promise<boolean>;
+}
+
+export interface CleanupDeps {
+	client: Pick<HerdrClient, "getWorkspace" | "removeWorktree">;
+	exec: HerdrExecutor;
+	runtime: Pick<RuntimeSnapshot, "workspaceId">;
+	keepBranch: boolean;
+	ui: CleanupUi;
+}
+
+export type CleanupResult =
+	| { status: "rejected"; message: string }
+	| { status: "cancelled" }
+	| { status: "removed"; keepBranch: boolean; branch?: string };
+
+function firstLine(text: string): string {
+	const line = text.trim().split(/\r?\n/, 1)[0] ?? "";
+	return line.length > 200 ? `${line.slice(0, 197)}...` : line;
+}
+
+async function runGit(exec: HerdrExecutor, cwd: string, args: string[]): Promise<string> {
+	const result = await exec("git", args, { cwd, timeout: GIT_TIMEOUT_MS });
+	if (result.code !== 0 || result.killed) throw new GitCommandError(args, result);
+	return result.stdout;
+}
+
+export async function inspectWorktreeGit(
+	exec: HerdrExecutor,
+	cwd: string,
+): Promise<{ branch?: string; dirty: boolean }> {
+	const branch = (await runGit(exec, cwd, ["branch", "--show-current"])).trim();
+	const porcelain = await runGit(exec, cwd, ["status", "--porcelain"]);
+	return {
+		...(branch ? { branch } : {}),
+		dirty: porcelain.trim().length > 0,
+	};
+}
+
+function confirmMessage(branch: string | undefined, keepBranch: boolean): string {
+	if (keepBranch) {
+		return branch
+			? `Remove this worktree and keep local branch ${branch}?`
+			: "Remove this worktree? The current checkout has no local branch.";
+	}
+	return `Remove this worktree and delete local branch ${branch}?`;
+}
+
+function assertSafeBranchName(branch: string): void {
+	if (!branch || /[\0\n\r]/.test(branch)) {
+		throw new Error("Refusing to delete an invalid local branch name.");
+	}
+}
+
+export async function cleanupCurrentWorktree(deps: CleanupDeps): Promise<CleanupResult> {
+	const workspaceId = deps.runtime.workspaceId?.trim();
+	if (!workspaceId) {
+		return {
+			status: "rejected",
+			message: "Cannot remove this worktree: the current Herdr workspace is unknown.",
+		};
+	}
+
+	const workspace = await deps.client.getWorkspace(workspaceId);
+	const worktree = workspace.worktree;
+	if (!worktree?.isLinkedWorktree) {
+		return {
+			status: "rejected",
+			message: "Refusing to remove the primary checkout. /herdr-worktree cleanup only works in a linked worktree.",
+		};
+	}
+
+	const cwd = worktree.checkoutPath;
+	const git = await inspectWorktreeGit(deps.exec, cwd);
+	if (!deps.keepBranch && !git.branch) {
+		return {
+			status: "rejected",
+			message: "HEAD is detached; there is no local branch to delete. Use --keep-branch to remove only the worktree.",
+		};
+	}
+	if (git.branch && PROTECTED_BRANCHES.has(git.branch)) {
+		return {
+			status: "rejected",
+			message: `Refusing to remove a worktree checked out on ${git.branch}.`,
+		};
+	}
+	if (git.dirty) {
+		return {
+			status: "rejected",
+			message: "Refusing to remove a dirty worktree. Commit, stash, or discard changes first.",
+		};
+	}
+
+	const confirmed = await deps.ui.confirm("Remove worktree", confirmMessage(git.branch, deps.keepBranch));
+	if (!confirmed) return { status: "cancelled" };
+
+	if (!deps.keepBranch) {
+		const branch = git.branch as string;
+		assertSafeBranchName(branch);
+		await runGit(deps.exec, cwd, ["checkout", "--detach"]);
+		await runGit(deps.exec, cwd, ["branch", "-D", "--", branch]);
+	}
+
+	await deps.client.removeWorktree(workspaceId);
+	return {
+		status: "removed",
+		keepBranch: deps.keepBranch,
+		...(git.branch ? { branch: git.branch } : {}),
+	};
+}

--- a/packages/pi-herdr-companion/src/worktree/command.ts
+++ b/packages/pi-herdr-companion/src/worktree/command.ts
@@ -1,0 +1,63 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { HerdrClient, HerdrExecutor } from "../herdr-client.ts";
+import type { RuntimeSnapshot } from "../runtime.ts";
+import { cleanupCurrentWorktree } from "./cleanup.ts";
+import { HERDR_WORKTREE_USAGE, parseHerdrWorktreeCommand } from "./router.ts";
+
+const COMPLETIONS = [
+	{
+		value: "cleanup",
+		label: "cleanup",
+		description: "Remove this linked worktree and delete the local branch",
+	},
+	{
+		value: "cleanup --keep-branch",
+		label: "cleanup --keep-branch",
+		description: "Remove this linked worktree and keep the local branch",
+	},
+];
+
+export function registerHerdrWorktreeCommand(
+	pi: ExtensionAPI,
+	options: {
+		runtime: RuntimeSnapshot;
+		client: Pick<HerdrClient, "getWorkspace" | "removeWorktree">;
+		exec: HerdrExecutor;
+	},
+): void {
+	pi.registerCommand("herdr-worktree", {
+		description: "cleanup [--keep-branch] — Remove this linked Herdr worktree",
+		getArgumentCompletions(argumentPrefix) {
+			const prefix = argumentPrefix.trim().toLowerCase();
+			return COMPLETIONS.filter((item) => item.value.startsWith(prefix));
+		},
+		handler: async (args, ctx) => {
+			const route = parseHerdrWorktreeCommand(args);
+			if (route.kind !== "cleanup") {
+				ctx.ui.notify(HERDR_WORKTREE_USAGE, "info");
+				return;
+			}
+			try {
+				const result = await cleanupCurrentWorktree({
+					client: options.client,
+					exec: options.exec,
+					runtime: options.runtime,
+					keepBranch: route.keepBranch,
+					ui: ctx.ui,
+				});
+				if (result.status === "rejected") {
+					ctx.ui.notify(result.message, "error");
+					return;
+				}
+				if (result.status === "cancelled") {
+					ctx.ui.notify("Worktree cleanup cancelled.", "info");
+				}
+			} catch (error) {
+				ctx.ui.notify(
+					`/herdr-worktree cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
+					"error",
+				);
+			}
+		},
+	});
+}

--- a/packages/pi-herdr-companion/src/worktree/command.ts
+++ b/packages/pi-herdr-companion/src/worktree/command.ts
@@ -1,10 +1,16 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { HerdrClient, HerdrExecutor } from "../herdr-client.ts";
+import type { HerdrExecutor } from "../herdr-client.ts";
 import type { RuntimeSnapshot } from "../runtime.ts";
 import { cleanupCurrentWorktree } from "./cleanup.ts";
 import { HERDR_WORKTREE_USAGE, parseHerdrWorktreeCommand } from "./router.ts";
+import { createStartController, registerStartRenderers, type DistillCompleter, type StartClient } from "./start.ts";
 
 const COMPLETIONS = [
+	{
+		value: "start",
+		label: "start",
+		description: "Distill a plan, then create a linked worktree and start Pi",
+	},
 	{
 		value: "cleanup",
 		label: "cleanup",
@@ -21,20 +27,28 @@ export function registerHerdrWorktreeCommand(
 	pi: ExtensionAPI,
 	options: {
 		runtime: RuntimeSnapshot;
-		client: Pick<HerdrClient, "getWorkspace" | "removeWorktree">;
+		client: StartClient;
 		exec: HerdrExecutor;
+		completeModel?: DistillCompleter;
 	},
 ): void {
+	registerStartRenderers(pi);
+	const start = createStartController(pi, options);
+
 	pi.registerCommand("herdr-worktree", {
-		description: "cleanup [--keep-branch] — Remove this linked Herdr worktree",
+		description: "start [branch] | cleanup [--keep-branch] — Dispatch or remove a linked Herdr worktree",
 		getArgumentCompletions(argumentPrefix) {
 			const prefix = argumentPrefix.trim().toLowerCase();
 			return COMPLETIONS.filter((item) => item.value.startsWith(prefix));
 		},
 		handler: async (args, ctx) => {
 			const route = parseHerdrWorktreeCommand(args);
-			if (route.kind !== "cleanup") {
+			if (route.kind === "usage") {
 				ctx.ui.notify(HERDR_WORKTREE_USAGE, "info");
+				return;
+			}
+			if (route.kind === "start") {
+				await start.beginDistill(route.branch, ctx);
 				return;
 			}
 			try {

--- a/packages/pi-herdr-companion/src/worktree/launch.ts
+++ b/packages/pi-herdr-companion/src/worktree/launch.ts
@@ -1,0 +1,99 @@
+import type { HerdrAgent, HerdrClient } from "../herdr-client.ts";
+import { PROTECTED_BRANCHES } from "./brief.ts";
+
+export const WORKING_CONFIRM_TIMEOUT_MS = 5_000;
+
+export type LaunchClient = Pick<
+	HerdrClient,
+	"listWorktrees" | "createWorktree" | "listAgents" | "startAgent" | "promptAgentUntil"
+>;
+
+export interface LaunchDeps {
+	client: LaunchClient;
+	sourceWorkspaceId: string;
+	branch: string;
+	brief: string;
+	label?: string;
+	base?: string;
+}
+
+export type LaunchResult =
+	| { status: "rejected"; message: string }
+	| { status: "started"; workspaceId: string; agentName: string; branch: string }
+	| { status: "incomplete"; message: string; workspaceId?: string; branch: string };
+
+export function agentNameFromBranch(branch: string): string {
+	const slug = branch.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+	const trimmed = slug.replace(/^[^a-z]+/, "") || "worktree";
+	return trimmed.slice(0, 32);
+}
+
+export function uniqueAgentName(base: string, taken: Iterable<string>): string {
+	const used = new Set(taken);
+	if (!used.has(base)) return base;
+	for (let index = 2; index < 100; index += 1) {
+		const suffix = `-${index}`;
+		const name = `${base.slice(0, Math.max(1, 32 - suffix.length))}${suffix}`;
+		if (!used.has(name)) return name;
+	}
+	throw new Error("Could not allocate a unique Herdr agent name.");
+}
+
+function takenAgentNames(agents: readonly HerdrAgent[]): string[] {
+	return agents.flatMap((agent) => agent.name ? [agent.name] : []);
+}
+
+export async function launchWorktreeSession(deps: LaunchDeps): Promise<LaunchResult> {
+	if (PROTECTED_BRANCHES.has(deps.branch)) {
+		return { status: "rejected", message: `Refusing to dispatch to ${deps.branch}.` };
+	}
+
+	const listed = await deps.client.listWorktrees({ workspaceId: deps.sourceWorkspaceId });
+	const existing = listed.find((worktree) => worktree.branch === deps.branch && worktree.isLinkedWorktree);
+	if (existing) {
+		return {
+			status: "rejected",
+			message: `A linked worktree for ${deps.branch} already exists.`,
+		};
+	}
+
+	const created = await deps.client.createWorktree({
+		workspaceId: deps.sourceWorkspaceId,
+		branch: deps.branch,
+		...(deps.base ? { base: deps.base } : {}),
+		label: deps.label ?? deps.branch,
+		focus: true,
+	});
+	const workspaceId = created.workspace.workspaceId;
+	if (!created.workspace.worktree?.isLinkedWorktree && !created.worktree.isLinkedWorktree) {
+		return {
+			status: "incomplete",
+			message: "Herdr created a workspace that is not a linked worktree.",
+			workspaceId,
+			branch: deps.branch,
+		};
+	}
+
+	try {
+		const agents = await deps.client.listAgents();
+		const agentName = uniqueAgentName(agentNameFromBranch(deps.branch), takenAgentNames(agents));
+		await deps.client.startAgent({
+			name: agentName,
+			kind: "pi",
+			paneId: created.rootPaneId,
+			args: [],
+		});
+		await deps.client.promptAgentUntil(agentName, deps.brief, {
+			until: "working",
+			timeoutMs: WORKING_CONFIRM_TIMEOUT_MS,
+		});
+		return { status: "started", workspaceId, agentName, branch: deps.branch };
+	} catch (error) {
+		return {
+			status: "incomplete",
+			message: error instanceof Error ? error.message : String(error),
+			workspaceId,
+			branch: deps.branch,
+		};
+	}
+}

--- a/packages/pi-herdr-companion/src/worktree/router.ts
+++ b/packages/pi-herdr-companion/src/worktree/router.ts
@@ -1,8 +1,10 @@
 export type HerdrWorktreeRoute =
 	| { kind: "cleanup"; keepBranch: boolean }
+	| { kind: "start"; branch?: string }
 	| { kind: "usage" };
 
 export const HERDR_WORKTREE_USAGE = `/herdr-worktree usage:
+/herdr-worktree start [branch]          distill a dispatch plan, then create a linked worktree and start Pi
 /herdr-worktree cleanup                 remove this linked worktree and delete the local branch
 /herdr-worktree cleanup --keep-branch   remove this linked worktree and keep the local branch`;
 
@@ -11,6 +13,10 @@ export function parseHerdrWorktreeCommand(input: string): HerdrWorktreeRoute {
 	if (tokens.length === 1 && tokens[0] === "cleanup") return { kind: "cleanup", keepBranch: false };
 	if (tokens.length === 2 && tokens[0] === "cleanup" && tokens[1] === "--keep-branch") {
 		return { kind: "cleanup", keepBranch: true };
+	}
+	if (tokens.length === 1 && tokens[0] === "start") return { kind: "start" };
+	if (tokens.length === 2 && tokens[0] === "start" && tokens[1] && !tokens[1].startsWith("-")) {
+		return { kind: "start", branch: tokens[1] };
 	}
 	return { kind: "usage" };
 }

--- a/packages/pi-herdr-companion/src/worktree/router.ts
+++ b/packages/pi-herdr-companion/src/worktree/router.ts
@@ -1,0 +1,16 @@
+export type HerdrWorktreeRoute =
+	| { kind: "cleanup"; keepBranch: boolean }
+	| { kind: "usage" };
+
+export const HERDR_WORKTREE_USAGE = `/herdr-worktree usage:
+/herdr-worktree cleanup                 remove this linked worktree and delete the local branch
+/herdr-worktree cleanup --keep-branch   remove this linked worktree and keep the local branch`;
+
+export function parseHerdrWorktreeCommand(input: string): HerdrWorktreeRoute {
+	const tokens = input.trim().split(/\s+/).filter(Boolean);
+	if (tokens.length === 1 && tokens[0] === "cleanup") return { kind: "cleanup", keepBranch: false };
+	if (tokens.length === 2 && tokens[0] === "cleanup" && tokens[1] === "--keep-branch") {
+		return { kind: "cleanup", keepBranch: true };
+	}
+	return { kind: "usage" };
+}

--- a/packages/pi-herdr-companion/src/worktree/start.ts
+++ b/packages/pi-herdr-companion/src/worktree/start.ts
@@ -1,0 +1,223 @@
+import { complete } from "@earendil-works/pi-ai/compat";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { HerdrClient } from "../herdr-client.ts";
+import type { RuntimeSnapshot } from "../runtime.ts";
+import {
+	DISPATCHED_ENTRY_TYPE,
+	DISTILL_MAX_TOKENS,
+	buildDistillInstruction,
+	parseDispatchBrief,
+	serializeSessionForDistill,
+	sessionHasDistillableConversation,
+	wrapDisplayLines,
+} from "./brief.ts";
+import { type LaunchClient, launchWorktreeSession } from "./launch.ts";
+
+export interface StartUi {
+	notify(message: string, type?: "info" | "warning" | "error"): void;
+	editor(title: string, prefill?: string): Promise<string | undefined>;
+}
+
+export type DistillCompleter = (
+	model: { provider: string; id: string },
+	context: {
+		systemPrompt: string;
+		messages: Array<{ role: "user"; content: Array<{ type: "text"; text: string }>; timestamp: number }>;
+	},
+	options: {
+		apiKey: string;
+		headers?: Record<string, string | null>;
+		env?: Record<string, string>;
+		maxTokens?: number;
+		signal?: AbortSignal;
+	},
+) => Promise<{
+	content: Array<{ type: string; text?: string }>;
+	stopReason?: string;
+	errorMessage?: string;
+}>;
+
+export interface StartCommandContext {
+	isIdle(): boolean;
+	model?: { provider: string; id: string };
+	modelRegistry: {
+		getApiKeyAndHeaders(model: unknown): Promise<{
+			ok: boolean;
+			apiKey?: string;
+			headers?: Record<string, string | null>;
+			env?: Record<string, string>;
+			error?: string;
+		}>;
+	};
+	ui: StartUi;
+	sessionManager: {
+		getEntries(): readonly { type?: string; message?: { role?: string; content?: unknown } }[];
+		getBranch?(): readonly { type?: string; message?: { role?: string; content?: unknown } }[];
+	};
+}
+
+export function registerStartRenderers(pi: ExtensionAPI): void {
+	pi.registerEntryRenderer<{ branch: string; workspaceId?: string; brief: string }>(
+		DISPATCHED_ENTRY_TYPE,
+		(entry, _options, theme) => {
+			const data = entry.data ?? { branch: "", brief: "" };
+			const heading = data.workspaceId
+				? `${theme.fg("accent", "[已派出]")} ${data.branch} · ${data.workspaceId}`
+				: `${theme.fg("accent", "[已派出]")} ${data.branch}`;
+			return {
+				render(width: number) {
+					return [heading, ...wrapDisplayLines(data.brief, width)];
+				},
+				invalidate() {},
+			};
+		},
+	);
+}
+
+function conversationEntries(ctx: StartCommandContext) {
+	return ctx.sessionManager.getBranch?.() ?? ctx.sessionManager.getEntries();
+}
+
+function textFromComplete(response: Awaited<ReturnType<DistillCompleter>>): string {
+	return response.content
+		.filter((item): item is { type: "text"; text: string } => item.type === "text" && typeof item.text === "string")
+		.map((item) => item.text)
+		.join("\n")
+		.trim();
+}
+
+export function createStartController(
+	pi: ExtensionAPI,
+	options: {
+		runtime: RuntimeSnapshot;
+		client: LaunchClient;
+		completeModel?: DistillCompleter;
+	},
+) {
+	const completeModel = options.completeModel ?? (complete as unknown as DistillCompleter);
+
+	async function distillPlan(ctx: StartCommandContext, branch?: string): Promise<string> {
+		if (!ctx.model) throw new Error("/herdr-worktree start requires an active model.");
+		const conversation = serializeSessionForDistill(conversationEntries(ctx));
+		if (!conversation) throw new Error("There is no conversation to distill into a dispatch plan.");
+		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(ctx.model);
+		if (!auth.ok || !auth.apiKey) {
+			throw new Error(auth.error ?? `No API key for ${ctx.model.provider}`);
+		}
+		const response = await completeModel(
+			ctx.model,
+			{
+				systemPrompt: buildDistillInstruction(branch),
+				messages: [{
+					role: "user",
+					content: [{ type: "text", text: conversation }],
+					timestamp: Date.now(),
+				}],
+			},
+			{
+				apiKey: auth.apiKey,
+				...(auth.headers ? { headers: auth.headers } : {}),
+				...(auth.env ? { env: auth.env } : {}),
+				maxTokens: DISTILL_MAX_TOKENS,
+			},
+		);
+		if (response.stopReason === "error" || response.stopReason === "aborted") {
+			throw new Error(response.errorMessage ?? "Dispatch plan generation failed.");
+		}
+		const text = textFromComplete(response);
+		if (!text) throw new Error("Dispatch plan generation returned no text.");
+		return text;
+	}
+
+	async function beginDistill(routeBranch: string | undefined, ctx: StartCommandContext): Promise<void> {
+		if (!ctx.isIdle()) {
+			ctx.ui.notify("/herdr-worktree start needs an idle session.", "warning");
+			return;
+		}
+		if (!options.runtime.workspaceId?.trim()) {
+			ctx.ui.notify("Cannot dispatch: the current Herdr workspace is unknown.", "error");
+			return;
+		}
+		if (routeBranch && (routeBranch === "main" || routeBranch === "master")) {
+			ctx.ui.notify(`Refusing to dispatch to ${routeBranch}.`, "error");
+			return;
+		}
+		if (!sessionHasDistillableConversation(conversationEntries(ctx))) {
+			ctx.ui.notify("There is no conversation to distill into a dispatch plan.", "error");
+			return;
+		}
+
+		ctx.ui.notify("整理派出计划…", "info");
+		let drafted: string;
+		try {
+			drafted = await distillPlan(ctx, routeBranch);
+		} catch (error) {
+			ctx.ui.notify(
+				`/herdr-worktree start failed: ${error instanceof Error ? error.message : String(error)}`,
+				"error",
+			);
+			return;
+		}
+
+		const parsed = parseDispatchBrief(drafted, routeBranch);
+		if (parsed.status === "not-ready") {
+			ctx.ui.notify(`Dispatch plan is not ready: ${parsed.reason}`, "warning");
+			return;
+		}
+		if (parsed.status === "invalid") {
+			ctx.ui.notify(parsed.message, "error");
+			return;
+		}
+
+		const edited = await ctx.ui.editor("Review dispatch plan", parsed.brief);
+		if (edited === undefined) {
+			ctx.ui.notify("Worktree start cancelled.", "info");
+			return;
+		}
+		const reviewed = parseDispatchBrief(edited, routeBranch);
+		if (reviewed.status !== "ready") {
+			const message = reviewed.status === "not-ready"
+				? `Dispatch plan is not ready: ${reviewed.reason}`
+				: reviewed.message;
+			ctx.ui.notify(message, "error");
+			return;
+		}
+
+		try {
+			const launched = await launchWorktreeSession({
+				client: options.client,
+				sourceWorkspaceId: options.runtime.workspaceId as string,
+				branch: reviewed.branch,
+				brief: reviewed.brief,
+			});
+			if (launched.status === "rejected") {
+				ctx.ui.notify(launched.message, "error");
+				return;
+			}
+			if (launched.status === "incomplete") {
+				ctx.ui.notify(
+					launched.workspaceId
+						? `Worktree ${launched.workspaceId} was created, but dispatch did not start: ${launched.message}`
+						: launched.message,
+					"error",
+				);
+				return;
+			}
+			pi.appendEntry(DISPATCHED_ENTRY_TYPE, {
+				branch: launched.branch,
+				workspaceId: launched.workspaceId,
+				brief: reviewed.brief,
+			});
+			ctx.ui.notify(`Dispatched ${launched.branch} to ${launched.workspaceId}.`, "info");
+		} catch (error) {
+			ctx.ui.notify(
+				`/herdr-worktree start failed: ${error instanceof Error ? error.message : String(error)}`,
+				"error",
+			);
+		}
+	}
+
+	return { beginDistill };
+}
+
+export type StartClient = LaunchClient & Pick<HerdrClient, "getWorkspace" | "removeWorktree">;

--- a/packages/pi-herdr-companion/tests/extension-registration.test.ts
+++ b/packages/pi-herdr-companion/tests/extension-registration.test.ts
@@ -189,7 +189,7 @@ describe.sequential("extension registration gates", () => {
 		const ctx = sessionContext("tui");
 		await emitSnapshot(h.handlers, "session_start", { type: "session_start", reason: "startup" }, ctx);
 		expect(h.tools).toEqual(["herdr_process"]);
-		expect(h.commands).toEqual(expect.arrayContaining(["btw", "herdr-config"]));
+		expect(h.commands).toEqual(expect.arrayContaining(["btw", "herdr-config", "herdr-worktree"]));
 		expect(h.tools).not.toContain("btw");
 		expect(h.tools).not.toContain("herdr_worker");
 		expect(h.tools).not.toContain("herdr_blocked");

--- a/packages/pi-herdr-companion/tests/extension-registration.test.ts
+++ b/packages/pi-herdr-companion/tests/extension-registration.test.ts
@@ -39,6 +39,8 @@ function fakePi() {
 		},
 		registerTool(tool: { name: string }) { tools.push(tool.name); },
 		registerCommand(name: string) { commands.push(name); },
+		registerMessageRenderer() {},
+		registerEntryRenderer() {},
 		events: {
 			on(name: string, handler: (data: unknown) => void) {
 				const values = eventHandlers.get(name) ?? [];

--- a/packages/pi-herdr-companion/tests/herdr-client.test.ts
+++ b/packages/pi-herdr-companion/tests/herdr-client.test.ts
@@ -324,4 +324,63 @@ describe("HerdrClient argv and response contracts", () => {
 		expect(calls[1]?.args).not.toContain("--force");
 		expect(calls[1]?.args).not.toContain("--keep-branch");
 	});
+
+	it("creates a focused worktree and prompts an agent only until working", async () => {
+		const { client, calls } = capture((args) => {
+			if (args[0] === "worktree" && args[1] === "list") {
+				return ok(JSON.stringify({
+					result: {
+						worktrees: [{
+							path: "/repo",
+							branch: "main",
+							is_linked_worktree: false,
+							open_workspace_id: "w1",
+						}],
+					},
+				}));
+			}
+			if (args[0] === "worktree" && args[1] === "create") {
+				return ok(JSON.stringify({
+					result: {
+						workspace: {
+							workspace_id: "w9",
+							worktree: {
+								checkout_path: "/worktrees/repo/feat",
+								is_linked_worktree: true,
+							},
+						},
+						root_pane: { pane_id: "w9:p1" },
+						worktree: {
+							path: "/worktrees/repo/feat",
+							branch: "feat/foo",
+							is_linked_worktree: true,
+						},
+					},
+				}));
+			}
+			if (args[0] === "agent" && args[1] === "list") {
+				return ok(JSON.stringify({ result: { agents: [{ pane_id: "w1:p1", name: "parent" }] } }));
+			}
+			return ok(JSON.stringify({ result: { agent: { pane_id: "w9:p1", name: args[2], agent_status: "working" } } }));
+		});
+		await expect(client.listWorktrees({ workspaceId: "w1" })).resolves.toEqual([
+			{ path: "/repo", branch: "main", isLinkedWorktree: false, openWorkspaceId: "w1" },
+		]);
+		await expect(client.createWorktree({ workspaceId: "w1", branch: "feat/foo", focus: true, label: "feat/foo" })).resolves.toMatchObject({
+			workspace: { workspaceId: "w9" },
+			rootPaneId: "w9:p1",
+			worktree: { branch: "feat/foo", isLinkedWorktree: true },
+		});
+		await expect(client.listAgents()).resolves.toEqual([{ paneId: "w1:p1", name: "parent" }]);
+		await client.promptAgentUntil("feat-foo", "do the work", { until: "working", timeoutMs: 5_000 });
+		expect(calls.map((call) => call.args)).toEqual([
+			["worktree", "list", "--workspace", "w1"],
+			["worktree", "create", "--workspace", "w1", "--branch", "feat/foo", "--label", "feat/foo", "--focus"],
+			["agent", "list"],
+			["agent", "prompt", "feat-foo", "do the work", "--wait", "--until", "working", "--timeout", "5000"],
+		]);
+		expect(calls[1]?.args).not.toContain("--force");
+		expect(calls[1]?.args).not.toContain("--keep-branch");
+		expect(calls[3]?.options.timeout).toBe(7_000);
+	});
 });

--- a/packages/pi-herdr-companion/tests/herdr-client.test.ts
+++ b/packages/pi-herdr-companion/tests/herdr-client.test.ts
@@ -284,4 +284,44 @@ describe("HerdrClient argv and response contracts", () => {
 		const { client } = capture(() => ({ stdout: "", stderr: "timed out", code: 0, killed: true }));
 		await expect(client.runPane("w1:p2", "watch")).rejects.toMatchObject({ killed: true });
 	});
+
+	it("parses workspace get worktree provenance and removes a worktree by workspace id only", async () => {
+		const { client, calls } = capture((args) => {
+			if (args[0] === "workspace") {
+				return ok(JSON.stringify({
+					result: {
+						type: "workspace_info",
+						workspace: {
+							workspace_id: args[2],
+							label: "feat",
+							worktree: {
+								checkout_path: "/worktrees/repo/feat",
+								is_linked_worktree: true,
+								repo_root: "/repo",
+							},
+						},
+					},
+				}));
+			}
+			return ok(JSON.stringify({
+				result: { type: "worktree_removed", workspace_id: "w1", path: "/worktrees/repo/feat", forced: false },
+			}));
+		});
+		await expect(client.getWorkspace("w1")).resolves.toEqual({
+			workspaceId: "w1",
+			label: "feat",
+			worktree: {
+				checkoutPath: "/worktrees/repo/feat",
+				isLinkedWorktree: true,
+				repoRoot: "/repo",
+			},
+		});
+		await expect(client.removeWorktree("w1")).resolves.toBeUndefined();
+		expect(calls).toEqual([
+			{ command: "herdr", args: ["workspace", "get", "w1"], options: { timeout: 5_000 } },
+			{ command: "herdr", args: ["worktree", "remove", "--workspace", "w1"], options: { timeout: 15_000 } },
+		]);
+		expect(calls[1]?.args).not.toContain("--force");
+		expect(calls[1]?.args).not.toContain("--keep-branch");
+	});
 });

--- a/packages/pi-herdr-companion/tests/worktree-cleanup.test.ts
+++ b/packages/pi-herdr-companion/tests/worktree-cleanup.test.ts
@@ -1,0 +1,246 @@
+import type { ExecOptions, ExecResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import type { HerdrWorkspace } from "../src/herdr-client.ts";
+import { cleanupCurrentWorktree } from "../src/worktree/cleanup.ts";
+import { registerHerdrWorktreeCommand } from "../src/worktree/command.ts";
+import { HERDR_WORKTREE_USAGE, parseHerdrWorktreeCommand } from "../src/worktree/router.ts";
+
+type Call = { command: string; args: string[]; options: ExecOptions };
+
+const CHECKOUT = "/worktrees/repo/feat-cleanup";
+const BRANCH = "feat/cleanup";
+
+function ok(stdout = ""): ExecResult {
+	return { stdout, stderr: "", code: 0, killed: false };
+}
+
+function linkedWorkspace(overrides: Partial<HerdrWorkspace["worktree"]> = {}): HerdrWorkspace {
+	return {
+		workspaceId: "w1",
+		label: "feat-cleanup",
+		worktree: {
+			checkoutPath: CHECKOUT,
+			isLinkedWorktree: true,
+			repoRoot: "/repo",
+			...overrides,
+		},
+	};
+}
+
+function harness(options: {
+	workspace?: HerdrWorkspace;
+	workspaceId?: string;
+	keepBranch?: boolean;
+	confirm?: boolean;
+	branch?: string;
+	dirty?: string;
+	git?: (args: string[]) => ExecResult | Promise<ExecResult>;
+} = {}) {
+	const ops: string[] = [];
+	const calls: Call[] = [];
+	const confirms: string[] = [];
+	let removed = 0;
+	const exec = async (command: string, args: string[], execOptions: ExecOptions) => {
+		calls.push({ command, args: [...args], options: { ...execOptions } });
+		ops.push([command, ...args].join(" "));
+		if (command !== "git") return ok();
+		if (options.git) return options.git(args);
+		if (args[0] === "branch" && args[1] === "--show-current") return ok(`${options.branch ?? BRANCH}\n`);
+		if (args[0] === "status") return ok(options.dirty ?? "");
+		return ok();
+	};
+	const client = {
+		async getWorkspace(workspaceId: string) {
+			ops.push(`herdr workspace get ${workspaceId}`);
+			return options.workspace ?? linkedWorkspace();
+		},
+		async removeWorktree(workspaceId: string) {
+			removed += 1;
+			ops.push(`herdr worktree remove --workspace ${workspaceId}`);
+		},
+	};
+	return {
+		ops,
+		calls,
+		confirms,
+		get removed() { return removed; },
+		run: () => cleanupCurrentWorktree({
+			client,
+			exec,
+			runtime: { workspaceId: options.workspaceId ?? "w1" },
+			keepBranch: options.keepBranch ?? false,
+			ui: {
+				async confirm(_title, message) {
+					confirms.push(message);
+					return options.confirm ?? true;
+				},
+			},
+		}),
+	};
+}
+
+describe("/herdr-worktree parser", () => {
+	it("accepts only cleanup and cleanup --keep-branch", () => {
+		expect(parseHerdrWorktreeCommand("cleanup")).toEqual({ kind: "cleanup", keepBranch: false });
+		expect(parseHerdrWorktreeCommand("  cleanup   --keep-branch  ")).toEqual({ kind: "cleanup", keepBranch: true });
+		expect(parseHerdrWorktreeCommand("")).toEqual({ kind: "usage" });
+		expect(parseHerdrWorktreeCommand("create")).toEqual({ kind: "usage" });
+		expect(parseHerdrWorktreeCommand("cleanup --force")).toEqual({ kind: "usage" });
+		expect(parseHerdrWorktreeCommand("cleanup --keep-branch extra")).toEqual({ kind: "usage" });
+		expect(HERDR_WORKTREE_USAGE).toContain("/herdr-worktree cleanup");
+		expect(HERDR_WORKTREE_USAGE).toContain("--keep-branch");
+		expect(HERDR_WORKTREE_USAGE).not.toContain("--force");
+	});
+});
+
+describe("/herdr-worktree cleanup guards", () => {
+	it("hard-rejects main and master without asking or mutating", async () => {
+		for (const branch of ["main", "master"]) {
+			const h = harness({ branch, confirm: true });
+			await expect(h.run()).resolves.toMatchObject({
+				status: "rejected",
+				message: `Refusing to remove a worktree checked out on ${branch}.`,
+			});
+			expect(h.confirms).toEqual([]);
+			expect(h.removed).toBe(0);
+			expect(h.ops.some((op) => op.includes("checkout") || op.includes("branch -D") || op.includes("worktree remove"))).toBe(false);
+		}
+	});
+
+	it("hard-rejects the primary checkout before git or confirm", async () => {
+		const h = harness({
+			workspace: {
+				workspaceId: "w1",
+				worktree: { checkoutPath: "/repo", isLinkedWorktree: false },
+			},
+		});
+		await expect(h.run()).resolves.toMatchObject({
+			status: "rejected",
+			message: expect.stringContaining("primary checkout"),
+		});
+		expect(h.confirms).toEqual([]);
+		expect(h.calls).toEqual([]);
+		expect(h.removed).toBe(0);
+	});
+
+	it("hard-rejects a workspace with no worktree provenance as primary", async () => {
+		const h = harness({ workspace: { workspaceId: "w1" } });
+		await expect(h.run()).resolves.toMatchObject({ status: "rejected" });
+		expect(h.calls).toEqual([]);
+		expect(h.removed).toBe(0);
+	});
+
+	it("hard-rejects a dirty tree without asking or mutating", async () => {
+		const h = harness({ dirty: " M src/extension.ts\n" });
+		await expect(h.run()).resolves.toMatchObject({
+			status: "rejected",
+			message: expect.stringContaining("dirty worktree"),
+		});
+		expect(h.confirms).toEqual([]);
+		expect(h.removed).toBe(0);
+		expect(h.ops.some((op) => op.includes("checkout") || op.includes("branch -D") || op.includes("worktree remove"))).toBe(false);
+	});
+
+	it("hard-rejects a detached HEAD unless --keep-branch is set", async () => {
+		const h = harness({ branch: "" });
+		await expect(h.run()).resolves.toMatchObject({
+			status: "rejected",
+			message: expect.stringContaining("HEAD is detached"),
+		});
+		expect(h.confirms).toEqual([]);
+		expect(h.removed).toBe(0);
+	});
+
+	it("does not mutate when the user cancels confirm", async () => {
+		const h = harness({ confirm: false });
+		await expect(h.run()).resolves.toEqual({ status: "cancelled" });
+		expect(h.confirms).toEqual([`Remove this worktree and delete local branch ${BRANCH}?`]);
+		expect(h.removed).toBe(0);
+		expect(h.ops).toEqual([
+			"herdr workspace get w1",
+			"git branch --show-current",
+			"git status --porcelain",
+		]);
+	});
+});
+
+describe("/herdr-worktree cleanup mutations", () => {
+	it("detaches, deletes the local branch, then asks Herdr to remove the worktree", async () => {
+		const h = harness({ confirm: true });
+		await expect(h.run()).resolves.toEqual({
+			status: "removed",
+			keepBranch: false,
+			branch: BRANCH,
+		});
+		expect(h.confirms).toEqual([`Remove this worktree and delete local branch ${BRANCH}?`]);
+		expect(h.ops).toEqual([
+			"herdr workspace get w1",
+			"git branch --show-current",
+			"git status --porcelain",
+			"git checkout --detach",
+			`git branch -D -- ${BRANCH}`,
+			"herdr worktree remove --workspace w1",
+		]);
+		expect(h.calls.filter((call) => call.command === "git").every((call) => call.options.cwd === CHECKOUT)).toBe(true);
+		expect(h.ops.some((op) => op.includes("workspace close") || op.includes("--keep-branch") || op.includes("--force"))).toBe(false);
+	});
+
+	it("skips detach and branch deletion when --keep-branch is set", async () => {
+		const h = harness({ keepBranch: true, confirm: true });
+		await expect(h.run()).resolves.toEqual({
+			status: "removed",
+			keepBranch: true,
+			branch: BRANCH,
+		});
+		expect(h.confirms).toEqual([`Remove this worktree and keep local branch ${BRANCH}?`]);
+		expect(h.ops).toEqual([
+			"herdr workspace get w1",
+			"git branch --show-current",
+			"git status --porcelain",
+			"herdr worktree remove --workspace w1",
+		]);
+		expect(h.ops.some((op) => op.includes("checkout") || op.includes("branch -D"))).toBe(false);
+	});
+
+	it("can remove a clean detached linked worktree with --keep-branch", async () => {
+		const h = harness({ keepBranch: true, branch: "", confirm: true });
+		await expect(h.run()).resolves.toEqual({ status: "removed", keepBranch: true });
+		expect(h.confirms).toEqual(["Remove this worktree? The current checkout has no local branch."]);
+		expect(h.ops.at(-1)).toBe("herdr worktree remove --workspace w1");
+		expect(h.ops.some((op) => op.includes("checkout") || op.includes("branch -D"))).toBe(false);
+	});
+});
+
+describe("/herdr-worktree command", () => {
+	it("prints usage for unimplemented subcommands and does not touch git or Herdr", async () => {
+		const notifications: Array<{ message: string; type?: string }> = [];
+		const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+		registerHerdrWorktreeCommand({
+			registerCommand(name: string, definition: { handler: (args: string, ctx: unknown) => Promise<void> }) {
+				commands.set(name, definition);
+			},
+		} as unknown as ExtensionAPI, {
+			runtime: { inside: true, workspaceId: "w1", paneId: "w1:p1", socketPath: "/tmp/herdr.sock" },
+			client: {
+				getWorkspace: async () => {
+					throw new Error("workspace get should not run");
+				},
+				removeWorktree: async () => {
+					throw new Error("worktree remove should not run");
+				},
+			},
+			exec: async () => {
+				throw new Error("git should not run");
+			},
+		});
+		const command = commands.get("herdr-worktree");
+		expect(command).toBeDefined();
+		await command!.handler("open", {
+			ui: {
+				notify(message: string, type?: string) { notifications.push({ message, type }); },
+				async confirm() { throw new Error("confirm should not run"); },
+			},
+		});
+		expect(notifications).toEqual([{ message: HERDR_WORKTREE_USAGE, type: "info" }]);
+	});
+});

--- a/packages/pi-herdr-companion/tests/worktree-cleanup.test.ts
+++ b/packages/pi-herdr-companion/tests/worktree-cleanup.test.ts
@@ -80,7 +80,7 @@ function harness(options: {
 }
 
 describe("/herdr-worktree parser", () => {
-	it("accepts only cleanup and cleanup --keep-branch", () => {
+	it("accepts cleanup forms and rejects unknown cleanup flags", () => {
 		expect(parseHerdrWorktreeCommand("cleanup")).toEqual({ kind: "cleanup", keepBranch: false });
 		expect(parseHerdrWorktreeCommand("  cleanup   --keep-branch  ")).toEqual({ kind: "cleanup", keepBranch: true });
 		expect(parseHerdrWorktreeCommand("")).toEqual({ kind: "usage" });
@@ -216,6 +216,13 @@ describe("/herdr-worktree command", () => {
 		const notifications: Array<{ message: string; type?: string }> = [];
 		const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
 		registerHerdrWorktreeCommand({
+			on() {},
+			registerMessageRenderer() {},
+			registerEntryRenderer() {},
+			getActiveTools: () => [],
+			setActiveTools() {},
+			sendMessage() {},
+			appendEntry() {},
 			registerCommand(name: string, definition: { handler: (args: string, ctx: unknown) => Promise<void> }) {
 				commands.set(name, definition);
 			},
@@ -227,6 +234,21 @@ describe("/herdr-worktree command", () => {
 				},
 				removeWorktree: async () => {
 					throw new Error("worktree remove should not run");
+				},
+				listWorktrees: async () => {
+					throw new Error("worktree list should not run");
+				},
+				createWorktree: async () => {
+					throw new Error("worktree create should not run");
+				},
+				listAgents: async () => {
+					throw new Error("agent list should not run");
+				},
+				startAgent: async () => {
+					throw new Error("agent start should not run");
+				},
+				promptAgentUntil: async () => {
+					throw new Error("agent prompt should not run");
 				},
 			},
 			exec: async () => {

--- a/packages/pi-herdr-companion/tests/worktree-start.test.ts
+++ b/packages/pi-herdr-companion/tests/worktree-start.test.ts
@@ -1,0 +1,311 @@
+import type { ExecOptions, ExecResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import type { HerdrAgent, HerdrWorktreeCheckout, HerdrWorkspace } from "../src/herdr-client.ts";
+import {
+	NOT_READY_PREFIX,
+	buildDistillInstruction,
+	lastAssistantText,
+	parseDispatchBrief,
+	serializeSessionForDistill,
+	sessionHasDistillableConversation,
+} from "../src/worktree/brief.ts";
+import { registerHerdrWorktreeCommand } from "../src/worktree/command.ts";
+import {
+	WORKING_CONFIRM_TIMEOUT_MS,
+	agentNameFromBranch,
+	launchWorktreeSession,
+	uniqueAgentName,
+} from "../src/worktree/launch.ts";
+import { HERDR_WORKTREE_USAGE, parseHerdrWorktreeCommand } from "../src/worktree/router.ts";
+
+function ok(stdout = ""): ExecResult {
+	return { stdout, stderr: "", code: 0, killed: false };
+}
+
+describe("/herdr-worktree start parser and brief", () => {
+	it("accepts start with an optional branch and rejects extra tokens", () => {
+		expect(parseHerdrWorktreeCommand("start")).toEqual({ kind: "start" });
+		expect(parseHerdrWorktreeCommand("  start   feat/foo  ")).toEqual({ kind: "start", branch: "feat/foo" });
+		expect(parseHerdrWorktreeCommand("start --keep-branch")).toEqual({ kind: "usage" });
+		expect(parseHerdrWorktreeCommand("start feat/foo extra")).toEqual({ kind: "usage" });
+		expect(HERDR_WORKTREE_USAGE).toContain("/herdr-worktree start");
+		expect(HERDR_WORKTREE_USAGE).toContain("/herdr-worktree cleanup");
+	});
+
+	it("parses a ready brief, pinned branch, NOT_READY, and protected names", () => {
+		expect(parseDispatchBrief("Branch: feat/foo\n目标：修清理\n1. 写测试")).toEqual({
+			status: "ready",
+			branch: "feat/foo",
+			brief: "Branch: feat/foo\n目标：修清理\n1. 写测试",
+		});
+		expect(parseDispatchBrief("Branch: other\nkeep me", "feat/pinned")).toMatchObject({
+			status: "ready",
+			branch: "feat/pinned",
+		});
+		expect(parseDispatchBrief(`${NOT_READY_PREFIX} 还没收敛`)).toEqual({
+			status: "not-ready",
+			reason: "还没收敛",
+		});
+		expect(parseDispatchBrief("Branch: main\n目标：不要")).toMatchObject({ status: "invalid" });
+		expect(parseDispatchBrief("没有分支头\n只有计划")).toMatchObject({ status: "invalid" });
+		expect(sessionHasDistillableConversation([
+			{ type: "message", message: { role: "user", content: [{ type: "text", text: "调查完了" }] } },
+		])).toBe(true);
+		expect(sessionHasDistillableConversation([])).toBe(false);
+		expect(lastAssistantText([
+			{ type: "message", message: { role: "user", content: [{ type: "text", text: "hi" }] } },
+			{ type: "message", message: { role: "assistant", content: [{ type: "text", text: "计划正文" }] } },
+		])).toBe("计划正文");
+		expect(buildDistillInstruction("feat/foo")).toContain("Branch: feat/foo");
+		expect(serializeSessionForDistill([
+			{ type: "message", message: { role: "user", content: [{ type: "text", text: "目标是修清理" }] } },
+			{ type: "message", message: { role: "assistant", content: [{ type: "text", text: "可以做" }] } },
+		])).toContain("User:\n目标是修清理");
+	});
+
+	it("slugs agent names to Herdr's live-name rules", () => {
+		expect(agentNameFromBranch("feat/herdr-companion-cleanup-worktree")).toBe("feat-herdr-companion-cleanup-wor");
+		expect(uniqueAgentName("feat-foo", ["feat-foo", "feat-foo-2"])).toBe("feat-foo-3");
+	});
+});
+
+describe("/herdr-worktree start launch", () => {
+	function launchHarness(options: {
+		existing?: HerdrWorktreeCheckout[];
+		agents?: HerdrAgent[];
+		failStart?: Error;
+		failPrompt?: Error;
+	} = {}) {
+		const ops: string[] = [];
+		const prompts: string[] = [];
+		const client = {
+			async listWorktrees() {
+				ops.push("herdr worktree list");
+				return options.existing ?? [];
+			},
+			async createWorktree(input: { branch: string; workspaceId?: string; focus?: boolean; base?: string }) {
+				ops.push([
+					"herdr worktree create",
+					input.workspaceId ? `--workspace ${input.workspaceId}` : "",
+					`--branch ${input.branch}`,
+					input.base ? `--base ${input.base}` : "",
+					input.focus ? "--focus" : "--no-focus",
+				].filter(Boolean).join(" "));
+				return {
+					workspace: {
+						workspaceId: "w9",
+						worktree: { checkoutPath: "/worktrees/repo/feat-foo", isLinkedWorktree: true },
+					} satisfies HerdrWorkspace,
+					rootPaneId: "w9:p1",
+					worktree: { path: "/worktrees/repo/feat-foo", branch: input.branch, isLinkedWorktree: true },
+				};
+			},
+			async listAgents() {
+				ops.push("herdr agent list");
+				return options.agents ?? [];
+			},
+			async startAgent(input: { name: string; kind: string; paneId: string }) {
+				ops.push(`herdr agent start ${input.name} --kind ${input.kind} --pane ${input.paneId}`);
+				if (options.failStart) throw options.failStart;
+			},
+			async promptAgentUntil(target: string, prompt: string, wait: { until: string; timeoutMs: number }) {
+				ops.push(`herdr agent prompt ${target} --wait --until ${wait.until} --timeout ${wait.timeoutMs}`);
+				prompts.push(prompt);
+				if (options.failPrompt) throw options.failPrompt;
+				return { paneId: "w9:p1", name: target, status: "working" };
+			},
+		};
+		return { ops, prompts, client };
+	}
+
+	it("refuses main and an already-open linked branch before creating", async () => {
+		const existing = launchHarness({
+			existing: [{ path: "/worktrees/repo/feat-foo", branch: "feat/foo", isLinkedWorktree: true, openWorkspaceId: "w2" }],
+		});
+		await expect(launchWorktreeSession({
+			client: existing.client,
+			sourceWorkspaceId: "w1",
+			branch: "feat/foo",
+			brief: "Branch: feat/foo\ndo it",
+		})).resolves.toMatchObject({ status: "rejected", message: expect.stringContaining("already exists") });
+		expect(existing.ops).toEqual(["herdr worktree list"]);
+
+		await expect(launchWorktreeSession({
+			client: launchHarness().client,
+			sourceWorkspaceId: "w1",
+			branch: "main",
+			brief: "Branch: main\ndo it",
+		})).resolves.toMatchObject({ status: "rejected", message: expect.stringContaining("main") });
+	});
+
+	it("creates a focused worktree, starts Pi, and waits only until working", async () => {
+		const h = launchHarness();
+		const brief = "Branch: feat/foo\n目标：做完\n1. 改代码";
+		await expect(launchWorktreeSession({
+			client: h.client,
+			sourceWorkspaceId: "w1",
+			branch: "feat/foo",
+			brief,
+		})).resolves.toEqual({
+			status: "started",
+			workspaceId: "w9",
+			agentName: "feat-foo",
+			branch: "feat/foo",
+		});
+		expect(h.ops).toEqual([
+			"herdr worktree list",
+			"herdr worktree create --workspace w1 --branch feat/foo --focus",
+			"herdr agent list",
+			"herdr agent start feat-foo --kind pi --pane w9:p1",
+			`herdr agent prompt feat-foo --wait --until working --timeout ${WORKING_CONFIRM_TIMEOUT_MS}`,
+		]);
+		expect(h.prompts).toEqual([brief]);
+		expect(h.ops.join("\n")).not.toContain("--keep-branch");
+		expect(h.ops.join("\n")).not.toContain("--force");
+		expect(h.ops.join("\n")).not.toContain("--until idle");
+		expect(h.ops.join("\n")).not.toContain("workspace close");
+	});
+
+	it("keeps the created workspace id when start or prompt fails", async () => {
+		const h = launchHarness({ failPrompt: new Error("agent_prompt_stalled") });
+		await expect(launchWorktreeSession({
+			client: h.client,
+			sourceWorkspaceId: "w1",
+			branch: "feat/foo",
+			brief: "Branch: feat/foo\ndo it",
+		})).resolves.toEqual({
+			status: "incomplete",
+			message: "agent_prompt_stalled",
+			workspaceId: "w9",
+			branch: "feat/foo",
+		});
+	});
+});
+
+describe("/herdr-worktree start command", () => {
+	function commandHarness(options: {
+		idle?: boolean;
+		entries?: Array<{ type?: string; message?: { role?: string; content?: unknown } }>;
+		editor?: string | undefined;
+		workspaceId?: string;
+		draft?: string;
+	} = {}) {
+		const notifications: Array<{ message: string; type?: string }> = [];
+		const appended: unknown[] = [];
+		const distillCalls: unknown[] = [];
+		const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+		const created: string[] = [];
+		const launch = {
+			listWorktrees: async () => [],
+			async createWorktree(input: { branch: string }) {
+				created.push(input.branch);
+				return {
+					workspace: { workspaceId: "w9", worktree: { checkoutPath: "/wt", isLinkedWorktree: true } },
+					rootPaneId: "w9:p1",
+					worktree: { path: "/wt", branch: input.branch, isLinkedWorktree: true },
+				};
+			},
+			listAgents: async () => [],
+			startAgent: async () => undefined,
+			promptAgentUntil: async () => ({ paneId: "w9:p1", name: "feat-foo", status: "working" }),
+			getWorkspace: async () => {
+				throw new Error("workspace get should not run");
+			},
+			removeWorktree: async () => {
+				throw new Error("remove should not run");
+			},
+		};
+
+		const pi = {
+			on() {},
+			registerCommand(name: string, definition: { handler: (args: string, ctx: unknown) => Promise<void> }) {
+				commands.set(name, definition);
+			},
+			registerMessageRenderer() {},
+			registerEntryRenderer() {},
+			sendMessage() {
+				throw new Error("session turn should not run");
+			},
+			appendEntry(type: string, data: unknown) { appended.push({ type, data }); },
+		} as unknown as ExtensionAPI;
+
+		const draft = options.draft ?? "Branch: feat/foo\n目标：做\n1. 写";
+		registerHerdrWorktreeCommand(pi, {
+			runtime: { inside: true, workspaceId: options.workspaceId ?? "w1", paneId: "w1:p1", socketPath: "/tmp/herdr.sock" },
+			client: launch,
+			exec: async (_command: string, _args: string[], _execOptions: ExecOptions) => ok(),
+			completeModel: async (model, context) => {
+				distillCalls.push({ model, systemPrompt: context.systemPrompt, user: context.messages[0]?.content[0]?.text });
+				return { content: [{ type: "text", text: draft }] };
+			},
+		});
+
+		const entries = options.entries ?? [
+			{ type: "message", message: { role: "user", content: [{ type: "text", text: "需求已经明确了" }] } },
+		];
+		const ctx = {
+			isIdle: () => options.idle ?? true,
+			model: { provider: "test", id: "model" },
+			modelRegistry: {
+				async getApiKeyAndHeaders() {
+					return { ok: true, apiKey: "test-key" };
+				},
+			},
+			sessionManager: { getEntries: () => entries },
+			ui: {
+				notify(message: string, type?: string) { notifications.push({ message, type }); },
+				async confirm() { return false; },
+				async editor(_title: string, prefill?: string) {
+					return options.editor === undefined && !("editor" in options) ? prefill : options.editor;
+				},
+			},
+		};
+		return { commands, notifications, appended, distillCalls, entries, ctx, created };
+	}
+
+	it("prints usage for unimplemented subcommands", async () => {
+		const h = commandHarness();
+		await h.commands.get("herdr-worktree")!.handler("open", h.ctx);
+		expect(h.notifications).toEqual([{ message: HERDR_WORKTREE_USAGE, type: "info" }]);
+		expect(h.distillCalls).toEqual([]);
+	});
+
+	it("rejects start when there is no conversation or the session is busy", async () => {
+		const empty = commandHarness({ entries: [] });
+		await empty.commands.get("herdr-worktree")!.handler("start", empty.ctx);
+		expect(empty.notifications[0]?.message).toMatch(/no conversation/);
+		expect(empty.distillCalls).toEqual([]);
+
+		const busy = commandHarness({ idle: false });
+		await busy.commands.get("herdr-worktree")!.handler("start feat/foo", busy.ctx);
+		expect(busy.notifications[0]?.message).toMatch(/idle/);
+		expect(busy.distillCalls).toEqual([]);
+	});
+
+	it("distills outside the session turn and does not launch on NOT_READY or cancel", async () => {
+		const notReady = commandHarness({ draft: `${NOT_READY_PREFIX} 还没写清目标` });
+		await notReady.commands.get("herdr-worktree")!.handler("start feat/foo", notReady.ctx);
+		expect(notReady.distillCalls).toHaveLength(1);
+		expect((notReady.distillCalls[0] as { systemPrompt: string }).systemPrompt).toBe(buildDistillInstruction("feat/foo"));
+		expect(notReady.notifications.some((item) => item.message.includes("not ready"))).toBe(true);
+		expect(notReady.created).toEqual([]);
+		expect(notReady.appended).toEqual([]);
+
+		const cancelled = commandHarness({ editor: undefined });
+		await cancelled.commands.get("herdr-worktree")!.handler("start feat/foo", cancelled.ctx);
+		expect(cancelled.notifications.some((item) => item.message.includes("cancelled"))).toBe(true);
+		expect(cancelled.created).toEqual([]);
+		expect(cancelled.appended).toEqual([]);
+	});
+
+	it("launches with the edited brief after review and only then writes transcript", async () => {
+		const edited = "Branch: feat/foo\n目标：只做这一件\n1. 改 companion";
+		const h = commandHarness({ editor: edited });
+		await h.commands.get("herdr-worktree")!.handler("start feat/foo", h.ctx);
+		expect(h.created).toEqual(["feat/foo"]);
+		expect(h.appended).toEqual([{
+			type: "herdr-worktree-dispatched",
+			data: { branch: "feat/foo", workspaceId: "w9", brief: edited },
+		}]);
+	});
+});


### PR DESCRIPTION
## Summary

- `/herdr-worktree start` distills an executable plan from the current session, then creates a linked worktree and starts Pi with only that plan
- `/herdr-worktree cleanup` removes the current linked Herdr worktree; by default it also deletes the local branch, `--keep-branch` keeps it, and remote branches are left untouched

## Release plan

- `@zhcsyncer/pi-herdr-companion`: `0.1.0` → `0.2.0` (minor)
- `@zhcsyncer/pi-extensions`: `0.25.1` → `0.26.0` (required aggregate-root minor)

## Validation

- `pnpm --filter @zhcsyncer/pi-herdr-companion check`
- `pnpm changeset status`