### PR TITLE
fix(pi-fast-mode): align with Pi 0.84.3

### DIFF
--- a/.changeset/fast-mode-pi-0843.md
+++ b/.changeset/fast-mode-pi-0843.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-fast-mode": patch
+"@zhcsyncer/pi-extensions": patch
+---
+
+Keep Fast Mode aligned with Pi 0.84.3: preserve tool choices in Responses wrappers and use response-aware priority billing for built-in xAI models.

--- a/docs/pi-fast-mode/extension.md
+++ b/docs/pi-fast-mode/extension.md
@@ -11,4 +11,6 @@
 - `/fast` 和 `Ctrl+F` 只改内存开关，不写 session jsonl。松开 `Ctrl+F` 不再切换。
 - `/fast default` 只写下次进程的默认值，不改当前开关。
 - 提供商列表写死：OpenAI、Codex、xAI。没有用户白名单。
-- 不能 `import @earendil-works/pi-ai/api/*`。Pi loader 把 `@earendil-works/pi-ai` 指到 `compat.js`，深路径加载即失败。OpenAI / Codex 的 options 必须本地保留一份 `streamSimple` 收口；升级 Pi 后对照原厂配方，只有原厂加了新字段才改本地副本。
+- Pi 0.84.3 的内置 xAI 模型已全部走 Responses。OpenAI、Codex 与内置 xAI 都通过 `registerProvider` 包官方 Responses 流；官方适配器负责序列化 `service_tier`，并按响应值调整本地费用：`priority` 通常约 2 倍，`default` 为 1 倍。
+- `before_provider_request` payload 钩子只兜底 `models.json` 中自定义的 xAI Completions 模型，不得再改内置 xAI Responses 请求。
+- 不能 `import @earendil-works/pi-ai/api/*`。Pi loader 把 `@earendil-works/pi-ai` 指到 `compat.js`，深路径加载即失败。Responses options 必须本地保留一份 `streamSimple` 收口；升级 Pi 后对照原厂配方，只有原厂加了新字段才改本地副本。

--- a/packages/pi-fast-mode/README.md
+++ b/packages/pi-fast-mode/README.md
@@ -73,17 +73,18 @@ The supported settings key is `fast-mode.enabled` in Pi `settings.json`:
 The provider list is fixed. There is no user allowlist.
 
 - OpenAI and Codex request `priority` when Fast Mode is on.
-- xAI requests `priority` when Fast Mode is on.
+- Pi's built-in xAI models all use Responses and request `priority` when Fast Mode is on.
+- Custom xAI Completions models in `models.json` remain supported.
 
 Unsupported models hide the footer and leave the request unchanged.
 
 ## Pricing and billing
 
-Do not assume every model is granted priority, and do not assume local cost is always about 2×.
+Do not assume every model is granted priority.
 
 - OpenAI Fast / priority is officially priced for the GPT-5.6 family. Older models may reject or ignore the request.
-- xAI may return `service_tier: "default"`.
-- Completions (current grok-4.6) does not apply priority to local `usage.cost`. Glance and session cost can under-report.
+- On Responses models, Pi uses the returned `service_tier` for local `usage.cost`: `priority` is typically about 2×, while `default` stays at 1×.
+- Custom xAI Completions models can request priority, but their local cost does not receive the Responses-specific adjustment.
 
 ## Session lifetime
 

--- a/packages/pi-fast-mode/README.zh-CN.md
+++ b/packages/pi-fast-mode/README.zh-CN.md
@@ -73,17 +73,18 @@ pi install git:github.com/zhcsyncer/pi-extensions
 提供商列表是固定的，没有用户白名单。
 
 - OpenAI 和 Codex 在 Fast Mode 开启时请求 `priority`。
-- xAI 在 Fast Mode 开启时请求 `priority`。
+- Pi 内置 xAI 模型已全部使用 Responses，并在 Fast Mode 开启时请求 `priority`。
+- `models.json` 里的自定义 xAI Completions 模型仍受支持。
 
 不支持的模型隐藏底栏状态，并且不改请求。
 
 ## 价格与计费
 
-不要假设每个模型都会被授予 priority，也不要假设本地费用总是大约 2 倍。
+不要假设每个模型都会被授予 priority。
 
 - OpenAI Fast / priority 官方定价面向 GPT-5.6 系列。更旧的模型可能拒绝或忽略该请求。
