### PR TITLE
feat(cursor-ask): refuse empty blobs and publish independently

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -11,7 +11,7 @@ We have a quick list of common questions to get you started engaging with this p
 
 Packages use independent versions. The root `@zhcsyncer/pi-extensions` package embeds bundled child
 package sources, so a changeset that releases a bundled child package must also release the root
-package. Standalone packages such as `@zhcsyncer/pi-adversarial-review` do not require a root release
+package. Standalone packages such as `@zhcsyncer/pi-adversarial-review`, `pi-provider-volcengine-agent-plan`, and `pi-provider-cursor-ask` do not require a root release
 unless root package contents or documentation also change. Unchanged sibling packages must be omitted.
 
 The root release type must be at least as high as the highest child release type in the release plan:

--- a/.changeset/cursor-ask-public-release.md
+++ b/.changeset/cursor-ask-public-release.md
@@ -1,0 +1,5 @@
+---
+"pi-provider-cursor-ask": minor
+---
+
+Publish the standalone Cursor Ask provider independently. It replaces `@rahularya01/pi-cursor` under the same `cursor` login, keeps tool execution in Pi, and maps only a curated subset of models: five always-thinking 1M Claude rows, Composer 2.5 / Fast, and Grok 4.6 / Fast when the live account catalog includes them. Other Cursor families are not registered. If Cursor asks for history that is no longer in the local blob store, the current generation fails instead of returning empty history; retry rebuilds from Pi.

--- a/README.md
+++ b/README.md
@@ -44,14 +44,13 @@ Search Hub ships only in the root bundle. Adversarial Review is published indepe
 
 ## Standalone providers
 
-These providers are not included in the root bundle. Cursor Ask is repository-only and is not published to npm; Agent Plan releases independently.
+These providers are not included in the root bundle and release independently.
 
-- [`pi-provider-cursor-ask`](./providers/pi-provider-cursor-ask) — a full `@rahularya01/pi-cursor` replacement that keeps the `cursor` provider/login identity and exposes five always-thinking 1M Fable/Opus/Sonnet rows plus Composer 2.5 / Fast.
+- [`pi-provider-cursor-ask`](./providers/pi-provider-cursor-ask) — a full `@rahularya01/pi-cursor` replacement that keeps the `cursor` provider/login identity and maps only a curated subset of models: five always-thinking 1M Fable/Opus/Sonnet rows, Composer 2.5 / Fast, and Grok 4.6 / Fast when the live catalog includes them.
 - [`pi-provider-volcengine-agent-plan`](./providers/pi-provider-volcengine-agent-plan) — an unofficial Volcengine Ark Agent Plan provider with tier-aware models and Pi login.
 
 ```bash
-# From a local checkout of this repository
-pi install ./providers/pi-provider-cursor-ask
+pi install npm:pi-provider-cursor-ask
 
 pi install npm:pi-provider-volcengine-agent-plan
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,14 +44,13 @@ Search Hub 只随根 bundle 提供。Adversarial Review 独立发布，不进入
 
 ## 独立 Providers
 
-以下 provider 不进入根 bundle。Cursor Ask 只保留在仓库源码中，不发布到 npm；Agent Plan 独立发版。
+以下 provider 不进入根 bundle，各自独立发版。
 
-- [`pi-provider-cursor-ask`](./providers/pi-provider-cursor-ask) — `@rahularya01/pi-cursor` 的整仓替代版，保留 `cursor` provider/登录身份，提供 5 行始终开启 thinking 的 1M Fable/Opus/Sonnet 模型及 Composer 2.5 / Fast。
+- [`pi-provider-cursor-ask`](./providers/pi-provider-cursor-ask) — `@rahularya01/pi-cursor` 的整仓替代版，保留 `cursor` provider/登录身份，只映射部分模型：5 行始终开启 thinking 的 1M Fable/Opus/Sonnet、Composer 2.5 / Fast，以及账号实时目录里有的 Grok 4.6 / Fast。
 - [`pi-provider-volcengine-agent-plan`](./providers/pi-provider-volcengine-agent-plan) — 非官方火山方舟 Agent Plan provider，支持按套餐过滤模型和 Pi 登录。
 
 ```bash
-# 在本仓库的本地 checkout 中执行
-pi install ./providers/pi-provider-cursor-ask
+pi install npm:pi-provider-cursor-ask
 
 pi install npm:pi-provider-volcengine-agent-plan
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,8 +17,9 @@ This repository publishes these public npm packages:
 - `@zhcsyncer/pi-meter`
 - `@zhcsyncer/pi-consult`
 - `pi-provider-volcengine-agent-plan`
+- `pi-provider-cursor-ask`
 
-Packages version independently. Because the aggregate root tarball embeds bundled child sources, every bundled child release must include a root release of at least the same bump level. The standalone `@zhcsyncer/pi-adversarial-review` and `pi-provider-volcengine-agent-plan` packages are excluded from the aggregate tarball and may release without the root. Unchanged siblings remain unreleased.
+Packages version independently. Because the aggregate root tarball embeds bundled child sources, every bundled child release must include a root release of at least the same bump level. The standalone `@zhcsyncer/pi-adversarial-review`, `pi-provider-volcengine-agent-plan`, and `pi-provider-cursor-ask` packages are excluded from the aggregate tarball and may release without the root. Unchanged siblings remain unreleased.
 
 A successful publish creates package-level Git tags and GitHub Releases. The root package also owns the repository `vX.Y.Z` tag and latest release.
 

