### PR TITLE
feat(cursor-ask): add Fable 5.1 and price short picker rows

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -20,6 +20,29 @@ Repository-level follow-up work that should remain discoverable across sessions.
   - Ordinary single-line typing keeps the compact composer.
   - Stash mark, status line, and border chrome still fit after the grow.
 
+## `@zhcsyncer/pi-meter`
+
+- [ ] **Guest quota adapters survive `/reload`**
+
+  Footer shows `cursor  no quota window` after `/reload` until Pi restarts. Guest sources (Cursor Ask) register through the `globalThis` mailbox host. Pi reloads extensions one at a time with `moduleCache: false`, so `src/quota/guest.ts` gets a fresh empty registry while the previous host object stays on `globalThis`. A guest that activates before pi-meter is re-imported sees the stale `register` and writes into the dead registry; the new `installQuotaAdapterHost()` then drains an empty mailbox. Fresh start is unaffected because no stale host exists. `tests/quota-guest-mailbox.test.ts` only covers the clean "registered before meter started" path.
+
+  Acceptance criteria:
+
+  - `installQuotaAdapterHost()` re-adopts adapters reachable from a previous host (`list()` / stale registry), not only the mailbox.
+  - A guest that calls a stale `register` still lands in the live registry, or the guest side also writes the mailbox so a later host install picks it up.
+  - Regression test: install host, register a guest, simulate reload (`vi.resetModules()` + re-import with the old host still on `globalThis`), assert `preferredProvider({ provider: "cursor", id: "fable-5.1" })` resolves.
+  - Cursor Ask footer keeps `cursor-api` / `cursor-auto` across `/reload` regardless of `settings.json` package order.
+
+- [ ] **Retry a failed quota snapshot while idle**
+
+  A failed guest fetch (10s timeout, token refresh miss, upstream 5xx) leaves `ok: false` and the footer shows `unavailable`. Refetch only happens on `agent_settled`, `model_select`, or `/usage`; the 30s status poll rereads `quota.json` but never fetches, so an idle session stays `unavailable` indefinitely. `quota.json` is shared across Pi processes, so another session's failure or `lastAttemptAt` also blocks this one.
+
+  Acceptance criteria:
+
+  - The idle status poll triggers a refresh when the preferred source's snapshot is `ok: false` and the min-interval has elapsed.
+  - A successful refetch replaces the failed snapshot without waiting for the next turn.
+  - Unsigned / built-in behavior is unchanged; no extra network calls when the snapshot is fresh.
+
 ## `@zhcsyncer/pi-tool-display-intent`
 
 - [ ] **Drop configurable visual styles; always use the Claude / aggregate look**

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Search Hub ships only in the root bundle. Adversarial Review is published indepe
 
 These providers are not included in the root bundle. Cursor Ask is repository-only and is not published to npm; Agent Plan releases independently.
 
-- [`pi-provider-cursor-ask`](./providers/pi-provider-cursor-ask) — a full `@rahularya01/pi-cursor` replacement that keeps the `cursor` provider/login identity and exposes four always-thinking 1M Fable/Opus/Sonnet rows plus Composer 2.5 / Fast.
+- [`pi-provider-cursor-ask`](./providers/pi-provider-cursor-ask) — a full `@rahularya01/pi-cursor` replacement that keeps the `cursor` provider/login identity and exposes five always-thinking 1M Fable/Opus/Sonnet rows plus Composer 2.5 / Fast.
 - [`pi-provider-volcengine-agent-plan`](./providers/pi-provider-volcengine-agent-plan) — an unofficial Volcengine Ark Agent Plan provider with tier-aware models and Pi login.
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,7 +45,7 @@ Search Hub 只随根 bundle 提供。Adversarial Review 独立发布，不进入
 
 以下 provider 不进入根 bundle。Cursor Ask 只保留在仓库源码中，不发布到 npm；Agent Plan 独立发版。
 