-- xAI 可能返回 `service_tier: "default"`。
-- Completions（当前 grok-4.6）不会把 priority 反映到本地 `usage.cost`。Glance 和 session 费用可能偏低。
+- 对 Responses 模型，Pi 会按响应里的 `service_tier` 计算本地 `usage.cost`：`priority` 通常约为 2 倍，`default` 仍为 1 倍。
+- 自定义 xAI Completions 模型可以请求 priority，但本地费用不会获得 Responses 专属的调整。
 
 ## Session 生命周期
 

--- a/packages/pi-fast-mode/extensions/fast-mode.ts
+++ b/packages/pi-fast-mode/extensions/fast-mode.ts
@@ -2,8 +2,8 @@
  * Fast / Priority mode for Pi.
  *
  * Same model, higher scheduling priority:
- * - openai / openai-codex Responses via options.serviceTier
- * - xAI Responses / Completions via payload service_tier
+ * - openai / openai-codex / xAI Responses via options.serviceTier
+ * - custom xAI Completions models via a payload service_tier fallback
  *
  * Toggle until you toggle again, /reload, or quit: /fast  or  Ctrl+F
  * Startup default: /fast default on|off
@@ -36,6 +36,7 @@ export const SHORTCUT_REPEAT_GUARD_MS = 800;
 export type ServiceTierOptions = ReturnType<typeof buildBaseOptions> & {
 	serviceTier?: typeof SERVICE_TIER;
 	reasoningEffort?: string;
+	toolChoice?: SimpleStreamOptions["toolChoice"];
 };
 
 export type FastModeModel = Pick<Model<Api>, "provider" | "api">;
@@ -110,7 +111,10 @@ export function buildStreamOptions(
 	options: SimpleStreamOptions | undefined,
 	serviceTier: typeof SERVICE_TIER | undefined,
 ): ServiceTierOptions {
-	const base = buildBaseOptions(model, context, options, options?.apiKey);
+	const base = {
+		...buildBaseOptions(model, context, options, options?.apiKey),
+		toolChoice: options?.toolChoice,
+	};
 	const clamped = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
 	const reasoningEffort = clamped === "off" ? undefined : clamped;
 	return {
@@ -138,7 +142,7 @@ export function applyXaiPriorityPayload(input: {
 	payload: unknown;
 }): Record<string, unknown> | undefined {
 	if (!input.enabled || input.model?.provider !== "xai") return undefined;
-	if (!supportsApi(input.model)) return undefined;
+	if (input.model.api !== "openai-completions") return undefined;
 	if (!isRecord(input.payload)) return undefined;
 	return { ...input.payload, service_tier: SERVICE_TIER };
 }
@@ -234,8 +238,20 @@ export default function fastMode(pi: ExtensionAPI): void {
 		},
 	});
 