--- a/providers/pi-provider-cursor-ask/README.md
+++ b/providers/pi-provider-cursor-ask/README.md
@@ -14,14 +14,16 @@ The fork differs in these user-visible ways:
 
 - Replaces the upstream extension under the same `cursor` provider/login identity and `cursor-native` stream API.
 - Keeps tool execution in Pi: requests with Pi tools expose only the Cursor MCP tool family; tool-free questions disable Cursor tools. Cursor-native filesystem, shell, and subagent tools are not offered.
-- Exposes five always-thinking 1M Claude rows plus Composer 2.5 / Composer 2.5 Fast; all other Cursor model families are filtered out.
+- Maps only a curated subset of Cursor models, not the full catalog: five always-thinking 1M Claude rows, Composer 2.5 / Composer 2.5 Fast, and Grok 4.6 / Grok 4.6 Fast when the live account catalog includes them. Other Cursor families are not registered.
 - Uses readable picker names without a separate default-context row, because Cursor bills these Claude models at one rate up to 1M.
-- Maps only advertised Pi thinking levels. Claude uses Cursor `effort`. Composer 2.5 has no effort parameter, so `off`/`max` are an explicit Max Mode switch and other levels stay unavailable.
-- Lives in this repository only, is not published to npm, and is not included in `@zhcsyncer/pi-extensions`.
+- Maps only advertised Pi thinking levels. Claude uses Cursor `effort`. Composer 2.5 has no effort parameter, so `off`/`max` are an explicit Max Mode switch and other levels stay unavailable. Grok keeps upstream `low`/`medium`/`high`/`xhigh` routing instead of the Claude 1M rebuild.
+- Publishes independently as `pi-provider-cursor-ask` and is not included in `@zhcsyncer/pi-extensions`.
 
 See [`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md) for the maintained fork record.
 
 ## Models
+
+This package maps only the models below. The rest of the Cursor catalog is omitted.
 
 - Fable 5.1
 - Fable 5
@@ -29,8 +31,9 @@ See [`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md) for the maintained fork record.
 - Opus 4.6
 - Sonnet 5
 - Composer 2.5 / Composer 2.5 Fast
+- Grok 4.6 / Grok 4.6 Fast (only when the account catalog includes them)
 
-Thinking cannot be disabled on the five Claude rows. Depending on Cursor's metadata for a Claude model, Pi may offer `low`, `medium`, `high`, `xhigh`, and `max`; unavailable levels are omitted. Composer 2.5 exposes only `off` (standard) and `max` (Max Mode).
+Thinking cannot be disabled on the five Claude rows. Depending on Cursor's metadata for a Claude model, Pi may offer `low`, `medium`, `high`, `xhigh`, and `max`; unavailable levels are omitted. Composer 2.5 exposes only `off` (standard) and `max` (Max Mode). Grok exposes `low`, `medium`, `high`, and `xhigh`.
 
 ## Requirements
 
@@ -40,10 +43,8 @@ Thinking cannot be disabled on the five Claude rows. Depending on Cursor's metad
 
 ## Install
 
-From a local checkout of this repository:
-
 ```bash
-pi install /absolute/path/to/pi-extensions/providers/pi-provider-cursor-ask
+pi install npm:pi-provider-cursor-ask
 ```
 
 Restart Pi or run `/reload`, then sign in:
@@ -62,12 +63,14 @@ List the filtered models:
 pi --list-models cursor
 ```
 
-Select `cursor/fable-5.1`, `cursor/fable-5`, `cursor/opus-5`, `cursor/opus-4.6`, or `cursor/sonnet-5`.
+Select `cursor/fable-5.1`, `cursor/fable-5`, `cursor/opus-5`, `cursor/opus-4.6`, `cursor/sonnet-5`, or, when advertised, `cursor/grok-4.6` / `cursor/grok-4.6-fast`.
 
 Available command:
 
 - `/cursor usage` — open a dashboard of Cursor plan usage.
 - `/cursor doctor` — open a dashboard of sanitized provider diagnostics.
+
+If Cursor requests history that is no longer available locally, the current generation fails with `Refusing to answer empty` instead of sending incomplete history. Retry to rebuild from Pi's conversation history.
 
 If `@zhcsyncer/pi-meter` is also loaded, the footer follows the current Cursor model: Composer uses the Auto pool, and Claude rows use the API pool.
 

--- a/providers/pi-provider-cursor-ask/README.zh-CN.md
+++ b/providers/pi-provider-cursor-ask/README.zh-CN.md
@@ -14,14 +14,16 @@
 
 - 使用与上游相同的 `cursor` provider/登录身份和 `cursor-native` stream API 直接替换旧扩展。
 - 工具仍由 Pi 执行：有 Pi 工具的请求只开放 Cursor MCP 工具通道；无工具问答关闭 Cursor 工具。不提供 Cursor 原生文件、shell 和子代理工具。
-- 不展示完整 Cursor 目录，只提供 5 行始终开启 thinking 的 1M Claude 模型，以及 Composer 2.5 / Composer 2.5 Fast；过滤其他所有模型系列。
+- 只映射部分 Cursor 模型，不是完整目录：5 行始终开启 thinking 的 1M Claude、Composer 2.5 / Composer 2.5 Fast，以及账号实时目录里有的 Grok 4.6 / Grok 4.6 Fast。其余系列不注册。
 - Picker 不再拆默认上下文行：Cursor 对这些 Claude 模型按同一费率计到 1M。
-- 只映射明确提供的 Pi thinking 档位。Claude 映射 Cursor `effort`。Composer 2.5 没有 effort 参数，因此只用 `off`/`max` 显式开关 Max Mode，其余档位保持不可用。
-- 只保留在本仓库源码中，不发布到 npm，也不进入 `@zhcsyncer/pi-extensions` 根 bundle。
+- 只映射明确提供的 Pi thinking 档位。Claude 映射 Cursor `effort`。Composer 2.5 没有 effort 参数，因此只用 `off`/`max` 显式开关 Max Mode，其余档位保持不可用。Grok 沿用上游 `low`/`medium`/`high`/`xhigh`，不做 Claude 的 1M 重建。
+- 以 `pi-provider-cursor-ask` 独立发布到 npm，不进入 `@zhcsyncer/pi-extensions` 根 bundle。
 
 维护中的 fork 来源记录见 [`UPSTREAM_SOURCE.md`](./UPSTREAM_SOURCE.md)。
 
 ## 模型
+
+本包只映射下列模型，其余 Cursor 目录不会出现。
 
 - Fable 5.1
 - Fable 5
@@ -29,8 +31,9 @@
 - Opus 4.6
 - Sonnet 5
 - Composer 2.5 / Composer 2.5 Fast
+- Grok 4.6 / Grok 4.6 Fast（仅当账号目录包含时）
 
-5 行 Claude 模型的 Thinking 无法关闭。根据 Cursor 为各 Claude 模型返回的 metadata，Pi 可能提供 `low`、`medium`、`high`、`xhigh` 和 `max`；不可用的档位不会显示。Composer 2.5 只提供 `off`（标准）和 `max`（Max Mode）。
+5 行 Claude 模型的 Thinking 无法关闭。根据 Cursor 为各 Claude 模型返回的 metadata，Pi 可能提供 `low`、`medium`、`high`、`xhigh` 和 `max`；不可用的档位不会显示。Composer 2.5 只提供 `off`（标准）和 `max`（Max Mode）。Grok 提供 `low`、`medium`、`high` 和 `xhigh`。
 
 ## 要求
 
@@ -40,10 +43,8 @@
 
 ## 安装
 
-在本仓库的本地 checkout 中执行：
-
 ```bash
-pi install /absolute/path/to/pi-extensions/providers/pi-provider-cursor-ask
+pi install npm:pi-provider-cursor-ask
 ```
 
 重启 Pi 或执行 `/reload`，然后登录：
@@ -62,12 +63,14 @@ Provider 也可以复用受支持的 Cursor CLI 或桌面端凭证。自动化�
 pi --list-models cursor
 ```
 
-可选择 `cursor/fable-5.1`、`cursor/fable-5`、`cursor/opus-5`、`cursor/opus-4.6` 或 `cursor/sonnet-5`。
+可选择 `cursor/fable-5.1`、`cursor/fable-5`、`cursor/opus-5`、`cursor/opus-4.6`、`cursor/sonnet-5`；账号目录有时还可选 `cursor/grok-4.6` / `cursor/grok-4.6-fast`。
 
 可用命令：
 
 - `/cursor usage` — 打开 Cursor 套餐用量面板。
 - `/cursor doctor` — 打开脱敏后的 provider 诊断面板。
+
+若 Cursor 请求的历史在本地已缺失，本轮生成会以 `Refusing to answer empty` 明确失败，而不是发送残缺历史。重试即可从 Pi 对话历史重建。
 
 若同时加载了 `@zhcsyncer/pi-meter`，底栏会跟当前 Cursor 模型走：Composer 看 Auto 池，Claude 行看 API 池。
 

--- a/providers/pi-provider-cursor-ask/UPSTREAM_SOURCE.md
+++ b/providers/pi-provider-cursor-ask/UPSTREAM_SOURCE.md
@@ -15,7 +15,7 @@ The production source, generated protobuf bindings, protocol schema, build tooli
 - Published independently as the unscoped `pi-provider-cursor-ask` package; it is not embedded in the repository's root bundle.
 - Keeps the upstream `cursor` provider/login identity and `cursor-native` stream API so existing Pi credentials continue to work. OAuth label is `Cursor Ask`, and diagnostics stay `/cursor` subcommands.
 - Declares `apiKey: "$CURSOR_ACCESS_TOKEN"` on `registerProvider` so Pi will list models when that env var is set (CI smoke). Ask still resolves the token itself; upstream relies on OAuth only at this layer.
-- Filters the processed Cursor catalog in `src/models/ask-catalog.ts` to the curated 1M Claude rows plus Composer 2.5 / Composer 2.5 Fast; all other families are removed and upstream `processModels` remains unchanged.
+- Filters the processed Cursor catalog in `src/models/ask-catalog.ts` to a curated subset: 1M Claude rows, Composer 2.5 / Composer 2.5 Fast, and passthrough Grok 4.6 / Fast rows when the live catalog contains them. Other families are not registered; upstream `processModels` remains unchanged.
 - Keeps thinking enabled for Claude rows and maps supported Pi levels to explicit Cursor `requestedModelId` plus `thinking`, `context`, `effort`, and `fast` parameters. Composer 2.5 maps Pi `off`/`max` to Cursor Max Mode instead of inventing an effort parameter.
 - Accepts both current folded Claude ids and legacy bundled-catalog spellings such as `claude-4.6-opus-thinking`.
 - Replaces the upstream user README and changelog with fork-specific bilingual usage documentation and release history.

