### PR TITLE
fix(cursor-ask): separate context from billed usage

### DIFF
--- a/docs/pi-provider-cursor-ask/upstream-protocol.md
+++ b/docs/pi-provider-cursor-ask/upstream-protocol.md
@@ -76,6 +76,15 @@ Cursor Ask is Node-only and manages streaming and unary RPCs directly with `node
 
 Silent retries (`PI_CURSOR_STREAM_IDLE_MAX_RETRIES`, default `5`) recover from silence and transport loss. Blind full-request restarts are blocked once text/thinking was streamed; checkpoint continuation is still allowed so partial output does not force a hard failure.
 
+## Usage and context semantics
+
+Cursor exposes two different token measurements during one agent turn:
+
+- `turnEnded` input/output/cache fields are cumulative billing totals across every internal model invocation, including invocations before and after tool calls.
+- `conversationCheckpointUpdate.tokenDetails.usedTokens` is the latest live conversation-context snapshot.
+
+Pi uses usage buckets for cost but `usage.totalTokens` for its context meter and compaction threshold. The adapter therefore preserves the disjoint cumulative billing buckets and their cost while setting `totalTokens` from the latest checkpoint when available. Intermediate `toolUse` messages report empty usage because the final `turnEnded` already includes those invocations; reporting partial output there would double-charge the turn and replace Pi's last trustworthy context snapshot with a near-zero value.
+
 ## Attributions
 
 Adapted from MIT community research and lineage docs:

--- a/providers/pi-provider-cursor-ask/src/stream/pi-adapter.ts
+++ b/providers/pi-provider-cursor-ask/src/stream/pi-adapter.ts
@@ -81,8 +81,18 @@ export function billedUsageFromTurnEnded(ended: {
   };
 }
 
-/** Convert Cursor's cache-inclusive input count into Pi's disjoint usage buckets. */
-function usageFromBilled(billed: CursorBilledUsage, model: Model<Api>): AssistantMessage["usage"] {
+/**
+ * Convert Cursor's cache-inclusive billed totals into Pi's disjoint cost buckets.
+ *
+ * One Cursor agent turn may invoke the model repeatedly around tool calls, so the billed fields
+ * are cumulative while `contextTokens` is the latest checkpoint's actual context snapshot. Pi
+ * reads `totalTokens` for context/compaction while the buckets and cost retain billed usage.
+ */
+function usageFromBilled(
+  billed: CursorBilledUsage,
+  model: Model<Api>,
+  contextTokens: number,
+): AssistantMessage["usage"] {
   const uncachedInput = Math.max(0, billed.input - billed.cacheRead - billed.cacheWrite);
   const costInput = tokenCost(uncachedInput, model.cost?.input);
   const costOutput = tokenCost(billed.output, model.cost?.output);
@@ -93,7 +103,10 @@ function usageFromBilled(billed: CursorBilledUsage, model: Model<Api>): Assistan
     output: billed.output,
     cacheRead: billed.cacheRead,
     cacheWrite: billed.cacheWrite,
-    totalTokens: uncachedInput + billed.output + billed.cacheRead + billed.cacheWrite,
+    totalTokens:
+      contextTokens > 0
+        ? contextTokens
+        : uncachedInput + billed.output + billed.cacheRead + billed.cacheWrite,
     cost: {
       input: costInput,
       output: costOutput,
@@ -111,7 +124,7 @@ export function applyCursorUsage(
 ): void {
   if (!state) return;
   if (state.billedUsage) {
-    output.usage = usageFromBilled(state.billedUsage, model);
+    output.usage = usageFromBilled(state.billedUsage, model, state.totalTokens);
     return;
   }
   const usage = computeUsage(state);

--- a/providers/pi-provider-cursor-ask/src/stream/stream-writer.ts
+++ b/providers/pi-provider-cursor-ask/src/stream/stream-writer.ts
@@ -119,7 +119,10 @@ export function createNativeStreamWriter(
       if (closed) return;
       ensureStarted();
       endActiveBlock();
-      applyCursorUsage(output, model, state);
+      // Cursor's turnEnded usage is cumulative across every internal model invocation around
+      // tool calls. Charging an intermediate toolUse message here would both double-count that
+      // turn and replace Pi's last trustworthy context snapshot with a near-zero partial value.
+      if (reason !== "toolUse") applyCursorUsage(output, model, state);
       output.stopReason = reason;
       stream.push({ type: "done", reason, message: output });
       closed = true;

--- a/providers/pi-provider-cursor-ask/src/stream/types.ts
+++ b/providers/pi-provider-cursor-ask/src/stream/types.ts
@@ -224,6 +224,7 @@ export interface StreamState {
   toolCallIndex: number;
   pendingExecs: PendingExec[];
   outputTokens: number;
+  /** Latest checkpoint `usedTokens`: a context snapshot, not turnEnded's cumulative bill. */
   totalTokens: number;
   /** Set once Cursor reported `turnEnded`; a connection close after it is a completed turn. */
   turnEnded: boolean;

--- a/providers/pi-provider-cursor-ask/tests/turn-ended-usage.test.ts
+++ b/providers/pi-provider-cursor-ask/tests/turn-ended-usage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { create } from "@bufbuild/protobuf";
-import type { Api, Model } from "@earendil-works/pi-ai";
+import { createAssistantMessageEventStream, type Api, type Model } from "@earendil-works/pi-ai";
 import {
   AgentServerMessageSchema,
   InteractionUpdateSchema,
@@ -12,6 +12,7 @@ import {
   createCursorAssistantMessage,
 } from "../src/stream/pi-adapter.js";
 import { processServerMessage } from "../src/stream/server-messages.js";
+import { createNativeStreamWriter } from "../src/stream/stream-writer.js";
 import type { StreamState } from "../src/stream/types.js";
 
 const composerCost = { input: 0.5, output: 2.5, cacheRead: 0.2, cacheWrite: 0 };
@@ -91,6 +92,34 @@ describe("applyCursorUsage", () => {
         cacheRead: 0.0016,
         cacheWrite: 0,
         total: 0.0022,
+      },
+    });
+  });
+
+  it("uses the latest checkpoint for context while preserving cumulative billed buckets", () => {
+    const output = createCursorAssistantMessage(composerModel());
+    applyCursorUsage(
+      output,
+      composerModel(),
+      emptyState({
+        // Two internal model calls around one tool execution billed 23,423 tokens in total,
+        // while Cursor's final checkpoint says the live context is only 11,775 tokens.
+        totalTokens: 11_775,
+        billedUsage: { input: 23_308, output: 115, cacheRead: 12_128, cacheWrite: 0 },
+      }),
+    );
+    expect(output.usage).toEqual({
+      input: 11_180,
+      output: 115,
+      cacheRead: 12_128,
+      cacheWrite: 0,
+      totalTokens: 11_775,
+      cost: {
+        input: 0.00559,
+        output: 0.0002875,
+        cacheRead: 0.0024256,
+        cacheWrite: 0,
+        total: 0.0083031,
       },
     });
   });
@@ -177,6 +206,27 @@ describe("applyCursorUsage", () => {
     });
     expect(output.usage.cost.cacheRead).toBe(0);
     expect(output.usage.cost.total).toBeCloseTo(0.0006);
+  });
+});
+
+describe("createNativeStreamWriter usage", () => {
+  it("leaves intermediate toolUse usage empty until cumulative turnEnded billing arrives", async () => {
+    const stream = createAssistantMessageEventStream();
+    const writer = createNativeStreamWriter(stream, composerModel());
+
+    writer.done("toolUse", emptyState({ outputTokens: 29, totalTokens: 11_648 }));
+
+    await expect(stream.result()).resolves.toMatchObject({
+      stopReason: "toolUse",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { total: 0 },
+      },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- keep Cursor `turnEnded` token buckets and costs as cumulative billing across internal model calls
- use the latest checkpoint `usedTokens` as Pi's current context snapshot and compaction input
- leave intermediate `toolUse` usage empty so it neither double-bills nor replaces the last trustworthy context snapshot

## Root cause

Cursor may invoke Composer repeatedly around tool calls. `turnEnded` totals all of those invocations, while `conversationCheckpointUpdate.tokenDetails.usedTokens` describes only the latest live context. Treating the former as Pi's `totalTokens` produced impossible values such as 600K/200K and false compaction attempts.

## Verification

- `pnpm --dir providers/pi-provider-cursor-ask check`
- `pnpm check`
- live `cursor/composer-2.5` tool round: billed buckets totaled 23,443 tokens while checkpoint/context correctly remained 11,786 tokens

No changeset: this provider is private and is not published.