-- [`pi-provider-cursor-ask`](./providers/pi-provider-cursor-ask) — `@rahularya01/pi-cursor` 的整仓替代版，保留 `cursor` provider/登录身份，提供 4 行始终开启 thinking 的 1M Fable/Opus/Sonnet 模型及 Composer 2.5 / Fast。
+- [`pi-provider-cursor-ask`](./providers/pi-provider-cursor-ask) — `@rahularya01/pi-cursor` 的整仓替代版，保留 `cursor` provider/登录身份，提供 5 行始终开启 thinking 的 1M Fable/Opus/Sonnet 模型及 Composer 2.5 / Fast。
 - [`pi-provider-volcengine-agent-plan`](./providers/pi-provider-volcengine-agent-plan) — 非官方火山方舟 Agent Plan provider，支持按套餐过滤模型和 Pi 登录。
 
 ```bash

--- a/providers/pi-provider-cursor-ask/README.md
+++ b/providers/pi-provider-cursor-ask/README.md
@@ -13,7 +13,7 @@ The package is a full fork of [`@rahularya01/pi-cursor`](https://github.com/Rahu
 The fork differs in these user-visible ways:
 
 - Replaces the upstream extension under the same `cursor` provider/login identity and `cursor-native` stream API.
-- Exposes four always-thinking 1M Claude rows plus Composer 2.5 / Composer 2.5 Fast; all other Cursor model families are filtered out.
+- Exposes five always-thinking 1M Claude rows plus Composer 2.5 / Composer 2.5 Fast; all other Cursor model families are filtered out.
 - Uses readable picker names without a separate default-context row, because Cursor bills these Claude models at one rate up to 1M.
 - Maps only advertised Pi thinking levels. Claude uses Cursor `effort`. Composer 2.5 has no effort parameter, so `off`/`max` are an explicit Max Mode switch and other levels stay unavailable.
 - Lives in this repository only, is not published to npm, and is not included in `@zhcsyncer/pi-extensions`.
@@ -22,13 +22,14 @@ See [`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md) for the maintained fork record.
 
 ## Models
 
+- Fable 5.1
 - Fable 5
 - Opus 5
 - Opus 4.6
 - Sonnet 5
 - Composer 2.5 / Composer 2.5 Fast
 
-Thinking cannot be disabled on the four Claude rows. Depending on Cursor's metadata for a Claude model, Pi may offer `low`, `medium`, `high`, `xhigh`, and `max`; unavailable levels are omitted. Composer 2.5 exposes only `off` (standard) and `max` (Max Mode).
+Thinking cannot be disabled on the five Claude rows. Depending on Cursor's metadata for a Claude model, Pi may offer `low`, `medium`, `high`, `xhigh`, and `max`; unavailable levels are omitted. Composer 2.5 exposes only `off` (standard) and `max` (Max Mode).
 
 ## Requirements
 
@@ -60,7 +61,7 @@ List the filtered models:
 pi --list-models cursor
 ```
 
-Select `cursor/fable-5`, `cursor/opus-5`, `cursor/opus-4.6`, or `cursor/sonnet-5`.
+Select `cursor/fable-5.1`, `cursor/fable-5`, `cursor/opus-5`, `cursor/opus-4.6`, or `cursor/sonnet-5`.
 
 Available command:
 

--- a/providers/pi-provider-cursor-ask/README.zh-CN.md
+++ b/providers/pi-provider-cursor-ask/README.zh-CN.md
@@ -13,7 +13,7 @@
 本 fork 的用户可见差异如下：
 
 - 使用与上游相同的 `cursor` provider/登录身份和 `cursor-native` stream API 直接替换旧扩展。
-- 不展示完整 Cursor 目录，只提供 4 行始终开启 thinking 的 1M Claude 模型，以及 Composer 2.5 / Composer 2.5 Fast；过滤其他所有模型系列。
+- 不展示完整 Cursor 目录，只提供 5 行始终开启 thinking 的 1M Claude 模型，以及 Composer 2.5 / Composer 2.5 Fast；过滤其他所有模型系列。
 - Picker 不再拆默认上下文行：Cursor 对这些 Claude 模型按同一费率计到 1M。
 - 只映射明确提供的 Pi thinking 档位。Claude 映射 Cursor `effort`。Composer 2.5 没有 effort 参数，因此只用 `off`/`max` 显式开关 Max Mode，其余档位保持不可用。
 - 只保留在本仓库源码中，不发布到 npm，也不进入 `@zhcsyncer/pi-extensions` 根 bundle。
@@ -22,13 +22,14 @@
 
 ## 模型
 
+- Fable 5.1
 - Fable 5
 - Opus 5
 - Opus 4.6
 - Sonnet 5
 - Composer 2.5 / Composer 2.5 Fast
 
-4 行 Claude 模型的 Thinking 无法关闭。根据 Cursor 为各 Claude 模型返回的 metadata，Pi 可能提供 `low`、`medium`、`high`、`xhigh` 和 `max`；不可用的档位不会显示。Composer 2.5 只提供 `off`（标准）和 `max`（Max Mode）。
+5 行 Claude 模型的 Thinking 无法关闭。根据 Cursor 为各 Claude 模型返回的 metadata，Pi 可能提供 `low`、`medium`、`high`、`xhigh` 和 `max`；不可用的档位不会显示。Composer 2.5 只提供 `off`（标准）和 `max`（Max Mode）。
 
 ## 要求
 
@@ -60,7 +61,7 @@ Provider 也可以复用受支持的 Cursor CLI 或桌面端凭证。自动化�
 pi --list-models cursor
 ```
 