--- a/providers/pi-provider-cursor-ask/package.json
+++ b/providers/pi-provider-cursor-ask/package.json
@@ -1,7 +1,6 @@
 {
   "name": "pi-provider-cursor-ask",
   "version": "0.0.0",
-  "private": true,
   "description": "Standalone Cursor provider for focused Pi advisor and review workflows.",
   "author": "zhcsyncer",
   "license": "MIT",
@@ -38,6 +37,9 @@
     "dist",
     "src"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup --silent",
     "prepare": "pnpm build",

--- a/providers/pi-provider-cursor-ask/src/index.ts
+++ b/providers/pi-provider-cursor-ask/src/index.ts
@@ -67,6 +67,7 @@ export {
 
 export {
   ASK_MODEL_SPECS,
+  PASSTHROUGH_ASK_SPECS,
   buildAskCatalog,
   supportedAskThinkingLevels,
 } from "./models/ask-catalog.js";

--- a/providers/pi-provider-cursor-ask/src/models/ask-catalog.ts
+++ b/providers/pi-provider-cursor-ask/src/models/ask-catalog.ts
@@ -231,6 +231,47 @@ export const COMPOSER_ASK_SPECS: readonly ComposerAskSpec[] = [
   },
 ];
 
+/**
+ * Non-Claude/Composer families registered as-is from upstream processing.
+ *
+ * Unlike the Claude specs these keep whatever effort routing `processModels`
+ * derived (no forced 1M/thinking parameter rebuild), and unlike every other
+ * spec they are only emitted when the account catalog actually contains the
+ * model — never advertised from defaults alone.
+ */
+export interface PassthroughAskSpec {
+  id: string;
+  name: string;
+  /** Processed ids in priority order; raw-mode fallbacks (effort-suffixed) may follow. */
+  candidates: readonly string[];
+}
+
+export const PASSTHROUGH_ASK_SPECS: readonly PassthroughAskSpec[] = [
+  {
+    id: "grok-4.6",
+    name: "Grok 4.6",
+    candidates: ["cursor-grok-4.6", "cursor-grok-4.6-medium"],
+  },
+  {
+    id: "grok-4.6-fast",
+    name: "Grok 4.6 Fast",
+    candidates: ["cursor-grok-4.6-fast", "cursor-grok-4.6-medium-fast"],
+  },
+];
+
+function buildPassthroughCatalog(processedModels: ProcessedModel[]): ProcessedModel[] {
+  const modelsById = new Map(processedModels.map((model) => [normalizedId(model.id), model]));
+  const rows: ProcessedModel[] = [];
+  for (const spec of PASSTHROUGH_ASK_SPECS) {
+    const source = spec.candidates
+      .map((candidate) => modelsById.get(normalizedId(candidate)))
+      .find((model) => model !== undefined);
+    if (!source) continue;
+    rows.push({ ...source, id: spec.id, name: spec.name });
+  }
+  return rows;
+}
+
 const COMPOSER_MAX_MODE_EFFORT_MAP: CursorEffortMap = {
   off: "none",
   minimal: null,
@@ -329,7 +370,11 @@ export function buildAskCatalog(processedModels: ProcessedModel[]): ProcessedMod
       rawRoutingByEffort: routes,
     } satisfies ProcessedModel;
   });
