### PR TITLE
feat(pi-fast-mode): per-model defaults and quieter toggles

### DIFF
--- a/.changeset/per-model-fast-default.md
+++ b/.changeset/per-model-fast-default.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": minor
+"@zhcsyncer/pi-fast-mode": minor
+---
+
+Make Fast Mode defaults per model. `/fast default` now sets only the current model's startup default; unconfigured models start off. Switching models follows that model's in-memory switch.

--- a/.changeset/per-model-fast-default.md
+++ b/.changeset/per-model-fast-default.md
@@ -3,4 +3,4 @@
 "@zhcsyncer/pi-fast-mode": minor
 ---
 
-Make Fast Mode defaults per model. `/fast default` sets only the current model's startup default and turns this session's switch to match. Unconfigured models start off. Switching models follows that model's in-memory switch.
+Make Fast Mode defaults per model. `/fast default` sets only the current model's startup default and turns this session's switch to match. Unconfigured models start off. Switching models follows that model's in-memory switch. Old global `enabled` and boolean maps are migrated on startup with a warning; a former global ON does not enable every model.

--- a/.changeset/per-model-fast-default.md
+++ b/.changeset/per-model-fast-default.md
@@ -3,4 +3,4 @@
 "@zhcsyncer/pi-fast-mode": minor
 ---
 
-Make Fast Mode defaults per model. `/fast default` now sets only the current model's startup default; unconfigured models start off. Switching models follows that model's in-memory switch.
+Make Fast Mode defaults per model. `/fast default` sets only the current model's startup default and turns this session's switch to match. Unconfigured models start off. Switching models follows that model's in-memory switch.

--- a/.changeset/quiet-fast-toggle.md
+++ b/.changeset/quiet-fast-toggle.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-extensions": patch
+"@zhcsyncer/pi-fast-mode": patch
+---
+
+Stop Fast Mode toggles from adding a chat notification. The footer now shows only `⚡ FAST` or dim `fast`.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A collection of Pi extensions by zhcsyncer.
 - [`@zhcsyncer/pi-herdr-companion`](./packages/pi-herdr-companion) — Herdr integration with cross-workspace managed-process identity, a navigable Process Widget, compact tool rendering, temporary `/btw` side threads, blocked status, and unified settings. Install it separately; the root bundle does not enable it.
 - [`@zhcsyncer/pi-subagents`](./packages/pi-subagents) — maintained fork of `@tintinweb/pi-subagents` with a brief ConversationViewer and collapsible tool TUI (model/effort chips). Also embedded in the root bundle.
 - [`@zhcsyncer/pi-adversarial-review`](./packages/pi-adversarial-review) — deterministic multi-model adversarial code review. Install it separately; the root bundle does not include it.
-- [`@zhcsyncer/pi-fast-mode`](./packages/pi-fast-mode) — same-model Fast / Priority scheduling for OpenAI and xAI, with an in-memory `/fast` and Ctrl+F switch.
+- [`@zhcsyncer/pi-fast-mode`](./packages/pi-fast-mode) — same-model Fast / Priority scheduling for OpenAI and xAI, with a per-model in-memory `/fast` and Ctrl+F switch.
 
   ![Fast Mode footer status](./packages/pi-fast-mode/assets/demo-fast-mode-status.png)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,7 +27,7 @@ zhcsyncer 维护的一组 Pi extensions。
 - [`@zhcsyncer/pi-herdr-companion`](./packages/pi-herdr-companion) — Herdr 集成，提供跨 Workspace 托管进程身份、可导航 Process Widget、紧凑 Tool 渲染、临时 `/btw` 支线、blocked 状态和统一设置；需单独安装，根 bundle 不会启用。
 - [`@zhcsyncer/pi-subagents`](./packages/pi-subagents) — `@tintinweb/pi-subagents` 维护 fork：摘要 ConversationViewer + 可折叠 tool TUI（model/effort）。也嵌入根 bundle。
 - [`@zhcsyncer/pi-adversarial-review`](./packages/pi-adversarial-review) — 确定性多模型对抗式代码评审。需单独安装，根 bundle 不包含。
-- [`@zhcsyncer/pi-fast-mode`](./packages/pi-fast-mode) — 同一模型的 Fast / Priority 调度，面向 OpenAI 与 xAI，内存开关为 `/fast` 和 Ctrl+F。
+- [`@zhcsyncer/pi-fast-mode`](./packages/pi-fast-mode) — 同一模型的 Fast / Priority 调度，面向 OpenAI 与 xAI，按模型的内存开关为 `/fast` 和 Ctrl+F。
 
   ![Fast Mode 底栏状态](./packages/pi-fast-mode/assets/demo-fast-mode-status.png)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@
 | [pi-glance/working-indicator.md](./pi-glance/working-indicator.md) | 已落地 | Glance working row 的显示边界与主题跟随 |
 | [pi-meter/extension.md](./pi-meter/extension.md) | 已落地 | 本地账本与订阅剩余两套账 |
 | [pi-meter/quota-status.md](./pi-meter/quota-status.md) | 已落地 | 底栏只画当前模型套餐；本地滚动/日历窗口 |
-| [pi-fast-mode/extension.md](./pi-fast-mode/extension.md) | 已落地 | 同模型 Fast / Priority：内存开关、loader 红线 |
+| [pi-fast-mode/extension.md](./pi-fast-mode/extension.md) | 已落地 | 同模型 Fast / Priority：按模型内存开关、loader 红线 |
 | [pi-herdr-companion/extension.md](./pi-herdr-companion/extension.md) | 已落地 | Herdr 可见进程、临时 `/btw`、blocked、当前 linked worktree 的确定性 cleanup；worker 实现保留但不注册 |
 | [pi-tool-display-intent/aggregate-layout.md](./pi-tool-display-intent/aggregate-layout.md) | 已落地 | aggregate Tools 账本：按请求汇总、不改执行与历史 |
 | [pi-tool-display-intent/aggregate-steer.md](./pi-tool-display-intent/aggregate-steer.md) | 已落地 | steer 留在同一轮：钉顶首行、结束后留一行、展开后时间线高亮 |

--- a/docs/pi-fast-mode/extension.md
+++ b/docs/pi-fast-mode/extension.md
@@ -9,7 +9,7 @@
 ## 红线
 
 - `/fast` 和 `Ctrl+F` 只改当前模型的内存开关，不写 session jsonl。松开 `Ctrl+F` 不再切换。
-- `/fast default` 只写当前模型的下次默认，不改当前开关。不支持 Fast 的模型直接失败。没有「所有模型」默认；旧的全局 `enabled` 布尔不再读取。
+- `/fast default` 写当前模型的下次默认，并且当前这次会话的开关跟着改。不支持 Fast 的模型直接失败。没有「所有模型」默认；旧的全局 `enabled` 布尔不再读取。
 - 换模型使用该模型自己的内存开关；第一次用到时从设置读取，没配过就是关。`/new` `/resume` `/fork` 保留各模型内存开关；`/reload` 或重启才重读设置。
 - 提供商列表写死：OpenAI、Codex、xAI。没有用户白名单。
 - Pi 0.84.3 的内置 xAI 模型已全部走 Responses。OpenAI、Codex 与内置 xAI 都通过 `registerProvider` 包官方 Responses 流；官方适配器负责序列化 `service_tier`，并按响应值调整本地费用：`priority` 通常约 2 倍，`default` 为 1 倍。

--- a/docs/pi-fast-mode/extension.md
+++ b/docs/pi-fast-mode/extension.md
@@ -4,12 +4,13 @@
 
 ## 为什么做
 
-向**同一个模型**要更高调度优先级。不是更快的模型变体，也不是 thinking-level。开关只活在当前进程；下次进程的默认值另写 `settings.json`。
+向**同一个模型**要更高调度优先级。不是更快的模型变体，也不是 thinking-level。每个模型的开关只活在当前进程；下次进程的默认按模型另写 `settings.json`。没配过的模型默认关，因为 Fast 按次计费。
 
 ## 红线
 
-- `/fast` 和 `Ctrl+F` 只改内存开关，不写 session jsonl。松开 `Ctrl+F` 不再切换。
-- `/fast default` 只写下次进程的默认值，不改当前开关。
+- `/fast` 和 `Ctrl+F` 只改当前模型的内存开关，不写 session jsonl。松开 `Ctrl+F` 不再切换。
+- `/fast default` 只写当前模型的下次默认，不改当前开关。不支持 Fast 的模型直接失败。没有「所有模型」默认；旧的全局 `enabled` 布尔不再读取。
+- 换模型使用该模型自己的内存开关；第一次用到时从设置读取，没配过就是关。`/new` `/resume` `/fork` 保留各模型内存开关；`/reload` 或重启才重读设置。
 - 提供商列表写死：OpenAI、Codex、xAI。没有用户白名单。
 - Pi 0.84.3 的内置 xAI 模型已全部走 Responses。OpenAI、Codex 与内置 xAI 都通过 `registerProvider` 包官方 Responses 流；官方适配器负责序列化 `service_tier`，并按响应值调整本地费用：`priority` 通常约 2 倍，`default` 为 1 倍。
 - `before_provider_request` payload 钩子只兜底 `models.json` 中自定义的 xAI Completions 模型，不得再改内置 xAI Responses 请求。

--- a/docs/pi-fast-mode/extension.md
+++ b/docs/pi-fast-mode/extension.md
@@ -9,7 +9,7 @@
 ## 红线
 
 - `/fast` 和 `Ctrl+F` 只改当前模型的内存开关，不写 session jsonl。松开 `Ctrl+F` 不再切换。