-	// xAI is mixed-API (4.5 Responses, 4.6 Completions). registerProvider() can
-	// wrap only one api id, so inject the field on the serialized payload for both.
+	pi.registerProvider("xai", {
+		api: "openai-responses",
+		streamSimple(model, context: Context, options?: SimpleStreamOptions) {
+			const tier = resolveTier(model);
+			return streamOpenAIResponses(
+				model as Model<"openai-responses">,
+				context,
+				buildStreamOptions(model, context, options, tier) as never,
+			);
+		},
+	});
+
+	// Pi's built-in xAI catalog is entirely Responses. Keep the serialized
+	// payload hook only for custom xAI Completions models from models.json.
 	pi.on("before_provider_request", (event, ctx) => {
 		return applyXaiPriorityPayload({
 			enabled,

--- a/packages/pi-fast-mode/package.json
+++ b/packages/pi-fast-mode/package.json
@@ -49,9 +49,9 @@
     "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.84.0",
-    "@earendil-works/pi-coding-agent": "0.84.0",
-    "@earendil-works/pi-tui": "0.84.0",
+    "@earendil-works/pi-ai": "0.84.3",
+    "@earendil-works/pi-coding-agent": "0.84.3",
+    "@earendil-works/pi-tui": "0.84.3",
     "@types/node": "25.6.0",
     "tsx": "4.22.4",
     "typescript": "6.0.3"

--- a/packages/pi-fast-mode/tests/fast-mode-command.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode-command.test.ts
@@ -15,6 +15,13 @@ type RegisteredCommand = {
 	handler: (args: string, ctx: ExtensionContext) => Promise<void> | void;
 };
 
+type RegisteredProvider = {
+	api?: string;
+	streamSimple?: (...args: never[]) => unknown;
+};
+
+type EventHandler = (event: { reason?: string; payload?: unknown }, ctx: ExtensionContext) => unknown;
+
 const KITTY_CTRL_F_RELEASE = "\x1b[102;5:3u";
 
 function createCtx(statuses: Array<string | undefined>, notifies: string[]) {
@@ -75,7 +82,8 @@ function createInputCtx(statuses: Array<string | undefined>, notifies: string[])
 async function withLoadedExtension<T>(
 	run: (input: {
 		commands: Map<string, RegisteredCommand>;
-		handlers: Map<string, (event: { reason?: string }, ctx: ExtensionContext) => void>;
+		handlers: Map<string, EventHandler>;
+		providers: Map<string, RegisteredProvider>;
 	}) => Promise<T>,
 ): Promise<T> {
 	const root = await mkdtemp(path.join(tmpdir(), "pi-fast-mode-cmd-"));
@@ -85,24 +93,35 @@ async function withLoadedExtension<T>(
 	process.env.PI_CODING_AGENT_DIR = agentDir;
 	try {
 		const commands = new Map<string, RegisteredCommand>();
-		const handlers = new Map<string, (event: { reason?: string }, ctx: ExtensionContext) => void>();
+		const handlers = new Map<string, EventHandler>();
+		const providers = new Map<string, RegisteredProvider>();
 		const pi = {
-			registerProvider() {},
+			registerProvider(name: string, spec: RegisteredProvider) {
+				providers.set(name, spec);
+			},
 			registerCommand(name: string, spec: RegisteredCommand) {
 				commands.set(name, spec);
 			},
-			on(event: string, handler: (event: { reason?: string }, ctx: ExtensionContext) => void) {
+			on(event: string, handler: EventHandler) {
 				handlers.set(event, handler);
 			},
 		} as unknown as ExtensionAPI;
 		fastMode(pi);
-		return await run({ commands, handlers });
+		return await run({ commands, handlers, providers });
 	} finally {
 		if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previous;
 		await rm(root, { recursive: true, force: true });
 	}
 }
+
+test("registers built-in xAI on the Responses wrapper", async () => {
+	await withLoadedExtension(async ({ providers }) => {
+		const xai = providers.get("xai");
+		assert.equal(xai?.api, "openai-responses");
+		assert.equal(typeof xai?.streamSimple, "function");
+	});
+});
 
 test("/fast default writes settings and leaves the current switch unchanged", async () => {
 	await withLoadedExtension(async ({ commands, handlers }) => {

--- a/packages/pi-fast-mode/tests/fast-mode.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode.test.ts
@@ -7,7 +7,14 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildBaseOptions as installedBuildBaseOptions } from "@earendil-works/pi-ai/api/simple-options";
-import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai/compat";
+import {
+	streamOpenAIResponses,
+	type Api,
+	type AssistantMessage,
+	type Context,
+	type Model,
+	type SimpleStreamOptions,
+} from "@earendil-works/pi-ai/compat";
 import {
 	applyXaiPriorityPayload,
 	buildStreamOptions,
@@ -125,9 +132,15 @@ test("local buildBaseOptions matches the installed pi-ai recipe", () => {
 
 test("buildStreamOptions copies Pi streamSimple options and only adds serviceTier", () => {
 	const gpt = openaiModel();
-	const options: SimpleStreamOptions = { maxTokens: 64000, temperature: 0.2, apiKey: "test-key" };
+	const options: SimpleStreamOptions = {
+		maxTokens: 64000,
+		temperature: 0.2,
+		apiKey: "test-key",
+		toolChoice: "none",
+	};
 	const expected = {
 		...buildBaseOptions(gpt, emptyContext, options, options.apiKey),
+		toolChoice: "none",
 		reasoningEffort: undefined,
 	};
 
@@ -136,6 +149,69 @@ test("buildStreamOptions copies Pi streamSimple options and only adds serviceTie
 		...expected,
 		serviceTier: SERVICE_TIER,
 	});
+});
+
+async function runXaiResponses(responseServiceTier: "priority" | "default") {
+	const payloads: Array<Record<string, unknown>> = [];
+	const fakeFetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+		const requestBody = init?.body;
+		if (typeof requestBody !== "string") throw new Error("Expected a JSON request body");
+		payloads.push(JSON.parse(requestBody) as Record<string, unknown>);
+		const response = {
+			id: "resp_test",
+			status: "completed",
+			output: [],
+			service_tier: responseServiceTier,
+			usage: {
+				input_tokens: 10,
+				output_tokens: 20,
+				total_tokens: 30,
+				input_tokens_details: { cached_tokens: 0 },
+				output_tokens_details: { reasoning_tokens: 0 },
+			},
+		};
+		return new Response(
+			`data: ${JSON.stringify({ type: "response.completed", response })}\n\ndata: [DONE]\n\n`,
+			{ status: 200, headers: { "content-type": "text/event-stream" } },
+		);
+	}) as typeof fetch;
+	const xai = openaiModel({
+		provider: "xai",
+		id: "grok-4.6",
+		baseUrl: "https://api.x.ai/v1",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
+	});
+	const options = buildStreamOptions(
+		xai,
+		emptyContext,
+		{ apiKey: "test-key", fetch: fakeFetch, toolChoice: "none" },
+		SERVICE_TIER,
+	);
+	let completed: AssistantMessage | undefined;
+	let errorMessage: string | undefined;
+	for await (const event of streamOpenAIResponses(
+		xai as Model<"openai-responses">,
+		emptyContext,
+		options as never,
+	)) {
+		if (event.type === "done") completed = event.message;
+		if (event.type === "error") errorMessage = event.error.errorMessage;
+	}
+	assert.ok(completed, errorMessage);
+	return { payload: payloads[0], cost: completed.usage.cost };
+}
+
+test("xAI Responses priority uses the returned service tier for local cost", async () => {
+	const priority = await runXaiResponses("priority");
+	assert.equal(priority.payload?.service_tier, SERVICE_TIER);
+	assert.equal(priority.payload?.tool_choice, "none");
+	assert.equal(priority.cost.total, 0.00028);
+
+	const fallback = await runXaiResponses("default");
+	assert.equal(fallback.payload?.service_tier, SERVICE_TIER);
+	assert.equal(fallback.cost.total, 0.00014);
 });
 
 test("buildStreamOptions keeps Pi maxTokens defaulting and context clamping", () => {
@@ -170,9 +246,9 @@ test("OpenAI streamSimple wrappers still match the installed pi-ai recipe", () =
 	const openaiSource = readInstalledApiSource("openai-responses.js");
 	const codexSource = readInstalledApiSource("openai-codex-responses.js");
 	const recipe =
-		/export const streamSimple = \(model, context, options\) => \{[\s\S]*?buildBaseOptions\(model, context, options, options\?\.apiKey\);[\s\S]*?clampThinkingLevel\(model, options\.reasoning\)[\s\S]*?return stream\(model, context, \{\s*\.\.\.base,\s*reasoningEffort,\s*\}\);/;
+		/export const streamSimple = \(model, context, options\) => \{[\s\S]*?const base = \{\s*\.\.\.buildBaseOptions\(model, context, options, options\?\.apiKey\),\s*toolChoice: options\?\.toolChoice,\s*\};[\s\S]*?clampThinkingLevel\(model, options\.reasoning\)[\s\S]*?return stream\(model, context, \{\s*\.\.\.base,\s*reasoningEffort,\s*\}\);/;
 	const codexRecipe =
-		/export const streamSimple = \(model, context, options\) => \{[\s\S]*?buildBaseOptions\(model, context, options, apiKey\);[\s\S]*?clampThinkingLevel\(model, options\.reasoning\)[\s\S]*?return stream\(model, context, \{\s*\.\.\.base,\s*reasoningEffort,\s*\}\);/;
+		/export const streamSimple = \(model, context, options\) => \{[\s\S]*?const base = \{\s*\.\.\.buildBaseOptions\(model, context, options, apiKey\),\s*toolChoice: options\?\.toolChoice,\s*\};[\s\S]*?clampThinkingLevel\(model, options\.reasoning\)[\s\S]*?return stream\(model, context, \{\s*\.\.\.base,\s*reasoningEffort,\s*\}\);/;
 
 	assert.match(
 		openaiSource,
@@ -191,7 +267,7 @@ function readInstalledApiSource(fileName: string): string {
 	return readFileSync(join(dirname(fileURLToPath(simpleOptionsUrl)), fileName), "utf8");
 }
 
-test("applyXaiPriorityPayload only mutates matching xAI payloads when enabled", () => {
+test("applyXaiPriorityPayload only mutates custom xAI Completions payloads when enabled", () => {
 	const payload = { model: "grok-4.6", max_tokens: 8000 };
 	assert.equal(
 		applyXaiPriorityPayload({ enabled: false, model: model("xai", "openai-completions"), payload }),
@@ -213,9 +289,9 @@ test("applyXaiPriorityPayload only mutates matching xAI payloads when enabled", 
 		applyXaiPriorityPayload({ enabled: true, model: model("xai", "openai-completions"), payload }),
 		{ model: "grok-4.6", max_tokens: 8000, service_tier: SERVICE_TIER },
 	);
-	assert.deepEqual(
+	assert.equal(
 		applyXaiPriorityPayload({ enabled: true, model: model("xai", "openai-responses"), payload }),
-		{ model: "grok-4.6", max_tokens: 8000, service_tier: SERVICE_TIER },
+		undefined,
 	);
 	assert.deepEqual(payload, { model: "grok-4.6", max_tokens: 8000 });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,14 +128,14 @@ importers:
   packages/pi-fast-mode:
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.84.0
-        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.3
+        version: 0.84.3(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: 0.84.0
-        version: 0.84.0(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.84.3
+        version: 0.84.3(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: 0.84.0
-        version: 0.84.0
+        specifier: 0.84.3
+        version: 0.84.3
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -689,8 +689,17 @@ packages:
     resolution: {integrity: sha512-L1lw0lwR5LXCzGEeHD9XNEruU2bg0H8clOA8ySdGMHvxutp8GC+yZL6MZp4tqQRnLKP3gHmY7TrWzQ3YnFdJYQ==}
     engines: {node: '>=22.19.0'}
 
+  '@earendil-works/pi-agent-core@0.84.3':
+    resolution: {integrity: sha512-VURr+xBRl3RxYcw3kT9Pn3yfi6LbRoCJgHF7h1mAblMjtLNV/MfG/RyF0uJizBAM886AEakSiw3j9c/aSngppg==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-ai@0.84.0':
     resolution: {integrity: sha512-N9RDk8q0eglGiy+NqTZ3Ev2j+6oFNXSAJa8b0CYhvWB9HGiKZjsoCESXkUvMDLybrn0wXp75sdsoBzEtHxk9kA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-ai@0.84.3':
+    resolution: {integrity: sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -698,8 +707,17 @@ packages:
     resolution: {integrity: sha512-fHXgw1FdLDh+uw42SvTkJRBfgc3nsrslghvbRFEAxdjfcOxJt7hPsTj4HHNK96wMy1f+zvQYL8Y2znvFoZ8JDA==}
     engines: {node: '>=22.19.0'}
 
+  '@earendil-works/pi-client@0.84.3':
+    resolution: {integrity: sha512-zfErYane+390W0xpBJ/FWCp6aktPpkpcIcXUeZiAziWLoxE80ZNQALRyOSa/gGS5V+1OkNnMYxRxbzN0zUvnOA==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-coding-agent@0.84.0':
     resolution: {integrity: sha512-oxEU7BT9xuVT6UKNwUNDzNP5dVGb+DZRGfaEyMyAab8dRlqTSxxyhSlMAxmYsu//YOeasj9E8n2+px1BzIai0g==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-coding-agent@0.84.3':
+    resolution: {integrity: sha512-Yr2p9PubrbFZmYEPYI+C8KmZP9xlFuLDnAG64RtU0ZDgrdiXYWa+y7WGyJO5OlqPliOkVCMd9IzVszO3/t0D0w==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -707,12 +725,24 @@ packages:
     resolution: {integrity: sha512-Fc28cCYGg5+aRnMzbAD7QAi6Xl//kbETyFroLHCs3Zf4oaXH9L2gzBqVLVAwrKIKeS0uffUrmihocGTECfKW6Q==}
     engines: {node: '>=22.19.0'}
 
+  '@earendil-works/pi-protocol@0.84.3':
+    resolution: {integrity: sha512-9a4g6WhLOvRqvsIOFaWxg/2gdrbY4Thclwj5ipLUPAWChfsDJ/8XdPc2sRhSOkD6EsxpEFJz3xppcfwI6EcZDg==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-telemetry@0.84.0':
     resolution: {integrity: sha512-g6hLxEfAUk3zJlDmFWhWHJNcYXYiNGeWuJC9YkcHpkdkj0gxD4uaMNNNU3QsAEJXW9Qcxnl21+U8GfhVsc8C5g==}
     engines: {node: '>=22.19.0'}
 
+  '@earendil-works/pi-telemetry@0.84.3':
+    resolution: {integrity: sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-tui@0.84.0':
     resolution: {integrity: sha512-nbs0FeZJ5rWDD6VpKfXXmYbEHnHqb40V9glE2l9f8ftoWpsP8nw0WcXK8jOjfRsDPnT9dJHy3dItOHdn/AFGjA==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.84.3':
+    resolution: {integrity: sha512-fS6OEQKEEALnKa6Uw8LcgZZ+9CWck7f3MQSCETQp6leUgIFwMEDtKmOUnL9nsYm+RIPmy7OmplVxYRbV6hiaFg==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.11.1':
@@ -2509,6 +2539,17 @@ packages:
       zod:
         optional: true
 
+  openai@6.40.0:
+    resolution: {integrity: sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==}
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -3600,6 +3641,22 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-agent-core@0.84.3(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.84.3(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-telemetry': 0.84.3
+      diff: 8.0.4
+      ignore: 7.0.5
+      typebox: 1.3.7
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-ai@0.84.0(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
@@ -3622,9 +3679,33 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-ai@0.84.3(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@earendil-works/pi-telemetry': 0.84.3
+      '@google/genai': 1.52.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.40.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.3.7
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-client@0.84.0':
     dependencies:
       '@earendil-works/pi-protocol': 0.84.0
+
+  '@earendil-works/pi-client@0.84.3':
+    dependencies:
+      '@earendil-works/pi-protocol': 0.84.3
 
   '@earendil-works/pi-coding-agent@0.84.0(ws@8.21.0)(zod@4.4.3)':
     dependencies:
@@ -3659,13 +3740,56 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-coding-agent@0.84.3(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.84.3(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.3(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-client': 0.84.3
+      '@earendil-works/pi-protocol': 0.84.3
+      '@earendil-works/pi-tui': 0.84.3
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      grok-mermaid: 0.2.2
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.3.7
+      undici: 8.9.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-protocol@0.84.0':
+    dependencies:
+      typebox: 1.3.7
+
+  '@earendil-works/pi-protocol@0.84.3':
     dependencies:
       typebox: 1.3.7
 
   '@earendil-works/pi-telemetry@0.84.0': {}
 
+  '@earendil-works/pi-telemetry@0.84.3': {}
+
   '@earendil-works/pi-tui@0.84.0':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
+
+  '@earendil-works/pi-tui@0.84.3':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
@@ -5228,6 +5352,11 @@ snapshots:
   obug@2.1.4: {}
 
   openai@6.26.0(ws@8.21.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.4.3
+
+  openai@6.40.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0
       zod: 4.4.3


### PR DESCRIPTION
## Summary

- preserve `toolChoice` in the OpenAI and Codex Responses wrappers
- route built-in xAI through the official Responses stream with response-aware priority billing
- retain the request-payload fallback only for custom xAI Completions models
- align Fast Mode development dependencies and canary coverage with Pi 0.84.3

## Release plan

- `@zhcsyncer/pi-extensions`: 0.27.0 → 0.27.1 (patch)
- `@zhcsyncer/pi-fast-mode`: 0.1.2 → 0.1.3 (patch)

## Verification

- `pnpm check`