### PR TITLE
fix(recap): OpenCode session headers and slimmer config

### DIFF
--- a/.changeset/recap-config-tui.md
+++ b/.changeset/recap-config-tui.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-recap": patch
+"@zhcsyncer/pi-extensions": patch
+---
+
+`/recap-config` now covers every recap option, including choosing a model from the currently enabled list. Fallback stays hidden while the model is `current`, and recap warns if a chosen model is missing and it falls back.

--- a/.changeset/recap-opencode-session.md
+++ b/.changeset/recap-opencode-session.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-recap": patch
+"@zhcsyncer/pi-extensions": patch
+---
+
+Recap no longer fails with 400 on OpenCode / OpenCode Go due to a missing `x-opencode-session` header. Out-of-band recap calls now go through Pi's model registry so they use the same authentication and custom endpoints as the main session.

--- a/.changeset/recap-session-name-policy.md
+++ b/.changeset/recap-session-name-policy.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-recap": patch
+"@zhcsyncer/pi-extensions": patch
+---
+
+Session-name handling is one setting again. `off` turns sync off; `if-empty`, `if-empty-or-auto`, and `always` keep their previous meaning.

--- a/.changeset/recap-slim-config.md
+++ b/.changeset/recap-slim-config.md
@@ -1,0 +1,6 @@
+---
+"@zhcsyncer/pi-recap": patch
+"@zhcsyncer/pi-extensions": patch
+---
+
+Recap config is now thinner: `/recap` is always available, and `/recap-config` only keeps auto recap, idle wait, model, language, whether to write the title into the session name (on = do not overwrite a manual name), plus multiplexer enablement and template.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@
 | [pi-subagents/delivery-and-resume.md](./pi-subagents/delivery-and-resume.md) | 契约 | 完整报告预算、投递时机、运行代次与终态恢复边界 |
 | [pi-subagents/configuration-and-integrations.md](./pi-subagents/configuration-and-integrations.md) | 已落地 | 配置位置与授权、进程内编排及运行时复用 |
 | [pi-subagents/pinned-extensions.md](./pi-subagents/pinned-extensions.md) | 已落地 | 子代理钉住观察者扩展：只保加载、不保工具 |
+| [pi-recap/extension.md](./pi-recap/extension.md) | 已落地 | 一行最近活动 recap：不是 compact；title → name → multiplexer；出环 one-shot |
 | [pi-plan-mode/plan-lifecycle.md](./pi-plan-mode/plan-lifecycle.md) | 已落地 | Plan 文档评审与工作生命周期正交 |
 | [pi-plan-mode/submit-plan-tool-display.md](./pi-plan-mode/submit-plan-tool-display.md) | 已落地 | `submit_plan` 的 TUI 投影 |
 | [providers/pi-provider-volcengine-agent-plan/quota-auto-refresh.md](./providers/pi-provider-volcengine-agent-plan/quota-auto-refresh.md) | 未实现 | 火山套餐余量与 tier 自动刷新 |

--- a/docs/pi-recap/extension.md
+++ b/docs/pi-recap/extension.md
@@ -8,7 +8,7 @@
 
 ## 意图
 
-一行 recap 是主产物。短 title 是副产物。是否改 Pi session name、是否同步最近一层终端复用器名称，是后面两级可选副作用。给人看的旋钮很少：`/recap` 常驻，auto 才是后台开关；打开 apply 时不覆盖手动 session name。
+一行 recap 是主产物。短 title 是副产物。是否改 Pi session name、是否同步最近一层终端复用器名称，是后面两级可选副作用。给人看的旋钮很少：`/recap` 常驻，auto 才是后台开关；session name 策略一项四档，`off` 关闭同步。
 
 ## 心智模型
 

--- a/docs/pi-recap/extension.md
+++ b/docs/pi-recap/extension.md
@@ -8,7 +8,7 @@
 
 ## 意图
 
-一行 recap 是主产物。短 title 是副产物。是否改 Pi session name、是否同步最近一层终端复用器名称，是后面两级可选副作用。出环调用应能配齐，不必为日常选项去改 JSON。
+一行 recap 是主产物。短 title 是副产物。是否改 Pi session name、是否同步最近一层终端复用器名称，是后面两级可选副作用。给人看的旋钮很少：`/recap` 常驻，auto 才是后台开关；打开 apply 时不覆盖手动 session name。
 
 ## 心智模型
 

--- a/docs/pi-recap/extension.md
+++ b/docs/pi-recap/extension.md
@@ -1,0 +1,29 @@
+# pi-recap
+
+状态：已落地
+
+## 为什么做
+
+离开一会儿再回来，要立刻知道「刚才发生了什么」。这不是 compact：不压缩历史、不替换对话、不进后续模型上下文。
+
+## 意图
+
+一行 recap 是主产物。短 title 是副产物。是否改 Pi session name、是否同步最近一层终端复用器名称，是后面两级可选副作用。出环调用应能配齐，不必为日常选项去改 JSON。
+
+## 心智模型
+
+```text
+最近活动 ──出环 one-shot──► recap widget
+                └─ title ──可选──► session name ──可选──► Herdr / tmux 名
+```
+
+recap 读当前分支的最近活动，一次性要一行摘要。title 只沿这条链向下流；同步模块不关心名字从哪来。
+
+出环调用不经过主循环，因此没有主循环那套 OpenRouter / NVIDIA / Cloudflare 归因头。
+
+## 红线
+
+- 不是 compact：不调用 compact，不注入 LLM 历史，不删不压消息。
+- recap 保持一行短句，不是整段会话总结。
+- 依赖单向：title → session name → multiplexer。不把命名同步做成独立主命令。
+- 出环 one-shot 不复制主循环归因头。

--- a/packages/pi-recap/README.md
+++ b/packages/pi-recap/README.md
@@ -12,9 +12,9 @@ Features:
 - Display automatic recap progress plus recap results and errors in an editor widget, without duplicating successful results in chat notifications.
 - Generate a short title as a recap side effect, with a deterministic recap-derived fallback and visible warning when the model omits a usable title.
 - Reject empty, truncated, failed, or malformed JSON-like model output without saving partial recap state.
-- Optionally apply the title to the Pi session name.
+- Optionally apply the title to the Pi session name. When this is on, recap only writes the name if it is empty or still the last recap title; a manual name is not overwritten.
 - Optionally sync Pi session name changes to the nearest terminal multiplexer: a Herdr pane label or tmux window name.
-- Configure every recap option with `/recap-config`, including the recap model from `current` plus currently enabled models.
+- `/recap` is always available. `/recap-config` only keeps auto recap, idle wait, model, language, whether to write the title into the session name, plus multiplexer enablement and template.
 - `/recap-config json` remains available as an escape hatch, but is not required for normal use.
 
 ### Installation
@@ -63,7 +63,7 @@ Generate a recent activity recap. It will:
 /recap-config
 ```
 
-Open the TUI config screen. It covers every recap setting and saves to:
+Open the TUI config screen. `/recap` is always available; auto recap is the background switch. It saves to:
 
 ```text
 $PI_CODING_AGENT_DIR/extension-data/pi-recap/config.json
@@ -75,7 +75,7 @@ The model list starts with `current` (the session model), then currently enabled
 /recap-config json
 ```
 
-Edit the full JSON config. This is optional; the TUI can set every field, including custom numbers and languages.
+Edit the JSON config. This is optional; the TUI covers the remaining settings, including a custom idle wait and language.
 
 ### TUI only
 
@@ -103,32 +103,18 @@ Default config:
 ```json
 {
   "recap": {
-    "enabled": true,
     "auto": true,
-    "manualCommand": true,
     "idleAfterTurnMs": 180000,
-    "minSessionTurns": 3,
-    "neverTwiceInARow": true,
     "model": "current",
     "fallbackToCurrentModel": true,
-    "maxRecentChars": 20000,
-    "maxTokens": 300,
     "language": "auto"
   },
-  "display": {
-    "widgetPlacement": "aboveEditor"
-  },
   "title": {
-    "generate": true,
-    "applyToSessionName": false,
-    "applyPolicy": "if-empty-or-auto",
-    "maxLength": 50
+    "applyToSessionName": false
   },
   "multiplexer": {
     "enabled": true,
-    "template": "π {session} · {project}",
-    "maxLength": 48,
-    "restoreOnShutdown": true
+    "template": "π {session} · {project}"
   }
 }
 ```
@@ -140,13 +126,12 @@ Apply generated titles to Pi session names:
 ```json
 {
   "title": {
-    "applyToSessionName": true,
-    "applyPolicy": "if-empty-or-auto"
+    "applyToSessionName": true
   }
 }
 ```
 
-When `title.generate` is enabled but the model omits a usable title, recap deterministically uses the cleaned one-line recap as the title, strictly capped by `title.maxLength`. The fallback still follows `title.applyToSessionName` and `title.applyPolicy`; `never`, `if-empty`, `if-empty-or-auto`, and `always` keep their existing meanings. The persisted recap records that the title came from the fallback, so the editor widget shows the warning after generation and after a session reload. Set `title.generate` to `false` to disable both model titles and this fallback.
+Titles are always generated. If the model omits a usable title, recap deterministically uses the cleaned one-line recap as the title. When apply is on, recap writes that title only if the session name is empty or still the last recap title; a manual name is not overwritten. The persisted recap records that the title came from the fallback, so the editor widget shows the warning after generation and after a session reload.
 
 Plain text and ordinary bullet recap responses remain valid. Empty recaps, malformed or truncated JSON-like responses, and completions stopped with `length` or `error` are treated as failed recaps: the widget shows the failure, no recap entry is appended, the session is not renamed, and the previous recap source position is preserved.
 
@@ -171,27 +156,16 @@ Use a specific recap model in `/recap-config`, or in JSON:
 }
 ```
 
-Choose widget placement:
+Recap display always uses an editor widget above the editor. Automatic recap progress is replaced by the result in that widget. Manual `/recap` uses a cancellable loader while generating, then shows the result in the widget. The widget is cleared when the next message starts. If an automatic recap is still running, it is cancelled and cannot later store or redisplay a stale result.
 
-```json
-{
-  "display": {
-    "widgetPlacement": "aboveEditor"
-  }
-}
-```
-
-Recap display always uses an editor widget; the display surface is not configurable. Automatic recap progress is replaced by the result in that widget. Manual `/recap` uses a cancellable loader while generating, then shows the result in the widget. The widget is cleared when the next message starts. If an automatic recap is still running, it is cancelled and cannot later store or redisplay a stale result.
-
-When an older config is loaded, obsolete `display.notify`, `display.mode`, `display.widget`, and `display.clearWidgetOnNextAgentStart` fields are removed and the source config file is updated. `display.widgetPlacement` is preserved. Legacy `tmux` settings are migrated to `multiplexer`; when both exist, explicitly configured `multiplexer` fields take precedence.
+When an older config is loaded, removed fields such as `enabled`, `manualCommand`, `title.generate`, `title.applyPolicy`, and `display` are dropped and the source config file is updated. A previous `enabled: false` becomes `auto: false`, so automatic recap stays off. Legacy `tmux` settings are migrated to `multiplexer`; when both exist, explicitly configured `multiplexer` fields take precedence.
 
 Customize the Herdr pane label or tmux window name:
 
 ```json
 {
   "multiplexer": {
-    "template": "π {project} · {session}",
-    "maxLength": 60
+    "template": "π {project} · {session}"
   }
 }
 ```
@@ -249,7 +223,7 @@ When `multiplexer.enabled` is true, recap automatically selects the directly hos
 
 In nested Herdr-inside-tmux sessions, recap only updates the Herdr pane. If Herdr is detected but its pane identity is incomplete or its CLI is unavailable, recap warns once and does not fall back to the inherited tmux layer.
 
-For tmux, recap keeps the original behavior of disabling `automatic-rename` while it owns the window name. The original pane/window name is restored only if the current name still equals recap's last successful write, so a later manual rename is preserved. Disabling sync or reloading the extension releases ownership immediately; reload always restores before the new extension instance reapplies the name. On ordinary Pi exit, `restoreOnShutdown` controls restoration. tmux's captured `automatic-rename` setting is restored whenever owned sync is restored or disabled.
+For tmux, recap keeps the original behavior of disabling `automatic-rename` while it owns the window name. The original pane/window name is restored only if the current name still equals recap's last successful write, so a later manual rename is preserved. Disabling sync or reloading the extension releases ownership immediately; reload always restores before the new extension instance reapplies the name. Ordinary Pi exit also restores the previous name. tmux's captured `automatic-rename` setting is restored whenever owned sync is restored or disabled.
 
 All of these trigger multiplexer sync:
 

--- a/packages/pi-recap/README.md
+++ b/packages/pi-recap/README.md
@@ -12,9 +12,9 @@ Features:
 - Display automatic recap progress plus recap results and errors in an editor widget, without duplicating successful results in chat notifications.
 - Generate a short title as a recap side effect, with a deterministic recap-derived fallback and visible warning when the model omits a usable title.
 - Reject empty, truncated, failed, or malformed JSON-like model output without saving partial recap state.
-- Optionally apply the title to the Pi session name. When this is on, recap only writes the name if it is empty or still the last recap title; a manual name is not overwritten.
+- Optionally apply the title to the Pi session name with `title.applyPolicy`: `off`, `if-empty`, `if-empty-or-auto`, or `always`. `off` leaves the name alone.
 - Optionally sync Pi session name changes to the nearest terminal multiplexer: a Herdr pane label or tmux window name.
-- `/recap` is always available. `/recap-config` only keeps auto recap, idle wait, model, language, whether to write the title into the session name, plus multiplexer enablement and template.
+- `/recap` is always available. `/recap-config` only keeps auto recap, idle wait, model, language, session-name policy, plus multiplexer enablement and template.
 - `/recap-config json` remains available as an escape hatch, but is not required for normal use.
 
 ### Installation