-- `/fast default` 写当前模型的下次默认，并且当前这次会话的开关跟着改。不支持 Fast 的模型直接失败。没有「所有模型」默认；旧的全局 `enabled` 布尔不再读取。
+- `/fast default` 写当前模型的下次默认，并且当前这次会话的开关跟着改。不支持 Fast 的模型直接失败。没有「所有模型」默认。启动或 `/reload` 时迁移旧的全局 `enabled` 和 boolean map，写成开启名单；以前的全局开不会扩散到所有模型，并必须 notify。
 - 换模型使用该模型自己的内存开关；第一次用到时从设置读取，没配过就是关。`/new` `/resume` `/fork` 保留各模型内存开关；`/reload` 或重启才重读设置。
 - 提供商列表写死：OpenAI、Codex、xAI。没有用户白名单。
 - Pi 0.84.3 的内置 xAI 模型已全部走 Responses。OpenAI、Codex 与内置 xAI 都通过 `registerProvider` 包官方 Responses 流；官方适配器负责序列化 `service_tier`，并按响应值调整本地费用：`priority` 通常约 2 倍，`default` 为 1 倍。

--- a/packages/pi-fast-mode/README.md
+++ b/packages/pi-fast-mode/README.md
@@ -7,8 +7,9 @@
 ## Features
 
 - Toggle Fast / Priority with `/fast` or `Ctrl+F`.
-- Keep the current switch in memory only. It is never written to the session jsonl.
-- Set the next-process default with `/fast default on|off`. That command writes `settings.json` only and does not change the current switch.
+- Keep each model's current switch in memory only. It is never written to the session jsonl.
+- Set the next-process default for the **current model** with `/fast default on|off`. That command writes `settings.json` only and does not change the current switch.
+- Unconfigured models start off. There is no all-models default.
 - Show a footer status on supported models. Hide it on unsupported models and leave the request unchanged.
 
 ## Install
@@ -42,23 +43,25 @@ Toggle or set the **current** in-memory switch. `Ctrl+F` is the same toggle, wit
 /fast default off
 ```
 
-Write only `settings.json` `fast-mode.enabled`. The current switch stays as it is.
+Write only this model's startup default. The current switch stays as it is. Unsupported models reject the command.
 
 There is no `/fast status` command and no `gpt-fast-mode` compatibility alias.
 
 ## Settings
 
-The supported settings key is `fast-mode.enabled` in Pi `settings.json`:
+Defaults are stored per `provider/id` in Pi `settings.json`. Only listed models start Fast:
 
 ```json
 {
   "fast-mode": {
-    "enabled": false
+    "models": {
+      "openai/gpt-5.6": true
+    }
   }
 }
 ```
 
-`/fast default` is the supported way to change that field. Manual edits are read on `/reload` or process restart.
+`/fast default` is the supported way to change that map. Manual edits are read on `/reload` or process restart. The old `fast-mode.enabled` boolean is ignored.
 
 ## Footer
 
@@ -89,7 +92,8 @@ Do not assume every model is granted priority.
 
 ## Session lifetime
 
-- `/fast` and `Ctrl+F` change the in-memory switch only.
-- `/new`, `/resume`, and `/fork` in the same Pi process keep the current switch.
-- `/reload` or a process restart reloads `fast-mode.enabled` from `settings.json`.
-- `/fast default on|off` writes only the settings default.
+- `/fast` and `Ctrl+F` change the current model's in-memory switch only.
+- Switching models follows that model's switch. First use reads its startup default, or off if it has none.
+- `/new`, `/resume`, and `/fork` in the same Pi process keep each model's current switch.
+- `/reload` or a process restart rereads per-model defaults from `settings.json`.
+- `/fast default on|off` writes only the current model's settings default.

--- a/packages/pi-fast-mode/README.md
+++ b/packages/pi-fast-mode/README.md
@@ -59,7 +59,7 @@ Defaults are a list of `provider/id` in Pi `settings.json`. Only listed models s
 }
 ```
 
-`/fast default` is the supported way to change that map. Manual edits are read on `/reload` or process restart. The old `fast-mode.enabled` boolean is ignored.
+`/fast default` is the supported way to change that list. Manual edits are read on `/reload` or process restart. An old `fast-mode.enabled` boolean or `{ "provider/id": true }` map is rewritten on startup or `/reload`. A former global ON does not enable every model; Fast Mode posts a warning in the chat when that happens.
 
 ## Footer
 

--- a/packages/pi-fast-mode/README.md
+++ b/packages/pi-fast-mode/README.md
@@ -64,9 +64,10 @@ The supported settings key is `fast-mode.enabled` in Pi `settings.json`:
 
 ![Fast Mode footer status](./assets/demo-fast-mode-status.png)
 
-- Supported model, on: `⚡ FAST` plus `priority if granted`
-- Supported model, off: dim `fast: off · Ctrl+F`
+- Supported model, on: `⚡ FAST`
+- Supported model, off: dim `fast`
 - Unsupported model: hide the status and do not mutate the request
+- `/fast` and `Ctrl+F` update the footer only. They do not add a chat notification.
 
 ## Supported providers
 

--- a/packages/pi-fast-mode/README.md
+++ b/packages/pi-fast-mode/README.md
@@ -8,7 +8,7 @@
 
 - Toggle Fast / Priority with `/fast` or `Ctrl+F`.
 - Keep each model's current switch in memory only. It is never written to the session jsonl.
-- Set the next-process default for the **current model** with `/fast default on|off`. That command writes `settings.json` only and does not change the current switch.
+- Set the next-process default for the **current model** with `/fast default on|off`. That command also turns the current session switch to match.
 - Unconfigured models start off. There is no all-models default.
 - Show a footer status on supported models. Hide it on unsupported models and leave the request unchanged.
 
@@ -43,20 +43,18 @@ Toggle or set the **current** in-memory switch. `Ctrl+F` is the same toggle, wit
 /fast default off
 ```
 
-Write only this model's startup default. The current switch stays as it is. Unsupported models reject the command.
+Write this model's startup default and turn the current session switch to match. Unsupported models reject the command.
 
 There is no `/fast status` command and no `gpt-fast-mode` compatibility alias.
 
 ## Settings
 
-Defaults are stored per `provider/id` in Pi `settings.json`. Only listed models start Fast:
+Defaults are a list of `provider/id` in Pi `settings.json`. Only listed models start Fast:
 
 ```json
 {
   "fast-mode": {
-    "models": {
-      "openai/gpt-5.6": true
-    }
+    "models": ["openai/gpt-5.6"]
   }
 }
 ```
@@ -96,4 +94,4 @@ Do not assume every model is granted priority.
 - Switching models follows that model's switch. First use reads its startup default, or off if it has none.
 - `/new`, `/resume`, and `/fork` in the same Pi process keep each model's current switch.
 - `/reload` or a process restart rereads per-model defaults from `settings.json`.
-- `/fast default on|off` writes only the current model's settings default.
+- `/fast default on|off` writes the current model's settings default and turns this session's switch to match.

--- a/packages/pi-fast-mode/README.zh-CN.md
+++ b/packages/pi-fast-mode/README.zh-CN.md
@@ -59,7 +59,7 @@ pi install git:github.com/zhcsyncer/pi-extensions
 }
 ```
 
-`/fast default` 是修改该列表的官方方式。手动编辑会在 `/reload` 或进程重启后生效。旧的 `fast-mode.enabled` 布尔值会被忽略。
+`/fast default` 是修改该列表的官方方式。手动编辑会在 `/reload` 或进程重启后生效。旧的 `fast-mode.enabled` 布尔值或 `{ "provider/id": true }` 映射会在启动或 `/reload` 时改写。以前的全局开不会变成所有模型都开；发生这种迁移时，Fast Mode 会在聊天里给出警告。
 
 ## 状态栏
 

--- a/packages/pi-fast-mode/README.zh-CN.md
+++ b/packages/pi-fast-mode/README.zh-CN.md
@@ -64,9 +64,10 @@ pi install git:github.com/zhcsyncer/pi-extensions
 
 ![Fast Mode 底栏状态](./assets/demo-fast-mode-status.png)
 
-- 支持的模型，开启：`⚡ FAST` 加上 `priority if granted`
-- 支持的模型，关闭：暗色 `fast: off · Ctrl+F`
+- 支持的模型，开启：`⚡ FAST`
+- 支持的模型，关闭：暗色 `fast`
 - 不支持的模型：隐藏状态，并且不改请求
+- `/fast` 和 `Ctrl+F` 只更新底栏。它们不会往聊天记录里加提示。
 
 ## 支持的提供商
 

--- a/packages/pi-fast-mode/README.zh-CN.md
+++ b/packages/pi-fast-mode/README.zh-CN.md
@@ -7,8 +7,9 @@
 ## 功能
 
 - 用 `/fast` 或 `Ctrl+F` 开关 Fast / Priority。
-- 当前开关只存在内存里，不会写入 session jsonl。
-- 用 `/fast default on|off` 设置下次进程的默认值。该命令只写 `settings.json`，不改当前开关。
+- 每个模型的当前开关只存在内存里，不会写入 session jsonl。
+- 用 `/fast default on|off` 设置**当前模型**下次进程的默认值。该命令只写 `settings.json`，不改当前开关。
+- 没配过的模型默认关闭。没有「所有模型」默认。
 - 在支持的模型上显示 footer 状态。不支持的模型隐藏状态，并且不改请求。
 
 ## 安装