-可选择 `cursor/fable-5`、`cursor/opus-5`、`cursor/opus-4.6` 或 `cursor/sonnet-5`。
+可选择 `cursor/fable-5.1`、`cursor/fable-5`、`cursor/opus-5`、`cursor/opus-4.6` 或 `cursor/sonnet-5`。
 
 可用命令：
 

--- a/providers/pi-provider-cursor-ask/UPSTREAM_SOURCE.md
+++ b/providers/pi-provider-cursor-ask/UPSTREAM_SOURCE.md
@@ -15,7 +15,7 @@ The production source, generated protobuf bindings, protocol schema, build tooli
 - Published independently as the unscoped `pi-provider-cursor-ask` package; it is not embedded in the repository's root bundle.
 - Keeps the upstream `cursor` provider/login identity and `cursor-native` stream API so existing Pi credentials continue to work. OAuth label is `Cursor Ask`, and diagnostics stay `/cursor` subcommands.
 - Declares `apiKey: "$CURSOR_ACCESS_TOKEN"` on `registerProvider` so Pi will list models when that env var is set (CI smoke). Ask still resolves the token itself; upstream relies on OAuth only at this layer.
-- Filters the processed Cursor catalog in `src/models/ask-catalog.ts` to four 1M Claude rows plus Composer 2.5 / Composer 2.5 Fast; all other families are removed and upstream `processModels` remains unchanged.
+- Filters the processed Cursor catalog in `src/models/ask-catalog.ts` to the curated 1M Claude rows plus Composer 2.5 / Composer 2.5 Fast; all other families are removed and upstream `processModels` remains unchanged.
 - Keeps thinking enabled for Claude rows and maps supported Pi levels to explicit Cursor `requestedModelId` plus `thinking`, `context`, `effort`, and `fast` parameters. Composer 2.5 maps Pi `off`/`max` to Cursor Max Mode instead of inventing an effort parameter.
 - Accepts both current folded Claude ids and legacy bundled-catalog spellings such as `claude-4.6-opus-thinking`.
 - Replaces the upstream user README and changelog with fork-specific bilingual usage documentation and release history.

--- a/providers/pi-provider-cursor-ask/src/models/ask-catalog.ts
+++ b/providers/pi-provider-cursor-ask/src/models/ask-catalog.ts
@@ -2,7 +2,7 @@
  * Stable, advisor-oriented Cursor Ask catalog.
  *
  * Upstream Cursor catalogs expose backend model ids and parameter variants.
- * This adapter runs after upstream processing, keeps four 1M Claude rows
+ * This adapter runs after upstream processing, keeps the curated 1M Claude rows
  * plus Composer 2.5 / Composer 2.5 Fast, and retains an explicit route back to
  * Cursor's requestedModelId and parameters for every supported Pi thinking level.
  * Composer has no Cursor effort parameter; its Pi thinking map is an explicit