@@ -110,7 +110,7 @@ Default config:
     "language": "auto"
   },
   "title": {
-    "applyToSessionName": false
+    "applyPolicy": "off"
   },
   "multiplexer": {
     "enabled": true,
@@ -126,12 +126,12 @@ Apply generated titles to Pi session names:
 ```json
 {
   "title": {
-    "applyToSessionName": true
+    "applyPolicy": "if-empty-or-auto"
   }
 }
 ```
 
-Titles are always generated. If the model omits a usable title, recap deterministically uses the cleaned one-line recap as the title. When apply is on, recap writes that title only if the session name is empty or still the last recap title; a manual name is not overwritten. The persisted recap records that the title came from the fallback, so the editor widget shows the warning after generation and after a session reload.
+Titles are always generated. If the model omits a usable title, recap deterministically uses the cleaned one-line recap as the title. `off` does not change the Pi session name. `if-empty` fills a blank name only. `if-empty-or-auto` also updates a name recap last wrote, without overwriting a later manual name. `always` overwrites. The persisted recap records that the title came from the fallback, so the editor widget shows the warning after generation and after a session reload.
 
 Plain text and ordinary bullet recap responses remain valid. Empty recaps, malformed or truncated JSON-like responses, and completions stopped with `length` or `error` are treated as failed recaps: the widget shows the failure, no recap entry is appended, the session is not renamed, and the previous recap source position is preserved.
 
@@ -158,7 +158,7 @@ Use a specific recap model in `/recap-config`, or in JSON:
 
 Recap display always uses an editor widget above the editor. Automatic recap progress is replaced by the result in that widget. Manual `/recap` uses a cancellable loader while generating, then shows the result in the widget. The widget is cleared when the next message starts. If an automatic recap is still running, it is cancelled and cannot later store or redisplay a stale result.
 
-When an older config is loaded, removed fields such as `enabled`, `manualCommand`, `title.generate`, `title.applyPolicy`, and `display` are dropped and the source config file is updated. A previous `enabled: false` becomes `auto: false`, so automatic recap stays off. Legacy `tmux` settings are migrated to `multiplexer`; when both exist, explicitly configured `multiplexer` fields take precedence.
+When an older config is loaded, removed fields such as `enabled`, `manualCommand`, `title.generate`, `title.applyToSessionName`, and `display` are dropped and the source config file is updated. A previous `enabled: false` becomes `auto: false`. `applyToSessionName: false` or `applyPolicy: "never"` becomes `applyPolicy: "off"`; other session-name policies are kept. Legacy `tmux` settings are migrated to `multiplexer`; when both exist, explicitly configured `multiplexer` fields take precedence.
 
 Customize the Herdr pane label or tmux window name:
 

--- a/packages/pi-recap/README.md
+++ b/packages/pi-recap/README.md
@@ -14,8 +14,8 @@ Features:
 - Reject empty, truncated, failed, or malformed JSON-like model output without saving partial recap state.
 - Optionally apply the title to the Pi session name.
 - Optionally sync Pi session name changes to the nearest terminal multiplexer: a Herdr pane label or tmux window name.
-- Configure common options with `/recap-config`.
-- Edit full JSON config with `/recap-config json`.
+- Configure every recap option with `/recap-config`, including the recap model from `current` plus currently enabled models.
+- `/recap-config json` remains available as an escape hatch, but is not required for normal use.
 
 ### Installation
 
@@ -63,17 +63,19 @@ Generate a recent activity recap. It will:
 /recap-config
 ```
 
-Open the TUI config screen and save common settings to:
+Open the TUI config screen. It covers every recap setting and saves to:
 
 ```text
 $PI_CODING_AGENT_DIR/extension-data/pi-recap/config.json
 ```
 
+The model list starts with `current` (the session model), then currently enabled models. A configured model that is not in that list still shows, and opening the picker does not change it. While the model is `current`, fallback is hidden and left unchanged. If you pick a specific model that later cannot be resolved and fallback is on, recap warns once and uses the session model. A cheaper dedicated recap model is recommended.
+
 ```text
 /recap-config json
 ```
 
-Edit the full JSON config.
+Edit the full JSON config. This is optional; the TUI can set every field, including custom numbers and languages.
 
 ### TUI only
 
@@ -158,7 +160,7 @@ Disable automatic recap and keep manual `/recap` only:
 }
 ```
 
-Use a specific recap model:
+Use a specific recap model in `/recap-config`, or in JSON:
 
 ```json
 {
@@ -265,6 +267,7 @@ and recap calling `pi.setSessionName(title)` when enabled by config. Recap does 
 
 - Recap makes an extra model call.
 - By default it uses the current Pi model: `recap.model = "current"`.
+- A cheaper dedicated recap model is recommended if you do not want to spend the session model on this side call.
 - Recent activity is sent to the current or configured provider.
 - Disable automatic recap if you do not want extra background model calls:
 

--- a/packages/pi-recap/README.zh-CN.md
+++ b/packages/pi-recap/README.zh-CN.md
@@ -14,8 +14,8 @@
 - 空输出、截断/失败响应或损坏的 JSON-like 输出不会保存半成品 recap 状态；
 - 是否用 title 更新 Pi session name 由配置控制；
 - session name 变化时可选同步最近一层终端复用器：Herdr pane label 或 tmux window name；
-- `/recap-config` 提供 TUI 常用配置；
-- `/recap-config json` 编辑完整 JSON 配置。
+- `/recap-config` 可配齐全部 recap 选项，模型列表为 `current` 加上当前启用的模型；
+- `/recap-config json` 仍可用，但日常不必靠它。
 
 ### 安装
 
@@ -63,17 +63,19 @@ pi -e ./packages/pi-recap
 /recap-config
 ```
 
-打开 TUI 配置界面，修改常用配置并保存到：
+打开 TUI 配置界面，可配齐全部 recap 选项，并保存到：
 
 ```text
 $PI_CODING_AGENT_DIR/extension-data/pi-recap/config.json
 ```
 
+模型列表第一项是 `current`（当前会话模型），其余来自当前启用的模型。已配置但不在列表里的值仍会显示，打开选择器不会改掉它。模型为 `current` 时隐藏 fallback，且不改 JSON 里的 fallback 值。指定模型找不到并允许回落时，会警告一次并改用当前会话模型。建议另配一个更便宜的 recap 模型。
+
 ```text
 /recap-config json
 ```
 
-编辑完整 JSON 配置。
+编辑完整 JSON 配置。这是逃生口，不是必经之路；TUI 已能设置全部字段，包括自定义数字和语言。
 
 ### TUI only
 
@@ -158,7 +160,7 @@ examples/recap.json
 }
 ```
 
-指定 recap 模型：
+在 `/recap-config` 里指定 recap 模型，或写 JSON：
 
 ```json
 {
@@ -265,6 +267,7 @@ pi --name "auth refresh"
 
 - recap 会额外调用模型。
 - 默认使用当前 Pi 模型：`recap.model = "current"`。
+- 如果不想把会话模型花在这次出环调用上，建议另配一个更便宜的 recap 模型。
 - 最近活动内容会发送给当前或配置的 provider。
 - 如果不希望自动额外调用模型，请设置：
 

--- a/packages/pi-recap/README.zh-CN.md
+++ b/packages/pi-recap/README.zh-CN.md
@@ -12,9 +12,9 @@
 - 使用 editor widget 展示自动 recap 的进度以及 recap 结果和错误，成功结果不会再重复显示为聊天区通知；
 - recap 时顺便生成短 title；模型未返回可用 title 时会确定性地从 recap 派生 fallback，并显示明确 warning；
 - 空输出、截断/失败响应或损坏的 JSON-like 输出不会保存半成品 recap 状态；
-- 是否用 title 更新 Pi session name 由配置控制；打开后仅在名为空、或仍是上次 recap 写入的名字时才改，不覆盖手动名；
+- 是否用 title 更新 Pi session name 由 `title.applyPolicy` 控制：`off` / `if-empty` / `if-empty-or-auto` / `always`。`off` 不改名；
 - session name 变化时可选同步最近一层终端复用器：Herdr pane label 或 tmux window name；
-- `/recap` 常驻。`/recap-config` 只保留自动 recap、idle、模型、语言、是否把标题写进 session name，以及 multiplexer 开关和模板；
+- `/recap` 常驻。`/recap-config` 只保留自动 recap、idle、模型、语言、session name 策略，以及 multiplexer 开关和模板；
 - `/recap-config json` 仍可用，但日常不必靠它。
 
 ### 安装
@@ -110,7 +110,7 @@ examples/recap.json
     "language": "auto"
   },
   "title": {
-    "applyToSessionName": false
+    "applyPolicy": "off"
   },
   "multiplexer": {
     "enabled": true,
@@ -126,12 +126,12 @@ examples/recap.json
 ```json
 {
   "title": {
-    "applyToSessionName": true
+    "applyPolicy": "if-empty-or-auto"
   }
 }
 ```
 
-title 总会生成。如果模型没有返回可用 title，recap 会确定性地使用清理成一行的 recap 作为 title。打开 apply 后，仅在 session name 为空、或仍是上次 recap 写入的名字时才改名，不覆盖手动名。持久化 recap 会记录 title 来自 fallback，因此生成后以及 session reload 后，editor widget 都会显示 warning。
+title 总会生成。如果模型没有返回可用 title，recap 会确定性地使用清理成一行的 recap 作为 title。`off` 不改 Pi session name；`if-empty` 只在名为空时写入；`if-empty-or-auto` 还会更新上次 recap 写下的名字，不覆盖之后的手动名；`always` 每次覆盖。持久化 recap 会记录 title 来自 fallback，因此生成后以及 session reload 后，editor widget 都会显示 warning。
 
 纯文本与普通 bullet recap 响应仍然有效。空 recap、损坏或截断的 JSON-like 响应，以及以 `length` 或 `error` 结束的模型响应都会被视为 recap 失败：widget 会显示失败信息，不会 append recap entry、不会更新 session name，也不会推进上一次 recap 的 source 位置。
 
@@ -158,7 +158,7 @@ title 总会生成。如果模型没有返回可用 title，recap 会确定性�
 
 recap 始终使用 editor 上方的 widget。自动 recap 的生成进度会在同一个 widget 中被最终结果替换；手动 `/recap` 生成时使用可取消 Loader，完成后在 widget 中显示结果。下一条消息开始时会清除 widget；如果自动 recap 仍在生成，该任务也会被取消，并且不会在稍后写入或重新展示过期结果。
 
-读取旧配置时，插件会丢弃已删除字段（如 `enabled`、`manualCommand`、`title.generate`、`title.applyPolicy`、`display`）并写回清理后的文件。以前的 `enabled: false` 会变成 `auto: false`，自动 recap 不会突然打开。旧的 `tmux` 配置会自动迁移到 `multiplexer`；两者同时存在时，显式设置的 `multiplexer` 字段优先。
+读取旧配置时，插件会丢弃已删除字段（如 `enabled`、`manualCommand`、`title.generate`、`title.applyToSessionName`、`display`）并写回清理后的文件。以前的 `enabled: false` 会变成 `auto: false`。`applyToSessionName: false` 或 `applyPolicy: "never"` 会变成 `applyPolicy: "off"`，其余 session name 策略原样保留。旧的 `tmux` 配置会自动迁移到 `multiplexer`；两者同时存在时，显式设置的 `multiplexer` 字段优先。
 
 自定义 Herdr pane label 或 tmux window 名称：
 

--- a/packages/pi-recap/README.zh-CN.md
+++ b/packages/pi-recap/README.zh-CN.md
@@ -12,9 +12,9 @@
 - 使用 editor widget 展示自动 recap 的进度以及 recap 结果和错误，成功结果不会再重复显示为聊天区通知；
 - recap 时顺便生成短 title；模型未返回可用 title 时会确定性地从 recap 派生 fallback，并显示明确 warning；
 - 空输出、截断/失败响应或损坏的 JSON-like 输出不会保存半成品 recap 状态；
-- 是否用 title 更新 Pi session name 由配置控制；
+- 是否用 title 更新 Pi session name 由配置控制；打开后仅在名为空、或仍是上次 recap 写入的名字时才改，不覆盖手动名；
 - session name 变化时可选同步最近一层终端复用器：Herdr pane label 或 tmux window name；
-- `/recap-config` 可配齐全部 recap 选项，模型列表为 `current` 加上当前启用的模型；
+- `/recap` 常驻。`/recap-config` 只保留自动 recap、idle、模型、语言、是否把标题写进 session name，以及 multiplexer 开关和模板；
 - `/recap-config json` 仍可用，但日常不必靠它。
 
 ### 安装
@@ -63,7 +63,7 @@ pi -e ./packages/pi-recap
 /recap-config
 ```
 
-打开 TUI 配置界面，可配齐全部 recap 选项，并保存到：
+打开 TUI 配置界面。`/recap` 常驻，auto 才是后台开关。保存到：
 
 ```text
 $PI_CODING_AGENT_DIR/extension-data/pi-recap/config.json
@@ -75,7 +75,7 @@ $PI_CODING_AGENT_DIR/extension-data/pi-recap/config.json
 /recap-config json
 ```
 
-编辑完整 JSON 配置。这是逃生口，不是必经之路；TUI 已能设置全部字段，包括自定义数字和语言。
+编辑 JSON 配置。这是逃生口，不是必经之路；TUI 已覆盖留下的选项，包括自定义 idle 和语言。
 
 ### TUI only
 
@@ -103,32 +103,18 @@ examples/recap.json
 ```json
 {
   "recap": {
-    "enabled": true,
     "auto": true,
-    "manualCommand": true,
     "idleAfterTurnMs": 180000,
-    "minSessionTurns": 3,
-    "neverTwiceInARow": true,
     "model": "current",
     "fallbackToCurrentModel": true,
-    "maxRecentChars": 20000,
-    "maxTokens": 300,
     "language": "auto"
   },
-  "display": {
-    "widgetPlacement": "aboveEditor"
-  },
   "title": {
-    "generate": true,
-    "applyToSessionName": false,
-    "applyPolicy": "if-empty-or-auto",
-    "maxLength": 50
+    "applyToSessionName": false
   },
   "multiplexer": {
     "enabled": true,
-    "template": "π {session} · {project}",
-    "maxLength": 48,
-    "restoreOnShutdown": true
+    "template": "π {session} · {project}"
   }
 }
 ```
@@ -140,13 +126,12 @@ examples/recap.json
 ```json
 {
   "title": {
-    "applyToSessionName": true,
-    "applyPolicy": "if-empty-or-auto"
+    "applyToSessionName": true
   }
 }
 ```
 
-启用 `title.generate` 后，如果模型没有返回可用 title，recap 会确定性地使用清理成一行的 recap 作为 title，并严格限制在 `title.maxLength` 内。fallback 仍遵守 `title.applyToSessionName` 与 `title.applyPolicy`；`never`、`if-empty`、`if-empty-or-auto`、`always` 的原有语义不变。持久化 recap 会记录 title 来自 fallback，因此生成后以及 session reload 后，editor widget 都会显示 warning。将 `title.generate` 设为 `false` 会同时禁用模型 title 和该 fallback。
+title 总会生成。如果模型没有返回可用 title，recap 会确定性地使用清理成一行的 recap 作为 title。打开 apply 后，仅在 session name 为空、或仍是上次 recap 写入的名字时才改名，不覆盖手动名。持久化 recap 会记录 title 来自 fallback，因此生成后以及 session reload 后，editor widget 都会显示 warning。
 
 纯文本与普通 bullet recap 响应仍然有效。空 recap、损坏或截断的 JSON-like 响应，以及以 `length` 或 `error` 结束的模型响应都会被视为 recap 失败：widget 会显示失败信息，不会 append recap entry、不会更新 session name，也不会推进上一次 recap 的 source 位置。
 
@@ -171,27 +156,16 @@ examples/recap.json
 }
 ```
 
-选择 widget 位置：
+recap 始终使用 editor 上方的 widget。自动 recap 的生成进度会在同一个 widget 中被最终结果替换；手动 `/recap` 生成时使用可取消 Loader，完成后在 widget 中显示结果。下一条消息开始时会清除 widget；如果自动 recap 仍在生成，该任务也会被取消，并且不会在稍后写入或重新展示过期结果。
 
-```json
-{
-  "display": {
-    "widgetPlacement": "aboveEditor"
-  }
-}
-```
-
-recap 始终使用 editor widget，展示区域不再支持配置。自动 recap 的生成进度会在同一个 widget 中被最终结果替换；手动 `/recap` 生成时使用可取消 Loader，完成后在 widget 中显示结果。下一条消息开始时会清除 widget；如果自动 recap 仍在生成，该任务也会被取消，并且不会在稍后写入或重新展示过期结果。
-
-读取旧配置时，插件会移除已废弃的 `display.notify`、`display.mode`、`display.widget` 和 `display.clearWidgetOnNextAgentStart`，并更新原配置文件；`display.widgetPlacement` 会保留。旧的 `tmux` 配置会自动迁移到 `multiplexer`；两者同时存在时，显式设置的 `multiplexer` 字段优先。
+读取旧配置时，插件会丢弃已删除字段（如 `enabled`、`manualCommand`、`title.generate`、`title.applyPolicy`、`display`）并写回清理后的文件。以前的 `enabled: false` 会变成 `auto: false`，自动 recap 不会突然打开。旧的 `tmux` 配置会自动迁移到 `multiplexer`；两者同时存在时，显式设置的 `multiplexer` 字段优先。
 
 自定义 Herdr pane label 或 tmux window 名称：
 
 ```json
 {
   "multiplexer": {
-    "template": "π {project} · {session}",
-    "maxLength": 60
+    "template": "π {project} · {session}"
   }
 }
 ```
@@ -249,7 +223,7 @@ recap 始终使用 editor widget，展示区域不再支持配置。自动 recap
 
 Herdr 嵌套在 tmux 中时，recap 只更新 Herdr pane。如果检测到了 Herdr，但 pane 身份不完整或 CLI 不可用，recap 只警告一次，不会回退修改继承的外层 tmux。
 
-对于 tmux，recap 延续原行为：持有 window name 期间关闭 `automatic-rename`。仅当当前名称仍等于 recap 最近一次成功写入的值时，才恢复原 pane/window 名称，因此后续手动改名不会被覆盖。运行时关闭同步或 reload 会立即释放持有状态；reload 会先恢复，再由新 extension 实例重新应用。普通 Pi 退出时是否恢复由 `restoreOnShutdown` 控制。同步被恢复或关闭时，tmux 捕获到的 `automatic-rename` 设置会一并恢复。
+对于 tmux，recap 延续原行为：持有 window name 期间关闭 `automatic-rename`。仅当当前名称仍等于 recap 最近一次成功写入的值时，才恢复原 pane/window 名称，因此后续手动改名不会被覆盖。运行时关闭同步或 reload 会立即释放持有状态；reload 会先恢复，再由新 extension 实例重新应用。普通 Pi 退出也会恢复原名。同步被恢复或关闭时，tmux 捕获到的 `automatic-rename` 设置会一并恢复。
 
 以下操作都会触发复用器同步：
 

--- a/packages/pi-recap/examples/recap.json
+++ b/packages/pi-recap/examples/recap.json
@@ -7,7 +7,7 @@
     "language": "auto"
   },
   "title": {
-    "applyToSessionName": false
+    "applyPolicy": "off"
   },
   "multiplexer": {
     "enabled": true,

--- a/packages/pi-recap/examples/recap.json
+++ b/packages/pi-recap/examples/recap.json
@@ -1,30 +1,16 @@
 {
   "recap": {
-    "enabled": true,
     "auto": true,
-    "manualCommand": true,
     "idleAfterTurnMs": 180000,
-    "minSessionTurns": 3,
-    "neverTwiceInARow": true,
     "model": "current",
     "fallbackToCurrentModel": true,
-    "maxRecentChars": 20000,
-    "maxTokens": 300,
     "language": "auto"
   },
-  "display": {
-    "widgetPlacement": "aboveEditor"
-  },
   "title": {
-    "generate": true,
-    "applyToSessionName": false,
-    "applyPolicy": "if-empty-or-auto",
-    "maxLength": 50
+    "applyToSessionName": false
   },
   "multiplexer": {
     "enabled": true,
-    "template": "π {session} · {project}",
-    "maxLength": 48,
-    "restoreOnShutdown": true
+    "template": "π {session} · {project}"
   }
 }

--- a/packages/pi-recap/extensions/recap-picker.ts
+++ b/packages/pi-recap/extensions/recap-picker.ts
@@ -1,0 +1,195 @@
+import { type Component, Input, isKeyRelease, type SelectItem, SelectList } from "@earendil-works/pi-tui";
+
+const MAX_VISIBLE_ROWS = 10;
+export const CUSTOM_VALUE = "__custom__";
+
+export type RecapPickerTheme = {
+	fg(color: string, text: string): string;
+};
+
+export function filterSelectItems(items: SelectItem[], query: string): SelectItem[] {
+	const needle = query.trim().toLowerCase();
+	if (!needle) return items;
+	return items.filter((item) => `${item.label} ${item.value}`.toLowerCase().includes(needle));
+}
+
+export function isBackspace(data: string): boolean {
+	return data === "\u007f" || data === "\b";
+}
+
+export function isPrintable(data: string): boolean {
+	if (data.length !== 1) return false;
+	const code = data.charCodeAt(0);
+	return code >= 0x20 && code !== 0x7f;
+}
+
+function selectListTheme(theme: RecapPickerTheme) {
+	return {
+		selectedPrefix: (text: string) => theme.fg("accent", text),
+		selectedText: (text: string) => theme.fg("accent", text),
+		description: (text: string) => theme.fg("muted", text),
+		scrollInfo: (text: string) => theme.fg("dim", text),
+		noMatch: (text: string) => theme.fg("warning", text),
+	};
+}
+
+export function filterableSelect(
+	items: SelectItem[],
+	theme: RecapPickerTheme,
+	done: (value?: string) => void,
+	opts: { preferredValue?: string } = {},
+): Component {
+	let query = "";
+	let list = buildFilterableList(items, query, theme, done, opts.preferredValue);
+
+	return {
+		render(width: number) {
+			const filter = query.length > 0 ? `Filter: ${query}` : "Type to filter…";
+			return [theme.fg(query.length > 0 ? "accent" : "dim", filter), ...list.render(width)];
+		},
+		invalidate() {
+			list.invalidate();
+		},
+		handleInput(data: string) {
+			if (isKeyRelease(data)) return;
+			if (isBackspace(data)) {
+				if (query.length === 0) return;
+				query = query.slice(0, -1);
+				list = buildFilterableList(items, query, theme, done, opts.preferredValue);
+				return;
+			}
+			if (isPrintable(data)) {
+				query += data;
+				list = buildFilterableList(items, query, theme, done, opts.preferredValue);
+				return;
+			}
+			list.handleInput(data);
+		},
+	};
+}
+
+function buildFilterableList(
+	items: SelectItem[],
+	query: string,
+	theme: RecapPickerTheme,
+	done: (value?: string) => void,
+	preferredValue?: string,
+): SelectList {
+	const filtered = filterSelectItems(items, query);
+	const visible = filtered.length > 0 ? filtered : [{ value: "", label: "No matches" }];
+	const list = new SelectList(visible, Math.min(visible.length, MAX_VISIBLE_ROWS), selectListTheme(theme));
+	list.onSelect = (item) => {
+		if (!item.value) return;
+		done(item.value);
+	};
+	list.onCancel = () => done(undefined);
+	if (query.length === 0 && preferredValue) {
+		const index = visible.findIndex((item) => item.value === preferredValue);
+		if (index >= 0) list.setSelectedIndex(index);
+	}
+	return list;
+}
+
+export type CustomValueOptions = {
+	title: string;
+	prefill: string;
+	parse: (raw: string) => string | undefined;
+};
+
+export function presetOrCustomPicker(
+	presets: SelectItem[],
+	theme: RecapPickerTheme,
+	done: (value?: string) => void,
+	opts: { preferredValue?: string; custom: CustomValueOptions },
+): Component {
+	const items = [...presets, { value: CUSTOM_VALUE, label: "custom…" }];
+	let mode: "list" | "custom" = "list";
+	const list = new SelectList(items, Math.min(items.length, MAX_VISIBLE_ROWS), selectListTheme(theme));
+	if (opts.preferredValue) {
+		const index = items.findIndex((item) => item.value === opts.preferredValue);
+		if (index >= 0) list.setSelectedIndex(index);
+	}
+	const input = createCustomInput(theme, opts.custom, done);
+	list.onSelect = (item) => {
+		if (item.value === CUSTOM_VALUE) {
+			mode = "custom";
+			return;
+		}
+		done(item.value);
+	};
+	list.onCancel = () => done(undefined);
+
+	return {
+		render(width: number) {
+			return mode === "custom" ? input.render(width) : list.render(width);
+		},
+		invalidate() {
+			if (mode === "custom") input.invalidate();
+			else list.invalidate();
+		},
+		handleInput(data: string) {
+			if (mode === "custom") input.handleInput?.(data);
+			else list.handleInput(data);
+		},
+	};
+}
+
+function createCustomInput(
+	theme: RecapPickerTheme,
+	custom: CustomValueOptions,
+	done: (value?: string) => void,
+): Component {
+	const input = new Input();
+	input.focused = true;
+	input.setValue(custom.prefill);
+	input.onSubmit = (value) => {
+		const parsed = custom.parse(value);
+		if (parsed === undefined) return;
+		done(parsed);
+	};
+	input.onEscape = () => done(undefined);
+
+	return {
+		render(width: number) {
+			return [
+				theme.fg("accent", custom.title),
+				...input.render(width),
+				theme.fg("dim", "Enter to save · Esc to cancel"),
+			];
+		},
+		invalidate() {
+			input.invalidate();
+		},
+		handleInput(data: string) {
+			input.handleInput(data);
+		},
+	};
+}
+
+export function editorSubmenu(
+	editor: ((title: string, prefill?: string) => Promise<string | undefined>) | undefined,
+	title: string,
+	prefill: string,
+	done: (value?: string) => void,
+): Component {
+	if (!editor) {
+		return {
+			render: () => ["Editor unavailable"],
+			invalidate() {},
+			handleInput() {
+				done(undefined);
+			},
+		};
+	}
+
+	void editor(title, prefill).then((edited) => {
+		if (edited === undefined || edited.trim() === "") done(undefined);
+		else done(edited);
+	});
+
+	return {
+		render: () => ["Opening editor…"],
+		invalidate() {},
+		handleInput() {},
+	};
+}

--- a/packages/pi-recap/extensions/recap.ts
+++ b/packages/pi-recap/extensions/recap.ts
@@ -22,8 +22,14 @@ import {
 	type ExtensionCommandContext,
 	type ExtensionContext,
 	type SessionEntry,
+	type Theme,
 } from "@earendil-works/pi-coding-agent";
-import { CancellableLoader, Container, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
+import { CancellableLoader, Container, type SelectItem, type SettingItem, SettingsList, Text } from "@earendil-works/pi-tui";
+import {
+	editorSubmenu,
+	filterableSelect,
+	presetOrCustomPicker,
+} from "./recap-picker.ts";
 import {
 	recapOutputWarning,
 	resolveRecapOutput,
@@ -535,7 +541,7 @@ function buildSystemPrompt(config: RecapConfig): string {
 	].join("\n");
 }
 
-function resolveRecapModel(ctx: ExtensionContext, config: RecapConfig) {
+export function resolveRecapModel(ctx: ExtensionContext, config: RecapConfig) {
 	if (config.recap.model === "current") return ctx.model;
 
 	const separator = config.recap.model.indexOf("/");
@@ -546,7 +552,12 @@ function resolveRecapModel(ctx: ExtensionContext, config: RecapConfig) {
 		if (model) return model;
 	}
 
-	return config.recap.fallbackToCurrentModel ? ctx.model : undefined;
+	if (!config.recap.fallbackToCurrentModel || !ctx.model) return undefined;
+	ctx.ui.notify(
+		`Recap model ${config.recap.model} is unavailable; falling back to the current model.`,
+		"warning",
+	);
+	return ctx.model;
 }
 
 export type TitleApplicationInput = {
@@ -849,8 +860,102 @@ function boolValue(value: boolean): string {
 	return value ? "on" : "off";
 }
 
-function settingItems(config: RecapConfig): SettingItem[] {
-	return [
+const IDLE_MS_PRESETS = [60_000, 180_000, 300_000, 600_000];
+const MIN_SESSION_TURN_PRESETS = [1, 2, 3, 5, 10];
+const MAX_RECENT_CHAR_PRESETS = [10_000, 20_000, 40_000, 80_000];
+const MAX_TOKEN_PRESETS = [150, 300, 500, 1000];
+const TITLE_MAX_LENGTH_PRESETS = [30, 50, 80];
+const MULTIPLEXER_MAX_LENGTH_PRESETS = [32, 48, 60, 80];
+const LANGUAGE_PRESETS = ["auto", "en", "zh-CN"];
+
+export function recapModelValues(
+	available: ReadonlyArray<{ provider?: string; id?: string }>,
+	configured: string,
+): string[] {
+	const values = ["current"];
+	const seen = new Set(values);
+	for (const model of available) {
+		if (!model.provider || !model.id) continue;
+		const key = `${model.provider}/${model.id}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		values.push(key);
+	}
+	if (configured && !seen.has(configured)) values.push(configured);
+	return values;
+}
+
+export function formatIdleAfterTurnMs(ms: number): string {
+	const minutes = ms / 60_000;
+	if (Number.isInteger(minutes)) return `${minutes} min`;
+	return `${Number(minutes.toFixed(2))} min`;
+}
+
+function uniqueSortedNumbers(presets: readonly number[], current: number): number[] {
+	return [...new Set([...presets, current])].sort((left, right) => left - right);
+}
+
+function numberSelectItems(presets: readonly number[], current: number): SelectItem[] {
+	return uniqueSortedNumbers(presets, current).map((value) => ({
+		value: String(value),
+		label: String(value),
+	}));
+}
+
+function idleSelectItems(currentMs: number): SelectItem[] {
+	return uniqueSortedNumbers(IDLE_MS_PRESETS, currentMs).map((ms) => ({
+		value: String(ms),
+		label: formatIdleAfterTurnMs(ms),
+	}));
+}
+
+function languageSelectItems(current: string): SelectItem[] {
+	const values = LANGUAGE_PRESETS.includes(current) ? [...LANGUAGE_PRESETS] : [...LANGUAGE_PRESETS, current];
+	return values.filter(Boolean).map((value) => ({ value, label: value }));
+}
+
+function parsePositiveNumberValue(raw: string): string | undefined {
+	const value = Number(raw.trim());
+	if (!Number.isFinite(value) || value <= 0) return undefined;
+	return String(Math.floor(value));
+}
+
+function parseIdleMinutesValue(raw: string): string | undefined {
+	const minutes = Number(raw.trim());
+	if (!Number.isFinite(minutes) || minutes <= 0) return undefined;
+	return String(Math.max(1, Math.round(minutes * 60_000)));
+}
+
+function parseLanguageValue(raw: string): string | undefined {
+	const value = raw.trim();
+	return value.length > 0 ? value : undefined;
+}
+
+export type RecapModelOption = { provider: string; id: string; name?: string };
+
+export type RecapSettingsOptions = {
+	availableModels?: ReadonlyArray<RecapModelOption>;
+	theme: Theme;
+	getConfig?: () => RecapConfig;
+	editor?: (title: string, prefill?: string) => Promise<string | undefined>;
+};
+
+function recapModelSelectItems(
+	available: ReadonlyArray<RecapModelOption>,
+	configured: string,
+): SelectItem[] {
+	return recapModelValues(available, configured).map((value) => {
+		if (value === "current") return { value, label: "current" };
+		const model = available.find((item) => `${item.provider}/${item.id}` === value);
+		if (model?.name) return { value, label: `${model.name}  (${value})` };
+		return { value, label: value };
+	});
+}
+
+export function settingItems(config: RecapConfig, options: RecapSettingsOptions): SettingItem[] {
+	const getConfig = options.getConfig ?? (() => config);
+	const availableModels = options.availableModels ?? [];
+	const items: SettingItem[] = [
 		{
 			id: "recap.enabled",
 			label: "Recap enabled",
@@ -866,19 +971,164 @@ function settingItems(config: RecapConfig): SettingItem[] {
 			values: ["on", "off"],
 		},
 		{
-			id: "title.applyToSessionName",
-			label: "Apply title to session name",
-			description: "Use generated title to rename the Pi session according to policy.",
-			currentValue: boolValue(config.title.applyToSessionName),
+			id: "recap.manualCommand",
+			label: "Manual /recap command",
+			description: "Allow generating a recap with /recap.",
+			currentValue: boolValue(config.recap.manualCommand),
 			values: ["on", "off"],
 		},
 		{
-			id: "title.applyPolicy",
-			label: "Session name policy",
-			description: "Controls when generated titles overwrite session name.",
-			currentValue: config.title.applyPolicy,
-			values: ["if-empty-or-auto", "if-empty", "always", "never"],
+			id: "recap.idleAfterTurnMs",
+			label: "Idle before auto recap",
+			description: "How long to wait after the agent finishes before auto recap.",
+			currentValue: formatIdleAfterTurnMs(config.recap.idleAfterTurnMs),
+			submenu: (_current, done) =>
+				presetOrCustomPicker(idleSelectItems(getConfig().recap.idleAfterTurnMs), options.theme, done, {
+					preferredValue: String(getConfig().recap.idleAfterTurnMs),
+					custom: {
+						title: "Idle minutes",
+						prefill: String(getConfig().recap.idleAfterTurnMs / 60_000),
+						parse: parseIdleMinutesValue,
+					},
+				}),
 		},
+		{
+			id: "recap.minSessionTurns",
+			label: "Minimum session turns",
+			description: "Skip auto recap until the session has at least this many user turns.",
+			currentValue: String(config.recap.minSessionTurns),
+			submenu: (_current, done) =>
+				presetOrCustomPicker(numberSelectItems(MIN_SESSION_TURN_PRESETS, getConfig().recap.minSessionTurns), options.theme, done, {
+					preferredValue: String(getConfig().recap.minSessionTurns),
+					custom: {
+						title: "Minimum session turns",
+						prefill: String(getConfig().recap.minSessionTurns),
+						parse: parsePositiveNumberValue,
+					},
+				}),
+		},
+		{
+			id: "recap.neverTwiceInARow",
+			label: "Never twice in a row",
+			description: "Skip auto recap when nothing new has happened since the last recap.",
+			currentValue: boolValue(config.recap.neverTwiceInARow),
+			values: ["on", "off"],
+		},
+		{
+			id: "recap.model",
+			label: "Recap model",
+			description: "Use the current session model, or pick from currently enabled models. A cheaper model is recommended.",
+			currentValue: config.recap.model,
+			submenu: (_current, done) =>
+				filterableSelect(
+					recapModelSelectItems(availableModels, getConfig().recap.model),
+					options.theme,
+					done,
+					{ preferredValue: getConfig().recap.model },
+				),
+		},
+	];
+
+	if (config.recap.model !== "current") {
+		items.push({
+			id: "recap.fallbackToCurrentModel",
+			label: "Fallback to current model",
+			description: "If the selected recap model is unavailable, use the current session model.",
+			currentValue: boolValue(config.recap.fallbackToCurrentModel),
+			values: ["on", "off"],
+		});
+	}
+
+	items.push(
+		{
+			id: "recap.maxRecentChars",
+			label: "Max recent characters",
+			description: "Cap the recent activity sent to the recap model.",
+			currentValue: String(config.recap.maxRecentChars),
+			submenu: (_current, done) =>
+				presetOrCustomPicker(numberSelectItems(MAX_RECENT_CHAR_PRESETS, getConfig().recap.maxRecentChars), options.theme, done, {
+					preferredValue: String(getConfig().recap.maxRecentChars),
+					custom: {
+						title: "Max recent characters",
+						prefill: String(getConfig().recap.maxRecentChars),
+						parse: parsePositiveNumberValue,
+					},
+				}),
+		},
+		{
+			id: "recap.maxTokens",
+			label: "Max tokens",
+			description: "Token cap for the recap model response.",
+			currentValue: String(config.recap.maxTokens),
+			submenu: (_current, done) =>
+				presetOrCustomPicker(numberSelectItems(MAX_TOKEN_PRESETS, getConfig().recap.maxTokens), options.theme, done, {
+					preferredValue: String(getConfig().recap.maxTokens),
+					custom: {
+						title: "Max tokens",
+						prefill: String(getConfig().recap.maxTokens),
+						parse: parsePositiveNumberValue,
+					},
+				}),
+		},
+		{
+			id: "recap.language",
+			label: "Language",
+			description: "auto follows recent activity. Custom values are sent as the recap language.",
+			currentValue: config.recap.language,
+			submenu: (_current, done) =>
+				presetOrCustomPicker(languageSelectItems(getConfig().recap.language), options.theme, done, {
+					preferredValue: getConfig().recap.language,
+					custom: {
+						title: "Recap language",
+						prefill: getConfig().recap.language,
+						parse: parseLanguageValue,
+					},
+				}),
+		},
+		{
+			id: "title.generate",
+			label: "Generate title",
+			description: "Also generate a short title as a recap side effect.",
+			currentValue: boolValue(config.title.generate),
+			values: ["on", "off"],
+		},
+	);
+
+	if (config.title.generate) {
+		items.push(
+			{
+				id: "title.applyToSessionName",
+				label: "Apply title to session name",
+				description: "Use generated title to rename the Pi session according to policy.",
+				currentValue: boolValue(config.title.applyToSessionName),
+				values: ["on", "off"],
+			},
+			{
+				id: "title.applyPolicy",
+				label: "Session name policy",
+				description: "Controls when generated titles overwrite session name.",
+				currentValue: config.title.applyPolicy,
+				values: ["if-empty-or-auto", "if-empty", "always", "never"],
+			},
+			{
+				id: "title.maxLength",
+				label: "Title max length",
+				description: "Maximum characters for the generated or fallback title.",
+				currentValue: String(config.title.maxLength),
+				submenu: (_current, done) =>
+					presetOrCustomPicker(numberSelectItems(TITLE_MAX_LENGTH_PRESETS, getConfig().title.maxLength), options.theme, done, {
+						preferredValue: String(getConfig().title.maxLength),
+						custom: {
+							title: "Title max length",
+							prefill: String(getConfig().title.maxLength),
+							parse: parsePositiveNumberValue,
+						},
+					}),
+			},
+		);
+	}
+
+	items.push(
 		{
 			id: "display.widgetPlacement",
 			label: "Widget placement",
@@ -894,16 +1144,51 @@ function settingItems(config: RecapConfig): SettingItem[] {
 			values: ["on", "off"],
 		},
 		{
+			id: "multiplexer.template",
+			label: "Multiplexer template",
+			description: "Name template. Variables: {session} {project} {cwd} {id}.",
+			currentValue: config.multiplexer.template,
+			submenu: (_current, done) =>
+				editorSubmenu(
+					options.editor,
+					"Multiplexer name template",
+					getConfig().multiplexer.template,
+					done,
+				),
+		},
+		{
+			id: "multiplexer.maxLength",
+			label: "Multiplexer name max length",
+			description: "Truncate the generated pane or window name to this length.",
+			currentValue: String(config.multiplexer.maxLength),
+			submenu: (_current, done) =>
+				presetOrCustomPicker(
+					numberSelectItems(MULTIPLEXER_MAX_LENGTH_PRESETS, getConfig().multiplexer.maxLength),
+					options.theme,
+					done,
+					{
+						preferredValue: String(getConfig().multiplexer.maxLength),
+						custom: {
+							title: "Multiplexer name max length",
+							prefill: String(getConfig().multiplexer.maxLength),
+							parse: parsePositiveNumberValue,
+						},
+					},
+				),
+		},
+		{
 			id: "multiplexer.restoreOnShutdown",
 			label: "Restore multiplexer on shutdown",
 			description: "Restore the previous pane or window name when Pi exits.",
 			currentValue: boolValue(config.multiplexer.restoreOnShutdown),
 			values: ["on", "off"],
 		},
-	];
+	);
+
+	return items;
 }
 
-function applyConfigSetting(config: RecapConfig, id: string, value: string): RecapConfig {
+export function applyConfigSetting(config: RecapConfig, id: string, value: string): RecapConfig {
 	const next = normalizeConfig(JSON.parse(JSON.stringify(config)) as RecapConfig);
 	const on = value === "on";
 
@@ -914,17 +1199,56 @@ function applyConfigSetting(config: RecapConfig, id: string, value: string): Rec
 		case "recap.auto":
 			next.recap.auto = on;
 			break;
+		case "recap.manualCommand":
+			next.recap.manualCommand = on;
+			break;
+		case "recap.neverTwiceInARow":
+			next.recap.neverTwiceInARow = on;
+			break;
+		case "recap.model":
+			next.recap.model = value.trim() || next.recap.model;
+			break;
+		case "recap.fallbackToCurrentModel":
+			next.recap.fallbackToCurrentModel = on;
+			break;
+		case "recap.idleAfterTurnMs":
+			next.recap.idleAfterTurnMs = positiveNumber(Number(value), next.recap.idleAfterTurnMs);
+			break;
+		case "recap.minSessionTurns":
+			next.recap.minSessionTurns = Math.max(0, Math.floor(positiveNumber(Number(value), next.recap.minSessionTurns)));
+			break;
+		case "recap.maxRecentChars":
+			next.recap.maxRecentChars = positiveNumber(Number(value), next.recap.maxRecentChars);
+			break;
+		case "recap.maxTokens":
+			next.recap.maxTokens = positiveNumber(Number(value), next.recap.maxTokens);
+			break;
+		case "recap.language":
+			next.recap.language = value.trim() || next.recap.language;
+			break;
+		case "title.generate":
+			next.title.generate = on;
+			break;
 		case "title.applyToSessionName":
 			next.title.applyToSessionName = on;
 			break;
 		case "title.applyPolicy":
 			next.title.applyPolicy = normalizeTitlePolicy(value);
 			break;
+		case "title.maxLength":
+			next.title.maxLength = positiveNumber(Number(value), next.title.maxLength);
+			break;
 		case "display.widgetPlacement":
 			next.display.widgetPlacement = value === "belowEditor" ? "belowEditor" : "aboveEditor";
 			break;
 		case "multiplexer.enabled":
 			next.multiplexer.enabled = on;
+			break;
+		case "multiplexer.template":
+			next.multiplexer.template = value;
+			break;
+		case "multiplexer.maxLength":
+			next.multiplexer.maxLength = positiveNumber(Number(value), next.multiplexer.maxLength);
 			break;
 		case "multiplexer.restoreOnShutdown":
 			next.multiplexer.restoreOnShutdown = on;
@@ -957,27 +1281,61 @@ async function editConfigJson(pi: ExtensionAPI, ctx: ExtensionContext, state: Re
 	}
 }
 
+type SettingsListInternals = {
+	items: SettingItem[];
+	filteredItems: SettingItem[];
+	selectedIndex: number;
+	searchInput?: { getValue(): string };
+	applyFilter?: (query: string) => void;
+};
+
+function replaceSettingsListItems(list: SettingsList, items: SettingItem[]) {
+	const mutable = list as unknown as SettingsListInternals;
+	const selectedId = mutable.items[mutable.selectedIndex]?.id;
+	mutable.items = items;
+	const query = mutable.searchInput?.getValue() ?? "";
+	if (query && typeof mutable.applyFilter === "function") {
+		mutable.applyFilter(query);
+	} else {
+		mutable.filteredItems = items;
+	}
+	const pool = query ? mutable.filteredItems : mutable.items;
+	const index = pool.findIndex((item) => item.id === selectedId);
+	if (index >= 0) mutable.selectedIndex = index;
+	else if (mutable.selectedIndex >= pool.length) mutable.selectedIndex = Math.max(0, pool.length - 1);
+}
+
 async function openConfigUi(pi: ExtensionAPI, ctx: ExtensionContext, state: RecapState) {
 	if (ctx.mode !== "tui") {
 		ctx.ui.notify("/recap-config requires TUI mode. Use /recap-config json to edit raw JSON in UI-capable modes.", "error");
 		return;
 	}
 
+	const availableModels = typeof ctx.modelRegistry.getAvailable === "function"
+		? ctx.modelRegistry.getAvailable()
+		: [];
+
 	await ctx.ui.custom((tui, theme, _kb, done) => {
+		const settingsOptions = (): RecapSettingsOptions => ({
+			availableModels,
+			theme,
+			getConfig: () => state.config,
+			editor: (title, prefill) => ctx.ui.editor(title, prefill),
+		});
 		const container = new Container();
 		container.addChild(new Text(theme.fg("accent", theme.bold("Recap Configuration")), 1, 0));
 		container.addChild(new Text(theme.fg("dim", `Saving to ${getGlobalConfigPath()}`), 1, 0));
-		container.addChild(new Text(theme.fg("dim", "Enter/Space cycles values · Esc closes · /recap-config json edits full JSON"), 1, 0));
+		container.addChild(new Text(theme.fg("dim", "Enter/Space to change · Esc closes · /recap-config json is optional"), 1, 0));
 
 		let settingsList: SettingsList;
 		settingsList = new SettingsList(
-			settingItems(state.config),
-			12,
+			settingItems(state.config, settingsOptions()),
+			14,
 			getSettingsListTheme(),
 			(id, newValue) => {
 				const next = applyConfigSetting(state.config, id, newValue);
 				state.config = next;
-				settingsList.updateValue(id, newValue);
+				replaceSettingsListItems(settingsList, settingItems(next, settingsOptions()));
 
 				if (!next.recap.enabled || !next.recap.auto) stopAutomaticRecap(ctx, state);
 				refreshRecapDisplay(ctx, state);

--- a/packages/pi-recap/extensions/recap.ts
+++ b/packages/pi-recap/extensions/recap.ts
@@ -586,6 +586,48 @@ function formatModelName(model: NonNullable<ExtensionContext["model"]> | undefin
 	return model ? `${model.provider}/${model.id}` : undefined;
 }
 
+const OPENCODE_HOST = "opencode.ai";
+
+function matchesOpenCodeHost(baseUrl: string | undefined): boolean {
+	if (!baseUrl) return false;
+	try {
+		return new URL(baseUrl).hostname === OPENCODE_HOST;
+	} catch {
+		return false;
+	}
+}
+
+function isOpenCodeModel(model: { provider?: string; baseUrl?: string }): boolean {
+	return model.provider === "opencode" || model.provider === "opencode-go" || matchesOpenCodeHost(model.baseUrl);
+}
+
+function readSessionId(ctx: ExtensionContext): string | undefined {
+	const getSessionId = ctx.sessionManager.getSessionId;
+	if (typeof getSessionId !== "function") return undefined;
+	try {
+		const sessionId = getSessionId.call(ctx.sessionManager);
+		return typeof sessionId === "string" && sessionId.length > 0 ? sessionId : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function getOpenCodeSessionHeaders(
+	model: { provider?: string; baseUrl?: string },
+	sessionId: string | undefined,
+): Record<string, string> | undefined {
+	if (!sessionId || !isOpenCodeModel(model)) return undefined;
+	return { "x-opencode-session": sessionId, "x-opencode-client": "pi" };
+}
+
+function resolveCompleteModel(ctx: ExtensionContext, completeModel: typeof complete | undefined): typeof complete {
+	if (completeModel) return completeModel;
+	if (typeof ctx.modelRegistry.complete === "function") {
+		return (model, context, opts) => ctx.modelRegistry.complete(model, context, opts as never);
+	}
+	return complete;
+}
+
 export type RunRecapOptions = {
 	force?: boolean;
 	signal?: AbortSignal;
@@ -601,7 +643,8 @@ export async function runRecap(
 	reason: RecapReason,
 	options: RunRecapOptions = {},
 ): Promise<RecapEntryData | undefined> {
-	const { force = false, signal, showProgress = true, completeModel = complete } = options;
+	const { force = false, signal, showProgress = true } = options;
+	const completeModel = resolveCompleteModel(ctx, options.completeModel);
 	if (state.running) return undefined;
 	if (!config.recap.enabled) {
 		if (reason === "manual" && ctx.mode === "tui") displayRecapError(ctx, config, "Recap is disabled by config");
@@ -647,40 +690,35 @@ export async function runRecap(
 	if (showProgress) showRecapProgress(ctx, config);
 
 	try {
-		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-		if (!isCurrentRecapRun(state, run)) return undefined;
-		if (!auth.ok) {
-			const message = "error" in auth ? auth.error : `Failed to resolve API key for ${model.provider}`;
-			displayRecapError(ctx, config, message);
+		const sessionId = readSessionId(ctx);
+		const headers = getOpenCodeSessionHeaders(model, sessionId);
+		let response;
+		try {
+			response = await completeModel(
+				model,
+				{
+					systemPrompt: buildSystemPrompt(config),
+					messages: [
+						{
+							role: "user" as const,
+							content: [{ type: "text" as const, text: source.conversation }],
+							timestamp: Date.now(),
+						},
+					],
+				},
+				{
+					maxTokens: config.recap.maxTokens,
+					signal: runSignal,
+					sessionId,
+					...(headers ? { headers } : {}),
+				},
+			);
+		} catch (error) {
+			if (runSignal?.aborted || state.activeRun !== run) return undefined;
+			displayRecapError(ctx, config, error instanceof Error ? error.message : String(error));
 			displayed = true;
 			return undefined;
 		}
-		if (!auth.apiKey) {
-			displayRecapError(ctx, config, `No API key for ${model.provider}`);
-			displayed = true;
-			return undefined;
-		}
-
-		const response = await completeModel(
-			model,
-			{
-				systemPrompt: buildSystemPrompt(config),
-				messages: [
-					{
-						role: "user" as const,
-						content: [{ type: "text" as const, text: source.conversation }],
-						timestamp: Date.now(),
-					},
-				],
-			},
-			{
-				apiKey: auth.apiKey,
-				headers: auth.headers,
-				env: auth.env,
-				maxTokens: config.recap.maxTokens,
-				signal: runSignal,
-			},
-		);
 
 		if (!isCurrentRecapRun(state, run) || response.stopReason === "aborted") return undefined;
 

--- a/packages/pi-recap/extensions/recap.ts
+++ b/packages/pi-recap/extensions/recap.ts
@@ -48,7 +48,7 @@ const WIDGET_KEY = "recap";
 const LEGACY_STATUS_KEY = "recap";
 
 export type RecapReason = "manual" | "auto";
-export type TitleApplyPolicy = "never" | "if-empty" | "if-empty-or-auto" | "always";
+export type TitleApplyPolicy = "off" | "if-empty" | "if-empty-or-auto" | "always";
 
 const MIN_SESSION_TURNS = 3;
 const RECAP_MAX_RECENT_CHARS = 20_000;
@@ -66,7 +66,7 @@ export type RecapConfig = {
 		language: string;
 	};
 	title: {
-		applyToSessionName: boolean;
+		applyPolicy: TitleApplyPolicy;
 	};
 	multiplexer: {
 		enabled: boolean;
@@ -98,7 +98,7 @@ export const DEFAULT_CONFIG: RecapConfig = {
 		language: "auto",
 	},
 	title: {
-		applyToSessionName: false,
+		applyPolicy: "off",
 	},
 	multiplexer: {
 		enabled: true,
@@ -133,7 +133,7 @@ type ConfigMigration = {
 
 const CONFIG_FIELDS: Record<string, ReadonlySet<string>> = {
 	recap: new Set(["auto", "idleAfterTurnMs", "model", "fallbackToCurrentModel", "language"]),
-	title: new Set(["applyToSessionName"]),
+	title: new Set(["applyPolicy"]),
 	multiplexer: new Set(["enabled", "template"]),
 };
 const emittedMigrationNotices = new Set<string>();
@@ -164,18 +164,39 @@ function stripUnknownConfig(value: unknown): { value: unknown; dropped: string[]
 
 function migrateRemovedFields(value: unknown): { value: unknown; changed: boolean } {
 	if (!isRecord(value)) return { value, changed: false };
-	const recap = isRecord(value.recap) ? { ...value.recap } : undefined;
-	if (!recap) return { value, changed: false };
 	let changed = false;
-	if (recap.enabled === false) {
-		recap.auto = false;
-		changed = true;
+	const next: Record<string, unknown> = { ...value };
+
+	if (isRecord(value.recap)) {
+		const recap = { ...value.recap };
+		if (recap.enabled === false) {
+			recap.auto = false;
+			changed = true;
+		}
+		if ("enabled" in recap) {
+			delete recap.enabled;
+			changed = true;
+		}
+		next.recap = recap;
 	}
-	if ("enabled" in recap) {
-		delete recap.enabled;
-		changed = true;
+
+	if (isRecord(value.title)) {
+		const title = { ...value.title };
+		if (title.applyToSessionName === false) {
+			title.applyPolicy = "off";
+			changed = true;
+		} else if (title.applyPolicy === "never") {
+			title.applyPolicy = "off";
+			changed = true;
+		}
+		if ("applyToSessionName" in title) {
+			delete title.applyToSessionName;
+			changed = true;
+		}
+		next.title = title;
 	}
-	return { value: { ...value, recap }, changed };
+
+	return { value: next, changed };
 }
 
 function migrateLegacyConfig(value: unknown): ConfigMigration {
@@ -375,7 +396,7 @@ export function normalizeConfig(config: RecapConfig): RecapConfig {
 				: DEFAULT_CONFIG.recap.language,
 		},
 		title: {
-			applyToSessionName: Boolean(config.title?.applyToSessionName),
+			applyPolicy: normalizeTitleApplyPolicy(config.title),
 		},
 		multiplexer: {
 			enabled: config.multiplexer?.enabled !== false,
@@ -388,6 +409,21 @@ export function normalizeConfig(config: RecapConfig): RecapConfig {
 
 function positiveNumber(value: unknown, fallback: number): number {
 	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function normalizeTitleApplyPolicy(title: { applyToSessionName?: boolean; applyPolicy?: string } | undefined): TitleApplyPolicy {
+	const incoming = title;
+	if (incoming?.applyToSessionName === false) return "off";
+	if (incoming?.applyPolicy === "never") return "off";
+	if (
+		incoming?.applyPolicy === "off" ||
+		incoming?.applyPolicy === "if-empty" ||
+		incoming?.applyPolicy === "if-empty-or-auto" ||
+		incoming?.applyPolicy === "always"
+	) {
+		return incoming.applyPolicy;
+	}
+	return DEFAULT_CONFIG.title.applyPolicy;
 }
 
 function currentSessionName(pi: ExtensionAPI, ctx: ExtensionContext): string | undefined {
@@ -550,16 +586,15 @@ export function resolveRecapModel(ctx: ExtensionContext, config: RecapConfig) {
 
 export type TitleApplicationInput = {
 	title?: string;
-	applyToSessionName: boolean;
-	policy: TitleApplyPolicy;
+	policy: TitleApplyPolicy | "never";
 	currentSessionName?: string;
 	lastAppliedSessionName: boolean;
 	lastAppliedTitle?: string;
 };
 
 export function shouldApplyTitleForPolicy(input: TitleApplicationInput): boolean {
-	if (!input.applyToSessionName || !input.title) return false;
-	if (input.policy === "never") return false;
+	if (!input.title) return false;
+	if (input.policy === "off" || input.policy === "never") return false;
 	if (input.policy === "always") return true;
 	if (!input.currentSessionName) return true;
 	if (input.policy === "if-empty") return false;
@@ -570,15 +605,10 @@ export function shouldApplyTitleForPolicy(input: TitleApplicationInput): boolean
 	);
 }
 
-function titleApplyPolicy(applyToSessionName: boolean): TitleApplyPolicy {
-	return applyToSessionName ? "if-empty-or-auto" : "never";
-}
-
 function shouldApplyTitle(title: string | undefined, pi: ExtensionAPI, ctx: ExtensionContext, config: RecapConfig, state: RecapState): boolean {
 	return shouldApplyTitleForPolicy({
 		title,
-		applyToSessionName: config.title.applyToSessionName,
-		policy: titleApplyPolicy(config.title.applyToSessionName),
+		policy: config.title.applyPolicy,
 		currentSessionName: currentSessionName(pi, ctx),
 		lastAppliedSessionName: state.lastAppliedSessionName,
 		lastAppliedTitle: state.lastAppliedTitle,
@@ -761,7 +791,7 @@ export async function runRecap(
 			},
 			generatedAt: Date.now(),
 			appliedSessionName,
-			sessionNamePolicy: titleApplyPolicy(config.title.applyToSessionName),
+			sessionNamePolicy: config.title.applyPolicy,
 		};
 
 		pi.appendEntry(CUSTOM_TYPE, data);
@@ -990,11 +1020,11 @@ export function settingItems(config: RecapConfig, options: RecapSettingsOptions)
 				}),
 		},
 		{
-			id: "title.applyToSessionName",
-			label: "Apply title to session name",
-			description: "When on, recap may set the session name if it is empty or still the last recap title. Manual names are not overwritten.",
-			currentValue: boolValue(config.title.applyToSessionName),
-			values: ["on", "off"],
+			id: "title.applyPolicy",
+			label: "Session name policy",
+			description: "off leaves the Pi session name alone. if-empty fills a blank name. if-empty-or-auto also updates a name recap last wrote. always overwrites.",
+			currentValue: config.title.applyPolicy,
+			values: ["off", "if-empty", "if-empty-or-auto", "always"],
 		},
 	);
 
@@ -1044,8 +1074,8 @@ export function applyConfigSetting(config: RecapConfig, id: string, value: strin
 		case "recap.language":
 			next.recap.language = value.trim() || next.recap.language;
 			break;
-		case "title.applyToSessionName":
-			next.title.applyToSessionName = on;
+		case "title.applyPolicy":
+			next.title.applyPolicy = normalizeTitleApplyPolicy({ applyPolicy: value });
 			break;
 		case "multiplexer.enabled":
 			next.multiplexer.enabled = on;

--- a/packages/pi-recap/extensions/recap.ts
+++ b/packages/pi-recap/extensions/recap.ts
@@ -49,32 +49,29 @@ const LEGACY_STATUS_KEY = "recap";
 
 export type RecapReason = "manual" | "auto";
 export type TitleApplyPolicy = "never" | "if-empty" | "if-empty-or-auto" | "always";
-type WidgetPlacement = "aboveEditor" | "belowEditor";
+
+const MIN_SESSION_TURNS = 3;
+const RECAP_MAX_RECENT_CHARS = 20_000;
+const RECAP_MAX_TOKENS = 300;
+const TITLE_MAX_LENGTH = 50;
+const MULTIPLEXER_MAX_LENGTH = 48;
+const WIDGET_PLACEMENT = "aboveEditor" as const;
 
 export type RecapConfig = {
 	recap: {
-		enabled: boolean;
 		auto: boolean;
-		manualCommand: boolean;
 		idleAfterTurnMs: number;
-		minSessionTurns: number;
-		neverTwiceInARow: boolean;
 		model: "current" | string;
 		fallbackToCurrentModel: boolean;
-		maxRecentChars: number;
-		maxTokens: number;
 		language: string;
 	};
-	display: {
-		widgetPlacement: WidgetPlacement;
-	};
 	title: {
-		generate: boolean;
 		applyToSessionName: boolean;
-		applyPolicy: TitleApplyPolicy;
-		maxLength: number;
 	};
-	multiplexer: MultiplexerConfig;
+	multiplexer: {
+		enabled: boolean;
+		template: string;
+	};
 };
 
 export type RecapEntryData = {
@@ -94,32 +91,18 @@ export type RecapEntryData = {
 
 export const DEFAULT_CONFIG: RecapConfig = {
 	recap: {
-		enabled: true,
 		auto: true,
-		manualCommand: true,
 		idleAfterTurnMs: 3 * 60_000,
-		minSessionTurns: 3,
-		neverTwiceInARow: true,
 		model: "current",
 		fallbackToCurrentModel: true,
-		maxRecentChars: 20_000,
-		maxTokens: 300,
 		language: "auto",
 	},
-	display: {
-		widgetPlacement: "aboveEditor",
-	},
 	title: {
-		generate: true,
 		applyToSessionName: false,
-		applyPolicy: "if-empty-or-auto",
-		maxLength: 50,
 	},
 	multiplexer: {
 		enabled: true,
 		template: "π {session} · {project}",
-		maxLength: 48,
-		restoreOnShutdown: true,
 	},
 };
 
@@ -149,10 +132,9 @@ type ConfigMigration = {
 };
 
 const CONFIG_FIELDS: Record<string, ReadonlySet<string>> = {
-	recap: new Set(["enabled", "auto", "manualCommand", "idleAfterTurnMs", "minSessionTurns", "neverTwiceInARow", "model", "fallbackToCurrentModel", "maxRecentChars", "maxTokens", "language"]),
-	display: new Set(["widgetPlacement"]),
-	title: new Set(["generate", "applyToSessionName", "applyPolicy", "maxLength"]),
-	multiplexer: new Set(["enabled", "template", "maxLength", "restoreOnShutdown"]),
+	recap: new Set(["auto", "idleAfterTurnMs", "model", "fallbackToCurrentModel", "language"]),
+	title: new Set(["applyToSessionName"]),
+	multiplexer: new Set(["enabled", "template"]),
 };
 const emittedMigrationNotices = new Set<string>();
 
@@ -180,12 +162,29 @@ function stripUnknownConfig(value: unknown): { value: unknown; dropped: string[]
 	return { value: result, dropped };
 }
 
+function migrateRemovedFields(value: unknown): { value: unknown; changed: boolean } {
+	if (!isRecord(value)) return { value, changed: false };
+	const recap = isRecord(value.recap) ? { ...value.recap } : undefined;
+	if (!recap) return { value, changed: false };
+	let changed = false;
+	if (recap.enabled === false) {
+		recap.auto = false;
+		changed = true;
+	}
+	if ("enabled" in recap) {
+		delete recap.enabled;
+		changed = true;
+	}
+	return { value: { ...value, recap }, changed };
+}
+
 function migrateLegacyConfig(value: unknown): ConfigMigration {
 	const multiplexerMigration = migrateMultiplexerConfig(value);
-	const stripped = stripUnknownConfig(multiplexerMigration.value);
+	const removed = migrateRemovedFields(multiplexerMigration.value);
+	const stripped = stripUnknownConfig(removed.value);
 	return {
 		value: stripped.value,
-		changed: multiplexerMigration.changed || stripped.dropped.length > 0,
+		changed: multiplexerMigration.changed || removed.changed || stripped.dropped.length > 0,
 		dropped: stripped.dropped,
 	};
 }
@@ -358,46 +357,37 @@ export async function loadRecapConfig(ctx: ExtensionContext): Promise<RecapConfi
 	return normalizeConfig(config);
 }
 
-function normalizeConfig(config: RecapConfig): RecapConfig {
-	const normalized: RecapConfig = {
+export function normalizeConfig(config: RecapConfig): RecapConfig {
+	const recapIn = (config.recap ?? {}) as RecapConfig["recap"] & { enabled?: boolean };
+	let auto = typeof recapIn.auto === "boolean" ? recapIn.auto : DEFAULT_CONFIG.recap.auto;
+	if (recapIn.enabled === false) auto = false;
+
+	return {
 		recap: {
-			...DEFAULT_CONFIG.recap,
-			...config.recap,
-			idleAfterTurnMs: positiveNumber(config.recap?.idleAfterTurnMs, DEFAULT_CONFIG.recap.idleAfterTurnMs),
-			minSessionTurns: Math.max(0, Math.floor(positiveNumber(config.recap?.minSessionTurns, DEFAULT_CONFIG.recap.minSessionTurns))),
-			maxRecentChars: positiveNumber(config.recap?.maxRecentChars, DEFAULT_CONFIG.recap.maxRecentChars),
-			maxTokens: positiveNumber(config.recap?.maxTokens, DEFAULT_CONFIG.recap.maxTokens),
-		},
-		display: {
-			...DEFAULT_CONFIG.display,
-			...config.display,
-			widgetPlacement: config.display?.widgetPlacement === "belowEditor" ? "belowEditor" : "aboveEditor",
+			auto,
+			idleAfterTurnMs: positiveNumber(recapIn.idleAfterTurnMs, DEFAULT_CONFIG.recap.idleAfterTurnMs),
+			model: typeof recapIn.model === "string" && recapIn.model ? recapIn.model : DEFAULT_CONFIG.recap.model,
+			fallbackToCurrentModel: typeof recapIn.fallbackToCurrentModel === "boolean"
+				? recapIn.fallbackToCurrentModel
+				: DEFAULT_CONFIG.recap.fallbackToCurrentModel,
+			language: typeof recapIn.language === "string" && recapIn.language
+				? recapIn.language
+				: DEFAULT_CONFIG.recap.language,
 		},
 		title: {
-			...DEFAULT_CONFIG.title,
-			...config.title,
-			applyPolicy: normalizeTitlePolicy(config.title?.applyPolicy),
-			maxLength: positiveNumber(config.title?.maxLength, DEFAULT_CONFIG.title.maxLength),
+			applyToSessionName: Boolean(config.title?.applyToSessionName),
 		},
 		multiplexer: {
-			...DEFAULT_CONFIG.multiplexer,
-			...config.multiplexer,
-			maxLength: positiveNumber(config.multiplexer?.maxLength, DEFAULT_CONFIG.multiplexer.maxLength),
+			enabled: config.multiplexer?.enabled !== false,
+			template: typeof config.multiplexer?.template === "string" && config.multiplexer.template
+				? config.multiplexer.template
+				: DEFAULT_CONFIG.multiplexer.template,
 		},
 	};
-
-	// `interactiveOnly` existed in 0.1.0 but recap is now always TUI-only.
-	delete (normalized.recap as Record<string, unknown>).interactiveOnly;
-	return normalized;
 }
 
 function positiveNumber(value: unknown, fallback: number): number {
 	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
-}
-
-function normalizeTitlePolicy(value: unknown): TitleApplyPolicy {
-	if (value === "never" || value === "if-empty" || value === "if-empty-or-auto" || value === "always") return value;
-	return DEFAULT_CONFIG.title.applyPolicy;
 }
 
 function currentSessionName(pi: ExtensionAPI, ctx: ExtensionContext): string | undefined {
@@ -522,9 +512,7 @@ function buildRecentConversation(entries: SessionEntry[], lastRecapSourceToEntry
 }
 
 function buildSystemPrompt(config: RecapConfig): string {
-	const titleInstruction = config.title.generate
-		? `Also generate a short title (max ${config.title.maxLength} characters) that identifies the current task.`
-		: "Set title to an empty string.";
+	const titleInstruction = `Also generate a short title (max ${TITLE_MAX_LENGTH} characters) that identifies the current task.`;
 
 	return [
 		"You generate a recent-activity recap for a terminal coding-agent session.",
@@ -582,11 +570,15 @@ export function shouldApplyTitleForPolicy(input: TitleApplicationInput): boolean
 	);
 }
 
+function titleApplyPolicy(applyToSessionName: boolean): TitleApplyPolicy {
+	return applyToSessionName ? "if-empty-or-auto" : "never";
+}
+
 function shouldApplyTitle(title: string | undefined, pi: ExtensionAPI, ctx: ExtensionContext, config: RecapConfig, state: RecapState): boolean {
 	return shouldApplyTitleForPolicy({
 		title,
 		applyToSessionName: config.title.applyToSessionName,
-		policy: config.title.applyPolicy,
+		policy: titleApplyPolicy(config.title.applyToSessionName),
 		currentSessionName: currentSessionName(pi, ctx),
 		lastAppliedSessionName: state.lastAppliedSessionName,
 		lastAppliedTitle: state.lastAppliedTitle,
@@ -657,25 +649,21 @@ export async function runRecap(
 	const { force = false, signal, showProgress = true } = options;
 	const completeModel = resolveCompleteModel(ctx, options.completeModel);
 	if (state.running) return undefined;
-	if (!config.recap.enabled) {
-		if (reason === "manual" && ctx.mode === "tui") displayRecapError(ctx, config, "Recap is disabled by config");
-		return undefined;
-	}
 	if (ctx.mode !== "tui") {
 		if (reason === "manual" && ctx.hasUI) ctx.ui.notify("recap requires TUI mode", "warning");
 		return undefined;
 	}
 
 	const entries = ctx.sessionManager.getBranch();
-	if (!force && countUserTurns(entries) < config.recap.minSessionTurns) return undefined;
+	if (!force && countUserTurns(entries) < MIN_SESSION_TURNS) return undefined;
 
-	const source = buildRecentConversation(entries, state.lastRecapSourceToEntryId, config.recap.maxRecentChars);
+	const source = buildRecentConversation(entries, state.lastRecapSourceToEntryId, RECAP_MAX_RECENT_CHARS);
 	if (!source.conversation.trim()) {
 		if (reason === "manual") displayRecapError(ctx, config, "No new activity to recap");
 		return undefined;
 	}
 
-	if (!force && config.recap.neverTwiceInARow && source.toEntryId && source.toEntryId === state.lastRecapSourceToEntryId) {
+	if (!force && source.toEntryId && source.toEntryId === state.lastRecapSourceToEntryId) {
 		return undefined;
 	}
 
@@ -718,7 +706,7 @@ export async function runRecap(
 					],
 				},
 				{
-					maxTokens: config.recap.maxTokens,
+					maxTokens: RECAP_MAX_TOKENS,
 					signal: runSignal,
 					sessionId,
 					...(headers ? { headers } : {}),
@@ -741,8 +729,8 @@ export async function runRecap(
 		const resolved = resolveRecapOutput(raw, {
 			stopReason: response.stopReason,
 			errorMessage: response.errorMessage,
-			generateTitle: config.title.generate,
-			titleMaxLength: config.title.maxLength,
+			generateTitle: true,
+			titleMaxLength: TITLE_MAX_LENGTH,
 		});
 		if (!resolved.ok) {
 			displayRecapError(ctx, config, resolved.error);
@@ -773,7 +761,7 @@ export async function runRecap(
 			},
 			generatedAt: Date.now(),
 			appliedSessionName,
-			sessionNamePolicy: config.title.applyPolicy,
+			sessionNamePolicy: titleApplyPolicy(config.title.applyToSessionName),
 		};
 
 		pi.appendEntry(CUSTOM_TYPE, data);
@@ -808,7 +796,7 @@ function clearRecapDisplay(ctx: ExtensionContext) {
 
 function showRecapProgress(ctx: ExtensionContext, config: RecapConfig) {
 	clearRecapDisplay(ctx);
-	ctx.ui.setWidget(WIDGET_KEY, ["RECAP  Generating..."], { placement: config.display.widgetPlacement });
+	ctx.ui.setWidget(WIDGET_KEY, ["RECAP  Generating..."], { placement: WIDGET_PLACEMENT });
 }
 
 function displayRecapError(ctx: ExtensionContext, config: RecapConfig, message: string) {
@@ -822,7 +810,7 @@ function displayRecapError(ctx: ExtensionContext, config: RecapConfig, message: 
 				1,
 				0,
 			),
-		{ placement: config.display.widgetPlacement },
+		{ placement: WIDGET_PLACEMENT },
 	);
 }
 
@@ -847,7 +835,7 @@ function displayRecapWidget(ctx: ExtensionContext, config: RecapConfig, data: Re
 
 			return new Text(text, 1, 0);
 		},
-		{ placement: config.display.widgetPlacement },
+		{ placement: WIDGET_PLACEMENT },
 	);
 }
 
@@ -861,11 +849,6 @@ function boolValue(value: boolean): string {
 }
 
 const IDLE_MS_PRESETS = [60_000, 180_000, 300_000, 600_000];
-const MIN_SESSION_TURN_PRESETS = [1, 2, 3, 5, 10];
-const MAX_RECENT_CHAR_PRESETS = [10_000, 20_000, 40_000, 80_000];
-const MAX_TOKEN_PRESETS = [150, 300, 500, 1000];
-const TITLE_MAX_LENGTH_PRESETS = [30, 50, 80];
-const MULTIPLEXER_MAX_LENGTH_PRESETS = [32, 48, 60, 80];
 const LANGUAGE_PRESETS = ["auto", "en", "zh-CN"];
 
 export function recapModelValues(
@@ -895,13 +878,6 @@ function uniqueSortedNumbers(presets: readonly number[], current: number): numbe
 	return [...new Set([...presets, current])].sort((left, right) => left - right);
 }
 
-function numberSelectItems(presets: readonly number[], current: number): SelectItem[] {
-	return uniqueSortedNumbers(presets, current).map((value) => ({
-		value: String(value),
-		label: String(value),
-	}));
-}
-
 function idleSelectItems(currentMs: number): SelectItem[] {
 	return uniqueSortedNumbers(IDLE_MS_PRESETS, currentMs).map((ms) => ({
 		value: String(ms),
@@ -912,12 +888,6 @@ function idleSelectItems(currentMs: number): SelectItem[] {
 function languageSelectItems(current: string): SelectItem[] {
 	const values = LANGUAGE_PRESETS.includes(current) ? [...LANGUAGE_PRESETS] : [...LANGUAGE_PRESETS, current];
 	return values.filter(Boolean).map((value) => ({ value, label: value }));
-}
-
-function parsePositiveNumberValue(raw: string): string | undefined {
-	const value = Number(raw.trim());
-	if (!Number.isFinite(value) || value <= 0) return undefined;
-	return String(Math.floor(value));
 }
 
 function parseIdleMinutesValue(raw: string): string | undefined {
@@ -957,24 +927,10 @@ export function settingItems(config: RecapConfig, options: RecapSettingsOptions)
 	const availableModels = options.availableModels ?? [];
 	const items: SettingItem[] = [
 		{
-			id: "recap.enabled",
-			label: "Recap enabled",
-			description: "Master switch for recap generation.",
-			currentValue: boolValue(config.recap.enabled),
-			values: ["on", "off"],
-		},
-		{
 			id: "recap.auto",
 			label: "Auto recap",
 			description: "Generate recap after an idle period following agent completion.",
 			currentValue: boolValue(config.recap.auto),
-			values: ["on", "off"],
-		},
-		{
-			id: "recap.manualCommand",
-			label: "Manual /recap command",
-			description: "Allow generating a recap with /recap.",
-			currentValue: boolValue(config.recap.manualCommand),
 			values: ["on", "off"],
 		},
 		{
@@ -991,28 +947,6 @@ export function settingItems(config: RecapConfig, options: RecapSettingsOptions)
 						parse: parseIdleMinutesValue,
 					},
 				}),
-		},
-		{
-			id: "recap.minSessionTurns",
-			label: "Minimum session turns",
-			description: "Skip auto recap until the session has at least this many user turns.",
-			currentValue: String(config.recap.minSessionTurns),
-			submenu: (_current, done) =>
-				presetOrCustomPicker(numberSelectItems(MIN_SESSION_TURN_PRESETS, getConfig().recap.minSessionTurns), options.theme, done, {
-					preferredValue: String(getConfig().recap.minSessionTurns),
-					custom: {
-						title: "Minimum session turns",
-						prefill: String(getConfig().recap.minSessionTurns),
-						parse: parsePositiveNumberValue,
-					},
-				}),
-		},
-		{
-			id: "recap.neverTwiceInARow",
-			label: "Never twice in a row",
-			description: "Skip auto recap when nothing new has happened since the last recap.",
-			currentValue: boolValue(config.recap.neverTwiceInARow),
-			values: ["on", "off"],
 		},
 		{
 			id: "recap.model",
@@ -1041,36 +975,6 @@ export function settingItems(config: RecapConfig, options: RecapSettingsOptions)
 
 	items.push(
 		{
-			id: "recap.maxRecentChars",
-			label: "Max recent characters",
-			description: "Cap the recent activity sent to the recap model.",
-			currentValue: String(config.recap.maxRecentChars),
-			submenu: (_current, done) =>
-				presetOrCustomPicker(numberSelectItems(MAX_RECENT_CHAR_PRESETS, getConfig().recap.maxRecentChars), options.theme, done, {
-					preferredValue: String(getConfig().recap.maxRecentChars),
-					custom: {
-						title: "Max recent characters",
-						prefill: String(getConfig().recap.maxRecentChars),
-						parse: parsePositiveNumberValue,
-					},
-				}),
-		},
-		{
-			id: "recap.maxTokens",
-			label: "Max tokens",
-			description: "Token cap for the recap model response.",
-			currentValue: String(config.recap.maxTokens),
-			submenu: (_current, done) =>
-				presetOrCustomPicker(numberSelectItems(MAX_TOKEN_PRESETS, getConfig().recap.maxTokens), options.theme, done, {
-					preferredValue: String(getConfig().recap.maxTokens),
-					custom: {
-						title: "Max tokens",
-						prefill: String(getConfig().recap.maxTokens),
-						parse: parsePositiveNumberValue,
-					},
-				}),
-		},
-		{
 			id: "recap.language",
 			label: "Language",
 			description: "auto follows recent activity. Custom values are sent as the recap language.",
@@ -1086,56 +990,15 @@ export function settingItems(config: RecapConfig, options: RecapSettingsOptions)
 				}),
 		},
 		{
-			id: "title.generate",
-			label: "Generate title",
-			description: "Also generate a short title as a recap side effect.",
-			currentValue: boolValue(config.title.generate),
+			id: "title.applyToSessionName",
+			label: "Apply title to session name",
+			description: "When on, recap may set the session name if it is empty or still the last recap title. Manual names are not overwritten.",
+			currentValue: boolValue(config.title.applyToSessionName),
 			values: ["on", "off"],
 		},
 	);
 
-	if (config.title.generate) {
-		items.push(
-			{
-				id: "title.applyToSessionName",
-				label: "Apply title to session name",
-				description: "Use generated title to rename the Pi session according to policy.",
-				currentValue: boolValue(config.title.applyToSessionName),
-				values: ["on", "off"],
-			},
-			{
-				id: "title.applyPolicy",
-				label: "Session name policy",
-				description: "Controls when generated titles overwrite session name.",
-				currentValue: config.title.applyPolicy,
-				values: ["if-empty-or-auto", "if-empty", "always", "never"],
-			},
-			{
-				id: "title.maxLength",
-				label: "Title max length",
-				description: "Maximum characters for the generated or fallback title.",
-				currentValue: String(config.title.maxLength),
-				submenu: (_current, done) =>
-					presetOrCustomPicker(numberSelectItems(TITLE_MAX_LENGTH_PRESETS, getConfig().title.maxLength), options.theme, done, {
-						preferredValue: String(getConfig().title.maxLength),
-						custom: {
-							title: "Title max length",
-							prefill: String(getConfig().title.maxLength),
-							parse: parsePositiveNumberValue,
-						},
-					}),
-			},
-		);
-	}
-
 	items.push(
-		{
-			id: "display.widgetPlacement",
-			label: "Widget placement",
-			description: "Where to render the recap widget.",
-			currentValue: config.display.widgetPlacement,
-			values: ["aboveEditor", "belowEditor"],
-		},
 		{
 			id: "multiplexer.enabled",
 			label: "Sync multiplexer name",
@@ -1156,33 +1019,6 @@ export function settingItems(config: RecapConfig, options: RecapSettingsOptions)
 					done,
 				),
 		},
-		{
-			id: "multiplexer.maxLength",
-			label: "Multiplexer name max length",
-			description: "Truncate the generated pane or window name to this length.",
-			currentValue: String(config.multiplexer.maxLength),
-			submenu: (_current, done) =>
-				presetOrCustomPicker(
-					numberSelectItems(MULTIPLEXER_MAX_LENGTH_PRESETS, getConfig().multiplexer.maxLength),
-					options.theme,
-					done,
-					{
-						preferredValue: String(getConfig().multiplexer.maxLength),
-						custom: {
-							title: "Multiplexer name max length",
-							prefill: String(getConfig().multiplexer.maxLength),
-							parse: parsePositiveNumberValue,
-						},
-					},
-				),
-		},
-		{
-			id: "multiplexer.restoreOnShutdown",
-			label: "Restore multiplexer on shutdown",
-			description: "Restore the previous pane or window name when Pi exits.",
-			currentValue: boolValue(config.multiplexer.restoreOnShutdown),
-			values: ["on", "off"],
-		},
 	);
 
 	return items;
@@ -1193,17 +1029,8 @@ export function applyConfigSetting(config: RecapConfig, id: string, value: strin
 	const on = value === "on";
 
 	switch (id) {
-		case "recap.enabled":
-			next.recap.enabled = on;
-			break;
 		case "recap.auto":
 			next.recap.auto = on;
-			break;
-		case "recap.manualCommand":
-			next.recap.manualCommand = on;
-			break;
-		case "recap.neverTwiceInARow":
-			next.recap.neverTwiceInARow = on;
 			break;
 		case "recap.model":
 			next.recap.model = value.trim() || next.recap.model;
@@ -1214,44 +1041,17 @@ export function applyConfigSetting(config: RecapConfig, id: string, value: strin
 		case "recap.idleAfterTurnMs":
 			next.recap.idleAfterTurnMs = positiveNumber(Number(value), next.recap.idleAfterTurnMs);
 			break;
-		case "recap.minSessionTurns":
-			next.recap.minSessionTurns = Math.max(0, Math.floor(positiveNumber(Number(value), next.recap.minSessionTurns)));
-			break;
-		case "recap.maxRecentChars":
-			next.recap.maxRecentChars = positiveNumber(Number(value), next.recap.maxRecentChars);
-			break;
-		case "recap.maxTokens":
-			next.recap.maxTokens = positiveNumber(Number(value), next.recap.maxTokens);
-			break;
 		case "recap.language":
 			next.recap.language = value.trim() || next.recap.language;
 			break;
-		case "title.generate":
-			next.title.generate = on;
-			break;
 		case "title.applyToSessionName":
 			next.title.applyToSessionName = on;
-			break;
-		case "title.applyPolicy":
-			next.title.applyPolicy = normalizeTitlePolicy(value);
-			break;
-		case "title.maxLength":
-			next.title.maxLength = positiveNumber(Number(value), next.title.maxLength);
-			break;
-		case "display.widgetPlacement":
-			next.display.widgetPlacement = value === "belowEditor" ? "belowEditor" : "aboveEditor";
 			break;
 		case "multiplexer.enabled":
 			next.multiplexer.enabled = on;
 			break;
 		case "multiplexer.template":
 			next.multiplexer.template = value;
-			break;
-		case "multiplexer.maxLength":
-			next.multiplexer.maxLength = positiveNumber(Number(value), next.multiplexer.maxLength);
-			break;
-		case "multiplexer.restoreOnShutdown":
-			next.multiplexer.restoreOnShutdown = on;
 			break;
 	}
 
@@ -1271,7 +1071,7 @@ async function editConfigJson(pi: ExtensionAPI, ctx: ExtensionContext, state: Re
 		const parsed = migrateLegacyConfig(JSON.parse(edited) as unknown).value;
 		const next = normalizeConfig(deepMerge(DEFAULT_CONFIG as unknown as Record<string, unknown>, parsed) as RecapConfig);
 		state.config = next;
-		if (!next.recap.enabled || !next.recap.auto) stopAutomaticRecap(ctx, state);
+		if (!next.recap.auto) stopAutomaticRecap(ctx, state);
 		refreshRecapDisplay(ctx, state);
 		await saveGlobalConfig(next);
 		await syncMultiplexer(pi, ctx, state);
@@ -1337,7 +1137,7 @@ async function openConfigUi(pi: ExtensionAPI, ctx: ExtensionContext, state: Reca
 				state.config = next;
 				replaceSettingsListItems(settingsList, settingItems(next, settingsOptions()));
 
-				if (!next.recap.enabled || !next.recap.auto) stopAutomaticRecap(ctx, state);
+				if (!next.recap.auto) stopAutomaticRecap(ctx, state);
 				refreshRecapDisplay(ctx, state);
 				void saveGlobalConfig(next)
 					.then(async () => {
@@ -1382,10 +1182,17 @@ function multiplexerNameContext(pi: ExtensionAPI, ctx: ExtensionContext): Multip
 	};
 }
 
+function toMultiplexerRuntime(config: RecapConfig["multiplexer"], enabled = config.enabled): MultiplexerConfig {
+	return {
+		enabled,
+		template: config.template,
+		maxLength: MULTIPLEXER_MAX_LENGTH,
+		restoreOnShutdown: true,
+	};
+}
+
 async function syncMultiplexer(pi: ExtensionAPI, ctx: ExtensionContext, state: RecapState) {
-	const config = ctx.mode === "tui"
-		? state.config.multiplexer
-		: { ...state.config.multiplexer, enabled: false };
+	const config = toMultiplexerRuntime(state.config.multiplexer, ctx.mode === "tui" ? state.config.multiplexer.enabled : false);
 	await state.multiplexer.sync(config, multiplexerNameContext(pi, ctx), multiplexerHooks(ctx));
 }
 
@@ -1434,7 +1241,7 @@ function stopAutomaticRecap(ctx: ExtensionContext, state: RecapState) {
 
 function refreshRecapDisplay(ctx: ExtensionContext, state: RecapState) {
 	clearRecapDisplay(ctx);
-	if (state.config.recap.enabled && state.lastRecap) {
+	if (state.lastRecap) {
 		displayRecapWidget(ctx, state.config, state.lastRecap);
 	}
 }
@@ -1443,7 +1250,7 @@ function scheduleAutoRecap(pi: ExtensionAPI, ctx: ExtensionContext, state: Recap
 	clearAutoTimer(state);
 
 	const config = state.config;
-	if (!config.recap.enabled || !config.recap.auto) return;
+	if (!config.recap.auto) return;
 	if (ctx.mode !== "tui") return;
 
 	state.autoTimer = setTimeout(() => {
@@ -1526,18 +1333,13 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_shutdown", async (event, ctx) => {
 		stopAutomaticRecap(ctx, state);
-		await state.multiplexer.shutdown(state.config.multiplexer, event.reason, multiplexerHooks(ctx));
+		await state.multiplexer.shutdown(toMultiplexerRuntime(state.config.multiplexer), event.reason, multiplexerHooks(ctx));
 	});
 
 	pi.registerCommand("recap", {
 		description: "Generate a recent activity recap",
 		handler: async (_args, ctx: ExtensionCommandContext) => {
 			stopAutomaticRecap(ctx, state);
-			if (!state.config.recap.manualCommand) {
-				if (ctx.mode === "tui") displayRecapError(ctx, state.config, "/recap is disabled by config");
-				else if (ctx.hasUI) ctx.ui.notify("/recap is disabled by config", "warning");
-				return;
-			}
 			await ctx.waitForIdle();
 			if (ctx.mode !== "tui") {
 				await runRecap(pi, ctx, state.config, state, "manual", { force: true });

--- a/packages/pi-recap/tests/config-migration.test.ts
+++ b/packages/pi-recap/tests/config-migration.test.ts
@@ -47,21 +47,25 @@ test("Recap migrates global and trusted project configs while dropping unmappabl
 		});
 
 		const untrusted = await loadRecapConfig(context(cwd, false, notifications));
-		assert.equal(untrusted.recap.enabled, false);
-		assert.equal(untrusted.title.maxLength, 50);
+		assert.equal(untrusted.recap.auto, false);
+		assert.equal(untrusted.title.applyToSessionName, false);
 		assert.equal(existsSync(getLegacyProjectConfigPath(cwd)), true);
 		assert.equal(existsSync(getProjectConfigPath(cwd)), false);
 
 		const trusted = await loadRecapConfig(context(cwd, true, notifications));
-		assert.equal(trusted.title.maxLength, 72);
+		assert.equal(trusted.recap.auto, false);
 		assert.equal(existsSync(getLegacyGlobalConfigPath()), false);
 		assert.equal(existsSync(getLegacyProjectConfigPath(cwd)), false);
 		assert.equal(existsSync(getGlobalConfigPath()), true);
 		assert.equal(existsSync(getProjectConfigPath(cwd)), true);
-		assert.doesNotMatch(await readFile(getGlobalConfigPath(), "utf8"), /removed|notify/);
+		const savedGlobal = await readFile(getGlobalConfigPath(), "utf8");
+		assert.doesNotMatch(savedGlobal, /removed|notify|"enabled"|manualCommand|maxLength|widgetPlacement|applyPolicy|restoreOnShutdown/);
+		assert.match(savedGlobal, /"auto": false/);
 		assert.match(notifications.join("\n"), /recap\.removed/);
-		assert.match(notifications.join("\n"), /display\.notify/);
+		assert.match(notifications.join("\n"), /display/);
 		assert.match(notifications.join("\n"), /title\.obsolete/);
+		assert.match(notifications.join("\n"), /title\.maxLength/);
+
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;

--- a/packages/pi-recap/tests/config-migration.test.ts
+++ b/packages/pi-recap/tests/config-migration.test.ts
@@ -41,6 +41,7 @@ test("Recap migrates global and trusted project configs while dropping unmappabl
 		await writeJson(getLegacyGlobalConfigPath(), {
 			recap: { enabled: false, removed: true },
 			display: { widgetPlacement: "belowEditor", notify: true },
+			title: { applyToSessionName: false, applyPolicy: "always" },
 		});
 		await writeJson(getLegacyProjectConfigPath(cwd), {
 			title: { maxLength: 72, obsolete: true },
@@ -48,7 +49,7 @@ test("Recap migrates global and trusted project configs while dropping unmappabl
 
 		const untrusted = await loadRecapConfig(context(cwd, false, notifications));
 		assert.equal(untrusted.recap.auto, false);
-		assert.equal(untrusted.title.applyToSessionName, false);
+		assert.equal(untrusted.title.applyPolicy, "off");
 		assert.equal(existsSync(getLegacyProjectConfigPath(cwd)), true);
 		assert.equal(existsSync(getProjectConfigPath(cwd)), false);
 
@@ -59,7 +60,8 @@ test("Recap migrates global and trusted project configs while dropping unmappabl
 		assert.equal(existsSync(getGlobalConfigPath()), true);
 		assert.equal(existsSync(getProjectConfigPath(cwd)), true);
 		const savedGlobal = await readFile(getGlobalConfigPath(), "utf8");
-		assert.doesNotMatch(savedGlobal, /removed|notify|"enabled"|manualCommand|maxLength|widgetPlacement|applyPolicy|restoreOnShutdown/);
+		assert.doesNotMatch(savedGlobal, /removed|notify|"enabled"|manualCommand|maxLength|widgetPlacement|applyToSessionName|restoreOnShutdown/);
+		assert.match(savedGlobal, /"applyPolicy": "off"/);
 		assert.match(savedGlobal, /"auto": false/);
 		assert.match(notifications.join("\n"), /recap\.removed/);
 		assert.match(notifications.join("\n"), /display/);

--- a/packages/pi-recap/tests/recap-contract.test.ts
+++ b/packages/pi-recap/tests/recap-contract.test.ts
@@ -216,7 +216,15 @@ function renderWidget(value: unknown): string {
 	return widget.render(200).join("\n");
 }
 
-function createRunHarness(spec: CompletionSpec) {
+type HarnessModel = { provider: string; id: string; baseUrl?: string };
+
+type HarnessOptions = {
+	model?: HarnessModel;
+	sessionId?: string;
+	omitGetSessionId?: boolean;
+};
+
+function createRunHarness(spec: CompletionSpec, harnessOptions: HarnessOptions = {}) {
 	const appended: Array<{ customType: string; data: RecapEntryData }> = [];
 	const sessionNames: string[] = [];
 	const widgets: unknown[] = [];
@@ -244,24 +252,32 @@ function createRunHarness(spec: CompletionSpec) {
 			sessionNames.push(title);
 		},
 	} as unknown as ExtensionAPI;
+	const sessionManager: {
+		getBranch(): SessionEntry[];
+		getSessionName(): string;
+		getSessionId?: () => string;
+	} = {
+		getBranch() {
+			return entries;
+		},
+		getSessionName() {
+			return currentSessionName;
+		},
+	};
+	if (!harnessOptions.omitGetSessionId) {
+		sessionManager.getSessionId = () => harnessOptions.sessionId ?? "session-id";
+	}
 	const ctx = {
 		mode: "tui",
 		hasUI: true,
 		signal: new AbortController().signal,
-		model: { provider: "test", id: "recap-model" },
+		model: harnessOptions.model ?? { provider: "test", id: "recap-model" },
 		modelRegistry: {
 			async getApiKeyAndHeaders() {
 				return { ok: true, apiKey: "test-key" };
 			},
 		},
-		sessionManager: {
-			getBranch() {
-				return entries;
-			},
-			getSessionName() {
-				return currentSessionName;
-			},
-		},
+		sessionManager,
 		ui: {
 			setStatus() {},
 			setWidget(_key: string, value: unknown) {
@@ -439,4 +455,80 @@ test("session_start restores a persisted fallback warning into the widget", asyn
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		await rm(root, { recursive: true, force: true });
 	}
+});
+
+type CapturedCompleteOptions = {
+	sessionId?: string;
+	headers?: Record<string, string | null>;
+};
+
+async function captureCompleteOptions(harnessOptions: HarnessOptions = {}): Promise<CapturedCompleteOptions | undefined> {
+	let captured: CapturedCompleteOptions | undefined;
+	const harness = createRunHarness(
+		{ text: '{"recap":"Fixed the parser.","title":"Parser fix"}', stopReason: "stop" },
+		harnessOptions,
+	);
+	await runRecap(harness.pi, harness.ctx, harness.config, harness.state, "manual", {
+		force: true,
+		showProgress: false,
+		completeModel: async (model, context, opts) => {
+			captured = { sessionId: opts?.sessionId, headers: opts?.headers };
+			return harness.completeModel(model, context, opts);
+		},
+	});
+	return captured;
+}
+
+function assertOpenCodeSessionHeaders(opts: CapturedCompleteOptions | undefined, sessionId: string) {
+	assert.equal(opts?.sessionId, sessionId);
+	assert.equal(opts?.headers?.["x-opencode-session"], sessionId);
+	assert.equal(opts?.headers?.["x-opencode-client"], "pi");
+}
+
+function assertNoOpenCodeSessionHeaders(opts: CapturedCompleteOptions | undefined) {
+	assert.equal(opts?.headers?.["x-opencode-session"], undefined);
+	assert.equal(opts?.headers?.["x-opencode-client"], undefined);
+}
+
+test("opencode-go recap complete options include session headers", async () => {
+	const opts = await captureCompleteOptions({
+		model: { provider: "opencode-go", id: "recap-model" },
+	});
+	assertOpenCodeSessionHeaders(opts, "session-id");
+});
+
+test("opencode recap complete options include session headers", async () => {
+	const opts = await captureCompleteOptions({
+		model: { provider: "opencode", id: "recap-model" },
+	});
+	assertOpenCodeSessionHeaders(opts, "session-id");
+});
+
+test("opencode.ai gateway recap complete options include session headers", async () => {
+	const opts = await captureCompleteOptions({
+		model: { provider: "custom-gateway", id: "recap-model", baseUrl: "https://opencode.ai/zen" },
+	});
+	assertOpenCodeSessionHeaders(opts, "session-id");
+});
+
+test("non-OpenCode recap complete options keep sessionId and omit OpenCode headers", async () => {
+	const opts = await captureCompleteOptions();
+	assert.equal(opts?.sessionId, "session-id");
+	assertNoOpenCodeSessionHeaders(opts);
+});
+
+test("missing or empty session id omits OpenCode headers without crashing", async () => {
+	const missing = await captureCompleteOptions({
+		model: { provider: "opencode", id: "recap-model" },
+		omitGetSessionId: true,
+	});
+	assert.equal(missing?.sessionId, undefined);
+	assertNoOpenCodeSessionHeaders(missing);
+
+	const empty = await captureCompleteOptions({
+		model: { provider: "opencode", id: "recap-model" },
+		sessionId: "",
+	});
+	assert.equal(empty?.sessionId, undefined);
+	assertNoOpenCodeSessionHeaders(empty);
 });

--- a/packages/pi-recap/tests/recap-contract.test.ts
+++ b/packages/pi-recap/tests/recap-contract.test.ts
@@ -174,11 +174,11 @@ test("title policies keep their existing behavior for fallback titles", () => {
 	const fallbackTitle = "Fallback title";
 	const base = {
 		title: fallbackTitle,
-		applyToSessionName: true,
 		currentSessionName: "User title",
 		lastAppliedSessionName: false,
 	};
 
+	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "off" }), false);
 	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "never" }), false);
 	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "always" }), true);
 	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "if-empty" }), false);
@@ -195,7 +195,6 @@ test("title policies keep their existing behavior for fallback titles", () => {
 		true,
 	);
 	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "always", title: undefined }), false);
-	assert.equal(shouldApplyTitleForPolicy({ ...base, policy: "always", applyToSessionName: false }), false);
 });
 
 type CompletionSpec = {
@@ -287,7 +286,7 @@ function createRunHarness(spec: CompletionSpec, harnessOptions: HarnessOptions =
 		},
 	} as unknown as ExtensionContext;
 	const config = structuredClone(DEFAULT_CONFIG) as RecapConfig;
-	config.title.applyToSessionName = true;
+	config.title.applyPolicy = "always";
 	const state = createRecapState(config);
 	const completeModel: NonNullable<RunRecapOptions["completeModel"]> = async () =>
 		({

--- a/packages/pi-recap/tests/recap-contract.test.ts
+++ b/packages/pi-recap/tests/recap-contract.test.ts
@@ -228,7 +228,7 @@ function createRunHarness(spec: CompletionSpec, harnessOptions: HarnessOptions =
 	const appended: Array<{ customType: string; data: RecapEntryData }> = [];
 	const sessionNames: string[] = [];
 	const widgets: unknown[] = [];
-	let currentSessionName = "Existing session";
+	let currentSessionName = "";
 	const entries = [
 		{
 			id: "source-entry",
@@ -288,8 +288,6 @@ function createRunHarness(spec: CompletionSpec, harnessOptions: HarnessOptions =
 	} as unknown as ExtensionContext;
 	const config = structuredClone(DEFAULT_CONFIG) as RecapConfig;
 	config.title.applyToSessionName = true;
-	config.title.applyPolicy = "always";
-	config.title.maxLength = 18;
 	const state = createRecapState(config);
 	const completeModel: NonNullable<RunRecapOptions["completeModel"]> = async () =>
 		({
@@ -310,10 +308,10 @@ test("always applies and persists a recap-derived fallback title", async () => {
 		completeModel: harness.completeModel,
 	});
 
-	assert.equal(result?.title, "Implemented fallb…");
+	assert.equal(result?.title, "Implemented fallback title behavior");
 	assert.equal(result?.titleSource, "recap-fallback");
 	assert.equal(result?.appliedSessionName, true);
-	assert.deepEqual(harness.sessionNames, ["Implemented fallb…"]);
+	assert.deepEqual(harness.sessionNames, ["Implemented fallback title behavior"]);
 	assert.equal(harness.appended.length, 1);
 	assert.equal(harness.appended[0]?.data.titleSource, "recap-fallback");
 	assert.equal(harness.state.lastRecapSourceToEntryId, "source-entry");

--- a/packages/pi-recap/tests/recap-settings.test.ts
+++ b/packages/pi-recap/tests/recap-settings.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import {
+	DEFAULT_CONFIG,
+	applyConfigSetting,
+	recapModelValues,
+	resolveRecapModel,
+	settingItems,
+	type RecapConfig,
+	type RecapModelOption,
+} from "../extensions/recap.ts";
+
+function theme(): Theme {
+	return {
+		fg: (_color: string, text: string) => text,
+		bold: (text: string) => text,
+	} as unknown as Theme;
+}
+
+function itemsFor(config: RecapConfig, available: RecapModelOption[] = []) {
+	return settingItems(config, {
+		availableModels: available,
+		theme: theme(),
+		getConfig: () => config,
+	});
+}
+
+function itemIds(config: RecapConfig, available: RecapModelOption[] = []) {
+	return itemsFor(config, available).map((item) => item.id);
+}
+
+const ALL_SETTING_IDS = [
+	"recap.enabled",
+	"recap.auto",
+	"recap.manualCommand",
+	"recap.idleAfterTurnMs",
+	"recap.minSessionTurns",
+	"recap.neverTwiceInARow",
+	"recap.model",
+	"recap.fallbackToCurrentModel",
+	"recap.maxRecentChars",
+	"recap.maxTokens",
+	"recap.language",
+	"title.generate",
+	"title.applyToSessionName",
+	"title.applyPolicy",
+	"title.maxLength",
+	"display.widgetPlacement",
+	"multiplexer.enabled",
+	"multiplexer.template",
+	"multiplexer.maxLength",
+	"multiplexer.restoreOnShutdown",
+] as const;
+
+test("recap model values put current first and keep unavailable configured models", () => {
+	assert.deepEqual(
+		recapModelValues(
+			[
+				{ provider: "google", id: "gemini-2.5-flash" },
+				{ provider: "openai", id: "gpt-4.1" },
+				{ provider: "google", id: "gemini-2.5-flash" },
+			],
+			"anthropic/claude-missing",
+		),
+		["current", "google/gemini-2.5-flash", "openai/gpt-4.1", "anthropic/claude-missing"],
+	);
+	assert.deepEqual(recapModelValues([{ provider: "google", id: "gemini-2.5-flash" }], "current"), [
+		"current",
+		"google/gemini-2.5-flash",
+	]);
+});
+
+test("setting items hide fallback on current and keep a configured unavailable model visible", () => {
+	const available: RecapModelOption[] = [{ provider: "google", id: "gemini-2.5-flash", name: "Gemini" }];
+	const current = structuredClone(DEFAULT_CONFIG) as RecapConfig;
+	assert.equal(current.recap.model, "current");
+	assert.ok(!itemIds(current, available).includes("recap.fallbackToCurrentModel"));
+
+	const configured = structuredClone(DEFAULT_CONFIG) as RecapConfig;
+	configured.recap.model = "anthropic/claude-missing";
+	const ids = itemIds(configured, available);
+	assert.ok(ids.includes("recap.fallbackToCurrentModel"));
+	assert.equal(itemsFor(configured, available).find((item) => item.id === "recap.model")?.currentValue, "anthropic/claude-missing");
+	assert.deepEqual(recapModelValues(available, configured.recap.model)[0], "current");
+	assert.ok(recapModelValues(available, configured.recap.model).includes("anthropic/claude-missing"));
+});
+
+test("switching to current hides fallback without clearing the stored fallback flag", () => {
+	const config = structuredClone(DEFAULT_CONFIG) as RecapConfig;
+	config.recap.model = "google/gemini-2.5-flash";
+	config.recap.fallbackToCurrentModel = false;
+	assert.ok(itemIds(config).includes("recap.fallbackToCurrentModel"));
+
+	const next = applyConfigSetting(config, "recap.model", "current");
+	assert.equal(next.recap.model, "current");
+	assert.equal(next.recap.fallbackToCurrentModel, false);
+	assert.ok(!itemIds(next).includes("recap.fallbackToCurrentModel"));
+});
+
+test("setting items cover every RecapConfig field while generate=false only hides title extras", () => {
+	const specific = structuredClone(DEFAULT_CONFIG) as RecapConfig;
+	specific.recap.model = "google/gemini-2.5-flash";
+	assert.deepEqual(itemIds(specific), [...ALL_SETTING_IDS]);
+
+	const withoutTitle = structuredClone(specific);
+	withoutTitle.title.generate = false;
+	withoutTitle.title.applyToSessionName = true;
+	withoutTitle.title.applyPolicy = "always";
+	withoutTitle.title.maxLength = 80;
+	const hidden = itemIds(withoutTitle);
+	assert.ok(!hidden.includes("title.applyToSessionName"));
+	assert.ok(!hidden.includes("title.applyPolicy"));
+	assert.ok(!hidden.includes("title.maxLength"));
+	assert.ok(hidden.includes("title.generate"));
+
+	const stillHidden = applyConfigSetting(withoutTitle, "recap.manualCommand", "off");
+	assert.equal(stillHidden.title.generate, false);
+	assert.equal(stillHidden.title.applyToSessionName, true);
+	assert.equal(stillHidden.title.applyPolicy, "always");
+	assert.equal(stillHidden.title.maxLength, 80);
+});
+
+test("apply writes custom numbers, language, template, and remaining flags", () => {
+	const next = applyConfigSetting(
+		applyConfigSetting(
+			applyConfigSetting(
+				applyConfigSetting(
+					applyConfigSetting(
+						applyConfigSetting(
+							applyConfigSetting(
+								applyConfigSetting(
+									applyConfigSetting(DEFAULT_CONFIG, "recap.idleAfterTurnMs", "60000"),
+									"recap.minSessionTurns",
+									"7",
+								),
+								"recap.maxRecentChars",
+								"12345",
+							),
+							"recap.maxTokens",
+							"777",
+						),
+						"title.maxLength",
+						"42",
+					),
+					"multiplexer.maxLength",
+					"55",
+				),
+				"recap.language",
+				"ja",
+			),
+			"multiplexer.template",
+			"{project} · {session}",
+		),
+		"recap.neverTwiceInARow",
+		"off",
+	);
+
+	assert.equal(next.recap.idleAfterTurnMs, 60_000);
+	assert.equal(next.recap.minSessionTurns, 7);
+	assert.equal(next.recap.maxRecentChars, 12_345);
+	assert.equal(next.recap.maxTokens, 777);
+	assert.equal(next.title.maxLength, 42);
+	assert.equal(next.multiplexer.maxLength, 55);
+	assert.equal(next.recap.language, "ja");
+	assert.equal(next.multiplexer.template, "{project} · {session}");
+	assert.equal(next.recap.neverTwiceInARow, false);
+	assert.equal(next.recap.manualCommand, true);
+});
+
+test("resolveRecapModel notifies only when a specific model misses and fallback is used", () => {
+	const notifications: string[] = [];
+	const current = { provider: "test", id: "session-model" };
+	const ctx = {
+		model: current,
+		modelRegistry: {
+			find() {
+				return undefined;
+			},
+		},
+		ui: {
+			notify(message: string) {
+				notifications.push(message);
+			},
+		},
+	} as unknown as ExtensionContext;
+
+	const fallbackConfig = structuredClone(DEFAULT_CONFIG) as RecapConfig;
+	fallbackConfig.recap.model = "google/missing";
+	fallbackConfig.recap.fallbackToCurrentModel = true;
+	assert.equal(resolveRecapModel(ctx, fallbackConfig), current);
+	assert.equal(notifications.length, 1);
+	assert.match(notifications[0] ?? "", /google\/missing/);
+
+	const currentConfig = structuredClone(DEFAULT_CONFIG) as RecapConfig;
+	assert.equal(resolveRecapModel(ctx, currentConfig), current);
+	assert.equal(notifications.length, 1);
+
+	const strictConfig = structuredClone(fallbackConfig);
+	strictConfig.recap.fallbackToCurrentModel = false;
+	assert.equal(resolveRecapModel(ctx, strictConfig), undefined);
+	assert.equal(notifications.length, 1);
+});

--- a/packages/pi-recap/tests/recap-settings.test.ts
+++ b/packages/pi-recap/tests/recap-settings.test.ts
@@ -38,7 +38,7 @@ const ALL_SETTING_IDS = [
 	"recap.model",
 	"recap.fallbackToCurrentModel",
 	"recap.language",
-	"title.applyToSessionName",
+	"title.applyPolicy",
 	"multiplexer.enabled",
 	"multiplexer.template",
 ] as const;
@@ -111,36 +111,33 @@ test("apply writes remaining fields including custom idle, language, and templat
 			"multiplexer.template",
 			"{project} · {session}",
 		),
-		"title.applyToSessionName",
-		"on",
+		"title.applyPolicy",
+		"if-empty-or-auto",
 	);
 
 	assert.equal(next.recap.idleAfterTurnMs, 60_000);
 	assert.equal(next.recap.language, "ja");
 	assert.equal(next.multiplexer.template, "{project} · {session}");
-	assert.equal(next.title.applyToSessionName, true);
+	assert.equal(next.title.applyPolicy, "if-empty-or-auto");
 });
 
-test("applyToSessionName on uses if-empty-or-auto and off does not rename", () => {
-	const off = applyConfigSetting(DEFAULT_CONFIG, "title.applyToSessionName", "off");
-	assert.equal(off.title.applyToSessionName, false);
+test("session name policy off leaves names alone and the other gears keep their old meaning", () => {
+	const off = applyConfigSetting(DEFAULT_CONFIG, "title.applyPolicy", "off");
+	assert.equal(off.title.applyPolicy, "off");
 	assert.equal(
 		shouldApplyTitleForPolicy({
 			title: "New title",
-			applyToSessionName: off.title.applyToSessionName,
-			policy: "if-empty-or-auto",
-			currentSessionName: "Manual name",
+			policy: off.title.applyPolicy,
+			currentSessionName: undefined,
 			lastAppliedSessionName: false,
 		}),
 		false,
 	);
 
-	const on = applyConfigSetting(DEFAULT_CONFIG, "title.applyToSessionName", "on");
-	assert.equal(on.title.applyToSessionName, true);
+	assert.equal(applyConfigSetting(DEFAULT_CONFIG, "title.applyPolicy", "always").title.applyPolicy, "always");
 	assert.equal(
 		shouldApplyTitleForPolicy({
 			title: "New title",
-			applyToSessionName: true,
 			policy: "if-empty-or-auto",
 			currentSessionName: "Manual name",
 			lastAppliedSessionName: false,
@@ -150,7 +147,6 @@ test("applyToSessionName on uses if-empty-or-auto and off does not rename", () =
 	assert.equal(
 		shouldApplyTitleForPolicy({
 			title: "New title",
-			applyToSessionName: true,
 			policy: "if-empty-or-auto",
 			currentSessionName: undefined,
 			lastAppliedSessionName: false,
@@ -160,13 +156,11 @@ test("applyToSessionName on uses if-empty-or-auto and off does not rename", () =
 	assert.equal(
 		shouldApplyTitleForPolicy({
 			title: "New title",
-			applyToSessionName: true,
-			policy: "if-empty-or-auto",
-			currentSessionName: "Previous recap",
-			lastAppliedSessionName: true,
-			lastAppliedTitle: "Previous recap",
+			policy: "if-empty",
+			currentSessionName: "Manual name",
+			lastAppliedSessionName: false,
 		}),
-		true,
+		false,
 	);
 });
 
@@ -182,7 +176,7 @@ test("enabled:false migrates to auto:false and dropped fields are omitted", () =
 			manualCommand: false,
 		},
 		title: {
-			applyToSessionName: true,
+			applyToSessionName: false,
 			generate: false,
 			applyPolicy: "always",
 			maxLength: 80,
@@ -197,17 +191,41 @@ test("enabled:false migrates to auto:false and dropped fields are omitted", () =
 	} as unknown as RecapConfig);
 
 	assert.equal(next.recap.auto, false);
-	assert.equal(next.title.applyToSessionName, true);
+	assert.equal(next.title.applyPolicy, "off");
 	assert.equal(next.multiplexer.enabled, true);
 	assert.equal(next.multiplexer.template, "π {session} · {project}");
 	assert.equal("enabled" in next.recap, false);
 	assert.equal("manualCommand" in next.recap, false);
 	assert.equal("generate" in next.title, false);
-	assert.equal("applyPolicy" in next.title, false);
+	assert.equal("applyToSessionName" in next.title, false);
 	assert.equal("maxLength" in next.title, false);
 	assert.equal("display" in next, false);
 	assert.equal("maxLength" in next.multiplexer, false);
 	assert.equal("restoreOnShutdown" in next.multiplexer, false);
+});
+
+test("never and applyToSessionName false become off; other policies stay", () => {
+	assert.equal(
+		normalizeConfig({
+			...DEFAULT_CONFIG,
+			title: { applyPolicy: "never" },
+		} as unknown as RecapConfig).title.applyPolicy,
+		"off",
+	);
+	assert.equal(
+		normalizeConfig({
+			...DEFAULT_CONFIG,
+			title: { applyToSessionName: true, applyPolicy: "always" },
+		} as unknown as RecapConfig).title.applyPolicy,
+		"always",
+	);
+	assert.equal(
+		normalizeConfig({
+			...DEFAULT_CONFIG,
+			title: { applyToSessionName: false, applyPolicy: "if-empty" },
+		} as unknown as RecapConfig).title.applyPolicy,
+		"off",
+	);
 });
 
 test("resolveRecapModel notifies only when a specific model misses and fallback is used", () => {

--- a/packages/pi-recap/tests/recap-settings.test.ts
+++ b/packages/pi-recap/tests/recap-settings.test.ts
@@ -4,9 +4,11 @@ import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import {
 	DEFAULT_CONFIG,
 	applyConfigSetting,
+	normalizeConfig,
 	recapModelValues,
 	resolveRecapModel,
 	settingItems,
+	shouldApplyTitleForPolicy,
 	type RecapConfig,
 	type RecapModelOption,
 } from "../extensions/recap.ts";
@@ -31,26 +33,14 @@ function itemIds(config: RecapConfig, available: RecapModelOption[] = []) {
 }
 
 const ALL_SETTING_IDS = [
-	"recap.enabled",
 	"recap.auto",
-	"recap.manualCommand",
 	"recap.idleAfterTurnMs",
-	"recap.minSessionTurns",
-	"recap.neverTwiceInARow",
 	"recap.model",
 	"recap.fallbackToCurrentModel",
-	"recap.maxRecentChars",
-	"recap.maxTokens",
 	"recap.language",
-	"title.generate",
 	"title.applyToSessionName",
-	"title.applyPolicy",
-	"title.maxLength",
-	"display.widgetPlacement",
 	"multiplexer.enabled",
 	"multiplexer.template",
-	"multiplexer.maxLength",
-	"multiplexer.restoreOnShutdown",
 ] as const;
 
 test("recap model values put current first and keep unavailable configured models", () => {
@@ -98,74 +88,126 @@ test("switching to current hides fallback without clearing the stored fallback f
 	assert.ok(!itemIds(next).includes("recap.fallbackToCurrentModel"));
 });
 
-test("setting items cover every RecapConfig field while generate=false only hides title extras", () => {
+test("setting items only expose the remaining recap knobs", () => {
 	const specific = structuredClone(DEFAULT_CONFIG) as RecapConfig;
 	specific.recap.model = "google/gemini-2.5-flash";
 	assert.deepEqual(itemIds(specific), [...ALL_SETTING_IDS]);
 
-	const withoutTitle = structuredClone(specific);
-	withoutTitle.title.generate = false;
-	withoutTitle.title.applyToSessionName = true;
-	withoutTitle.title.applyPolicy = "always";
-	withoutTitle.title.maxLength = 80;
-	const hidden = itemIds(withoutTitle);
-	assert.ok(!hidden.includes("title.applyToSessionName"));
-	assert.ok(!hidden.includes("title.applyPolicy"));
-	assert.ok(!hidden.includes("title.maxLength"));
-	assert.ok(hidden.includes("title.generate"));
-
-	const stillHidden = applyConfigSetting(withoutTitle, "recap.manualCommand", "off");
-	assert.equal(stillHidden.title.generate, false);
-	assert.equal(stillHidden.title.applyToSessionName, true);
-	assert.equal(stillHidden.title.applyPolicy, "always");
-	assert.equal(stillHidden.title.maxLength, 80);
+	const current = structuredClone(DEFAULT_CONFIG) as RecapConfig;
+	assert.deepEqual(
+		itemIds(current),
+		ALL_SETTING_IDS.filter((id) => id !== "recap.fallbackToCurrentModel"),
+	);
 });
 
-test("apply writes custom numbers, language, template, and remaining flags", () => {
+test("apply writes remaining fields including custom idle, language, and template", () => {
 	const next = applyConfigSetting(
 		applyConfigSetting(
 			applyConfigSetting(
-				applyConfigSetting(
-					applyConfigSetting(
-						applyConfigSetting(
-							applyConfigSetting(
-								applyConfigSetting(
-									applyConfigSetting(DEFAULT_CONFIG, "recap.idleAfterTurnMs", "60000"),
-									"recap.minSessionTurns",
-									"7",
-								),
-								"recap.maxRecentChars",
-								"12345",
-							),
-							"recap.maxTokens",
-							"777",
-						),
-						"title.maxLength",
-						"42",
-					),
-					"multiplexer.maxLength",
-					"55",
-				),
+				applyConfigSetting(DEFAULT_CONFIG, "recap.idleAfterTurnMs", "60000"),
 				"recap.language",
 				"ja",
 			),
 			"multiplexer.template",
 			"{project} · {session}",
 		),
-		"recap.neverTwiceInARow",
-		"off",
+		"title.applyToSessionName",
+		"on",
 	);
 
 	assert.equal(next.recap.idleAfterTurnMs, 60_000);
-	assert.equal(next.recap.minSessionTurns, 7);
-	assert.equal(next.recap.maxRecentChars, 12_345);
-	assert.equal(next.recap.maxTokens, 777);
-	assert.equal(next.title.maxLength, 42);
-	assert.equal(next.multiplexer.maxLength, 55);
 	assert.equal(next.recap.language, "ja");
 	assert.equal(next.multiplexer.template, "{project} · {session}");
-	assert.equal(next.recap.neverTwiceInARow, false);
-	assert.equal(next.recap.manualCommand, true);
+	assert.equal(next.title.applyToSessionName, true);
+});
+
+test("applyToSessionName on uses if-empty-or-auto and off does not rename", () => {
+	const off = applyConfigSetting(DEFAULT_CONFIG, "title.applyToSessionName", "off");
+	assert.equal(off.title.applyToSessionName, false);
+	assert.equal(
+		shouldApplyTitleForPolicy({
+			title: "New title",
+			applyToSessionName: off.title.applyToSessionName,
+			policy: "if-empty-or-auto",
+			currentSessionName: "Manual name",
+			lastAppliedSessionName: false,
+		}),
+		false,
+	);
+
+	const on = applyConfigSetting(DEFAULT_CONFIG, "title.applyToSessionName", "on");
+	assert.equal(on.title.applyToSessionName, true);
+	assert.equal(
+		shouldApplyTitleForPolicy({
+			title: "New title",
+			applyToSessionName: true,
+			policy: "if-empty-or-auto",
+			currentSessionName: "Manual name",
+			lastAppliedSessionName: false,
+		}),
+		false,
+	);
+	assert.equal(
+		shouldApplyTitleForPolicy({
+			title: "New title",
+			applyToSessionName: true,
+			policy: "if-empty-or-auto",
+			currentSessionName: undefined,
+			lastAppliedSessionName: false,
+		}),
+		true,
+	);
+	assert.equal(
+		shouldApplyTitleForPolicy({
+			title: "New title",
+			applyToSessionName: true,
+			policy: "if-empty-or-auto",
+			currentSessionName: "Previous recap",
+			lastAppliedSessionName: true,
+			lastAppliedTitle: "Previous recap",
+		}),
+		true,
+	);
+});
+
+test("enabled:false migrates to auto:false and dropped fields are omitted", () => {
+	const next = normalizeConfig({
+		recap: {
+			enabled: false,
+			auto: true,
+			idleAfterTurnMs: 180_000,
+			model: "current",
+			fallbackToCurrentModel: true,
+			language: "auto",
+			manualCommand: false,
+		},
+		title: {
+			applyToSessionName: true,
+			generate: false,
+			applyPolicy: "always",
+			maxLength: 80,
+		},
+		display: { widgetPlacement: "belowEditor" },
+		multiplexer: {
+			enabled: true,
+			template: "π {session} · {project}",
+			maxLength: 80,
+			restoreOnShutdown: false,
+		},
+	} as unknown as RecapConfig);
+
+	assert.equal(next.recap.auto, false);
+	assert.equal(next.title.applyToSessionName, true);
+	assert.equal(next.multiplexer.enabled, true);
+	assert.equal(next.multiplexer.template, "π {session} · {project}");
+	assert.equal("enabled" in next.recap, false);
+	assert.equal("manualCommand" in next.recap, false);
+	assert.equal("generate" in next.title, false);
+	assert.equal("applyPolicy" in next.title, false);
+	assert.equal("maxLength" in next.title, false);
+	assert.equal("display" in next, false);
+	assert.equal("maxLength" in next.multiplexer, false);
+	assert.equal("restoreOnShutdown" in next.multiplexer, false);
 });
 
 test("resolveRecapModel notifies only when a specific model misses and fallback is used", () => {


### PR DESCRIPTION
Closes #127

## Summary

- Recap out-of-band model calls now go through `modelRegistry.complete` and send `x-opencode-session` / `x-opencode-client` on OpenCode / OpenCode Go (and `opencode.ai` gateways). This fixes the MissingSessionID 400.
- `/recap` is always available. `/recap-config` only keeps auto recap, idle wait, model, fallback (when the model is not `current`), language, session-name policy (`off` / `if-empty` / `if-empty-or-auto` / `always`), plus multiplexer enablement and template.

## 摘要

- recap 出环调用改走 `modelRegistry.complete`，并在 OpenCode / OpenCode Go（以及 `opencode.ai` 网关）补上 `x-opencode-session` / `x-opencode-client`，修复 MissingSessionID 400。
- `/recap` 常驻；`/recap-config` 只留 auto、idle、model、fallback（非 current 时）、language、session name 策略（off / if-empty / if-empty-or-auto / always）、multiplexer 开关和模板。