@@ -42,23 +43,25 @@ pi install git:github.com/zhcsyncer/pi-extensions
 /fast default off
 ```
 
-只写入 `settings.json` 的 `fast-mode.enabled`。当前开关保持不变。
+只写入当前模型的下次默认。当前开关保持不变。当前模型不支持 Fast 时命令失败。
 
 没有 `/fast status` 命令，也没有 `gpt-fast-mode` 兼容别名。
 
 ## 设置
 
-支持的设置键是 Pi `settings.json` 里的 `fast-mode.enabled`：
+默认值按 `provider/id` 存在 Pi `settings.json`。只有写进列表的模型会默认开启：
 
 ```json
 {
   "fast-mode": {
-    "enabled": false
+    "models": {
+      "openai/gpt-5.6": true
+    }
   }
 }
 ```
 
-`/fast default` 是修改该字段的官方方式。手动编辑会在 `/reload` 或进程重启后生效。
+`/fast default` 是修改该列表的官方方式。手动编辑会在 `/reload` 或进程重启后生效。旧的 `fast-mode.enabled` 布尔值会被忽略。
 
 ## 状态栏
 
@@ -89,7 +92,8 @@ pi install git:github.com/zhcsyncer/pi-extensions
 
 ## Session 生命周期
 
-- `/fast` 和 `Ctrl+F` 只改内存开关。
-- 同一 Pi 进程里的 `/new`、`/resume`、`/fork` 会保留当前开关。
-- `/reload` 或进程重启会从 `settings.json` 重新读取 `fast-mode.enabled`。
-- `/fast default on|off` 只写设置里的默认值。
+- `/fast` 和 `Ctrl+F` 只改当前模型的内存开关。
+- 换模型跟该模型自己的开关。第一次用到时读它的下次默认；没配过就是关。
+- 同一 Pi 进程里的 `/new`、`/resume`、`/fork` 会保留各模型当前开关。
+- `/reload` 或进程重启会从 `settings.json` 重新读取按模型默认。
+- `/fast default on|off` 只写当前模型的设置默认。

--- a/packages/pi-fast-mode/README.zh-CN.md
+++ b/packages/pi-fast-mode/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 - 用 `/fast` 或 `Ctrl+F` 开关 Fast / Priority。
 - 每个模型的当前开关只存在内存里，不会写入 session jsonl。
-- 用 `/fast default on|off` 设置**当前模型**下次进程的默认值。该命令只写 `settings.json`，不改当前开关。
+- 用 `/fast default on|off` 设置**当前模型**下次进程的默认值。当前这次会话的开关也会跟着改。
 - 没配过的模型默认关闭。没有「所有模型」默认。
 - 在支持的模型上显示 footer 状态。不支持的模型隐藏状态，并且不改请求。
 
@@ -43,20 +43,18 @@ pi install git:github.com/zhcsyncer/pi-extensions
 /fast default off
 ```
 
-只写入当前模型的下次默认。当前开关保持不变。当前模型不支持 Fast 时命令失败。
+写入当前模型的下次默认，并且当前这次会话的开关跟着改。当前模型不支持 Fast 时命令失败。
 
 没有 `/fast status` 命令，也没有 `gpt-fast-mode` 兼容别名。
 
 ## 设置
 
-默认值按 `provider/id` 存在 Pi `settings.json`。只有写进列表的模型会默认开启：
+默认值是 Pi `settings.json` 里一份 `provider/id` 名单。只有写进列表的模型会默认开启：
 
 ```json
 {
   "fast-mode": {
-    "models": {
-      "openai/gpt-5.6": true
-    }
+    "models": ["openai/gpt-5.6"]
   }
 }
 ```
@@ -96,4 +94,4 @@ pi install git:github.com/zhcsyncer/pi-extensions
 - 换模型跟该模型自己的开关。第一次用到时读它的下次默认；没配过就是关。
 - 同一 Pi 进程里的 `/new`、`/resume`、`/fork` 会保留各模型当前开关。
 - `/reload` 或进程重启会从 `settings.json` 重新读取按模型默认。
-- `/fast default on|off` 只写当前模型的设置默认。
+- `/fast default on|off` 写当前模型的设置默认，并且当前这次会话的开关跟着改。

--- a/packages/pi-fast-mode/extensions/fast-mode.ts
+++ b/packages/pi-fast-mode/extensions/fast-mode.ts
@@ -5,11 +5,12 @@
  * - openai / openai-codex / xAI Responses via options.serviceTier
  * - custom xAI Completions models via a payload service_tier fallback
  *
- * Toggle until you toggle again, /reload, or quit: /fast  or  Ctrl+F
- * Startup default: /fast default on|off
+ * Toggle until you toggle that model again, /reload, or quit: /fast  or  Ctrl+F
+ * Startup default for the current model: /fast default on|off
+ * Unconfigured models start off. There is no all-models default.
  *
- * Settings key: fast-mode.enabled
- * Current switch is in-memory only; it is not stored in the session.
+ * Settings: fast-mode.models["provider/id"] = true
+ * Current switches are in-memory per model; they are not stored in the session.
  */
 import {
 	clampThinkingLevel,
@@ -41,7 +42,14 @@ export type ServiceTierOptions = ReturnType<typeof buildBaseOptions> & {
 	toolChoice?: SimpleStreamOptions["toolChoice"];
 };
 
-export type FastModeModel = Pick<Model<Api>, "provider" | "api">;
+export type FastModeModel = Pick<Model<Api>, "provider" | "api"> & {
+	id?: string;
+};
+
+export type FastModeModelRef = {
+	provider?: string;
+	id?: string;
+};
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -65,14 +73,21 @@ export function readSettingsFile(): { path: string; parsed: Record<string, unkno
 	}
 }
 