-  return [...claudeModels, ...buildComposerCatalog(processedModels)];
+  return [
+    ...claudeModels,
+    ...buildComposerCatalog(processedModels),
+    ...buildPassthroughCatalog(processedModels),
+  ];
 }
 
 export function supportedAskThinkingLevels(model: ProcessedModel): PiThinkingLevel[] {

--- a/providers/pi-provider-cursor-ask/src/models/cost.ts
+++ b/providers/pi-provider-cursor-ask/src/models/cost.ts
@@ -39,6 +39,9 @@ export const MODEL_COST_TABLE: Record<string, ModelCost> = {
   "gpt-5.4-mini": { input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0 },
   "gpt-5.5": { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
   "grok-4.20": { input: 2, output: 6, cacheRead: 0.2, cacheWrite: 0 },
+  // Mirrors pi core's built-in xai/grok-4.6 row (models.dev): 2 / 6 / 0.5 / 0.
+  // Cursor-side billing may differ; users can override via models.json.
+  "grok-4.6": { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
   "kimi-k2.5": { input: 0.6, output: 3, cacheRead: 0.1, cacheWrite: 0 },
 };
 
@@ -101,6 +104,10 @@ export const MODEL_COST_PATTERNS: Array<{ match: (id: string) => boolean; cost: 
     cost: MODEL_COST_TABLE["gemini-2.5-flash"] ?? DEFAULT_COST,
   },
   { match: (id) => /gemini/i.test(id), cost: MODEL_COST_TABLE["gemini-3-pro"] ?? DEFAULT_COST },
+  {
+    match: (id) => /grok-4\.6/i.test(id),
+    cost: MODEL_COST_TABLE["grok-4.6"] ?? DEFAULT_COST,
+  },
   { match: (id) => /grok/i.test(id), cost: MODEL_COST_TABLE["grok-4.20"] ?? DEFAULT_COST },
   { match: (id) => /kimi/i.test(id), cost: MODEL_COST_TABLE["kimi-k2.5"] ?? DEFAULT_COST },
 ];

--- a/providers/pi-provider-cursor-ask/src/stream/native-core.ts
+++ b/providers/pi-provider-cursor-ask/src/stream/native-core.ts
@@ -1272,6 +1272,7 @@ function writeNativeStream(
             idleWatchdog.setTimeoutMs(parkTimeoutMs);
             idleWatchdog.reset();
           },
+          convKey,
         );
         if (progress === "work") {
           if (parkedExecCase !== undefined) {

--- a/providers/pi-provider-cursor-ask/src/stream/server-messages.ts
+++ b/providers/pi-provider-cursor-ask/src/stream/server-messages.ts
@@ -102,6 +102,7 @@ export function processServerMessage(
   onMcpExec: (exec: PendingExec) => void,
   onCheckpoint?: (checkpointBytes: Uint8Array, contextTokens?: number) => void,
   onExecUnanswerable?: (execCase: string | undefined) => void,
+  convKey?: string,
 ): StreamProgress {
   const msgCase = msg.message.case;
   debugLog("server_message", { msgCase, msg });
@@ -181,7 +182,7 @@ export function processServerMessage(
     return "none";
   }
   if (msgCase === "kvServerMessage") {
-    return handleKvMessage(msg.message.value as KvServerMessage, blobStore, sendFrame)
+    return handleKvMessage(msg.message.value as KvServerMessage, blobStore, sendFrame, convKey)
       ? "work"
       : "none";
   }
@@ -288,6 +289,7 @@ function handleKvMessage(
   kvMsg: KvServerMessage,
   blobStore: Map<string, Uint8Array>,
   sendFrame: (data: Uint8Array) => void,
+  convKey?: string,
 ): boolean {
   const kvCase = (kvMsg as any).message.case;
   if (kvCase === "getBlobArgs") {
@@ -295,22 +297,17 @@ function handleKvMessage(
     const blobIdKey = Buffer.from(blobId).toString("hex");
     const blobData = blobStore.get(blobIdKey);
     if (!blobData) {
-      // Cursor only asks for a blob it holds a reference to, so a miss means a
-      // piece of the replayed conversation is gone. The protocol has no way to
-      // say so — an empty result is indistinguishable from an empty blob — and
-      // the turn continues with that history silently blank. Record it so the
-      // amnesia is at least diagnosable from /cursor.doctor and the lifecycle log,
-      // and invalidate the checkpoint so the next turn rebuilds from Pi history.
+      // An empty result is valid history to Cursor, not a missing-blob error.
+      // Refuse the round-trip and fail this generation so the next turn rebuilds
+      // from Pi. Invalidate by conversation key: the live blob store is a clone.
       lifecycleLog("kv_blob_miss", { blobId: blobIdKey.slice(0, 16), storeSize: blobStore.size });
       setLastStreamEvent("kv_blob_miss");
-      markBlobMiss(blobStore);
+      if (convKey) markBlobMiss(convKey);
+      throw new Error(
+        `Cursor asked for blob ${blobIdKey.slice(0, 16)} that is not in the local store (${blobStore.size} entries). Refusing to answer empty. Retry to rebuild from Pi history.`,
+      );
     }
-    sendKvResponse(
-      kvMsg,
-      "getBlobResult",
-      create(GetBlobResultSchema, blobData ? { blobData } : {}),
-      sendFrame,
-    );
+    sendKvResponse(kvMsg, "getBlobResult", create(GetBlobResultSchema, { blobData }), sendFrame);
     return true;
   }
   if (kvCase === "setBlobArgs") {

--- a/providers/pi-provider-cursor-ask/src/stream/session-state.ts
+++ b/providers/pi-provider-cursor-ask/src/stream/session-state.ts
@@ -113,17 +113,16 @@ export function clearStoredCheckpoint(stored: StoredConversation, clearBlobStore
  * Drop the checkpoint and rotate the conversation id so the next turn rebuilds
  * from Pi's transcript instead of replaying holes.
  */
-export function markBlobMiss(blobStore: Map<string, Uint8Array>): void {
-  for (const [convKey, stored] of conversationStates) {
-    if (stored.blobStore !== blobStore) continue;
-    debugLog("conversation.blob_miss_invalidate", {
-      convKey,
-      hadCheckpoint: !!stored.checkpoint,
-    });
-    clearStoredCheckpoint(stored, false);
-    stored.conversationId = randomUUID();
-    persistJournal(convKey, stored);
-  }
+export function markBlobMiss(convKey: string): void {
+  const stored = conversationStates.get(convKey);
+  if (!stored) return;
+  debugLog("conversation.blob_miss_invalidate", {
+    convKey,
+    hadCheckpoint: !!stored.checkpoint,
+  });
+  clearStoredCheckpoint(stored, false);
+  stored.conversationId = randomUUID();
+  persistJournal(convKey, stored);
 }
 
 /**

--- a/providers/pi-provider-cursor-ask/tests/ask-catalog.test.ts
+++ b/providers/pi-provider-cursor-ask/tests/ask-catalog.test.ts
@@ -4,6 +4,7 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import {
   ASK_MODEL_SPECS,
   COMPOSER_ASK_SPECS,
+  PASSTHROUGH_ASK_SPECS,
   buildAskCatalog,
   supportedAskThinkingLevels,
 } from "../src/models/ask-catalog.js";
@@ -12,7 +13,8 @@ import type {
   CursorModelRouting,
   ProcessedModel,
 } from "../src/models/processing.js";
-import { modelConfig } from "../src/models/processing.js";
+import { modelConfig, processModels } from "../src/models/processing.js";
+import type { CursorModel } from "../src/stream/model-discovery.js";
 import { resolveNativeReasoningEffort } from "../src/stream/pi-adapter.js";
 
 type Level = "low" | "medium" | "high" | "xhigh" | "max";
@@ -192,6 +194,56 @@ describe("Cursor Ask catalog contract", () => {
         /not supported/i,
       );
     }
+  });
+
+  it("registers passthrough families only when the account catalog has them", () => {
+    expect(PASSTHROUGH_ASK_SPECS.map((spec) => spec.id)).toEqual(["grok-4.6", "grok-4.6-fast"]);
+    const withoutGrok = buildAskCatalog([plainModel("gpt-5.5", "GPT-5.5")]);
+    expect(withoutGrok.some((model) => /grok/i.test(model.id))).toBe(false);
+
+    // Shape the input the way live discovery does: raw effort/fast variants,
+    // folded by processModels before the Ask catalog runs.
+    const raw: CursorModel[] = [
+      "cursor-grok-4.6-low",
+      "cursor-grok-4.6-medium",
+      "cursor-grok-4.6-high",
+      "cursor-grok-4.6-xhigh",
+      "cursor-grok-4.6-low-fast",
+      "cursor-grok-4.6-medium-fast",
+      "cursor-grok-4.6-high-fast",
+      "cursor-grok-4.6-xhigh-fast",
+    ].map((id) => ({
+      id,
+      name: id,
+      reasoning: false,
+      contextWindow: 200_000,
+      maxTokens: 64_000,
+    }));
+    const catalog = buildAskCatalog(processModels(raw));
+
+    const grok = catalog.find((model) => model.id === "grok-4.6");
+    const grokFast = catalog.find((model) => model.id === "grok-4.6-fast");
+    expect(grok?.name).toBe("Grok 4.6");
+    expect(grokFast?.name).toBe("Grok 4.6 Fast");
+    expect(catalog.some((model) => model.id.startsWith("cursor-grok"))).toBe(false);
+
+    // Upstream-derived effort routing is kept as-is (no Claude-style rebuild):
+    // four selectable levels, no off/minimal/max.
+    for (const model of [grok, grokFast]) {
+      expect(model?.supportsEffort).toBe(true);
+      expect(supportedAskThinkingLevels(model!)).toEqual(["low", "medium", "high", "xhigh"]);
+      expect(model?.effortMap).toMatchObject({
+        off: null,
+        minimal: null,
+        max: null,
+      });
+      expect(model?.rawRoutingByEffort?.high?.modelId).toMatch(/^cursor-grok-4\.6-high/);
+    }
+    expect(grok?.rawRoutingByEffort?.high?.modelId).toBe("cursor-grok-4.6-high");
+    expect(grokFast?.rawRoutingByEffort?.high?.modelId).toBe("cursor-grok-4.6-high-fast");
+
+    // Priced from pi core's xai/grok-4.6 row, not the generic grok-4.20 fallback.
+    expect(modelConfig(grok!).cost).toEqual({ input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 });
   });
 
   it("does not treat Fable 5's 1M row as Fable 5.1", () => {

--- a/providers/pi-provider-cursor-ask/tests/checkpoint-retry-context.test.ts
+++ b/providers/pi-provider-cursor-ask/tests/checkpoint-retry-context.test.ts
@@ -12,6 +12,11 @@ import {
   setBridgeFactoryForTests,
 } from "../src/stream/native-core.js";
 import { resetCacheDirForTests } from "../src/utils/cache-dir.js";
+import {
+  conversationStates,
+  deriveConversationKeyFromSessionId,
+  getOrHydrateConversation,
+} from "../src/stream/session-state.js";
 import { estimateMessageTokens, type CursorAssistantMessage } from "../src/stream/context-usage.js";
 
 const model: Model<Api> = {
@@ -50,14 +55,21 @@ function channel() {
   let closed = (_code: number) => {};
   let done = () => {};
   let requestTokens: number | undefined;
+  const sent: ReturnType<typeof create<typeof AgentClientMessageSchema>>[] = [];
+  let ready!: () => void;
+  const requestReady = new Promise<void>((resolve) => {
+    ready = resolve;
+  });
   const bridge: BridgeHandle = {
     alive: true,
     reusable: false,
     lastStderr: () => "",
     write(bytes) {
       const message = fromBinary(AgentClientMessageSchema, bytes.subarray(5));
+      sent.push(message);
       if (message.message.case === "runRequest") {
         requestTokens = message.message.value.conversationState?.tokenDetails?.usedTokens;
+        ready();
       }
     },
     openStream() {},
@@ -83,6 +95,12 @@ function channel() {
   };
   return {
     bridge,
+    sent,
+    requestReady,
+    get request() {
+      const message = sent.find((message) => message.message.case === "runRequest")?.message;
+      return message?.case === "runRequest" ? message.value : undefined;
+    },
     get requestTokens() {
       return requestTokens;
     },
@@ -102,6 +120,107 @@ function channel() {
     },
   };
 }
+
+describe("blob miss recovery", () => {
+  it("fails without a blob reply, durably invalidates the checkpoint, and rebuilds next turn", async () => {
+    const peers = [channel(), channel(), channel()];
+    let attempts = 0;
+    setBridgeFactoryForTests(() => peers[attempts++]!.bridge);
+    const streamFn = createCursorNativeStream({ getAccessToken: async () => "test-only-token" });
+    const options = { sessionId: "blob-miss" };
+    const convKey = deriveConversationKeyFromSessionId(options.sessionId);
+    const missingId = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const context = {
+      systemPrompt: "Reply briefly",
+      messages: [
+        { role: "user" as const, content: "Remember the violet lighthouse", timestamp: 1 },
+      ],
+      tools: [],
+    };
+    const first = streamFn(model, context, options);
+    await peers[0]!.requestReady;
+    peers[0]!.send({
+      message: {
+        case: "conversationCheckpointUpdate",
+        value: { rootPromptMessagesJson: [missingId] },
+      },
+    });
+    peers[0]!.send({
+      message: {
+        case: "interactionUpdate",
+        value: { message: { case: "textDelta", value: { text: "Remembered" } } },
+      },
+    });
+    peers[0]!.finish();
+    const answer = await first.result();
+    expect(answer.stopReason).toBe("stop");
+    const oldConversationId = peers[0]!.request!.conversationId;
+    const continuedContext = {
+      ...context,
+      messages: [
+        ...context.messages,
+        answer,
+        { role: "user" as const, content: "Continue", timestamp: 2 },
+      ],
+    };
+
+    const failed = streamFn(model, continuedContext, options);
+    await peers[1]!.requestReady;
+    // Prove this is a live checkpoint replay, not a stale-checkpoint discard.
+    expect(peers[1]!.request!.conversationState!.rootPromptMessagesJson).toContainEqual(missingId);
+    peers[1]!.send({
+      message: {
+        case: "kvServerMessage",
+        value: { id: 7, message: { case: "getBlobArgs", value: { blobId: missingId } } },
+      },
+    });
+    // The old behavior replies empty and parks; check before waiting for the terminal result.
+    expect(peers[1]!.sent.filter((message) => message.message.case === "kvClientMessage")).toEqual(
+      [],
+    );
+    const failure = await failed.result();
+    expect(failure.stopReason).toBe("error");
+    expect(failure.errorMessage).toMatch(/not in the local store.*Refusing to answer empty/);
+    expect(peers[1]!.bridge.alive).toBe(false);
+    expect(attempts).toBe(2); // No blind retry inside the failed generation.
+    expect(conversationStates.get(convKey)!.checkpoint).toBeNull();
+    expect(conversationStates.get(convKey)!.conversationId).not.toBe(oldConversationId);
+
+    // A restart must not resurrect the broken checkpoint from disk.
+    conversationStates.clear();
+    const restored = getOrHydrateConversation(convKey)!;
+    expect(restored.checkpoint).toBeNull();
+    expect(restored.checkpointSource).toBeUndefined();
+    expect(restored.checkpointTurnCount).toBeUndefined();
+    expect(restored.checkpointHistoryFingerprint).toBeUndefined();
+    expect(restored.conversationId).not.toBe(oldConversationId);
+
+    const retry = streamFn(model, continuedContext, options);
+    await peers[2]!.requestReady;
+    const rebuilt = peers[2]!.request!;
+    expect(rebuilt.conversationId).toBe(restored.conversationId);
+    expect(rebuilt.conversationState!.rootPromptMessagesJson).not.toContainEqual(missingId);
+    for (const blobId of rebuilt.conversationState!.rootPromptMessagesJson) {
+      peers[2]!.send({
+        message: {
+          case: "kvServerMessage",
+          value: { id: 8, message: { case: "getBlobArgs", value: { blobId } } },
+        },
+      });
+    }
+    const prompt = peers[2]!.sent
+      .flatMap(({ message }) =>
+        message.case === "kvClientMessage" && message.value.message.case === "getBlobResult"
+          ? [new TextDecoder().decode(message.value.message.value.blobData)]
+          : [],
+      )
+      .join("\n");
+    expect(prompt).toContain("Remember the violet lighthouse");
+    expect(prompt).toContain("Remembered");
+    peers[2]!.finish();
+    expect((await retry.result()).stopReason).toBe("stop");
+  });
+});
 
 // Real provider retry orchestration, with transport replaced by an isolated test peer.
 describe("first-response checkpoint recovery", () => {

--- a/providers/pi-provider-cursor-ask/tests/cost.test.ts
+++ b/providers/pi-provider-cursor-ask/tests/cost.test.ts
@@ -21,6 +21,19 @@ describe("estimateModelCost", () => {
     expect(estimateModelCost("fable-5")).toEqual(estimateModelCost("claude-fable-5"));
   });
 
+  it("prices Grok 4.6 from pi core's xai row, ahead of the generic grok fallback", () => {
+    expect(estimateModelCost("grok-4.6")).toEqual({
+      input: 2,
+      output: 6,
+      cacheRead: 0.5,
+      cacheWrite: 0,
+    });
+    expect(estimateModelCost("cursor-grok-4.6-medium grok-4.6")).toEqual(
+      estimateModelCost("grok-4.6"),
+    );
+    expect(estimateModelCost("grok-4.20").cacheRead).toBe(0.2);
+  });
+
   it("does not let Fable 5's 1M id steal Fable 5.1 pricing", () => {
     expect(estimateModelCost("claude-fable-5-1m-thinking").cacheRead).toBe(1);
     expect(estimateModelCost("claude-fable-5-1-1m-thinking").cacheRead).toBe(0.25);

--- a/providers/pi-provider-cursor-ask/tests/idle-progress.test.ts
+++ b/providers/pi-provider-cursor-ask/tests/idle-progress.test.ts
@@ -34,6 +34,42 @@ afterEach(() => {
 });
 
 describe("idle progress classification", () => {
+  it.each([new Uint8Array(), new Uint8Array([1, 2, 3])])(
+    "answers a stored blob even when it is genuinely empty (%j)",
+    (blobData) => {
+      const frames: Uint8Array[] = [];
+      const message = create(AgentServerMessageSchema, {
+        message: {
+          case: "kvServerMessage",
+          value: {
+            id: 7,
+            message: { case: "getBlobArgs", value: { blobId: new Uint8Array([0xab]) } },
+          },
+        },
+      });
+      expect(
+        processServerMessage(
+          message,
+          new Map([["ab", blobData]]),
+          [],
+          (frame) => frames.push(frame),
+          { toolCallIndex: 0, pendingExecs: [], outputTokens: 0, totalTokens: 0, turnEnded: false },
+          () => {},
+          () => {},
+        ),
+      ).toBe("work");
+      expect(frames).toHaveLength(1);
+      const response = fromBinary(AgentClientMessageSchema, frames[0]!.subarray(5));
+      expect(response.message).toMatchObject({
+        case: "kvClientMessage",
+        value: {
+          id: 7,
+          message: { case: "getBlobResult", value: { blobData: Buffer.from(blobData) } },
+        },
+      });
+    },
+  );
+
   it("rejects MCP executions for tools that were not advertised", () => {
     const message = create(AgentServerMessageSchema, {
       message: {

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -22,6 +22,7 @@ const packagePaths = [
 	"./packages/pi-consult",
 	"./packages/pi-adversarial-review",
 	"./providers/pi-provider-volcengine-agent-plan",
+	"./providers/pi-provider-cursor-ask",
 ];
 
 const requiredPackFiles = new Map([
@@ -284,6 +285,12 @@ const requiredPackFiles = new Map([
 		"README.zh-CN.md",
 		"LICENSE",
 	]],
+	["./providers/pi-provider-cursor-ask", [
+		"src/index.ts",
+		"README.md",
+		"README.zh-CN.md",
+		"LICENSE",
+	]],
 ]);
 const maintainedReadmes = [
 	".changeset/README.md",
@@ -445,6 +452,10 @@ for (const packagePath of packagePaths) {
 		assert.ok(
 			![...files].some((file) => file.startsWith("packages/pi-adversarial-review/")),
 			"root npm pack must not include the standalone pi-adversarial-review package",
+		);
+		assert.ok(
+			![...files].some((file) => file.startsWith("providers/pi-provider-cursor-ask/")),
+			"root npm pack must not include the standalone pi-provider-cursor-ask package",
 		);
 	}
 	if (packagePath === "./packages/pi-adversarial-review") {

--- a/scripts/reconcile-release.sh
+++ b/scripts/reconcile-release.sh
@@ -17,6 +17,7 @@ PACKAGES=(
   "@zhcsyncer/pi-consult|packages/pi-consult/package.json|packages/pi-consult/CHANGELOG.md|pi-consult|child"
   "@zhcsyncer/pi-adversarial-review|packages/pi-adversarial-review/package.json|packages/pi-adversarial-review/CHANGELOG.md|pi-adversarial-review|child"
   "pi-provider-volcengine-agent-plan|providers/pi-provider-volcengine-agent-plan/package.json|providers/pi-provider-volcengine-agent-plan/CHANGELOG.md|pi-provider-volcengine-agent-plan|child"
+  "pi-provider-cursor-ask|providers/pi-provider-cursor-ask/package.json|providers/pi-provider-cursor-ask/CHANGELOG.md|pi-provider-cursor-ask|child"
 )
 
 wait_for_package() {

--- a/scripts/release-policy.test.mjs
+++ b/scripts/release-policy.test.mjs
@@ -19,6 +19,7 @@ const METER = "@zhcsyncer/pi-meter";
 const CONSULT = "@zhcsyncer/pi-consult";
 const ADVERSARIAL_REVIEW = "@zhcsyncer/pi-adversarial-review";
 const AGENT_PLAN = "pi-provider-volcengine-agent-plan";
+const CURSOR_ASK = "pi-provider-cursor-ask";
 
 function releases(...entries) {
 	return {
@@ -43,6 +44,12 @@ test("allows the root package to release independently", () => {
 
 test("allows the standalone Agent Plan provider to release without the root", () => {
 	assert.deepEqual(validateReleasePolicy(releases([AGENT_PLAN, "patch"])), []);
+});
+
+test("allows the standalone Cursor Ask provider to release without the root", () => {
+	assert.deepEqual(validateReleasePolicy(releases([CURSOR_ASK, "minor"])), []);
+	const script = readFileSync(new URL("./reconcile-release.sh", import.meta.url), "utf8");
+	assert.match(script, /pi-provider-cursor-ask/u);
 });
 
 test("allows standalone adversarial review to release without the root", () => {


### PR DESCRIPTION
## Summary
- Cursor Ask no longer answers a missing `getBlobArgs` with an empty blob. The current generation fails, the checkpoint is dropped, and the next turn rebuilds from Pi history.
- Register Grok 4.6 / Fast as passthrough rows when the live catalog includes them.
- Publish `pi-provider-cursor-ask` independently. Docs state this provider maps only a curated subset of Cursor models.

## Release plan
- `pi-provider-cursor-ask` 0.0.0 → 0.1.0 (minor)
- Standalone package; no root bundle release.

## Test plan
- `pnpm --filter pi-provider-cursor-ask check`
- `node --test scripts/release-policy.test.mjs`
- `node scripts/check-release-policy.mjs`
- `node scripts/check-pack.mjs`