@@ -26,6 +26,21 @@ export interface AskModelSpec {
 }
 
 const families = {
+  fable51: {
+    requestedModelId: "claude-fable-5-1",
+    defaultContext: "300k" as const,
+    candidates: [
+      "claude-fable-5-1-thinking",
+      "claude-fable-5.1-thinking",
+      "claude-5-1-fable-thinking",
+    ],
+    // Not `claude-fable-5-1m-thinking`: that is Fable 5's 1M row.
+    oneMillionCandidates: [
+      "claude-fable-5-1-1m-thinking",
+      "claude-fable-5.1-1m-thinking",
+      "claude-5-1-fable-1m-thinking",
+    ],
+  },
   fable5: {
     requestedModelId: "claude-fable-5",
     defaultContext: "300k" as const,
@@ -80,6 +95,7 @@ function specForFamily(options: {
 }
 
 export const ASK_MODEL_SPECS: readonly AskModelSpec[] = [
+  specForFamily({ id: "fable-5.1", name: "Fable 5.1", ...families.fable51 }),
   specForFamily({ id: "fable-5", name: "Fable 5", ...families.fable5 }),
   specForFamily({ id: "opus-5", name: "Opus 5", ...families.opus5 }),
   specForFamily({ id: "opus-4.6", name: "Opus 4.6", ...families.opus46 }),
@@ -283,7 +299,7 @@ function buildComposerCatalog(processedModels: ProcessedModel[]): ProcessedModel
   });
 }
 
-/** Return the four 1M Claude rows followed by Composer 2.5 / Fast. */
+/** Return the curated 1M Claude rows followed by Composer 2.5 / Fast. */
 export function buildAskCatalog(processedModels: ProcessedModel[]): ProcessedModel[] {
   const modelsById = new Map(processedModels.map((model) => [normalizedId(model.id), model]));
   const claudeModels = ASK_MODEL_SPECS.map((spec) => {

--- a/providers/pi-provider-cursor-ask/src/models/cost.ts
+++ b/providers/pi-provider-cursor-ask/src/models/cost.ts
@@ -16,9 +16,16 @@ export const MODEL_COST_TABLE: Record<string, ModelCost> = {
   "claude-4.5-sonnet": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
   "claude-4.6-opus": { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   "claude-4.6-sonnet": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  "claude-fable-5": { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+  "claude-fable-5-1": { input: 10, output: 50, cacheRead: 0.25, cacheWrite: 12.5 },
+  "claude-opus-4-6": { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  "claude-opus-5": { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  "claude-sonnet-5": { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
   "composer-1": { input: 1.25, output: 10, cacheRead: 0.125, cacheWrite: 0 },
   "composer-1.5": { input: 3.5, output: 17.5, cacheRead: 0.35, cacheWrite: 0 },
   "composer-2": { input: 0.5, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
+  "composer-2.5": { input: 0.5, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
+  "composer-2.5-fast": { input: 3, output: 15, cacheRead: 0.5, cacheWrite: 0 },
   "gemini-2.5-flash": { input: 0.3, output: 2.5, cacheRead: 0.03, cacheWrite: 0 },
   "gemini-3-flash": { input: 0.5, output: 3, cacheRead: 0.05, cacheWrite: 0 },
   "gemini-3-pro": { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 0 },
@@ -39,11 +46,23 @@ export const DEFAULT_COST: ModelCost = { input: 3, output: 15, cacheRead: 0.3, c
 
 export const MODEL_COST_PATTERNS: Array<{ match: (id: string) => boolean; cost: ModelCost }> = [
   {
+    match: (id) => /fable-5\.1|fable-5-1(?!m)/i.test(id),
+    cost: MODEL_COST_TABLE["claude-fable-5-1"] ?? DEFAULT_COST,
+  },
+  {
+    match: (id) => /fable/i.test(id),
+    cost: MODEL_COST_TABLE["claude-fable-5"] ?? DEFAULT_COST,
+  },
+  {
+    match: (id) => /sonnet-5/i.test(id),
+    cost: MODEL_COST_TABLE["claude-sonnet-5"] ?? DEFAULT_COST,
+  },
+  {
     match: (id) => /claude.*opus.*fast/i.test(id),
     cost: { input: 30, output: 150, cacheRead: 3, cacheWrite: 37.5 },
   },
   {
-    match: (id) => /claude.*opus/i.test(id),
+    match: (id) => /claude.*opus|opus-5|opus-4/i.test(id),
     cost: MODEL_COST_TABLE["claude-4.6-opus"] ?? DEFAULT_COST,
   },
   {
@@ -53,6 +72,14 @@ export const MODEL_COST_PATTERNS: Array<{ match: (id: string) => boolean; cost: 
   {
     match: (id) => /claude.*sonnet/i.test(id),
     cost: MODEL_COST_TABLE["claude-4.6-sonnet"] ?? DEFAULT_COST,
+  },
+  {
+    match: (id) => /composer-2\.5.*fast|composer-2\.5-fast/i.test(id),
+    cost: MODEL_COST_TABLE["composer-2.5-fast"] ?? DEFAULT_COST,
+  },
+  {
+    match: (id) => /composer-2\.5/i.test(id),
+    cost: MODEL_COST_TABLE["composer-2.5"] ?? DEFAULT_COST,
   },
   { match: (id) => /composer/i.test(id), cost: MODEL_COST_TABLE["composer-1"] ?? DEFAULT_COST },
   { match: (id) => /gpt-5\.5/i.test(id), cost: MODEL_COST_TABLE["gpt-5.5"] ?? DEFAULT_COST },

--- a/providers/pi-provider-cursor-ask/src/models/processing.ts
+++ b/providers/pi-provider-cursor-ask/src/models/processing.ts
@@ -302,7 +302,11 @@ export function modelConfig(m: ProcessedModel) {
         thinkingLevelMap: m.effortMap,
       }),
     input,
-    cost: estimateModelCost(m.id),
+    // Picker ids stay short (`fable-5.1`); price against the Cursor model id
+    // behind them, then the picker id so Fast/alias rows still match.
+    cost: estimateModelCost(
+      [m.requestedModelId, m.id].filter((value): value is string => Boolean(value)).join(" "),
+    ),
     contextWindow: m.contextWindow,
     maxTokens: m.maxTokens,
   };

--- a/providers/pi-provider-cursor-ask/tests/ask-catalog.test.ts
+++ b/providers/pi-provider-cursor-ask/tests/ask-catalog.test.ts
@@ -85,21 +85,26 @@ function parameters(route: CursorModelRouting): Record<string, string> {
 }
 
 describe("Cursor Ask catalog contract", () => {
-  it("always exposes the four 1M Claude rows plus Composer 2.5 / Fast", () => {
+  it("always exposes the curated 1M Claude rows plus Composer 2.5 / Fast", () => {
     const catalog = buildAskCatalog([]);
+    const claudeCount = ASK_MODEL_SPECS.length;
 
     expect(catalog.map(({ id, name }) => ({ id, name }))).toEqual([
       ...ASK_MODEL_SPECS.map(({ id, name }) => ({ id, name })),
       ...COMPOSER_ASK_SPECS.map(({ id, name }) => ({ id, name })),
     ]);
-    expect(catalog).toHaveLength(6);
+    expect(catalog).toHaveLength(claudeCount + COMPOSER_ASK_SPECS.length);
     expect(catalog.every((model) => model.reasoning && model.supportsEffort)).toBe(true);
-    expect(catalog.slice(0, 4).every((model) => model.effortMap?.off === null)).toBe(true);
+    expect(catalog.slice(0, claudeCount).every((model) => model.effortMap?.off === null)).toBe(
+      true,
+    );
     expect(catalog.every((model) => model.effortMap?.minimal === null)).toBe(true);
-    expect(catalog.slice(0, 4).every((model) => model.contextWindow === 1_000_000)).toBe(true);
+    expect(catalog.slice(0, claudeCount).every((model) => model.contextWindow === 1_000_000)).toBe(
+      true,
+    );
     expect(
       catalog
-        .slice(0, 4)
+        .slice(0, claudeCount)
         .some((model) => /200k|300k|\[1m\]|-1m$/i.test(`${model.id} ${model.name}`)),
     ).toBe(false);
   });
@@ -112,7 +117,7 @@ describe("Cursor Ask catalog contract", () => {
         context: spec.context,
       }),
     );
-    const catalog = buildAskCatalog(sources).slice(0, 4);
+    const catalog = buildAskCatalog(sources).slice(0, ASK_MODEL_SPECS.length);
 
     for (const [index, model] of catalog.entries()) {
       const spec = ASK_MODEL_SPECS[index]!;
@@ -143,7 +148,7 @@ describe("Cursor Ask catalog contract", () => {
       plainModel("claude-fable-5-thinking", "Fable backend row"),
     ]);
 
-    expect(catalog.slice(4).map(({ id, name }) => ({ id, name }))).toEqual([
+    expect(catalog.slice(ASK_MODEL_SPECS.length).map(({ id, name }) => ({ id, name }))).toEqual([
       { id: "composer-2.5", name: "Composer 2.5" },
       { id: "composer-2.5-fast", name: "Composer 2.5 Fast" },
     ]);
@@ -151,7 +156,7 @@ describe("Cursor Ask catalog contract", () => {
       catalog.some((model) => /^(gpt|gemini|claude-|composer-1|composer-2$)/i.test(model.id)),
     ).toBe(false);
 
-    for (const model of catalog.slice(4)) {
+    for (const model of catalog.slice(ASK_MODEL_SPECS.length)) {
       const fast = model.id.endsWith("-fast") ? "true" : "false";
       expect(supportedAskThinkingLevels(model)).toEqual(["off", "max"]);
       expect(model.effortMap).toEqual({
@@ -187,6 +192,26 @@ describe("Cursor Ask catalog contract", () => {
         /not supported/i,
       );
     }
+  });
+
+  it("does not treat Fable 5's 1M row as Fable 5.1", () => {
+    const catalog = buildAskCatalog([
+      sourceModel({
+        id: "claude-fable-5-1m-thinking",
+        requestedModelId: "claude-fable-5",
+        context: "1m",
+      }),
+      sourceModel({
+        id: "claude-fable-5-1-1m-thinking",
+        requestedModelId: "claude-fable-5-1",
+        context: "1m",
+      }),
+    ]);
+    const fable51 = catalog.find((model) => model.id === "fable-5.1");
+    const fable5 = catalog.find((model) => model.id === "fable-5");
+
+    expect(fable51?.rawRoutingByEffort?.high?.modelId).toBe("claude-fable-5-1");
+    expect(fable5?.rawRoutingByEffort?.high?.modelId).toBe("claude-fable-5");
   });
 
   it("accepts the old Opus 4.6 fallback id without inventing missing effort levels", () => {

--- a/providers/pi-provider-cursor-ask/tests/cost.test.ts
+++ b/providers/pi-provider-cursor-ask/tests/cost.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAskCatalog } from "../src/models/ask-catalog.js";
+import { estimateModelCost } from "../src/models/cost.js";
+import { modelConfig } from "../src/models/processing.js";
+
+describe("estimateModelCost", () => {
+  it("prices Fable 5.1 cheaper on cache reads than Fable 5", () => {
+    expect(estimateModelCost("claude-fable-5-1")).toEqual({
+      input: 10,
+      output: 50,
+      cacheRead: 0.25,
+      cacheWrite: 12.5,
+    });
+    expect(estimateModelCost("fable-5.1")).toEqual(estimateModelCost("claude-fable-5-1"));
+    expect(estimateModelCost("claude-fable-5")).toMatchObject({
+      input: 10,
+      output: 50,
+      cacheRead: 1,
+    });
+    expect(estimateModelCost("fable-5")).toEqual(estimateModelCost("claude-fable-5"));
+  });
+
+  it("does not let Fable 5's 1M id steal Fable 5.1 pricing", () => {
+    expect(estimateModelCost("claude-fable-5-1m-thinking").cacheRead).toBe(1);
+    expect(estimateModelCost("claude-fable-5-1-1m-thinking").cacheRead).toBe(0.25);
+  });
+});
+
+describe("Ask catalog local prices", () => {
+  it("keeps short picker ids and prices them from the Cursor model behind each row", () => {
+    const catalog = buildAskCatalog([]);
+    const cost = Object.fromEntries(
+      catalog.map((model) => [model.id, modelConfig(model).cost]),
+    );
+
+    expect(catalog.map((model) => model.name)).toEqual([
+      "Fable 5.1",
+      "Fable 5",
+      "Opus 5",
+      "Opus 4.6",
+      "Sonnet 5",
+      "Composer 2.5",
+      "Composer 2.5 Fast",
+    ]);
+    expect(cost["fable-5.1"]).toEqual({
+      input: 10,
+      output: 50,
+      cacheRead: 0.25,
+      cacheWrite: 12.5,
+    });
+    expect(cost["fable-5"]).toEqual({
+      input: 10,
+      output: 50,
+      cacheRead: 1,
+      cacheWrite: 12.5,
+    });
+    expect(cost["opus-5"]).toMatchObject({ input: 5, output: 25 });
+    expect(cost["sonnet-5"]).toEqual({
+      input: 2,
+      output: 10,
+      cacheRead: 0.2,
+      cacheWrite: 2.5,
+    });
+    expect(cost["composer-2.5"]).toMatchObject({ input: 0.5, output: 2.5 });
+    expect(cost["composer-2.5-fast"]).toMatchObject({ input: 3, output: 15 });
+  });
+});

--- a/providers/pi-provider-cursor-ask/tests/cost.test.ts
+++ b/providers/pi-provider-cursor-ask/tests/cost.test.ts
@@ -30,9 +30,7 @@ describe("estimateModelCost", () => {
 describe("Ask catalog local prices", () => {
   it("keeps short picker ids and prices them from the Cursor model behind each row", () => {
     const catalog = buildAskCatalog([]);
-    const cost = Object.fromEntries(
-      catalog.map((model) => [model.id, modelConfig(model).cost]),
-    );
+    const cost = Object.fromEntries(catalog.map((model) => [model.id, modelConfig(model).cost]));
 
     expect(catalog.map((model) => model.name)).toEqual([
       "Fable 5.1",

--- a/providers/pi-provider-cursor-ask/tests/identity.test.ts
+++ b/providers/pi-provider-cursor-ask/tests/identity.test.ts
@@ -32,8 +32,9 @@ describe("drop-in Cursor provider identity", () => {
     expect(registeredName).toBe("cursor");
     expect(registeredConfig?.api).toBe("cursor-native");
     expect(registeredConfig?.oauth?.name).toBe("Cursor Ask");
-    expect(registeredConfig?.models).toHaveLength(6);
+    expect(registeredConfig?.models).toHaveLength(7);
     expect(models.map((model) => model.id)).toEqual([
+      "fable-5.1",
       "fable-5",
       "opus-5",
       "opus-4.6",

--- a/scripts/check-smoke.mjs
+++ b/scripts/check-smoke.mjs
@@ -128,7 +128,7 @@ export function runSmokeChecks() {
 				const modelCount = (result.stdout ?? "")
 					.split("\n")
 					.filter((line) => line.startsWith(`${providerId} `)).length;
-				const expectedCount = isAgentPlan ? 13 : 6;
+				const expectedCount = isAgentPlan ? 13 : 7;
 				if (modelCount !== expectedCount) {
 					process.stderr.write(result.stderr ?? "");
 					process.stderr.write(result.stdout ?? "");


### PR DESCRIPTION
Cursor Ask is repository-only and is not published; no changeset.

- Add `cursor/fable-5.1` as a 1M always-thinking row beside Fable 5.
- Price short picker names from the Cursor model behind them (Fable 5.1 cache reads $0.25 vs Fable 5 $1).
- Record pi-meter guest quota drop after `/reload` in BACKLOG.