-export function loadDefaultEnabled(): boolean {
+export function modelKey(model: FastModeModelRef | undefined): string | undefined {
+	if (!model?.provider || !model.id) return undefined;
+	return `${model.provider}/${model.id}`;
+}
+
+export function loadDefaultEnabled(key: string): boolean {
 	const settings = readSettingsFile();
 	if (!settings) return false;
 	const block = settings.parsed[SETTINGS_FIELD];
-	return isRecord(block) && block.enabled === true;
+	if (!isRecord(block)) return false;
+	const models = block.models;
+	return isRecord(models) && models[key] === true;
 }
 
-export function writeDefaultEnabled(enabled: boolean): void {
+export function writeDefaultEnabled(key: string, enabled: boolean): void {
 	const path = resolveSettingsPath();
 	let parsed: Record<string, unknown> = {};
 	if (existsSync(path)) {
@@ -81,7 +96,14 @@ export function writeDefaultEnabled(enabled: boolean): void {
 		parsed = raw;
 	}
 	const previous = isRecord(parsed[SETTINGS_FIELD]) ? parsed[SETTINGS_FIELD] : {};
-	parsed[SETTINGS_FIELD] = { ...previous, enabled };
+	const models = isRecord(previous.models) ? { ...previous.models } : {};
+	if (enabled) models[key] = true;
+	else delete models[key];
+	const next: Record<string, unknown> = { ...previous };
+	delete next.enabled;
+	if (Object.keys(models).length > 0) next.models = models;
+	else delete next.models;
+	parsed[SETTINGS_FIELD] = next;
 	const temporary = `${path}.${process.pid}.tmp`;
 	writeFileSync(temporary, `${JSON.stringify(parsed, null, 2)}\n`, { encoding: "utf8" });
 	try {
@@ -160,22 +182,33 @@ function modelLabel(model: ExtensionContext["model"]): string {
 }
 
 export default function fastMode(pi: ExtensionAPI): void {
-	let enabled = loadDefaultEnabled();
+	const remembered = new Map<string, boolean>();
 	let unsubscribeTerminalInput: (() => void) | undefined;
 	let shortcutRepeatGuard: ReturnType<typeof setTimeout> | undefined;
 	let shortcutLatched = false;
 
+	function enabledFor(model: FastModeModelRef | undefined): boolean {
+		const key = modelKey(model);
+		if (!key) return false;
+		const cached = remembered.get(key);
+		if (cached !== undefined) return cached;
+		const fromSettings = loadDefaultEnabled(key);
+		remembered.set(key, fromSettings);
+		return fromSettings;
+	}
+
 	function resolveTier(model: Model<Api> | undefined): typeof SERVICE_TIER | undefined {
-		return resolveServiceTier(enabled, model);
+		return resolveServiceTier(enabledFor(model), model);
 	}
 
 	function updateStatus(ctx: ExtensionContext): void {
-		const label = footerStatusLabel(enabled, supportsApi(ctx.model));
+		const on = enabledFor(ctx.model);
+		const label = footerStatusLabel(on, supportsApi(ctx.model));
 		if (!label) {
 			ctx.ui.setStatus(STATUS_KEY, undefined);
 			return;
 		}
-		if (enabled) {
+		if (on) {
 			ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("warning", ctx.ui.theme.bold(label)));
 			return;
 		}
@@ -183,7 +216,8 @@ export default function fastMode(pi: ExtensionAPI): void {
 	}
 
 	function setEnabled(ctx: ExtensionContext, next: boolean): void {
-		enabled = next;
+		const key = modelKey(ctx.model);
+		if (key) remembered.set(key, next);
 		updateStatus(ctx);
 		// Successful toggles stay in the footer. notify() is appended to the chat
 		// transcript, so only use it when the footer cannot show the new state.
@@ -193,20 +227,29 @@ export default function fastMode(pi: ExtensionAPI): void {
 	}
 
 	function toggle(ctx: ExtensionContext): void {
-		setEnabled(ctx, !enabled);
+		setEnabled(ctx, !enabledFor(ctx.model));
 	}
 
 	function setDefaultEnabled(ctx: ExtensionContext, next: boolean): void {
+		if (!supportsApi(ctx.model)) {
+			ctx.ui.notify(`Cannot set Fast default: ${modelLabel(ctx.model)} is not supported`, "error");
+			return;
+		}
+		const key = modelKey(ctx.model);
+		if (!key) {
+			ctx.ui.notify("Cannot set Fast default: unknown model", "error");
+			return;
+		}
 		try {
-			writeDefaultEnabled(next);
+			writeDefaultEnabled(key, next);
 		} catch (error) {
 			ctx.ui.notify(`Failed to write fast-mode default: ${error instanceof Error ? error.message : String(error)}`, "error");
 			return;
 		}
 		ctx.ui.notify(
 			next
-				? "Startup default is Fast ON. Current switch is unchanged."
-				: "Startup default is Fast OFF. Current switch is unchanged.",
+				? `Startup default for ${key} is Fast ON. Current switch is unchanged.`
+				: `Startup default for ${key} is Fast OFF. Current switch is unchanged.`,
 			"info",
 		);
 		updateStatus(ctx);
@@ -252,14 +295,14 @@ export default function fastMode(pi: ExtensionAPI): void {
 	// payload hook only for custom xAI Completions models from models.json.
 	pi.on("before_provider_request", (event, ctx) => {
 		return applyXaiPriorityPayload({
-			enabled,
+			enabled: enabledFor(ctx.model),
 			model: ctx.model,
 			payload: event.payload,
 		});
 	});
 
 	pi.registerCommand("fast", {
-		description: "Toggle Fast / Priority mode, or set the new-session default",
+		description: "Toggle Fast / Priority mode, or set this model's startup default",
 		getArgumentCompletions: (prefix) => {
 			const values = ["on", "off", "default on", "default off"];
 			const items = values.filter((value) => value.startsWith(prefix.trim().toLowerCase()));
@@ -297,7 +340,7 @@ export default function fastMode(pi: ExtensionAPI): void {
 
 	pi.on("session_start", (event, ctx) => {
 		if (shouldReloadEnabledFromSettings(event.reason)) {
-			enabled = loadDefaultEnabled();
+			remembered.clear();
 		}
 		unsubscribeTerminalInput?.();
 		if (shortcutRepeatGuard) clearTimeout(shortcutRepeatGuard);

--- a/packages/pi-fast-mode/extensions/fast-mode.ts
+++ b/packages/pi-fast-mode/extensions/fast-mode.ts
@@ -28,6 +28,8 @@ import { join } from "node:path";
 import { buildBaseOptions } from "./stream-options.ts";
 
 export const STATUS_KEY = "fast-mode";
+export const STATUS_ON = "⚡ FAST";
+export const STATUS_OFF = "fast";
 export const SETTINGS_FIELD = "fast-mode";
 export const SERVICE_TIER = "priority" as const;
 export const SHORTCUT = "ctrl+f";
@@ -132,6 +134,11 @@ export function resolveServiceTier(
 	return SERVICE_TIER;
 }
 
+export function footerStatusLabel(enabled: boolean, supported: boolean): string | undefined {
+	if (!supported) return undefined;
+	return enabled ? STATUS_ON : STATUS_OFF;
+}
+
 export function shouldReloadEnabledFromSettings(reason: unknown): boolean {
 	return reason === "startup" || reason === "reload";
 }
@@ -163,35 +170,26 @@ export default function fastMode(pi: ExtensionAPI): void {
 	}
 
 	function updateStatus(ctx: ExtensionContext): void {
-		if (!supportsApi(ctx.model)) {
+		const label = footerStatusLabel(enabled, supportsApi(ctx.model));
+		if (!label) {
 			ctx.ui.setStatus(STATUS_KEY, undefined);
 			return;
 		}
-		if (!enabled) {
-			ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("dim", "fast: off · Ctrl+F"));
+		if (enabled) {
+			ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("warning", ctx.ui.theme.bold(label)));
 			return;
 		}
-		const label = ctx.ui.theme.fg("warning", ctx.ui.theme.bold("⚡ FAST"));
-		const detail = ctx.ui.theme.fg("muted", " priority if granted");
-		ctx.ui.setStatus(STATUS_KEY, `${label}${detail}`);
-	}
-
-	function announce(ctx: ExtensionContext): void {
-		if (!enabled) {
-			ctx.ui.notify("Fast mode OFF", "info");
-			return;
-		}
-		if (supportsApi(ctx.model)) {
-			ctx.ui.notify(`Fast mode ON · requesting ${SERVICE_TIER} · billed if granted`, "warning");
-			return;
-		}
-		ctx.ui.notify(`Fast mode ON, but ${modelLabel(ctx.model)} is not supported`, "warning");
+		ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("dim", label));
 	}
 
 	function setEnabled(ctx: ExtensionContext, next: boolean): void {
 		enabled = next;
 		updateStatus(ctx);
-		announce(ctx);
+		// Successful toggles stay in the footer. notify() is appended to the chat
+		// transcript, so only use it when the footer cannot show the new state.
+		if (next && !supportsApi(ctx.model)) {
+			ctx.ui.notify(`Fast mode ON, but ${modelLabel(ctx.model)} is not supported`, "warning");
+		}
 	}
 
 	function toggle(ctx: ExtensionContext): void {

--- a/packages/pi-fast-mode/extensions/fast-mode.ts
+++ b/packages/pi-fast-mode/extensions/fast-mode.ts
@@ -79,16 +79,50 @@ export function modelKey(model: FastModeModelRef | undefined): string | undefine
 	return `${model.provider}/${model.id}`;
 }
 
-export function readEnabledModelList(block: unknown): string[] {
-	if (!isRecord(block) || !Array.isArray(block.models)) return [];
+export type SettingsMigration = {
+	migrated: boolean;
+	notice?: string;
+};
+
+export function uniqueModelIds(items: string[]): string[] {
 	const seen = new Set<string>();
 	const models: string[] = [];
-	for (const item of block.models) {
-		if (typeof item !== "string" || item.length === 0 || seen.has(item)) continue;
+	for (const item of items) {
+		if (item.length === 0 || seen.has(item)) continue;
 		seen.add(item);
 		models.push(item);
 	}
 	return models;
+}
+
+export function readEnabledModelList(block: unknown): string[] {
+	if (!isRecord(block) || !Array.isArray(block.models)) return [];
+	return uniqueModelIds(block.models.filter((item): item is string => typeof item === "string"));
+}
+
+export function modelsFromLegacyMap(models: unknown): string[] | undefined {
+	if (!isRecord(models)) return undefined;
+	return uniqueModelIds(
+		Object.entries(models)
+			.filter(([, value]) => value === true)
+			.map(([key]) => key),
+	);
+}
+
+function writeSettingsFile(parsed: Record<string, unknown>): void {
+	const path = resolveSettingsPath();
+	const temporary = `${path}.${process.pid}.tmp`;
+	writeFileSync(temporary, `${JSON.stringify(parsed, null, 2)}\n`, { encoding: "utf8" });
+	try {
+		renameSync(temporary, path);
+	} catch (error) {
+		try {
+			unlinkSync(temporary);
+		} catch {
+			// ignore cleanup failure
+		}
+		throw error;
+	}
 }
 
 export function loadDefaultEnabled(key: string): boolean {
@@ -113,18 +147,42 @@ export function writeDefaultEnabled(key: string, enabled: boolean): void {
 	if (models.length > 0) next.models = models;
 	else delete next.models;
 	parsed[SETTINGS_FIELD] = next;
-	const temporary = `${path}.${process.pid}.tmp`;
-	writeFileSync(temporary, `${JSON.stringify(parsed, null, 2)}\n`, { encoding: "utf8" });
-	try {
-		renameSync(temporary, path);
-	} catch (error) {
-		try {
-			unlinkSync(temporary);
-		} catch {
-			// ignore cleanup failure
-		}
-		throw error;
+	writeSettingsFile(parsed);
+}
+
+export function migrateFastModeSettings(): SettingsMigration {
+	const settings = readSettingsFile();
+	if (!settings) return { migrated: false };
+	const block = settings.parsed[SETTINGS_FIELD];
+	if (!isRecord(block)) return { migrated: false };
+
+	const hasLegacyEnabled = Object.hasOwn(block, "enabled");
+	const fromMap = modelsFromLegacyMap(block.models);
+	if (!hasLegacyEnabled && fromMap === undefined) return { migrated: false };
+
+	const models = fromMap ?? readEnabledModelList(block);
+	const hadGlobalOn = block.enabled === true;
+	const next: Record<string, unknown> = { ...block };
+	delete next.enabled;
+	if (models.length > 0) next.models = models;
+	else delete next.models;
+	settings.parsed[SETTINGS_FIELD] = next;
+	writeSettingsFile(settings.parsed);
+
+	const notices: string[] = [];
+	if (hadGlobalOn) {
+		notices.push(
+			"Fast Mode no longer has a global ON default. Unconfigured models start off. Use /fast default on for each model you want Fast.",
+		);
 	}
+	if (fromMap !== undefined) {
+		notices.push(
+			fromMap.length > 0
+				? `Fast Mode defaults are now an allowlist. Kept: ${fromMap.join(", ")}.`
+				: "Fast Mode defaults are now an allowlist. No models were kept.",
+		);
+	}
+	return notices.length > 0 ? { migrated: true, notice: notices.join(" ") } : { migrated: true };
 }
 
 export function supportsApi(model: FastModeModel | undefined): boolean {
@@ -347,6 +405,15 @@ export default function fastMode(pi: ExtensionAPI): void {
 
 	pi.on("session_start", (event, ctx) => {
 		if (shouldReloadEnabledFromSettings(event.reason)) {
+			try {
+				const migration = migrateFastModeSettings();
+				if (migration.notice) ctx.ui.notify(migration.notice, "warning");
+			} catch (error) {
+				ctx.ui.notify(
+					`Failed to migrate fast-mode settings: ${error instanceof Error ? error.message : String(error)}`,
+					"error",
+				);
+			}
 			remembered.clear();
 		}
 		unsubscribeTerminalInput?.();

--- a/packages/pi-fast-mode/extensions/fast-mode.ts
+++ b/packages/pi-fast-mode/extensions/fast-mode.ts
@@ -7,9 +7,10 @@
  *
  * Toggle until you toggle that model again, /reload, or quit: /fast  or  Ctrl+F
  * Startup default for the current model: /fast default on|off
+ * That command also turns this session's switch to match.
  * Unconfigured models start off. There is no all-models default.
  *
- * Settings: fast-mode.models["provider/id"] = true
+ * Settings: fast-mode.models is a list of "provider/id" that start Fast.
  * Current switches are in-memory per model; they are not stored in the session.
  */
 import {
@@ -78,13 +79,22 @@ export function modelKey(model: FastModeModelRef | undefined): string | undefine
 	return `${model.provider}/${model.id}`;
 }
 
+export function readEnabledModelList(block: unknown): string[] {
+	if (!isRecord(block) || !Array.isArray(block.models)) return [];
+	const seen = new Set<string>();
+	const models: string[] = [];
+	for (const item of block.models) {
+		if (typeof item !== "string" || item.length === 0 || seen.has(item)) continue;
+		seen.add(item);
+		models.push(item);
+	}
+	return models;
+}
+
 export function loadDefaultEnabled(key: string): boolean {
 	const settings = readSettingsFile();
 	if (!settings) return false;
-	const block = settings.parsed[SETTINGS_FIELD];
-	if (!isRecord(block)) return false;
-	const models = block.models;
-	return isRecord(models) && models[key] === true;
+	return readEnabledModelList(settings.parsed[SETTINGS_FIELD]).includes(key);
 }
 
 export function writeDefaultEnabled(key: string, enabled: boolean): void {
@@ -96,12 +106,11 @@ export function writeDefaultEnabled(key: string, enabled: boolean): void {
 		parsed = raw;
 	}
 	const previous = isRecord(parsed[SETTINGS_FIELD]) ? parsed[SETTINGS_FIELD] : {};
-	const models = isRecord(previous.models) ? { ...previous.models } : {};
-	if (enabled) models[key] = true;
-	else delete models[key];
+	const models = readEnabledModelList(previous).filter((item) => item !== key);
+	if (enabled) models.push(key);
 	const next: Record<string, unknown> = { ...previous };
 	delete next.enabled;
-	if (Object.keys(models).length > 0) next.models = models;
+	if (models.length > 0) next.models = models;
 	else delete next.models;
 	parsed[SETTINGS_FIELD] = next;
 	const temporary = `${path}.${process.pid}.tmp`;
@@ -246,13 +255,11 @@ export default function fastMode(pi: ExtensionAPI): void {
 			ctx.ui.notify(`Failed to write fast-mode default: ${error instanceof Error ? error.message : String(error)}`, "error");
 			return;
 		}
+		setEnabled(ctx, next);
 		ctx.ui.notify(
-			next
-				? `Startup default for ${key} is Fast ON. Current switch is unchanged.`
-				: `Startup default for ${key} is Fast OFF. Current switch is unchanged.`,
+			next ? `Startup default for ${key} is Fast ON.` : `Startup default for ${key} is Fast OFF.`,
 			"info",
 		);
-		updateStatus(ctx);
 	}
 
 	pi.registerProvider("openai-codex", {

--- a/packages/pi-fast-mode/tests/fast-mode-command.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode-command.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -7,6 +7,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import fastMode, {
 	footerStatusLabel,
 	loadDefaultEnabled,
+	resolveSettingsPath,
 	SHORTCUT_REPEAT_GUARD_MS,
 	STATUS_KEY,
 	writeDefaultEnabled,
@@ -24,15 +25,33 @@ type RegisteredProvider = {
 type EventHandler = (event: { reason?: string; payload?: unknown }, ctx: ExtensionContext) => unknown;
 
 const KITTY_CTRL_F_RELEASE = "\x1b[102;5:3u";
+const GPT = {
+	provider: "openai",
+	id: "gpt-5.6",
+	api: "openai-responses",
+} as const;
+const GROK = {
+	provider: "xai",
+	id: "grok-4.6",
+	api: "openai-responses",
+} as const;
+const CLAUDE = {
+	provider: "anthropic",
+	id: "claude-opus-4-6",
+	api: "anthropic-messages",
+} as const;
+
+function setCtxModel(
+	ctx: ExtensionContext,
+	model: { provider: string; id: string; api: string },
+): void {
+	(ctx as unknown as { model: { provider: string; id: string; api: string } }).model = model;
+}
 
 function createCtx(
 	statuses: Array<string | undefined>,
 	notifies: string[],
-	model: { provider: string; id: string; api: string } = {
-		provider: "openai",
-		id: "gpt-5.6",
-		api: "openai-responses",
-	},
+	model: { provider: string; id: string; api: string } = GPT,
 ) {
 	return {
 		model,
@@ -132,7 +151,7 @@ test("registers built-in xAI on the Responses wrapper", async () => {
 	});
 });
 
-test("/fast default writes settings and leaves the current switch unchanged", async () => {
+test("/fast default writes this model's setting and leaves the current switch unchanged", async () => {
 	await withLoadedExtension(async ({ commands, handlers }) => {
 		const statuses: Array<string | undefined> = [];
 		const notifies: string[] = [];
@@ -150,9 +169,17 @@ test("/fast default writes settings and leaves the current switch unchanged", as
 		notifies.length = 0;
 		await command.handler("default off", ctx);
 
-		assert.equal(loadDefaultEnabled(), false);
+		assert.equal(loadDefaultEnabled("openai/gpt-5.6"), false);
 		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+		assert.match(notifies.join("\n"), /openai\/gpt-5\.6/);
 		assert.match(notifies.join("\n"), /Current switch is unchanged/);
+
+		statuses.length = 0;
+		notifies.length = 0;
+		await command.handler("default on", ctx);
+		assert.equal(loadDefaultEnabled("openai/gpt-5.6"), true);
+		assert.equal(loadDefaultEnabled("xai/grok-4.6"), false);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
 	});
 });
 
@@ -233,7 +260,7 @@ test("/new /resume /fork keep the current switch; /reload rereads settings", asy
 		sessionStart({ reason: "startup" }, ctx);
 		await command.handler("on", ctx);
 		assert.equal(notifies.length, 0);
-		writeDefaultEnabled(false);
+		writeDefaultEnabled("openai/gpt-5.6", false);
 
 		for (const reason of ["new", "resume", "fork"] as const) {
 			sessionStart({ reason }, ctx);
@@ -242,7 +269,7 @@ test("/new /resume /fork keep the current switch; /reload rereads settings", asy
 
 		sessionStart({ reason: "reload" }, ctx);
 		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
-		assert.equal(loadDefaultEnabled(), false);
+		assert.equal(loadDefaultEnabled("openai/gpt-5.6"), false);
 	});
 });
 
@@ -274,11 +301,7 @@ test("/fast on notifies only when the footer cannot show the state", async () =>
 	await withLoadedExtension(async ({ commands, handlers }) => {
 		const statuses: Array<string | undefined> = [];
 		const notifies: string[] = [];
-		const ctx = createCtx(statuses, notifies, {
-			provider: "anthropic",
-			id: "claude-opus-4-6",
-			api: "anthropic-messages",
-		});
+		const ctx = createCtx(statuses, notifies, CLAUDE);
 		const command = commands.get("fast");
 		const sessionStart = handlers.get("session_start");
 		assert.ok(command);
@@ -290,5 +313,144 @@ test("/fast on notifies only when the footer cannot show the state", async () =>
 		await command.handler("on", ctx);
 		assert.equal(statuses.at(-1), undefined);
 		assert.match(notifies.join("\n"), /not supported/);
+	});
+});
+
+test("/fast default refuses unsupported models and does not write settings", async () => {
+	await withLoadedExtension(async ({ commands, handlers }) => {
+		const statuses: Array<string | undefined> = [];
+		const notifies: string[] = [];
+		const ctx = createCtx(statuses, notifies, CLAUDE);
+		const command = commands.get("fast");
+		const sessionStart = handlers.get("session_start");
+		assert.ok(command);
+		assert.ok(sessionStart);
+
+		sessionStart({ reason: "startup" }, ctx);
+		await command.handler("default on", ctx);
+		assert.match(notifies.join("\n"), /Cannot set Fast default/);
+		assert.equal(loadDefaultEnabled("anthropic/claude-opus-4-6"), false);
+	});
+});
+
+test("legacy global enabled does not turn Fast on at startup", async () => {
+	await withLoadedExtension(async ({ handlers }) => {
+		await writeFile(
+			resolveSettingsPath(),
+			`${JSON.stringify({ "fast-mode": { enabled: true } })}\n`,
+			"utf8",
+		);
+		const statuses: Array<string | undefined> = [];
+		const notifies: string[] = [];
+		const ctx = createCtx(statuses, notifies);
+		const sessionStart = handlers.get("session_start");
+		assert.ok(sessionStart);
+
+		sessionStart({ reason: "startup" }, ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
+		assert.equal(notifies.length, 0);
+	});
+});
+
+test("switching models follows that model's in-memory switch", async () => {
+	await withLoadedExtension(async ({ commands, handlers }) => {
+		const statuses: Array<string | undefined> = [];
+		const notifies: string[] = [];
+		const ctx = createCtx(statuses, notifies, GPT);
+		const command = commands.get("fast");
+		const sessionStart = handlers.get("session_start");
+		const modelSelect = handlers.get("model_select");
+		assert.ok(command);
+		assert.ok(sessionStart);
+		assert.ok(modelSelect);
+
+		sessionStart({ reason: "startup" }, ctx);
+		await command.handler("on", ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+
+		setCtxModel(ctx, GROK);
+		modelSelect({}, ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
+
+		setCtxModel(ctx, GPT);
+		modelSelect({}, ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+		assert.equal(notifies.length, 0);
+	});
+});
+
+test("first use of a model reads only that model's startup default", async () => {
+	await withLoadedExtension(async ({ commands, handlers }) => {
+		writeDefaultEnabled("openai/gpt-5.6", true);
+		const statuses: Array<string | undefined> = [];
+		const notifies: string[] = [];
+		const ctx = createCtx(statuses, notifies, GPT);
+		const command = commands.get("fast");
+		const sessionStart = handlers.get("session_start");
+		const modelSelect = handlers.get("model_select");
+		assert.ok(command);
+		assert.ok(sessionStart);
+		assert.ok(modelSelect);
+
+		sessionStart({ reason: "startup" }, ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+
+		setCtxModel(ctx, GROK);
+		modelSelect({}, ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
+
+		await command.handler("on", ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+
+		sessionStart({ reason: "new" }, ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+
+		sessionStart({ reason: "reload" }, ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
+		assert.equal(loadDefaultEnabled("xai/grok-4.6"), false);
+	});
+});
+
+test("/fast default on does not turn the current switch on until reload", async () => {
+	await withLoadedExtension(async ({ commands, handlers }) => {
+		const statuses: Array<string | undefined> = [];
+		const notifies: string[] = [];
+		const ctx = createCtx(statuses, notifies, GPT);
+		const command = commands.get("fast");
+		const sessionStart = handlers.get("session_start");
+		assert.ok(command);
+		assert.ok(sessionStart);
+
+		sessionStart({ reason: "startup" }, ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
+
+		await command.handler("default on", ctx);
+		assert.equal(loadDefaultEnabled("openai/gpt-5.6"), true);
+		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
+
+		sessionStart({ reason: "reload" }, ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+	});
+});
+
+test("turning Fast on for an unsupported model does not leak to the next model", async () => {
+	await withLoadedExtension(async ({ commands, handlers }) => {
+		const statuses: Array<string | undefined> = [];
+		const notifies: string[] = [];
+		const ctx = createCtx(statuses, notifies, CLAUDE);
+		const command = commands.get("fast");
+		const sessionStart = handlers.get("session_start");
+		const modelSelect = handlers.get("model_select");
+		assert.ok(command);
+		assert.ok(sessionStart);
+		assert.ok(modelSelect);
+
+		sessionStart({ reason: "startup" }, ctx);
+		await command.handler("on", ctx);
+		assert.match(notifies.join("\n"), /not supported/);
+
+		setCtxModel(ctx, GPT);
+		modelSelect({}, ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
 	});
 });

--- a/packages/pi-fast-mode/tests/fast-mode-command.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode-command.test.ts
@@ -334,7 +334,7 @@ test("/fast default refuses unsupported models and does not write settings", asy
 	});
 });
 
-test("legacy global enabled does not turn Fast on at startup", async () => {
+test("legacy global ON migrates off and warns once at startup", async () => {
 	await withLoadedExtension(async ({ handlers }) => {
 		await writeFile(
 			resolveSettingsPath(),
@@ -349,7 +349,37 @@ test("legacy global enabled does not turn Fast on at startup", async () => {
 
 		sessionStart({ reason: "startup" }, ctx);
 		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
+		assert.match(notifies.join("\n"), /no longer has a global ON default/);
+		assert.equal(loadDefaultEnabled("openai/gpt-5.6"), false);
+
+		notifies.length = 0;
+		sessionStart({ reason: "new" }, ctx);
 		assert.equal(notifies.length, 0);
+
+		sessionStart({ reason: "reload" }, ctx);
+		assert.equal(notifies.length, 0);
+	});
+});
+
+test("legacy model map migrates to an allowlist and warns at startup", async () => {
+	await withLoadedExtension(async ({ handlers }) => {
+		await writeFile(
+			resolveSettingsPath(),
+			`${JSON.stringify({ "fast-mode": { models: { "openai/gpt-5.6": true, "xai/grok-4.6": false } } })}\n`,
+			"utf8",
+		);
+		const statuses: Array<string | undefined> = [];
+		const notifies: string[] = [];
+		const ctx = createCtx(statuses, notifies, GPT);
+		const sessionStart = handlers.get("session_start");
+		assert.ok(sessionStart);
+
+		sessionStart({ reason: "startup" }, ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+		assert.match(notifies.join("\n"), /allowlist/);
+		assert.match(notifies.join("\n"), /openai\/gpt-5\.6/);
+		assert.equal(loadDefaultEnabled("openai/gpt-5.6"), true);
+		assert.equal(loadDefaultEnabled("xai/grok-4.6"), false);
 	});
 });
 

--- a/packages/pi-fast-mode/tests/fast-mode-command.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode-command.test.ts
@@ -151,7 +151,7 @@ test("registers built-in xAI on the Responses wrapper", async () => {
 	});
 });
 
-test("/fast default writes this model's setting and leaves the current switch unchanged", async () => {
+test("/fast default writes this model's setting and turns the current switch to match", async () => {
 	await withLoadedExtension(async ({ commands, handlers }) => {
 		const statuses: Array<string | undefined> = [];
 		const notifies: string[] = [];
@@ -170,9 +170,9 @@ test("/fast default writes this model's setting and leaves the current switch un
 		await command.handler("default off", ctx);
 
 		assert.equal(loadDefaultEnabled("openai/gpt-5.6"), false);
-		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
 		assert.match(notifies.join("\n"), /openai\/gpt-5\.6/);
-		assert.match(notifies.join("\n"), /Current switch is unchanged/);
+		assert.match(notifies.join("\n"), /Fast OFF/);
 
 		statuses.length = 0;
 		notifies.length = 0;
@@ -180,6 +180,7 @@ test("/fast default writes this model's setting and leaves the current switch un
 		assert.equal(loadDefaultEnabled("openai/gpt-5.6"), true);
 		assert.equal(loadDefaultEnabled("xai/grok-4.6"), false);
 		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+		assert.match(notifies.join("\n"), /Fast ON/);
 	});
 });
 
@@ -411,7 +412,7 @@ test("first use of a model reads only that model's startup default", async () =>
 	});
 });
 
-test("/fast default on does not turn the current switch on until reload", async () => {
+test("/fast default on turns the current switch on immediately", async () => {
 	await withLoadedExtension(async ({ commands, handlers }) => {
 		const statuses: Array<string | undefined> = [];
 		const notifies: string[] = [];
@@ -426,7 +427,7 @@ test("/fast default on does not turn the current switch on until reload", async 
 
 		await command.handler("default on", ctx);
 		assert.equal(loadDefaultEnabled("openai/gpt-5.6"), true);
-		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
 
 		sessionStart({ reason: "reload" }, ctx);
 		assert.equal(statuses.at(-1), footerStatusLabel(true, true));

--- a/packages/pi-fast-mode/tests/fast-mode-command.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode-command.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import fastMode, {
+	footerStatusLabel,
 	loadDefaultEnabled,
 	SHORTCUT_REPEAT_GUARD_MS,
 	STATUS_KEY,
@@ -24,9 +25,17 @@ type EventHandler = (event: { reason?: string; payload?: unknown }, ctx: Extensi
 
 const KITTY_CTRL_F_RELEASE = "\x1b[102;5:3u";
 
-function createCtx(statuses: Array<string | undefined>, notifies: string[]) {
+function createCtx(
+	statuses: Array<string | undefined>,
+	notifies: string[],
+	model: { provider: string; id: string; api: string } = {
+		provider: "openai",
+		id: "gpt-5.6",
+		api: "openai-responses",
+	},
+) {
 	return {
-		model: { provider: "openai", id: "gpt-5.6", api: "openai-responses" },
+		model,
 		ui: {
 			theme: {
 				fg: (_color: string, text: string) => text,
@@ -135,14 +144,14 @@ test("/fast default writes settings and leaves the current switch unchanged", as
 
 		sessionStart({ reason: "startup" }, ctx);
 		await command.handler("on", ctx);
-		assert.match(String(statuses.at(-1)), /FAST/);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
 
 		statuses.length = 0;
 		notifies.length = 0;
 		await command.handler("default off", ctx);
 
 		assert.equal(loadDefaultEnabled(), false);
-		assert.match(String(statuses.at(-1)), /FAST/);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
 		assert.match(notifies.join("\n"), /Current switch is unchanged/);
 	});
 });
@@ -159,11 +168,13 @@ test("Ctrl+F consumes the key and keeps the repeat guard", async () => {
 		assert.equal(handle("x"), undefined);
 
 		assert.deepEqual(handle("\u0006"), { consume: true });
-		assert.match(String(statuses.at(-1)), /FAST/);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+		assert.equal(notifies.length, 0);
 		const afterFirst = statuses.at(-1);
 
 		assert.deepEqual(handle("\u0006"), { consume: true });
 		assert.equal(statuses.at(-1), afterFirst);
+		assert.equal(notifies.length, 0);
 	});
 });
 
@@ -177,12 +188,13 @@ test("Kitty Ctrl+F release is consumed and does not toggle", async () => {
 
 		sessionStart({ reason: "startup" }, ctx);
 		assert.deepEqual(handle("\u0006"), { consume: true });
-		assert.match(String(statuses.at(-1)), /FAST/);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+		assert.equal(notifies.length, 0);
 		const afterPress = statuses.at(-1);
 
 		assert.deepEqual(handle(KITTY_CTRL_F_RELEASE), { consume: true });
 		assert.equal(statuses.at(-1), afterPress);
-		assert.equal(notifies.at(-1)?.includes("Fast mode OFF"), false);
+		assert.equal(notifies.length, 0);
 	});
 });
 
@@ -197,13 +209,14 @@ test("Kitty Ctrl+F release after the repeat guard expires still does not toggle"
 
 		sessionStart({ reason: "startup" }, ctx);
 		assert.deepEqual(handle("\u0006"), { consume: true });
-		assert.match(String(statuses.at(-1)), /FAST/);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+		assert.equal(notifies.length, 0);
 		const afterPress = statuses.at(-1);
 
 		t.mock.timers.tick(SHORTCUT_REPEAT_GUARD_MS);
 		assert.deepEqual(handle(KITTY_CTRL_F_RELEASE), { consume: true });
 		assert.equal(statuses.at(-1), afterPress);
-		assert.equal(notifies.at(-1)?.includes("Fast mode OFF"), false);
+		assert.equal(notifies.length, 0);
 	});
 });
 
@@ -219,15 +232,63 @@ test("/new /resume /fork keep the current switch; /reload rereads settings", asy
 
 		sessionStart({ reason: "startup" }, ctx);
 		await command.handler("on", ctx);
+		assert.equal(notifies.length, 0);
 		writeDefaultEnabled(false);
 
 		for (const reason of ["new", "resume", "fork"] as const) {
 			sessionStart({ reason }, ctx);
-			assert.match(String(statuses.at(-1)), /FAST/, reason);
+			assert.equal(statuses.at(-1), footerStatusLabel(true, true), reason);
 		}
 
 		sessionStart({ reason: "reload" }, ctx);
-		assert.match(String(statuses.at(-1)), /fast: off/);
+		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
 		assert.equal(loadDefaultEnabled(), false);
+	});
+});
+
+test("/fast toggle updates the footer without a transcript notify", async () => {
+	await withLoadedExtension(async ({ commands, handlers }) => {
+		const statuses: Array<string | undefined> = [];
+		const notifies: string[] = [];
+		const ctx = createCtx(statuses, notifies);
+		const command = commands.get("fast");
+		const sessionStart = handlers.get("session_start");
+		assert.ok(command);
+		assert.ok(sessionStart);
+
+		sessionStart({ reason: "startup" }, ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
+		assert.equal(notifies.length, 0);
+
+		await command.handler("", ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(true, true));
+		assert.deepEqual(notifies, []);
+
+		await command.handler("off", ctx);
+		assert.equal(statuses.at(-1), footerStatusLabel(false, true));
+		assert.deepEqual(notifies, []);
+	});
+});
+
+test("/fast on notifies only when the footer cannot show the state", async () => {
+	await withLoadedExtension(async ({ commands, handlers }) => {
+		const statuses: Array<string | undefined> = [];
+		const notifies: string[] = [];
+		const ctx = createCtx(statuses, notifies, {
+			provider: "anthropic",
+			id: "claude-opus-4-6",
+			api: "anthropic-messages",
+		});
+		const command = commands.get("fast");
+		const sessionStart = handlers.get("session_start");
+		assert.ok(command);
+		assert.ok(sessionStart);
+
+		sessionStart({ reason: "startup" }, ctx);
+		assert.equal(statuses.at(-1), undefined);
+
+		await command.handler("on", ctx);
+		assert.equal(statuses.at(-1), undefined);
+		assert.match(notifies.join("\n"), /not supported/);
 	});
 });

--- a/packages/pi-fast-mode/tests/fast-mode.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode.test.ts
@@ -18,10 +18,13 @@ import {
 import {
 	applyXaiPriorityPayload,
 	buildStreamOptions,
+	footerStatusLabel,
 	loadDefaultEnabled,
 	resolveServiceTier,
 	resolveSettingsPath,
 	SERVICE_TIER,
+	STATUS_OFF,
+	STATUS_ON,
 	shouldReloadEnabledFromSettings,
 	supportsApi,
 	writeDefaultEnabled,
@@ -58,6 +61,13 @@ test("supportsApi accepts only the hardcoded OpenAI and xAI surfaces", () => {
 	assert.equal(supportsApi(model("openai-codex", "openai-responses")), true);
 	assert.equal(supportsApi(model("anthropic", "openai-responses")), false);
 	assert.equal(supportsApi(model("google", "google-generative-ai")), false);
+});
+
+test("footerStatusLabel is a short on/off badge and hides unsupported models", () => {
+	assert.equal(footerStatusLabel(true, true), STATUS_ON);
+	assert.equal(footerStatusLabel(false, true), STATUS_OFF);
+	assert.equal(footerStatusLabel(true, false), undefined);
+	assert.equal(footerStatusLabel(false, false), undefined);
 });
 
 test("resolveServiceTier injects priority only when the in-memory switch is on", () => {

--- a/packages/pi-fast-mode/tests/fast-mode.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode.test.ts
@@ -20,6 +20,7 @@ import {
 	buildStreamOptions,
 	footerStatusLabel,
 	loadDefaultEnabled,
+	migrateFastModeSettings,
 	modelKey,
 	readEnabledModelList,
 	resolveServiceTier,
@@ -406,6 +407,62 @@ test("writeDefaultEnabled atomically updates only the named model default", asyn
 		});
 		assert.equal(loadDefaultEnabled(gpt), false);
 		assert.equal(loadDefaultEnabled(grok), true);
+	});
+});
+
+test("migrateFastModeSettings rewrites legacy shapes and only notices behavior changes", async () => {
+	await withSettingsDir(async (agentDir) => {
+		const settingsPath = path.join(agentDir, "settings.json");
+		const gpt = "openai/gpt-5.6";
+		const grok = "xai/grok-4.6";
+
+		assert.deepEqual(migrateFastModeSettings(), { migrated: false });
+
+		await writeFile(
+			settingsPath,
+			`${JSON.stringify({ theme: "dark", "fast-mode": { extra: "keep-me", enabled: false } })}\n`,
+			"utf8",
+		);
+		assert.deepEqual(migrateFastModeSettings(), { migrated: true });
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			theme: "dark",
+			"fast-mode": { extra: "keep-me" },
+		});
+		assert.deepEqual(migrateFastModeSettings(), { migrated: false });
+
+		await writeFile(
+			settingsPath,
+			`${JSON.stringify({ "fast-mode": { enabled: true } })}\n`,
+			"utf8",
+		);
+		const globalOn = migrateFastModeSettings();
+		assert.equal(globalOn.migrated, true);
+		assert.match(String(globalOn.notice), /no longer has a global ON default/);
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), { "fast-mode": {} });
+		assert.equal(loadDefaultEnabled(gpt), false);
+
+		await writeFile(
+			settingsPath,
+			`${JSON.stringify({ "fast-mode": { models: { [gpt]: true, [grok]: false, extra: 1 } } })}\n`,
+			"utf8",
+		);
+		const fromMap = migrateFastModeSettings();
+		assert.equal(fromMap.migrated, true);
+		assert.match(String(fromMap.notice), /allowlist/);
+		assert.match(String(fromMap.notice), /openai\/gpt-5\.6/);
+		assert.equal(String(fromMap.notice).includes(grok), false);
+		assert.deepEqual(JSON.parse(await readFile(settingsPath, "utf8")), {
+			"fast-mode": { models: [gpt] },
+		});
+		assert.equal(loadDefaultEnabled(gpt), true);
+		assert.equal(loadDefaultEnabled(grok), false);
+
+		await writeFile(
+			settingsPath,
+			`${JSON.stringify({ "fast-mode": { models: [gpt] } })}\n`,
+			"utf8",
+		);
+		assert.deepEqual(migrateFastModeSettings(), { migrated: false });
 	});
 });
 

--- a/packages/pi-fast-mode/tests/fast-mode.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode.test.ts
@@ -20,6 +20,7 @@ import {
 	buildStreamOptions,
 	footerStatusLabel,
 	loadDefaultEnabled,
+	modelKey,
 	resolveServiceTier,
 	resolveSettingsPath,
 	SERVICE_TIER,
@@ -315,65 +316,90 @@ test("new, resume, and fork keep the current switch; startup and reload reread s
 	assert.equal(shouldReloadEnabledFromSettings(undefined), false);
 });
 
-test("loadDefaultEnabled reads only settings.json fast-mode.enabled", async () => {
+test("modelKey uses provider/id and ignores incomplete models", () => {
+	assert.equal(modelKey(undefined), undefined);
+	assert.equal(modelKey({ provider: "openai" }), undefined);
+	assert.equal(modelKey({ id: "gpt-5.6" }), undefined);
+	assert.equal(modelKey({ provider: "openai", id: "gpt-5.6" }), "openai/gpt-5.6");
+	assert.equal(modelKey({ provider: "openai-codex", id: "gpt-5.6" }), "openai-codex/gpt-5.6");
+});
+
+test("loadDefaultEnabled reads only the named model's default and ignores the old global flag", async () => {
 	await withSettingsDir(async (agentDir) => {
+		const gpt = "openai/gpt-5.6";
+		const grok = "xai/grok-4.6";
 		assert.equal(resolveSettingsPath(), path.join(agentDir, "settings.json"));
-		assert.equal(loadDefaultEnabled(), false);
+		assert.equal(loadDefaultEnabled(gpt), false);
 
 		await writeFile(
 			path.join(agentDir, "settings.json"),
 			`${JSON.stringify({ "fast-mode": { enabled: true }, other: 1 })}\n`,
 			"utf8",
 		);
-		assert.equal(loadDefaultEnabled(), true);
+		assert.equal(loadDefaultEnabled(gpt), false);
 
 		await writeFile(
 			path.join(agentDir, "settings.json"),
-			`${JSON.stringify({ "fast-mode": { enabled: false } })}\n`,
+			`${JSON.stringify({ "fast-mode": { models: { [gpt]: true } } })}\n`,
 			"utf8",
 		);
-		assert.equal(loadDefaultEnabled(), false);
+		assert.equal(loadDefaultEnabled(gpt), true);
+		assert.equal(loadDefaultEnabled(grok), false);
+		assert.equal(loadDefaultEnabled("openai-codex/gpt-5.6"), false);
+
+		await writeFile(
+			path.join(agentDir, "settings.json"),
+			`${JSON.stringify({ "fast-mode": { models: { [gpt]: false } } })}\n`,
+			"utf8",
+		);
+		assert.equal(loadDefaultEnabled(gpt), false);
 
 		await writeFile(path.join(agentDir, "settings.json"), "{not-json", "utf8");
-		assert.equal(loadDefaultEnabled(), false);
+		assert.equal(loadDefaultEnabled(gpt), false);
 	});
 });
 
-test("writeDefaultEnabled atomically updates only the fast-mode object", async () => {
+test("writeDefaultEnabled atomically updates only the named model default", async () => {
 	await withSettingsDir(async (agentDir) => {
 		const settingsPath = path.join(agentDir, "settings.json");
+		const gpt = "openai/gpt-5.6";
+		const grok = "xai/grok-4.6";
 		await writeFile(
 			settingsPath,
-			`${JSON.stringify({ theme: "dark", "fast-mode": { extra: "keep-me" } }, null, 2)}\n`,
+			`${JSON.stringify({ theme: "dark", "fast-mode": { extra: "keep-me", enabled: true } }, null, 2)}\n`,
 			"utf8",
 		);
 
-		writeDefaultEnabled(true);
+		writeDefaultEnabled(gpt, true);
 		const afterOn = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
 		assert.deepEqual(afterOn, {
 			theme: "dark",
-			"fast-mode": { extra: "keep-me", enabled: true },
+			"fast-mode": { extra: "keep-me", models: { [gpt]: true } },
 		});
-		assert.equal(loadDefaultEnabled(), true);
+		assert.equal(loadDefaultEnabled(gpt), true);
+		assert.equal(loadDefaultEnabled(grok), false);
 
-		writeDefaultEnabled(false);
+		writeDefaultEnabled(grok, true);
+		writeDefaultEnabled(gpt, false);
 		const afterOff = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
 		assert.deepEqual(afterOff, {
 			theme: "dark",
-			"fast-mode": { extra: "keep-me", enabled: false },
+			"fast-mode": { extra: "keep-me", models: { [grok]: true } },
 		});
-		assert.equal(loadDefaultEnabled(), false);
+		assert.equal(loadDefaultEnabled(gpt), false);
+		assert.equal(loadDefaultEnabled(grok), true);
 	});
 });
 
 test("writing the default does not imply a current-switch change", async () => {
 	await withSettingsDir(async () => {
+		const gpt = "openai/gpt-5.6";
 		let current = true;
-		writeDefaultEnabled(false);
+		writeDefaultEnabled(gpt, false);
 		assert.equal(current, true);
-		assert.equal(loadDefaultEnabled(), false);
+		assert.equal(loadDefaultEnabled(gpt), false);
 		current = !current;
 		assert.equal(current, false);
-		assert.equal(loadDefaultEnabled(), false);
+		assert.equal(loadDefaultEnabled(gpt), false);
 	});
 });

--- a/packages/pi-fast-mode/tests/fast-mode.test.ts
+++ b/packages/pi-fast-mode/tests/fast-mode.test.ts
@@ -21,6 +21,7 @@ import {
 	footerStatusLabel,
 	loadDefaultEnabled,
 	modelKey,
+	readEnabledModelList,
 	resolveServiceTier,
 	resolveSettingsPath,
 	SERVICE_TIER,
@@ -316,6 +317,15 @@ test("new, resume, and fork keep the current switch; startup and reload reread s
 	assert.equal(shouldReloadEnabledFromSettings(undefined), false);
 });
 
+test("readEnabledModelList keeps unique string ids and ignores the rest", () => {
+	assert.deepEqual(readEnabledModelList(undefined), []);
+	assert.deepEqual(readEnabledModelList({ models: { "openai/gpt-5.6": true } }), []);
+	assert.deepEqual(
+		readEnabledModelList({ models: ["openai/gpt-5.6", "", 1, "openai/gpt-5.6", "xai/grok-4.6"] }),
+		["openai/gpt-5.6", "xai/grok-4.6"],
+	);
+});
+
 test("modelKey uses provider/id and ignores incomplete models", () => {
 	assert.equal(modelKey(undefined), undefined);
 	assert.equal(modelKey({ provider: "openai" }), undefined);
@@ -340,7 +350,7 @@ test("loadDefaultEnabled reads only the named model's default and ignores the ol
 
 		await writeFile(
 			path.join(agentDir, "settings.json"),
-			`${JSON.stringify({ "fast-mode": { models: { [gpt]: true } } })}\n`,
+			`${JSON.stringify({ "fast-mode": { models: [gpt] } })}\n`,
 			"utf8",
 		);
 		assert.equal(loadDefaultEnabled(gpt), true);
@@ -349,7 +359,14 @@ test("loadDefaultEnabled reads only the named model's default and ignores the ol
 
 		await writeFile(
 			path.join(agentDir, "settings.json"),
-			`${JSON.stringify({ "fast-mode": { models: { [gpt]: false } } })}\n`,
+			`${JSON.stringify({ "fast-mode": { models: { [gpt]: true } } })}\n`,
+			"utf8",
+		);
+		assert.equal(loadDefaultEnabled(gpt), false);
+
+		await writeFile(
+			path.join(agentDir, "settings.json"),
+			`${JSON.stringify({ "fast-mode": { models: [] } })}\n`,
 			"utf8",
 		);
 		assert.equal(loadDefaultEnabled(gpt), false);
@@ -374,17 +391,18 @@ test("writeDefaultEnabled atomically updates only the named model default", asyn
 		const afterOn = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
 		assert.deepEqual(afterOn, {
 			theme: "dark",
-			"fast-mode": { extra: "keep-me", models: { [gpt]: true } },
+			"fast-mode": { extra: "keep-me", models: [gpt] },
 		});
 		assert.equal(loadDefaultEnabled(gpt), true);
 		assert.equal(loadDefaultEnabled(grok), false);
 
+		writeDefaultEnabled(gpt, true);
 		writeDefaultEnabled(grok, true);
 		writeDefaultEnabled(gpt, false);
 		const afterOff = JSON.parse(await readFile(settingsPath, "utf8")) as Record<string, unknown>;
 		assert.deepEqual(afterOff, {
 			theme: "dark",
-			"fast-mode": { extra: "keep-me", models: { [grok]: true } },
+			"fast-mode": { extra: "keep-me", models: [grok] },
 		});
 		assert.equal(loadDefaultEnabled(gpt), false);
 		assert.equal(loadDefaultEnabled(grok), true);


### PR DESCRIPTION
## Summary
- Successful `/fast` and Ctrl+F switches update only the footer (`⚡ FAST` / dim `fast`); they no longer add a chat notification.
- `/fast default on|off` is per current model (`provider/id` allowlist). It also turns this session's switch to match. Unconfigured models start off.
- Switching models follows that model's in-memory switch. Old global `enabled` and boolean maps migrate on startup/`/reload` with a warning; a former global ON does not enable every model.

## Release plan
| Package | Current | Bump | Target |
|---|---|---|---|
| `@zhcsyncer/pi-fast-mode` | 0.1.3 | minor | 0.2.0 |
| `@zhcsyncer/pi-extensions` | 0.28.0 | minor | 0.29.0 |

## Test plan
- [x] `pnpm --filter @zhcsyncer/pi-fast-mode check` (32 tests)